### PR TITLE
AP_AHRS: create and use active_estimates pointer

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -1513,33 +1513,7 @@ bool AP_AHRS::get_velocity_D(float &velD, bool high_vibes) const
 // This is different to the vertical velocity from the EKF which is not always consistent with the vertical position due to the various errors that are being corrected for.
 bool AP_AHRS::get_vert_pos_rate_D(float &velocity) const
 {
-    switch (active_EKF_type()) {
-#if AP_AHRS_DCM_ENABLED
-    case EKFType::DCM:
-        return dcm_estimates.get_vert_pos_rate_D(velocity);
-#endif
-
-#if HAL_NAVEKF2_AVAILABLE
-    case EKFType::TWO:
-        return ekf2_estimates.get_vert_pos_rate_D(velocity);
-#endif
-
-#if HAL_NAVEKF3_AVAILABLE
-    case EKFType::THREE:
-        return ekf3_estimates.get_vert_pos_rate_D(velocity);
-#endif
-
-#if AP_AHRS_SIM_ENABLED
-    case EKFType::SIM:
-        return sim_estimates.get_vert_pos_rate_D(velocity);
-#endif
-#if AP_AHRS_EXTERNAL_ENABLED
-    case EKFType::EXTERNAL:
-        return external_estimates.get_vert_pos_rate_D(velocity);
-#endif
-    }
-    // since there is no default case above, this is unreachable
-    return false;
+    return active_estimates->get_vert_pos_rate_D(velocity);
 }
 
 // get latest height above ground level estimate in metres and a validity flag

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -495,7 +495,7 @@ void AP_AHRS::update_state(void)
         use_recorded_origin_maybe();
     }
 
-    state.velocity_NED_ok = _get_velocity_NED(state.velocity_NED);
+    state.velocity_NED_ok = active_estimates->get_velocity_NED(state.velocity_NED);
 }
 
 // update run at loop rate
@@ -1430,40 +1430,6 @@ bool AP_AHRS::have_inertial_nav(void) const
     return active_EKF_type() != EKFType::DCM;
 #endif
     return true;
-}
-
-// return a ground velocity in meters/second, North/East/Down
-// order. Must only be called if have_inertial_nav() is true
-bool AP_AHRS::_get_velocity_NED(Vector3f &vec) const
-{
-    switch (active_EKF_type()) {
-#if AP_AHRS_DCM_ENABLED
-    case EKFType::DCM:
-        break;
-#endif
-#if HAL_NAVEKF2_AVAILABLE
-    case EKFType::TWO:
-        return ekf2_estimates.get_velocity_NED(vec);
-#endif
-
-#if HAL_NAVEKF3_AVAILABLE
-    case EKFType::THREE:
-        return ekf3_estimates.get_velocity_NED(vec);
-#endif
-
-#if AP_AHRS_SIM_ENABLED
-    case EKFType::SIM:
-        return sim_estimates.get_velocity_NED(vec);
-#endif
-#if AP_AHRS_EXTERNAL_ENABLED
-    case EKFType::EXTERNAL:
-        return external_estimates.get_velocity_NED(vec);
-#endif
-    }
-#if AP_AHRS_DCM_ENABLED
-    return dcm_estimates.get_velocity_NED(vec);
-#endif
-    return false;
 }
 
 // returns the expected NED magnetic field

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -458,7 +458,7 @@ void AP_AHRS::update_state(void)
     state.airspeed_EAS_ok = _airspeed_EAS(state.airspeed_EAS, state.airspeed_estimate_type);
     state.airspeed_TAS_ok = _airspeed_TAS(state.airspeed_TAS);
     state.airspeed_TAS_vec_ok = _airspeed_TAS(state.airspeed_TAS_vec);
-    state.quat_ok = _get_quaternion(state.quat);
+    state.quat_ok = active_estimates->get_quaternion(state.quat);
     state.secondary_attitude_ok = _get_secondary_attitude(state.secondary_attitude);
     state.secondary_quat_ok = _get_secondary_quaternion(state.secondary_quat);
     state.location_ok = _get_location(state.location);
@@ -1157,49 +1157,6 @@ bool AP_AHRS::use_compass(void)
     return active_backend->use_compass();
 }
 
-bool AP_AHRS::_get_quaternion(Quaternion &quat) const
-{
-    return _get_quaternion_for_ekf_type(quat, active_EKF_type());
-}
-
-// return the quaternion defining the rotation from NED to XYZ (body) axes
-bool AP_AHRS::_get_quaternion_for_ekf_type(Quaternion &quat, EKFType type) const
-{
-    // backends must always return the result in the vehicle body
-    // frame.  A backend using the autopilot sensors will need to
-    // rotate according to the TRIM parameters.  An ExternalAHRS
-    // won't!
-    switch (type) {
-#if AP_AHRS_DCM_ENABLED
-    case EKFType::DCM:
-        quat = dcm_estimates.quaternion;
-        return dcm_estimates.attitude_valid;
-#endif
-#if HAL_NAVEKF2_AVAILABLE
-    case EKFType::TWO:
-        quat = ekf2_estimates.quaternion;
-        return ekf2_estimates.attitude_valid;
-#endif
-#if HAL_NAVEKF3_AVAILABLE
-    case EKFType::THREE:
-        quat = ekf3_estimates.quaternion;
-        return ekf3_estimates.attitude_valid;
-#endif
-#if AP_AHRS_SIM_ENABLED
-    case EKFType::SIM:
-        quat = sim_estimates.quaternion;
-        return sim_estimates.attitude_valid;
-#endif
-#if AP_AHRS_EXTERNAL_ENABLED
-    case EKFType::EXTERNAL:
-        quat = external_estimates.quaternion;
-        return external_estimates.attitude_valid;
-#endif
-    }
-
-    return false;
-}
-
 const AP_AHRS_Backend::Estimates *AP_AHRS::get_secondary_estimates() const
 {
     EKFType secondary_ekf_type;
@@ -1256,11 +1213,11 @@ bool AP_AHRS::_get_secondary_attitude(Vector3f &eulers) const
 // return secondary attitude solution if available, as quaternion
 bool AP_AHRS::_get_secondary_quaternion(Quaternion &quat) const
 {
-    EKFType secondary_ekf_type;
-    if (!_get_secondary_EKF_type(secondary_ekf_type)) {
+    const auto *estimates = get_secondary_estimates();
+    if (estimates == nullptr) {
         return false;
     }
-    return _get_quaternion_for_ekf_type(quat, secondary_ekf_type);
+    return estimates->get_quaternion(quat);
 }
 
 // return secondary position solution if available

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -299,6 +299,7 @@ void AP_AHRS::update_active_EKF_type()
     if (new_backend != nullptr) {
         state.active_EKF_type = new_type;
         active_backend = new_backend;
+        active_estimates = estimates_for_type(new_type);
         return;
     }
     INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -468,7 +468,7 @@ void AP_AHRS::update_state(void)
     }
 #endif  // CONFIG_HAL_BOARD == HAL_BOARD_SITL
     state.secondary_pos_ok = _get_secondary_position(state.secondary_pos);
-    state.ground_speed_vec = active_backend->groundspeed_vector();
+    state.ground_speed_vec = active_estimates->velocity_NE;
     state.ground_speed = state.ground_speed_vec.length();
     _getCorrectedDeltaVelocityNED(state.corrected_dv, state.corrected_dv_dt);
 

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -1199,67 +1199,58 @@ bool AP_AHRS::_get_quaternion_for_ekf_type(Quaternion &quat, EKFType type) const
     return false;
 }
 
-// return secondary attitude solution if available, as eulers in radians
-bool AP_AHRS::_get_secondary_attitude(Vector3f &eulers) const
+const AP_AHRS_Backend::Estimates *AP_AHRS::get_secondary_estimates() const
 {
     EKFType secondary_ekf_type;
     if (!_get_secondary_EKF_type(secondary_ekf_type)) {
-        return false;
+        return nullptr;
     }
+    return estimates_for_type(secondary_ekf_type);
+}
 
-    switch (secondary_ekf_type) {
-
+AP_AHRS_Backend::Estimates *AP_AHRS::estimates_for_type(EKFType type)
+{
+    switch (type) {
 #if AP_AHRS_DCM_ENABLED
     case EKFType::DCM:
-        // DCM is secondary
-        eulers[0] = dcm_estimates.roll_rad;
-        eulers[1] = dcm_estimates.pitch_rad;
-        eulers[2] = dcm_estimates.yaw_rad;
-        return dcm_estimates.attitude_valid;
+        return &dcm_estimates;
 #endif
 
 #if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
-        // EKF2 is secondary
-        eulers[0] = ekf2_estimates.roll_rad;
-        eulers[1] = ekf2_estimates.pitch_rad;
-        eulers[2] = ekf2_estimates.yaw_rad;
-        return ekf2_estimates.attitude_valid;
+        return &ekf2_estimates;
 #endif
 
 #if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
-        // EKF3 is secondary
-        eulers[0] = ekf3_estimates.roll_rad;
-        eulers[1] = ekf3_estimates.pitch_rad;
-        eulers[2] = ekf3_estimates.yaw_rad;
-        return ekf3_estimates.attitude_valid;
+        return &ekf3_estimates;
 #endif
 
 #if AP_AHRS_SIM_ENABLED
     case EKFType::SIM:
-        // SITL is secondary (should never happen)
-        eulers[0] = sim_estimates.roll_rad;
-        eulers[1] = sim_estimates.pitch_rad;
-        eulers[2] = sim_estimates.yaw_rad;
-        return sim_estimates.attitude_valid;
+        return &sim_estimates;
 #endif
 
 #if AP_AHRS_EXTERNAL_ENABLED
-    case EKFType::EXTERNAL: {
-        // External is secondary
-        eulers[0] = external_estimates.roll_rad;
-        eulers[1] = external_estimates.pitch_rad;
-        eulers[2] = external_estimates.yaw_rad;
-        return external_estimates.attitude_valid;
-    }
+    case EKFType::EXTERNAL:
+        return &external_estimates;
 #endif
     }
-
-    // since there is no default case above, this is unreachable
-    return false;
+    return nullptr;
 }
 
+// return secondary attitude solution if available, as eulers in radians
+bool AP_AHRS::_get_secondary_attitude(Vector3f &eulers) const
+{
+    const auto *estimates = get_secondary_estimates();
+    if (estimates == nullptr) {
+        return false;
+    }
+    eulers[0] = estimates->roll_rad;
+    eulers[1] = estimates->pitch_rad;
+    eulers[2] = estimates->yaw_rad;
+    return estimates->attitude_valid;
+}
 
 // return secondary attitude solution if available, as quaternion
 bool AP_AHRS::_get_secondary_quaternion(Quaternion &quat) const

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -1109,8 +1109,14 @@ private:
     const AP_AHRS_Backend *backend_for_type(EKFType type) const {
         return const_cast<AP_AHRS*>(this)->backend_for_type(type);
     }
+    AP_AHRS_Backend::Estimates *estimates_for_type(EKFType type);
+    const AP_AHRS_Backend::Estimates *estimates_for_type(EKFType type) const {
+        return const_cast<AP_AHRS*>(this)->estimates_for_type(type);
+    }
 
     AP_AHRS_Backend *active_backend;
+
+    const AP_AHRS_Backend::Estimates *get_secondary_estimates() const;
 };
 
 namespace AP {

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -960,13 +960,6 @@ private:
     // returns false if estimate is unavailable
     bool _airspeed_TAS(Vector3f &vec) const;
 
-    // return the quaternion defining the rotation from NED to XYZ (body) axes
-    bool _get_quaternion(Quaternion &quat) const WARN_IF_UNUSED;
-
-    // return the quaternion defining the rotation from NED to XYZ
-    // (body) axes for the passed-in type
-    bool _get_quaternion_for_ekf_type(Quaternion &quat, EKFType type) const;
-
     // return secondary position solution if available
     bool _get_secondary_position(Location &loc) const;
 

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -1115,6 +1115,7 @@ private:
     }
 
     AP_AHRS_Backend *active_backend;
+    AP_AHRS_Backend::Estimates *active_estimates;
 
     const AP_AHRS_Backend::Estimates *get_secondary_estimates() const;
 };

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -62,6 +62,15 @@ public:
         Matrix3f dcm_matrix;
         Quaternion quaternion;
 
+        // backends must always return the result in the vehicle body
+        // frame.  A backend using the autopilot sensors will need to
+        // rotate according to the TRIM parameters.  An ExternalAHRS
+        // won't!
+        bool get_quaternion(Quaternion &quat) const {
+            quat = quaternion;
+            return attitude_valid;
+        }
+
         Vector3f gyro_estimate;
         Vector3f gyro_drift;
         Vector3f accel_ef;

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -78,6 +78,8 @@ public:
             vel = velocity_NED;
             return true;
         };
+        // ground velocity estimate in meters/second, in North/East order
+        Vector2f velocity_NE;
 
         // a derivative of the vertical position in m/s which is
         // kinematically consistent with the vertical position is
@@ -193,9 +195,6 @@ public:
         return false;
     #endif
     }
-
-    // return a ground vector estimate in meters/second, in North/East order
-    virtual Vector2f groundspeed_vector(void) = 0;
 
     virtual bool set_origin(const Location &loc) {
         return false;

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -160,6 +160,11 @@ void AP_AHRS_DCM::get_results(AP_AHRS_Backend::Estimates &results)
     results.accel_ef = _accel_ef;
 
     results.velocity_NED_valid = get_velocity_NED(results.velocity_NED);
+
+    // ground velocity estimate in meters/second, in North/East order
+    // note: velocity_NE is significantly different to results.velocity_NED.xy()!
+    results.velocity_NE = groundspeed_vector();
+
     results.vert_pos_rate_D_valid = get_vert_pos_rate_D(results.vert_pos_rate_D);
 
     results.location_valid = get_location(results.location);

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -90,9 +90,6 @@ public:
     // if we have an estimate from a specific sensor index
     bool airspeed_EAS(uint8_t airspeed_index, float &airspeed_ret) const override;
 
-    // return a ground vector estimate in meters/second, in North/East order
-    Vector2f groundspeed_vector() override;
-
     bool            use_compass() override;
 
     void estimate_wind(void);
@@ -124,6 +121,8 @@ private:
     bool get_vert_pos_rate_D(float &velocity) const;
 
     bool get_velocity_NED(Vector3f &vec) const;
+    // return a ground velocity estimate in meters/second, in North/East order
+    Vector2f groundspeed_vector();
 
     // dead-reckoning support
     bool get_location(Location &loc) const;

--- a/libraries/AP_AHRS/AP_AHRS_External.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_External.cpp
@@ -50,15 +50,11 @@ void AP_AHRS_External::get_results(AP_AHRS_Backend::Estimates &results)
     // This is different to the vertical velocity from the EKF which is not always consistent with the vertical position due to the various errors that are being corrected for.
     results.vert_pos_rate_D_valid = AP::externalAHRS().get_speed_down(results.vert_pos_rate_D);
 
+    // ground velocity estimate in meters/second, in North/East order
+    results.velocity_NE = AP::externalAHRS().get_groundspeed_vector();
 
     results.location_valid = AP::externalAHRS().get_location(results.location);
 }
-
-Vector2f AP_AHRS_External::groundspeed_vector()
-{
-    return AP::externalAHRS().get_groundspeed_vector();
-}
-
 
 bool AP_AHRS_External::get_relative_position_NED_origin(Vector3p &vec) const
 {

--- a/libraries/AP_AHRS/AP_AHRS_External.h
+++ b/libraries/AP_AHRS/AP_AHRS_External.h
@@ -52,9 +52,6 @@ public:
         return false;
     }
 
-    // return a ground vector estimate in meters/second, in North/East order
-    Vector2f groundspeed_vector() override;
-
     bool            use_compass() override {
         // this is actually never called at the moment; we use dcm's
         // return value.

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF2.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF2.cpp
@@ -64,6 +64,9 @@ void AP_AHRS_NavEKF2::get_results(AP_AHRS_Backend::Estimates &results)
     results.vert_pos_rate_D = EKF2.getPosDownDerivative();
     results.vert_pos_rate_D_valid = true;
 
+    // ground velocity estimate in meters/second, in North/East order
+    results.velocity_NE = results.velocity_NED.xy();
+
     /*
      * position estimates
      */

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF2.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF2.h
@@ -70,12 +70,6 @@ public:
         return true;
     }
 
-    Vector2f groundspeed_vector(void) override {
-        Vector3f vec;
-        EKF2.getVelNED(vec);
-        return vec.xy();
-    }
-
     bool use_compass() override {
         return EKF2.use_compass();
     }

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
@@ -67,6 +67,9 @@ void AP_AHRS_NavEKF3::get_results(AP_AHRS_Backend::Estimates &results)
     results.vert_pos_rate_D = EKF3.getPosDownDerivative();
     results.vert_pos_rate_D_valid = true;
 
+    // ground velocity estimate in meters/second, in North/East order
+    results.velocity_NE = results.velocity_NED.xy();
+
     /*
      * position estimates
      */

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF3.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF3.h
@@ -69,12 +69,6 @@ public:
         return EKF3.getWind(wind);
     }
 
-    Vector2f groundspeed_vector(void) override {
-        Vector3f vec;
-        EKF3.getVelNED(vec);
-        return vec.xy();
-    }
-
     bool            use_compass() override {
         return EKF3.use_compass();
     }

--- a/libraries/AP_AHRS/AP_AHRS_SIM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_SIM.cpp
@@ -45,17 +45,6 @@ bool AP_AHRS_SIM::airspeed_EAS(uint8_t index, float &airspeed_ret) const
     return airspeed_EAS(airspeed_ret);
 }
 
-Vector2f AP_AHRS_SIM::groundspeed_vector(void)
-{
-    if (_sitl == nullptr) {
-        return Vector2f{};
-    }
-
-    const struct SITL::sitl_fdm &fdm = _sitl->state;
-
-    return Vector2f(fdm.speedN, fdm.speedE);
-}
-
 bool AP_AHRS_SIM::get_hagl(float &height) const
 {
     if (_sitl == nullptr) {
@@ -221,6 +210,9 @@ void AP_AHRS_SIM::get_results(AP_AHRS_Backend::Estimates &results)
 
     results.velocity_NED = Vector3f(fdm.speedN, fdm.speedE, fdm.speedD);
     results.velocity_NED_valid = true;
+
+    // ground velocity estimate in meters/second, in North/East order
+    results.velocity_NE = results.velocity_NED.xy();
 
     // a derivative of the vertical position in m/s which is kinematically consistent with the vertical position is required by some control loops.
     // This is different to the vertical velocity from the EKF which is not always consistent with the vertical position due to the various errors that are being corrected for.

--- a/libraries/AP_AHRS/AP_AHRS_SIM.h
+++ b/libraries/AP_AHRS/AP_AHRS_SIM.h
@@ -76,9 +76,6 @@ public:
     // if we have an estimate from a specific sensor index
     bool airspeed_EAS(uint8_t airspeed_index, float &airspeed_ret) const override;
 
-    // return a ground vector estimate in meters/second, in North/East order
-    Vector2f groundspeed_vector() override;
-
     bool            use_compass() override { return true; }
 
     // is the AHRS subsystem healthy?


### PR DESCRIPTION
### Summary

Augments active_backend pointer with active_estimates pointer to reduce code duplication

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request


### Description

Augments the pattern we've started to use to hold an active backend pointer by adding a active_estimates method.  Use that to remove a bunch of code.
