### PR TITLE
AP_NavEKF3: do not look at takeoff for zero velocity fusion

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -696,14 +696,13 @@ void NavEKF3_core::SelectVelPosFusion()
             }
         } else {
             fusePosData = true;
-            // When stationary on ground or armed before takeoff, fuse zero velocity
+            // When stationary on ground, fuse zero velocity
             // to constrain gyro bias and Z-axis accel bias learning. XY accel biases
             // remain unobservable until the vehicle accelerates and are separately
             // inhibited by dvelBiasAxisInhibit in CovariancePrediction.
             // Use onGroundNotMoving to avoid fusing zero velocity when the vehicle
             // is being moved (e.g. on a boat or carried by hand).
-            // takeoff_expected covers the armed-on-ground case before liftoff.
-            const bool onGroundNotFlying = onGroundNotMoving || dal.get_takeoff_expected();
+            const bool onGroundNotFlying = onGroundNotMoving;
             if (onGroundNotFlying && tiltAlignComplete) {
                 fuseVelData = true;
                 fusingStationaryZeroVel = true;
@@ -729,7 +728,7 @@ void NavEKF3_core::SelectVelPosFusion()
     // when the vehicle is being moved, and takeoff_expected for armed-on-ground.
     // Gate behind fuseHgtData to limit fusion rate to baro rate (~10Hz) and avoid
     // overconstraining the filter by fusing at IMU rate.
-    const bool onGroundNotFlying = onGroundNotMoving || dal.get_takeoff_expected();
+    const bool onGroundNotFlying = onGroundNotMoving;
 
     if (fuseHgtData && PV_AidingMode != AID_NONE && onGroundNotFlying) {
         // Check if we have recent velocity aiding from any source


### PR DESCRIPTION
### Summary

Fixes the plane dead reckoning tests, by not considering takeoff as a potential time to not fuse.

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [X] Automated test(s) verify changes (e.g. unit test, autotest)
- [X] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

This is a simpler fix than https://github.com/ArduPilot/ardupilot/pull/32986 - it fixes the dead reckoning tests in an obvious way. It does mean that zero velocity fusion occurs when armed and on the ground, but t hat was true before anyway