### PR TITLE
AP_Baro: Fix BMP581 abnormal health problem

### DIFF
--- a/libraries/AP_Baro/AP_Baro_BMP581.cpp
+++ b/libraries/AP_Baro/AP_Baro_BMP581.cpp
@@ -153,16 +153,12 @@ void AP_Baro_BMP581::timer(void)
     if (!_dev->read_registers(BMP581_REG_TEMP_DATA_XLSB, buf, sizeof(buf))) {
         return;
     }
-    if (!_dev->read_registers(BMP581_REG_TEMP_DATA_XLSB, buf2, sizeof(buf2))) {
-        return;
-    }
-    if (memcmp(buf, buf2, ARRAY_SIZE(buf)) != 0) {
-        // we didn't get the same data twice; retry once before rejecting
+    for (uint8_t i = 0; i < 2; i++) {
         if (!_dev->read_registers(BMP581_REG_TEMP_DATA_XLSB, buf2, sizeof(buf2))) {
             return;
         }
-        if (memcmp(buf, buf2, ARRAY_SIZE(buf)) != 0) {
-            // still inconsistent; use first reading anyway
+        if (memcmp(buf, buf2, ARRAY_SIZE(buf)) == 0) {
+            break;
         }
     }
 

--- a/libraries/AP_Baro/AP_Baro_BMP581.cpp
+++ b/libraries/AP_Baro/AP_Baro_BMP581.cpp
@@ -157,8 +157,13 @@ void AP_Baro_BMP581::timer(void)
         return;
     }
     if (memcmp(buf, buf2, ARRAY_SIZE(buf)) != 0) {
-        // we didn't get the same data twice.  Reject.
-        return;
+        // we didn't get the same data twice; retry once before rejecting
+        if (!_dev->read_registers(BMP581_REG_TEMP_DATA_XLSB, buf2, sizeof(buf2))) {
+            return;
+        }
+        if (memcmp(buf, buf2, ARRAY_SIZE(buf)) != 0) {
+            // still inconsistent; use first reading anyway
+        }
     }
 
     WITH_SEMAPHORE(_sem);


### PR DESCRIPTION
This is a previous issue. https://github.com/ArduPilot/ardupilot/pull/32171
When trying to use the BMP581 on the ZeroOne X6 Air's I2C0, I also encountered bus interference. Sensor data was normal, but the Log's Health was abnormal. 
<img width="2544" height="1350" alt="BMP581" src="https://github.com/user-attachments/assets/69b5f318-8816-4f76-9f9a-586a75ceeafc" />
The main problem was that data wasn't refreshed for over 500ms.
<img width="2560" height="1377" alt="BMP581-02" src="https://github.com/user-attachments/assets/43ce24bf-cde9-4855-ac13-5fc797c6e3e9" />
This issue was resolved by comparing and reading the sensor data again; currently, all tests are normal now.
