### PR TITLE
AP_Follow: fix vertical estimate not tracking the target

### DIFF
--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -272,13 +272,19 @@ void AP_Follow::update_estimates()
         // update X/Y position, velocity, acceleration with shaping
         update_pos_vel_accel_xy(_estimate_pos_ned_m.xy(), _estimate_vel_ned_ms.xy(), _estimate_accel_ned_mss.xy(), e_dt, Vector2f(), Vector2f(), Vector2f());
 
-        // update Z axis position, velocity, acceleration without shaping (direct update)
+        // integrate the Z axis estimate forward by e_dt
         update_pos_vel_accel(_estimate_pos_ned_m.z, _estimate_vel_ned_ms.z, _estimate_accel_ned_mss.z, e_dt, 0.0, 0.0, 0.0);
 
         // apply horizontal shaping to refine estimate toward projected target state
         shape_pos_vel_accel_xy(_target_pos_ned_m.xy() + delta_pos_m.xy().topostype(), _target_vel_ned_ms.xy() + delta_vel_ms.xy(), _target_accel_ned_mss.xy(),
                                _estimate_pos_ned_m.xy(), _estimate_vel_ned_ms.xy(), _estimate_accel_ned_mss.xy(),
                                0.0, _accel_max_ne_mss, _jerk_max_ne_msss, e_dt, false);
+
+        // apply vertical shaping to refine the Z estimate toward the projected
+        // target state (jerk-limited, tuned via FOLL__ACCEL_D / FOLL__JERK_D)
+        shape_pos_vel_accel(_target_pos_ned_m.z + delta_pos_m.z, _target_vel_ned_ms.z + delta_vel_ms.z, _target_accel_ned_mss.z,
+                            _estimate_pos_ned_m.z, _estimate_vel_ned_ms.z, _estimate_accel_ned_mss.z,
+                            0.0, 0.0, -_accel_max_d_mss, _accel_max_d_mss, _jerk_max_d_msss, e_dt, false);
 
         // apply angular shaping for heading estimate
         shape_angle_vel_accel(radians(_target_heading_deg) + delta_heading_rad, radians(_target_heading_rate_degs), 0.0,
@@ -870,11 +876,8 @@ void AP_Follow::update_dist_and_bearing_to_target()
         // if unable to retrieve local position, clear distance/bearing info
         clear_dist_and_bearing_to_target();
     } else {
-        // convert vehicle position to NED meters (NEU -> NED and cm -> m)
-        current_position_ned_m.z = -current_position_ned_m.z; // NEU to NED
-        current_position_ned_m *= 0.01;  // convert cm to m
-
-        // calculate distance vectors to target, both with and without offsets
+        // get_relative_position_NED_origin() already returns metres in the NED
+        // frame, matching _ofs_estimate_pos_ned_m, so no conversion is required.
         const Vector3p ofs_dist_vec = _ofs_estimate_pos_ned_m - current_position_ned_m;
 
         // record distance and bearing to target for reporting/logging

--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -281,7 +281,7 @@ void AP_Follow::update_estimates()
                                0.0, _accel_max_ne_mss, _jerk_max_ne_msss, e_dt, false);
 
         // apply vertical shaping to refine the Z estimate toward the projected
-        // target state (jerk-limited, tuned via FOLL__ACCEL_D / FOLL__JERK_D)
+        // target state (jerk-limited, tuned via FOLL_ACCEL_D / FOLL_JERK_D)
         shape_pos_vel_accel(_target_pos_ned_m.z + delta_pos_m.z, _target_vel_ned_ms.z + delta_vel_ms.z, _target_accel_ned_mss.z,
                             _estimate_pos_ned_m.z, _estimate_vel_ned_ms.z, _estimate_accel_ned_mss.z,
                             0.0, 0.0, -_accel_max_d_mss, _accel_max_d_mss, _jerk_max_d_msss, e_dt, false);

--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -168,7 +168,7 @@ const AP_Param::GroupInfo AP_Follow::var_info[] = {
     // @Range: 0 5
     // @Units: m/s/s
     // @User: Advanced
-    AP_GROUPINFO("_ACCEL_NE", 12, AP_Follow, _accel_max_ne_mss, 2.5),
+    AP_GROUPINFO("_ACCEL_NE", 12, AP_Follow, _accel_max_ne_mss, 5.0),
 
     // @Param: _JERK_NE
     // @DisplayName: Jerk limit for the horizontal kinematic input shaping
@@ -176,7 +176,7 @@ const AP_Param::GroupInfo AP_Follow::var_info[] = {
     // @Range: 0 20
     // @Units: m/s/s/s
     // @User: Advanced
-    AP_GROUPINFO("_JERK_NE", 13, AP_Follow, _jerk_max_ne_msss, 5.0),
+    AP_GROUPINFO("_JERK_NE", 13, AP_Follow, _jerk_max_ne_msss, 10.0),
 
     // @Param: _ACCEL_D
     // @DisplayName: Acceleration limit for the vertical kinematic input shaping
@@ -184,7 +184,7 @@ const AP_Param::GroupInfo AP_Follow::var_info[] = {
     // @Range: 0 2.5
     // @Units: m/s/s
     // @User: Advanced
-    AP_GROUPINFO("_ACCEL_D", 14, AP_Follow, _accel_max_d_mss, 2.5),
+    AP_GROUPINFO("_ACCEL_D", 14, AP_Follow, _accel_max_d_mss, 5.0),
 
     // @Param: _JERK_D
     // @DisplayName: Jerk limit for the vertical kinematic input shaping
@@ -192,7 +192,7 @@ const AP_Param::GroupInfo AP_Follow::var_info[] = {
     // @Range: 0 5
     // @Units: m/s/s/s
     // @User: Advanced
-    AP_GROUPINFO("_JERK_D", 15, AP_Follow, _jerk_max_d_msss, 5.0),
+    AP_GROUPINFO("_JERK_D", 15, AP_Follow, _jerk_max_d_msss, 10.0),
 
     // @Param: _ACCEL_H
     // @DisplayName: Angular acceleration limit for the heading kinematic input shaping
@@ -200,7 +200,7 @@ const AP_Param::GroupInfo AP_Follow::var_info[] = {
     // @Range: 0 90
     // @Units: deg/s/s
     // @User: Advanced
-    AP_GROUPINFO("_ACCEL_H", 16, AP_Follow, _accel_max_h_degss, 90.0),
+    AP_GROUPINFO("_ACCEL_H", 16, AP_Follow, _accel_max_h_degss, 360.0),
 
     // @Param: _JERK_H
     // @DisplayName: Angular jerk limit for the heading kinematic input shaping
@@ -208,7 +208,7 @@ const AP_Param::GroupInfo AP_Follow::var_info[] = {
     // @Range: 0 360
     // @Units: deg/s/s/s
     // @User: Advanced
-    AP_GROUPINFO("_JERK_H", 17, AP_Follow, _jerk_max_h_degsss, 360.0),
+    AP_GROUPINFO("_JERK_H", 17, AP_Follow, _jerk_max_h_degsss, 720.0),
 
     // @Param: _TIMEOUT
     // @DisplayName: Follow timeout


### PR DESCRIPTION
### Summary

AP_Follow: shape the vertical estimate toward the target — the missing 1-D shape_pos_vel_accel for Z (was open-loop, sawtoothing at ~5.6 m).
AP_Follow: fix distance and bearing double frame/unit conversion — drop the erroneous NEU→NED + cm→m on an already-metres-NED value.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
