### PR TITLE
AP_InertialSensor:fix ZeroOne_FPGA_SCH16T Fifo driver

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_ZeroOne_FPGA_SCH16T.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_ZeroOne_FPGA_SCH16T.cpp
@@ -94,7 +94,7 @@ static constexpr uint16_t SPI_SOFT_RESET = (0b1010);
 #define SEPARATOR_BYTE (0xff)
 #define DUMMY_BYTE (0xff)
 
-#define SPI_2MHZ 31 // 2M = 1/((31-1) × 16.667ns)
+#define SPI_12MHZ 10 // 12M = 120M/12
 /*
 Addr_R32_Verison
 check the version of FPGA
@@ -190,9 +190,10 @@ AP_InertialSensor_ZeroOne_FPGA_SCH16T::probe(AP_InertialSensor &imu,
         return nullptr;
     }
 
-    auto sensor = NEW_NOTHROW AP_InertialSensor_ZeroOne_FPGA_SCH16T(imu, std::move(dev), rotation);
+    AP_InertialSensor_ZeroOne_FPGA_SCH16T *sensor = NEW_NOTHROW AP_InertialSensor_ZeroOne_FPGA_SCH16T(imu, std::move(dev), rotation);
 
-    if (!sensor) {
+    if (!sensor || !sensor->init()) {
+        delete sensor;
         return nullptr;
     }
 
@@ -227,7 +228,7 @@ void AP_InertialSensor_ZeroOne_FPGA_SCH16T::sensor_ctrl(uint8_t fifo_rst)
     reg |= ((fifo_cmd_num - 1) & 0xff) << CTRL_Shift_CmdNumSub1;
     reg |= ((fifo_baudrate - 1) & 0xff) << CTRL_Shift_BaudSub1;
 
-    SensorCtl sensor_ctl;
+    SensorCtl sensor_ctl{};
 
     sensor_ctl.reg.cmd = FuncBit_Write | FuncBit_Reg | FuncBit_Bit32;
     sensor_ctl.reg.reg_addr_l = Addr_W32_Sch16tCtrl & 0xff;
@@ -240,11 +241,29 @@ void AP_InertialSensor_ZeroOne_FPGA_SCH16T::sensor_ctrl(uint8_t fifo_rst)
     dev->transfer_fullduplex(sensor_ctl.raw, 7);
 }
 
-void AP_InertialSensor_ZeroOne_FPGA_SCH16T::init(void)
+bool AP_InertialSensor_ZeroOne_FPGA_SCH16T::init()
+{
+    WITH_SEMAPHORE(dev->get_semaphore());
+    
+    uint8_t tries = 2;
+    do{
+        hal.scheduler->delay(250);//wait thr fpga power on
+        reset_chip();
+        hal.scheduler->delay(250);//wait thr fpga reset
+    }while(!read_product_id()&&--tries);
+
+    if (tries == 0) {
+        return false;
+    }
+
+    return true;
+}
+
+void AP_InertialSensor_ZeroOne_FPGA_SCH16T::init_fpga()
 {
 
     fifo_cmd_num = 17;
-    fifo_baudrate = SPI_2MHZ;
+    fifo_baudrate = SPI_12MHZ;
 
     fifo_enable = 0;
     direct_mode = CtrlMode_Direct;
@@ -363,12 +382,6 @@ void AP_InertialSensor_ZeroOne_FPGA_SCH16T::fpga_write_cmd(uint32_t addr, uint8_
 void AP_InertialSensor_ZeroOne_FPGA_SCH16T::run_state_machine()
 {
     switch (_state) {
-    case State::PowerOn: {
-        _state = State::Reset;
-        dev->adjust_periodic_callback(periodic_handle, 250000UL);//wait 250ms power on
-        break;
-    }
-
     case State::Reset: {
         failure_count = 0;
         reset_chip();
@@ -378,11 +391,6 @@ void AP_InertialSensor_ZeroOne_FPGA_SCH16T::run_state_machine()
     }
 
     case State::Configure: {
-        if (!read_product_id()) {
-            _state = State::Reset;
-            dev->adjust_periodic_callback(periodic_handle, 2000000UL); //wait 2s restart
-            break;
-        }
         configure_registers();
         _state = State::LockConfiguration;
         dev->adjust_periodic_callback(periodic_handle, 250000UL);
@@ -403,11 +411,11 @@ void AP_InertialSensor_ZeroOne_FPGA_SCH16T::run_state_machine()
         // Check that registers are configured properly and that the sensor status is OK
         if (validate_sensor_status() && validate_register_configuration()) {
             _state = State::Read;
-            init();
+            init_fpga();
             dev->adjust_periodic_callback(periodic_handle, 1000000UL / backend_rate_hz);
 
         } else {
-            _state = State::Reset;
+            _state = State::Configure;
             dev->adjust_periodic_callback(periodic_handle, 250000UL);
         }
         break;
@@ -437,13 +445,12 @@ void AP_InertialSensor_ZeroOne_FPGA_SCH16T::run_state_machine()
 
 bool AP_InertialSensor_ZeroOne_FPGA_SCH16T::collect_and_publish()
 {
-    bool result = read_data();
-    return result;
+    return read_data();
 }
 
 bool AP_InertialSensor_ZeroOne_FPGA_SCH16T::read_data()
 {
-    uint8_t pkt_num;
+    uint8_t pkt_num{};
 
     pkt_num = fpga_read_reg8(Addr_RW8_SensorFifoCtrl);
     //if there is no data to be read,return false
@@ -454,7 +461,7 @@ bool AP_InertialSensor_ZeroOne_FPGA_SCH16T::read_data()
     dev->adjust_periodic_callback(periodic_handle, 1000000UL / backend_rate_hz);
 
     uint8_t buff[32];
-    SensorData data = {};
+    SensorData data{};
     for (; pkt_num>1; pkt_num--) {
         fpga_read_fifo8(Addr_W8_SensorValueFifo8, buff, 24);//one packet contains 24 bytes
         fpga_write_reg8(Addr_RW8_SensorFifoCtrl, 0x01);//notice the fpga to load next packet
@@ -509,13 +516,14 @@ void AP_InertialSensor_ZeroOne_FPGA_SCH16T::reset_chip()
 bool AP_InertialSensor_ZeroOne_FPGA_SCH16T::read_product_id()
 {
     uint32_t comp_id = 0, asic_id = 0;
-    register_read(COMP_ID, 0);//the FPGA doesn't process the first instruction,it only starts processing after receiving the second instruction,resulting in the same command being sent twice.
-    register_read(ASIC_ID, &comp_id);
-    register_read(ASIC_ID, &asic_id);
+    // the FPGA ignores the first instruction, so the first read is a dummy
+    UNUSED_RESULT(register_read(COMP_ID, 0));
+    if (!register_read(ASIC_ID, &comp_id) ||
+        !register_read(ASIC_ID, &asic_id)) {
+        return false;
+    }
 
-    bool success = asic_id == 0x21 && comp_id == 0x21;
-
-    return success;
+    return asic_id == 0x21 && comp_id == 0x21;
 }
 
 void AP_InertialSensor_ZeroOne_FPGA_SCH16T::configure_registers()
@@ -523,11 +531,15 @@ void AP_InertialSensor_ZeroOne_FPGA_SCH16T::configure_registers()
     for (auto &r : _registers) {
         register_write(r.addr, r.value);
     }
-    uint32_t reg_value;
-    register_read(CTRL_USER_IF, 0);//the FPGA doesn't process the first instruction,it only starts processing after receiving the second instruction,resulting in the same command being sent twice.
-    register_read(CTRL_USER_IF, &reg_value);
-    reg_value |= DRY_DRV_EN;
-    register_write(CTRL_USER_IF, reg_value);
+    uint32_t reg_value = 0;
+    // the FPGA ignores the first instruction, so the first read is a dummy
+    UNUSED_RESULT(register_read(CTRL_USER_IF, 0));
+    // only modify-write the register if we actually read it back; otherwise
+    // we would write an uninitialised value to a control register
+    if (register_read(CTRL_USER_IF, &reg_value)) {
+        reg_value |= DRY_DRV_EN;
+        register_write(CTRL_USER_IF, reg_value);
+    }
     register_write(CTRL_MODE, EN_SENSOR);
 }
 
@@ -546,11 +558,15 @@ bool AP_InertialSensor_ZeroOne_FPGA_SCH16T::validate_sensor_status()
 
 bool AP_InertialSensor_ZeroOne_FPGA_SCH16T::validate_register_configuration()
 {
-    uint32_t value;
+    uint32_t value{};
 
     for (auto &r : _registers) {
-        register_read(r.addr,0); ////the FPGA doesn't process the first instruction,it only starts processing after receiving the second instruction,resulting in the same command being sent twice.
-        register_read(r.addr,&value);
+        // the FPGA ignores the first instruction, so the first read is a dummy
+        UNUSED_RESULT(register_read(r.addr, 0));
+        if (!register_read(r.addr, &value)) {
+            // a failed read leaves value unset; treat as validation failure
+            return false;
+        }
 
         if (value != r.value) {
             return false;
@@ -561,7 +577,7 @@ bool AP_InertialSensor_ZeroOne_FPGA_SCH16T::validate_register_configuration()
 }
 
 
-uint8_t AP_InertialSensor_ZeroOne_FPGA_SCH16T::wait_direct_busy(void)
+uint8_t AP_InertialSensor_ZeroOne_FPGA_SCH16T::wait_direct_busy()
 {
     uint16_t timeout = 0x200;
     while (timeout) {
@@ -575,7 +591,7 @@ uint8_t AP_InertialSensor_ZeroOne_FPGA_SCH16T::wait_direct_busy(void)
 
 uint16_t AP_InertialSensor_ZeroOne_FPGA_SCH16T::_sch16t_read_status(uint16_t addr)
 {
-    uint32_t value;
+    uint32_t value{};
 
     if (register_read(addr, &value) == 0) {
         return 0;
@@ -766,16 +782,16 @@ void AP_InertialSensor_ZeroOne_FPGA_SCH16T::fill_fpga_frame(FpgaFrame& frame, ui
     }
 }
 
-uint8_t AP_InertialSensor_ZeroOne_FPGA_SCH16T::fpga_test(void)
+bool AP_InertialSensor_ZeroOne_FPGA_SCH16T::fpga_test()
 {
     uint16_t wreg, rreg = 0;
     wreg = rand() & 0xffff;
     fpga_write_reg16(Addr_RW16_TestReg, wreg);
     rreg = fpga_read_reg16(Addr_RW16_TestReg);
     if (wreg != rreg) {
-        return 0;
+        return false;
     }
-    return 1;
+    return true;
 }
 
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_ZeroOne_FPGA_SCH16T.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_ZeroOne_FPGA_SCH16T.h
@@ -125,9 +125,10 @@ private:
 
     } RegCtl;
 
-    void init(void);
+    bool init();
+    void init_fpga();
     void sensor_ctrl(uint8_t fifo_rst);
-    void fpga_read_config(void);
+    void fpga_read_config();
     uint8_t gen_crc8(uint8_t* data);
     void _register_write(uint16_t addr, uint32_t value, uint8_t* buff);
     void _register_read(uint16_t addr, uint8_t* buff);
@@ -152,21 +153,20 @@ private:
     void fpga_write_ram8(uint16_t reg, uint16_t ram_addr, uint8_t* value, uint16_t size);
     void fpga_read_ram8(uint16_t reg, uint16_t ram_addr, uint8_t* value, uint16_t size);
     void fill_fpga_frame(FpgaFrame& frame, uint8_t cmd, uint16_t reg_addr, uint16_t ram_addr);
-    uint8_t wait_direct_busy(void);
+    uint8_t wait_direct_busy();
     uint16_t _sch16t_read_status(uint16_t addr);
-    uint8_t fpga_test(void);
+    bool fpga_test();
 
     AP_HAL::OwnPtr<AP_HAL::Device> dev;
     AP_HAL::Device::PeriodicHandle periodic_handle;
 
     enum class State : uint8_t {
-        PowerOn,
         Reset,
         Configure,
         LockConfiguration,
         Validate,
         Read,
-    } _state = State::PowerOn;
+    } _state = State::Reset;
 
     int failure_count;
     const enum Rotation rotation;


### PR DESCRIPTION
Fixed the bug where the bus was continuously occupied when instantiation failed, assigned values when initializing local variables