### PR TITLE
autotest: add reasons to every delay_sim_time call

### DIFF
--- a/Tools/autotest/antennatracker.py
+++ b/Tools/autotest/antennatracker.py
@@ -217,7 +217,7 @@ class AutoTestTracker(vehicle_test_suite.TestSuite):
         self.send_statustext(short_message_text)
         self.send_statustext(long_message_text)
 
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="statustext to be logged")
         dfreader = self.dfreader_for_current_onboard_log()
         self.reboot_sitl()
 

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -221,7 +221,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.progress("Fly eastbound away from home")
         self.set_rc(2, 1800)
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="copter to fly east")
         self.set_rc(2, 1500)
         self.hover()
         self.progress("Copter staging 50 meters east of home at 50 meters altitude In mode Alt Hold")
@@ -937,10 +937,10 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.set_parameter('FS_OPTIONS', 0)
         self.takeoffAndMoveAway()
         self.set_parameter("SIM_RC_FAIL", 1)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="radio failsafe to not trigger")
         self.wait_mode("ALT_HOLD")
         self.set_parameter("SIM_RC_FAIL", 0)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="RC to restore")
         self.wait_mode("ALT_HOLD")
         self.end_subtest("Completed Radio failsafe disabled test")
 
@@ -951,9 +951,9 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.set_parameter('FS_THR_ENABLE', 1)
         self.set_parameter("SIM_RC_FAIL", 1)
         self.wait_mode("RTL")
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="RTL to progress")
         self.set_parameter("SIM_RC_FAIL", 0)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="RC to restore")
         self.set_rc(5, 1050)
         self.wait_mode("CIRCLE")
         self.set_rc(5, 1950)
@@ -1004,7 +1004,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.set_parameter('FS_THR_ENABLE', 1)
         self.takeoffAndMoveAway()
         self.set_parameter('SIM_GPS1_ENABLE', 0)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="GPS disable to take effect")
         self.set_parameter("SIM_RC_FAIL", 1)
         self.wait_mode("LAND")
         self.wait_landed_and_disarmed()
@@ -1019,7 +1019,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.set_parameter('FS_THR_ENABLE', 4)
         self.takeoffAndMoveAway()
         self.set_parameter('SIM_GPS1_ENABLE', 0)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="GPS disable to take effect")
         self.set_parameter("SIM_RC_FAIL", 1)
         self.wait_mode("LAND")
         self.wait_landed_and_disarmed()
@@ -1034,7 +1034,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.set_parameter('FS_THR_ENABLE', 5)
         self.takeoffAndMoveAway()
         self.set_parameter('SIM_GPS1_ENABLE', 0)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="GPS disable to take effect")
         self.set_parameter("SIM_RC_FAIL", 1)
         self.wait_mode("LAND")
         self.wait_landed_and_disarmed()
@@ -1052,7 +1052,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.wait_statustext("SmartRTL deactivated: bad position", timeout=60)
         self.set_parameter('SIM_GPS1_ENABLE', 1)
         self.wait_ekf_happy()
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="EKF to stabilise after GPS restore")
         self.set_parameter("SIM_RC_FAIL", 1)
         self.wait_mode("RTL")
         self.wait_rtl_complete()
@@ -1068,7 +1068,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.wait_statustext("SmartRTL deactivated: bad position", timeout=60)
         self.set_parameter('SIM_GPS1_ENABLE', 1)
         self.wait_ekf_happy()
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="EKF to stabilise after GPS restore")
         self.set_parameter("SIM_RC_FAIL", 1)
         self.wait_mode("LAND")
         self.wait_landed_and_disarmed()
@@ -1085,10 +1085,10 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.takeoffAndMoveAway()
         self.change_mode("GUIDED")
         self.set_parameter("SIM_RC_FAIL", 1)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="radio failsafe to not trigger")
         self.wait_mode("GUIDED")
         self.set_parameter("SIM_RC_FAIL", 0)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="RC to restore")
         self.change_mode("ALT_HOLD")
         self.setGCSfailsafe(0)
         # self.change_mode("RTL")
@@ -1107,10 +1107,10 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 #        self.takeoffAndMoveAway()
         self.change_mode("AUTO")
         self.set_parameter("SIM_RC_FAIL", 1)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="radio failsafe to not trigger")
         self.wait_mode("AUTO")
         self.set_parameter("SIM_RC_FAIL", 0)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="RC to restore")
         self.wait_mode("AUTO")
         # self.change_mode("RTL")
         # self.wait_disarmed()
@@ -1172,7 +1172,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             channel: 1300,
         })
         self.wait_servo_channel_value(channel, trim_value)
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="RC failsafe passthrough to settle")
 
     # Tests all actions and logic behind the GCS failsafe
     def GCSFailsafe(self, side=60, timeout=360):
@@ -1221,10 +1221,10 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.setGCSfailsafe(0)
         self.takeoffAndMoveAway()
         self.set_heartbeat_rate(0)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="GCS failsafe to not trigger")
         self.wait_mode("ALT_HOLD")
         self.set_heartbeat_rate(self.speedup)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="GCS link to restore")
         self.wait_mode("ALT_HOLD")
         self.end_subtest("Completed GCS failsafe disabled test")
 
@@ -1251,7 +1251,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         new_gcs_timeout = old_gcs_timeout * 2
         self.set_parameter("FS_GCS_TIMEOUT", new_gcs_timeout)
         self.set_heartbeat_rate(0)
-        self.delay_sim_time(old_gcs_timeout + (new_gcs_timeout - old_gcs_timeout) / 2)
+        self.delay_sim_time(old_gcs_timeout + (new_gcs_timeout - old_gcs_timeout) / 2, reason="GCS failsafe timeout to elapse")
         self.assert_mode("LOITER")
         self.wait_mode("RTL")
         self.set_heartbeat_rate(self.speedup)
@@ -1326,7 +1326,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.progress("Testing continue in pilot controlled modes")
         self.set_heartbeat_rate(0)
         self.wait_statustext("GCS Failsafe - Continuing Pilot Control", timeout=60)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="GCS failsafe to not trigger")
         self.wait_mode("ALT_HOLD")
         self.set_heartbeat_rate(self.speedup)
         self.wait_statustext("GCS Failsafe Cleared", timeout=60)
@@ -1334,10 +1334,10 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.progress("Testing continue in auto mission")
         self.set_parameter('FS_OPTIONS', 2)
         self.change_mode("AUTO")
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="auto mode to start")
         self.set_heartbeat_rate(0)
         self.wait_statustext("GCS Failsafe - Continuing Auto Mode", timeout=60)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="GCS failsafe to not trigger")
         self.wait_mode("AUTO")
         self.set_heartbeat_rate(self.speedup)
         self.wait_statustext("GCS Failsafe Cleared", timeout=60)
@@ -1345,10 +1345,10 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.progress("Testing continue landing in land mode")
         self.set_parameter('FS_OPTIONS', 8)
         self.change_mode("LAND")
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="land mode to start")
         self.set_heartbeat_rate(0)
         self.wait_statustext("GCS Failsafe - Continuing Landing", timeout=60)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="GCS failsafe to not trigger")
         self.wait_mode("LAND")
         self.wait_landed_and_disarmed()
         self.set_heartbeat_rate(self.speedup)
@@ -1455,14 +1455,14 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         m = self.assert_receive_message('BATTERY_STATUS')
         if m.charge_state != mavutil.mavlink.MAV_BATTERY_CHARGE_STATE_LOW:
             raise NotAchievedException("Expected state low")
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="battery failsafe to not trigger")
         self.wait_mode("ALT_HOLD")
         self.set_parameter('SIM_BATT_VOLTAGE', 10.0)
         self.wait_statustext("Battery 1 is critical", timeout=60)
         m = self.assert_receive_message('BATTERY_STATUS')
         if m.charge_state != mavutil.mavlink.MAV_BATTERY_CHARGE_STATE_CRITICAL:
             raise NotAchievedException("Expected state critical")
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="battery critical failsafe to not trigger")
         self.wait_mode("ALT_HOLD")
         self.change_mode("RTL")
         self.wait_rtl_complete()
@@ -1475,19 +1475,19 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         # complete.
         self.start_subtest("Two stage battery failsafe test with RTL and Land")
         self.takeoffAndMoveAway()
-        self.delay_sim_time(3)
+        self.delay_sim_time(3, reason="vehicle to move away")
         self.set_parameters({
             'BATT_FS_LOW_ACT': 2,
             'BATT_FS_CRT_ACT': 1,
             'SIM_BATT_VOLTAGE': 11.4,
         })
         self.wait_statustext("Battery 1 is low", timeout=60)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="battery failsafe to trigger")
         self.wait_mode("RTL")
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="RTL to progress")
         self.set_parameter('SIM_BATT_VOLTAGE', 10.0)
         self.wait_statustext("Battery 1 is critical", timeout=60)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="battery critical failsafe to trigger")
         self.wait_mode("LAND")
         self.wait_landed_and_disarmed()
         self.set_parameter('SIM_BATT_VOLTAGE', 12.5)
@@ -1501,16 +1501,16 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.takeoffAndMoveAway()
         self.set_parameter('BATT_FS_LOW_ACT', 3)
         self.set_parameter('BATT_FS_CRT_ACT', 4)
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="vehicle to move away")
         self.set_parameter('SIM_BATT_VOLTAGE', 11.4)
         self.wait_statustext("Battery 1 is low", timeout=60)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="battery failsafe to trigger")
         self.wait_mode("SMART_RTL")
         self.change_mode("LOITER")
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="loiter to stabilise before critical voltage")
         self.set_parameter('SIM_BATT_VOLTAGE', 10.0)
         self.wait_statustext("Battery 1 is critical", timeout=60)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="battery critical failsafe to trigger")
         self.wait_mode("SMART_RTL")
         self.wait_disarmed()
         self.set_parameter('SIM_BATT_VOLTAGE', 12.5)
@@ -1524,10 +1524,10 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.takeoffAndMoveAway()
         self.set_parameter('FS_OPTIONS', 8)
         self.change_mode("LAND")
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="landing to begin")
         self.set_parameter('SIM_BATT_VOLTAGE', 11.4)
         self.wait_statustext("Battery 1 is low", timeout=60)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="battery failsafe to not interrupt landing")
         self.wait_mode("LAND")
         self.wait_landed_and_disarmed()
         self.set_parameter('SIM_BATT_VOLTAGE', 12.5)
@@ -1545,13 +1545,13 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             'BATT_FS_CRT_ACT': 1,
             'FS_THR_ENABLE': 1,
         })
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="vehicle to move away")
         self.set_parameter('SIM_BATT_VOLTAGE', 10.0)
         self.wait_statustext("Battery 1 is critical", timeout=60)
         self.wait_mode("LAND")
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="landing to progress")
         self.set_parameter("SIM_RC_FAIL", 1)
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="RC failsafe to not interrupt landing")
         self.wait_mode("LAND")
         self.wait_landed_and_disarmed()
         self.set_parameter('SIM_BATT_VOLTAGE', 12.5)
@@ -1564,7 +1564,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.context_push()
         self.takeoffAndMoveAway()
         self.set_parameter('BATT_FS_LOW_ACT', 7)
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="vehicle to move away")
         self.change_mode('LOITER')
         self.set_rc(1, 2000)
         self.wait_groundspeed(8, 10)
@@ -1582,7 +1582,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.takeoffAndMoveAway()
         self.set_parameter('BATT_FS_LOW_ACT', 7)
         self.set_parameter('SIM_GPS1_ENABLE', 0)
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="GPS disable to take effect")
         self.set_parameter('SIM_BATT_VOLTAGE', 11.4)
         self.wait_statustext("Battery 1 is low", timeout=60)
         self.wait_mode('LAND')
@@ -1595,7 +1595,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.start_subtest("Battery failsafe terminate")
         self.takeoffAndMoveAway()
         self.set_parameter('BATT_FS_LOW_ACT', 5)
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="vehicle to move away")
         self.set_parameter('SIM_BATT_VOLTAGE', 11.4)
         self.wait_statustext("Battery 1 is low", timeout=60)
         self.wait_disarmed()
@@ -1757,7 +1757,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.context_push()
 
         self.start_test("Test zero bias")
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="EKF to initialise")
         dfreader_tstart = self.assert_dataflash_message_field_level_at(
             "XKF2",
             "AZ",
@@ -1772,7 +1772,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         })
 
         self.start_subtest("Ensuring second core has bias")
-        self.delay_sim_time(30)
+        self.delay_sim_time(30, reason="EKF to learn accel bias")
         dfreader_tstart = self.assert_dataflash_message_field_level_at(
             "XKF2", "AZ", 0.7,
             condition="XKF2.C==1",
@@ -1793,7 +1793,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         })
         self.reboot_sitl()
 
-        self.delay_sim_time(30)
+        self.delay_sim_time(30, reason="EKF to initialise after reboot")
         dfreader_tstart = self.assert_dataflash_message_field_level_at(
             "XKF2", "AZ", 0.0,
             condition="XKF2.C==0",
@@ -1805,7 +1805,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         })
 
         self.start_subtest("Ensuring first core now has bias")
-        self.delay_sim_time(30)
+        self.delay_sim_time(30, reason="EKF to learn accel bias")
         dfreader_tstart = self.assert_dataflash_message_field_level_at(
             "XKF2", "AZ", 0.7,
             condition="XKF2.C==0",
@@ -1846,7 +1846,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.set_parameters({
             'SIM_ACC2_BIAS_Z': 0.7,
         })
-        self.delay_sim_time(30)
+        self.delay_sim_time(30, reason="EKF to learn accel bias")
         self.assert_dataflash_message_field_level_at(
             "XKF2", "AZ", 0.7,
             condition="XKF2.C==1",
@@ -1859,7 +1859,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         })
         self.reboot_sitl()
         self.wait_ready_to_arm()
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="SITL to initialise after reboot")
 
         # Phase 2: Start ship movement, then inject bias - it should NOT be learned
         self.start_subtest("Test: verify bias NOT learned during ground movement")
@@ -1876,7 +1876,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         # Wait for vehicle to be moving with the ship
         self.wait_groundspeed(9, 11)
         # Allow time for onGroundNotMoving to transition to false
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="onGroundNotMoving to transition")
 
         # Record timestamp, then inject Z-bias while vehicle is moving on ground
         tstart_inject_us = self.get_sim_time() * 1.0e6
@@ -1885,7 +1885,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         })
 
         # Wait for potential (unwanted) bias learning
-        self.delay_sim_time(30)
+        self.delay_sim_time(30, reason="potential bias learning period")
 
         # Check that AZ stayed near 0 during the movement period.
         # Skip the first 20s after injection to give time for any erroneous
@@ -1910,7 +1910,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         })
         self.wait_groundspeed(0, 2)
 
-        self.delay_sim_time(60)
+        self.delay_sim_time(60, reason="accel bias to reconverge after movement stops")
         self.assert_dataflash_message_field_level_at(
             "XKF2", "AZ", 0.7,
             condition="XKF2.C==1",
@@ -1946,7 +1946,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.set_parameters({
             'SIM_ACC2_BIAS_Z': 0.7,
         })
-        self.delay_sim_time(30)
+        self.delay_sim_time(30, reason="EKF to learn accel bias via zero velocity fusion")
         self.assert_dataflash_message_field_level_at(
             "XKF2", "AZ", 0.7,
             condition="XKF2.C==1",
@@ -1995,7 +1995,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         # During initial acceleration onGroundNotMoving briefly goes
         # false, but recovers once at constant speed.
         self.wait_groundspeed(13, 17)
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="movement filters to settle")
 
         # Verify EKF velocity matches GPS, not zero. If zero velocity
         # fusion were incorrectly active, groundspeed would drift to 0.
@@ -2009,7 +2009,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.set_parameters({
             'SIM_ACC2_BIAS_Z': 0.7,
         })
-        self.delay_sim_time(30)
+        self.delay_sim_time(30, reason="EKF to learn accel bias via GPS velocity")
         self.assert_dataflash_message_field_level_at(
             "XKF2", "AZ", 0.7,
             condition="XKF2.C==1",
@@ -2177,11 +2177,11 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.start_subtest("ensure we can't arm if outside fence")
         self.load_fence("fence-in-middle-of-nowhere.txt")
 
-        self.delay_sim_time(5) # let fence check run so it loads-from-eeprom
+        self.delay_sim_time(5, reason="fence check to run so it loads-from-eeprom")
         self.assert_prearm_failure("Vehicle breaching Polygon fence")
         self.progress("Failed to arm outside fence (good!)")
         self.clear_fence()
-        self.delay_sim_time(5) # let fence breach clear
+        self.delay_sim_time(5, reason="fence breach to clear")
         self.drain_mav()
         self.end_subtest("ensure we can't arm if outside fence")
 
@@ -2539,7 +2539,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.wait_altitude(5, 15, relative=True)
         self.change_mode('LOITER')
         # wait for manual recovery to expire
-        self.delay_sim_time(15)
+        self.delay_sim_time(15, reason="manual recovery to expire")
 
         # lower throttle and try and land
         self.set_rc(3, 1300)
@@ -3026,14 +3026,14 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.set_parameters({
             "SIM_GPS1_ENABLE": 0,
         })
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="GPS disable to take effect")
         self.set_parameters({
             "SIM_GPS1_ENABLE": 1,
         })
         # regaining GPS should not result in it falling back to a non-navigation mode
         self.wait_ekf_flags(mavutil.mavlink.ESTIMATOR_POS_HORIZ_ABS, 0, timeout=1)
         # It should still be navigating after enougnh time has passed for any pending timeouts to activate.
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="pending EKF timeouts to activate")
         self.wait_ekf_flags(mavutil.mavlink.ESTIMATOR_POS_HORIZ_ABS, 0, timeout=1)
         self.change_mode("AUTO")
 
@@ -3305,7 +3305,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.change_mode('CIRCLE')
 
-        self.delay_sim_time(20)
+        self.delay_sim_time(20, reason="copter to circle and build attitude history")
 
         self.context_collect("STATUSTEXT")
 
@@ -3317,7 +3317,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.wait_statustext("EKF3 IMU0 switching to compass 1", check_context=True)
         self.progress("compass switch 1 OK")
 
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="EKF to settle on new compass")
 
         self.context_clear_collection("STATUSTEXT")
 
@@ -3329,13 +3329,13 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.progress("compass switch 2 OK")
 
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="EKF to settle on new compass")
 
         self.context_clear_collection("STATUSTEXT")
 
         self.progress("Failing 3rd compass")
         self.set_parameter("SIM_MAG3_FAIL", 1)
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="EKF to detect compass failure")
         self.set_parameter("SIM_MAG1_FAIL", 0)
 
         self.wait_statustext("EKF2 IMU0 switching to compass 0", check_context=True)
@@ -3363,7 +3363,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.progress("Compass switch detected")
 
         self.context_clear_collection("STATUSTEXT")
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="EKF to settle on new compass")
 
         self.progress("Re-enabling compass")
         self.set_parameter("SIM_MAG1_FAIL", 0)
@@ -3507,7 +3507,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.wait_sensor_state(mavutil.mavlink.MAV_SYS_STATUS_SENSOR_OPTICAL_FLOW, True, True, True, verbose=True)
 
         self.change_mode('LOITER')
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="mode change to take effect")
         self.wait_statustext("Need Position Estimate", timeout=300)
 
         self.context_pop()
@@ -3824,18 +3824,18 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.wait_ready_to_arm()
         self.takeoff(3)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="EKF to stabilise after takeoff")
 
         self.progress("Injecting VICON glitch")
         self.set_parameter("SIM_VICON_GLIT_X", 100)
         self.set_parameter("SIM_VICON_GLIT_Y", 100)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="VICON glitch to take effect")
         self.set_parameter("SIM_VICON_GLIT_X", 0)
         self.set_parameter("SIM_VICON_GLIT_Y", 0)
 
         self.progress("Injecting BARO glitch")
         self.set_parameter("SIM_BARO_GLITCH", 10)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="baro glitch to take effect")
         self.set_parameter("SIM_BARO_GLITCH", 0)
 
         self.do_RTL()
@@ -3949,14 +3949,14 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
                 self.progress("Check original gains are re-instated by switch")
                 self.set_rc(8, 1100)
-                self.delay_sim_time(1)
+                self.delay_sim_time(1, reason="gains to update after switch")
                 current_gains = get_roll_gains("set-original")
                 if not gains_same(original_gains, current_gains):
                     raise NotAchievedException("AUTOTUNE original gains not restored")
 
                 self.progress("Use autotuned gains")
                 self.set_rc(8, 1850)
-                self.delay_sim_time(1)
+                self.delay_sim_time(1, reason="gains to update after switch")
                 tuned_gains = get_roll_gains("tuned")
                 if gains_same(tuned_gains, original_gains):
                     raise NotAchievedException("AUTOTUNE tuned gains same as pre gains")
@@ -4061,7 +4061,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
                 self.progress("Use autotuned gains")
                 self.set_rc(8, 1850)
-                self.delay_sim_time(1)
+                self.delay_sim_time(1, reason="gains to update after switch")
                 tuned_gains = get_roll_gains("tuned")
                 if gains_same(tuned_gains, original_gains):
                     raise NotAchievedException("AUTOTUNE tuned gains same as pre gains")
@@ -4070,14 +4070,14 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
                 self.progress("Check original gains are re-instated by switch")
                 self.set_rc(8, 1100)
-                self.delay_sim_time(1)
+                self.delay_sim_time(1, reason="gains to update after switch")
                 current_gains = get_roll_gains("set-original")
                 if not gains_same(original_gains, current_gains):
                     raise NotAchievedException("AUTOTUNE original gains not restored")
 
                 self.progress("land using Autotune Gains")
                 self.set_rc(8, 1850)
-                self.delay_sim_time(1)
+                self.delay_sim_time(1, reason="gains to update after switch")
                 self.set_rc(3, 1000)
                 self.wait_altitude(-1, 5, relative=True)
                 self.wait_disarmed()
@@ -4226,7 +4226,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 lng_1e7,
                 alt_mm
             )
-            self.delay_sim_time(2)
+            self.delay_sim_time(2, reason="GPS origin to propagate")
             gpi = self.assert_receive_message('GLOBAL_POSITION_INT')
             self.progress("gpi=%s" % str(gpi))
             if gpi.lat != 0:
@@ -4431,7 +4431,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.start_sup_program(instance=0, args="-M")
         self.stop_sup_program(instance=1)
         self.start_sup_program(instance=1, args="-M")
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="supplemental programs to start")
         self.context_collect('STATUSTEXT')
         self.run_cmd(
             mavutil.mavlink.MAV_CMD_COMPONENT_ARM_DISARM,
@@ -4580,7 +4580,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.takeoff(50, mode='ALT_HOLD')
 
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="EKF to stabilise after takeoff")
 
         ####################################################################################
         self.start_subtest("Ensure no lane switch occurs with EK3_OPTIONS = 2")
@@ -4589,7 +4589,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             "INS_ACCOFFS_X" : 5
         })
 
-        self.delay_sim_time(10)  # Wait to confirm no switch
+        self.delay_sim_time(10, reason="confirming no lane switch occurs")  # Wait to confirm no switch
         if self.lane_switches:
             raise NotAchievedException(f"Unexpected lane switch occurred: {self.lane_switches}")
         self.progress("Success: No lane switch occurred with EK3_OPTIONS = 2")
@@ -4916,7 +4916,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             self.arm_vehicle()
             self.wait_waypoint(num_wp-1, num_wp-1)
             self.wait_disarmed()
-            self.delay_sim_time(20)
+            self.delay_sim_time(20, reason="SITL to reset before next run")
 
     def FlyMissionTwiceWithReset(self):
         '''Fly a mission twice in a row without changing modes in between.
@@ -4940,7 +4940,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             self.arm_vehicle()
             self.wait_waypoint(num_wp-1, num_wp-1)
             self.wait_disarmed()
-            self.delay_sim_time(20)
+            self.delay_sim_time(20, reason="SITL to reset before next run")
 
     def MissionIndexValidity(self):
         '''Confirm that attempting to select an invalid mission item is rejected.'''
@@ -5181,7 +5181,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             raise NotAchievedException("Laser not enabled in SYS_STATUS")
         self.progress("Disabling laser using switch")
         self.set_rc(9, 1000)
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="rangefinder switch to take effect")
         self.progress("Checking RangeFinder is marked as disabled in mavlink")
         m = self.assert_receive_message('SYS_STATUS', timeout=10)
         flags = m.onboard_control_sensors_enabled
@@ -5190,7 +5190,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.progress("Re-enabling rangefinder")
         self.set_rc(9, 2000)
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="rangefinder switch to take effect")
         m = self.assert_receive_message('SYS_STATUS', timeout=10)
         flags = m.onboard_control_sensors_enabled
         if not flags & mavutil.mavlink.MAV_SYS_STATUS_SENSOR_LASER_POSITION:
@@ -5347,7 +5347,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             self.change_mode("GUIDED")
             self.guided_achieve_heading(bearing, direction=1, accuracy=1)
             self.change_mode("LOITER")
-            self.delay_sim_time(2)
+            self.delay_sim_time(2, reason="loiter to stabilise")
             m = self.assert_receive_message('GLOBAL_POSITION_INT')
             orig_absolute_alt_mm = m.alt
 
@@ -6538,7 +6538,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.start_subtest("Checking that WP_YAW_BEHAVIOUR 0 works")
         self.set_parameter('WP_YAW_BEHAVIOR', 0)
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="parameter change to take effect")
         orig_heading = self.get_heading()
         self.fly_guided_move_local(5, 0, 10)
         # ensure our heading hasn't changed:
@@ -7161,21 +7161,21 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.takeoff(10, mode='GUIDED')
         self.set_rc(6, 1000) # tilt mount down 45 degs
-        self.delay_sim_time(.1) # allow mount to move
+        self.delay_sim_time(.1, reason="mount to move")  # allow mount to move
 
         self.progress("checking mount angles")
         mount_roll, mount_pitch, mount_yaw, mount_yaw_is_absolute = self.get_mount_roll_pitch_yaw_deg()
         assert -46 <= mount_pitch <= -44, f"Initial Mount Pitch is out of range: {mount_pitch}"
 
         self.set_rc(10, 1900)  # engage poi lock
-        self.delay_sim_time(5) # allow time to compute POI
+        self.delay_sim_time(5, reason="POI computation")  # allow time to compute POI
         self.set_rc(10, 1500)  # revert mode, keep POI
 
         self.fly_guided_move_local(100, 100, 70)   # move to new position
         WaitAndMaintainAttitude(self, 0, 0, epsilon=1, minimum_duration=1, timeout=5).run()
 
         self.set_rc(10, 1900)  # re-engage poi lock and check angles again
-        self.delay_sim_time(.1) # allow mount to move
+        self.delay_sim_time(.1, reason="mount to move")  # allow mount to move
 
         mount_roll, mount_pitch, mount_yaw, mount_yaw_is_absolute = self.get_mount_roll_pitch_yaw_deg()
         assert (-178 <= mount_yaw <= -176), f"Mount Yaw2 is out of range: {mount_yaw}"
@@ -7183,7 +7183,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.progress(f"Mount Pitch2 = {mount_pitch}. Mount Yaw2 = {mount_yaw}")
 
         self.set_rc(10, 1500)  # return to RC target mode and check that mount reverts to initial angles
-        self.delay_sim_time(.1) # allow mount to move
+        self.delay_sim_time(.1, reason="mount to move")  # allow mount to move
 
         mount_roll, mount_pitch, mount_yaw, mount_yaw_is_absolute = self.get_mount_roll_pitch_yaw_deg()
         assert -46 <= mount_pitch <= -44, f"Mount Pitch3 is out of range: {mount_pitch}"
@@ -7451,7 +7451,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 p3=y,
                 p7=mavutil.mavlink.MAV_MOUNT_MODE_MAVLINK_TARGETING,
             )
-            self.delay_sim_time(2)
+            self.delay_sim_time(2, reason="mount to reach target angles")
             self.assert_mount_rpy(r, p, y)
             self.neutralise_gimbal()
 
@@ -7476,7 +7476,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 mavutil.mavlink.MAV_CMD_DO_MOUNT_CONTROL,
                 p7=mavutil.mavlink.MAV_MOUNT_MODE_RETRACT,
             )
-            self.delay_sim_time(3)
+            self.delay_sim_time(3, reason="mount to reach retract position")
             self.assert_mount_rpy(retract_r, retract_p, retract_y)
             self.context_pop()
 
@@ -7517,7 +7517,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 p3=mount_yaw,
                 p7=mavutil.mavlink.MAV_MOUNT_MODE_MAVLINK_TARGETING,
             )
-            self.delay_sim_time(5)
+            self.delay_sim_time(5, reason="mount to reach target angles and copter to yaw")
             # We have disabled yaw servo, so expect mount yaw to be zero
             self.assert_mount_rpy(r, p, 0)
             # But we expect the copter to yaw instead
@@ -7607,10 +7607,10 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.progress("current heading %u" % m.heading)
         self.set_parameter("SERVO%u_FUNCTION" % yaw_servo, 0) # yaw
         self.progress("Waiting for check_servo_map to do its job")
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="servo map to update")
         self.progress("Pointing North")
         self.guided_achieve_heading(0, direction=1, accuracy=1)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="heading to stabilise")
         start = self.mav.location()
         (roi_lat, roi_lon) = mavextra.gps_offset(start.lat,
                                                  start.lng,
@@ -8848,7 +8848,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         # expecting home to change when disarmed
         self.wait_landed_and_disarmed()
         # wait a while for home to move (it shouldn't):
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="confirming home does not move after landing")
         m = self.assert_receive_message('GLOBAL_POSITION_INT')
         new_home_offset_mm = m.alt - m.relative_alt
         home_offset_delta_mm = orig_home_offset_mm - new_home_offset_mm
@@ -8945,7 +8945,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             "EK3_SRC1_VELXY": 0,
         })
         self.reboot_sitl()
-        self.delay_sim_time(30)  # wait for accels/gyros to settle
+        self.delay_sim_time(30, reason="accels/gyros to settle")  # wait for accels/gyros to settle
 
         # check for expected EKF flags
         ahrs_ekf_type = self.get_parameter("AHRS_EKF_TYPE")
@@ -8988,7 +8988,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.set_rc(3, 1000)
         self.wait_ready_to_arm()
         self.arm_vehicle()
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="confirming vehicle stays on ground before throttle")
         # check we are still on the ground...
         relative_alt = self.get_altitude(relative=True)
         if relative_alt > 0.1:
@@ -8996,7 +8996,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.progress("Pushing throttle up")
         self.set_rc(3, 1710)
-        self.delay_sim_time(0.5)
+        self.delay_sim_time(0.5, reason="throttle input to take effect")
         self.progress("Bringing back to hover throttle")
         self.set_rc(3, 1500)
 
@@ -9745,7 +9745,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         validator = vehicle_test_suite.TestSuite.ValidateGlobalPositionIntAgainstSimState(self, max_allowed_divergence=10)
         self.install_message_hook_context(validator)
 
-        self.delay_sim_time(20)
+        self.delay_sim_time(20, reason="position tracking validation")
         self.progress("Tracked location just fine")
         self.context_pop()
 
@@ -9840,7 +9840,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.progress("Climb to 20m in LOITER and yaw spin for 30 seconds")
         self.takeoff(10, mode="LOITER")
         self.set_rc(4, 1400)
-        self.delay_sim_time(30)
+        self.delay_sim_time(30, reason="wind estimation via yaw spin")
 
         # check wind estimates
         m = self.assert_receive_message('WIND')
@@ -9983,7 +9983,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.start_subsubtest("Protocol %i: Checking original voltage (electrical)" % proto_ver)
         # ArduPilot spits out essentially uninitialised battery
         # messages until we read things from the battery:
-        self.delay_sim_time(30)
+        self.delay_sim_time(30, reason="generator battery data to initialise")
         original_elec_m = self.wait_message_field_values('BATTERY_STATUS', {
             "charge_state": mavutil.mavlink.MAV_BATTERY_CHARGE_STATE_OK
         }, instance=elec_battery_instance)
@@ -10100,20 +10100,20 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.assert_parameter_value("GEN_L_IDLE_TH", 25)
 
-        self.delay_sim_time(10)  # so we can actually receive messages...
+        self.delay_sim_time(10, reason="generator driver to initialise")  # so we can actually receive messages...
 
         #######################################################################
         # Generator OFF subtest.
         #######################################################################
         self.start_subtest("Checking GENERATOR_STATUS while OFF.")
         self.set_message_rate_hz("GENERATOR_STATUS", 10)
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="message rate to take effect")
 
         self.wait_generator_speed_and_state(0, 0, mavutil.mavlink.MAV_GENERATOR_STATUS_FLAG_OFF)
 
         self.start_subtest("Checking EFI_STATUS while OFF.")
         self.set_message_rate_hz("EFI_STATUS", 10)
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="message rate to take effect")
         self.assert_received_message_field_values('EFI_STATUS', {
             "health": 1,
             "ecu_index": 1.0,
@@ -10159,7 +10159,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.start_subtest("Setting generator to IDLE state.")
         self.set_rc(gen_ctrl_ch, 1500) # remember this is a switch position - idle
         self.wait_statustext("Generator MIDDLE", check_context=True)
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="generator to reach idle state")
         self.drain_mav()
         self.assert_received_message_field_values('EFI_STATUS', {
             "intake_manifold_pressure": 94,
@@ -10403,20 +10403,20 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.assert_parameter_value("GEN_L_IDLE_TH", 25)
 
-        self.delay_sim_time(10)  # so we can actually receive messages...
+        self.delay_sim_time(10, reason="generator driver to initialise")  # so we can actually receive messages...
 
         #######################################################################
         # Generator OFF subtest.
         #######################################################################
         self.start_subtest("Checking GENERATOR_STATUS while OFF.")
         self.set_message_rate_hz("GENERATOR_STATUS", 10)
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="message rate to take effect")
 
         self.wait_generator_speed_and_state(0, 0, mavutil.mavlink.MAV_GENERATOR_STATUS_FLAG_OFF)
 
         self.start_subtest("Checking EFI_STATUS while OFF.")
         self.set_message_rate_hz("EFI_STATUS", 10)
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="message rate to take effect")
         self.assert_received_message_field_values('EFI_STATUS', {
             "health": 1,
             "ecu_index": 1.0,
@@ -10460,7 +10460,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         for i in 1000, rc_trim:
             self.progress("Checking %u pwm" % i)
             self.set_rc(loweheiser_man_throt_ch, i)
-            self.delay_sim_time(1)
+            self.delay_sim_time(1, reason="throttle change to propagate")
             self.assert_received_message_field_values('EFI_STATUS', {
                 "throttle_position": 0,
                 "rpm": 0,
@@ -10476,7 +10476,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.start_subtest("Setting generator to IDLE state.")
         self.set_rc(gen_ctrl_ch, 1500) # remember this is a switch position - idle
         self.wait_statustext("Generator MIDDLE", check_context=True)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="generator to reach idle state")
 
         # Ensure the generator has not auto-started.
         self.assert_received_message_field_values('EFI_STATUS', {
@@ -10691,7 +10691,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         # Start the generator anew.
         self.set_rc(gen_ctrl_ch, 1500)
         self.set_rc(loweheiser_man_start_ch, 2000)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="generator starter to engage")
         self.set_rc(loweheiser_man_start_ch, 1000)
         self.set_rc(gen_ctrl_ch, 2000)
         self.wait_generator_speed_and_state(8000, 30000, mavutil.mavlink.MAV_GENERATOR_STATUS_FLAG_GENERATING)
@@ -10727,18 +10727,18 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.assert_mission_count(5)
         self.progress("Clear mission")
         self.set_rc(7, 2000)
-        self.delay_sim_time(1) # allow switch to debounce
+        self.delay_sim_time(1, reason="switch to debounce")  # allow switch to debounce
         self.assert_mission_count(0)
         self.set_rc(7, 1000)
         self.set_parameter("RC7_OPTION", 24) # reset mission
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="parameter change to take effect")
         self.load_mission("copter_loiter_to_alt.txt")
         set_wp = 4
         self.set_current_waypoint(set_wp)
         self.wait_current_waypoint(set_wp, timeout=10)
         self.progress("Reset mission")
         self.set_rc(7, 2000)
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="switch to debounce")
         self.wait_current_waypoint(0, timeout=10)
         self.set_rc(7, 1000)
 
@@ -10819,14 +10819,14 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.set_parameters({
             "SIM_TETH_ENABLE": 1,
         })
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="tether parameter to take effect")
         self.reboot_sitl()
 
         # Set tether line length
         self.set_parameters({
             "SIM_TETH_LINELEN": 10,
         })
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="tether line length parameter to take effect")
 
         # Prepare and take off
         self.wait_ready_to_arm()
@@ -10926,10 +10926,10 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             if self.sensor_has_state(mavutil.mavlink.MAV_SYS_STATUS_SENSOR_PROXIMITY, True, True, True):
                 self.progress("Sensor has good state")
                 break
-            self.delay_sim_time(0.1)
+            self.delay_sim_time(0.1, reason="poll interval")
 
         self.progress("Should be unhealthy again if we stop sending messages")
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="sensor timeout to expire")
         self.assert_sensor_state(mavutil.mavlink.MAV_SYS_STATUS_SENSOR_PROXIMITY, True, True, False)
 
         # now make sure we get echoed back the same sorts of things we send:
@@ -11026,10 +11026,10 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 if self.sensor_has_state(mavutil.mavlink.MAV_SYS_STATUS_SENSOR_LASER_POSITION, True, True, True):
                     self.progress("Sensor has good state")
                     break
-                self.delay_sim_time(0.1)
+                self.delay_sim_time(0.1, reason="poll interval")
 
             self.progress("Should be unhealthy again if we stop sending messages")
-            self.delay_sim_time(1)
+            self.delay_sim_time(1, reason="sensor timeout to expire")
             self.assert_sensor_state(mavutil.mavlink.MAV_SYS_STATUS_SENSOR_LASER_POSITION, True, True, False)
 
             self.progress("Landing gear should deploy with current_distance below min_distance")
@@ -11053,7 +11053,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                     self.arm_vehicle()
                 except Exception:  # noqa: BLE001
                     pass
-            self.delay_sim_time(1)  # servo function maps only periodically updated
+            self.delay_sim_time(1, reason="servo function maps to update")  # servo function maps only periodically updated
 #            self.send_debug_trap()
 
             self.run_cmd(
@@ -11076,7 +11076,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                     mavutil.mavlink.MAV_SENSOR_ROTATION_PITCH_270, # orientation
                     255  # covariance
                 )
-                self.delay_sim_time(0.1)
+                self.delay_sim_time(0.1, reason="poll interval")
                 try:
                     self.wait_text("LandingGear: RETRACT", check_context=True, timeout=0.1)
                 except Exception:  # noqa: BLE001
@@ -11121,7 +11121,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.reboot_sitl()
         self.takeoff(20, mode='LOITER')
         self.set_rc(2, 1400)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="GSF to accumulate data")
         self.set_rc(2, 1500)
         self.progress("Path: %s" % self.current_onboard_log_filepath())
         dfreader = self.dfreader_for_current_onboard_log()
@@ -11567,7 +11567,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.assert_parameter_value("RNGFND1_MAX", m.max_distance * 0.01, epsilon=0.00001)
         self.assert_parameter_value("RNGFND1_MIN", m.min_distance * 0.01, epsilon=0.00001)
         self.send_statustext(text_good)
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="rangefinder log marker to be written")
 
         dfreader = self.dfreader_for_current_onboard_log()
 
@@ -11710,7 +11710,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
     def ParameterValidation(self):
         '''Test parameters are checked for validity'''
         # wait 10 seconds for initialisation
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="SITL to initialise")
         self.progress("invalid; min must be less than max:")
         self.set_parameters({
             "MOT_PWM_MIN": 100,
@@ -11755,7 +11755,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             for name in param_names:
                 sp[name] = param_value
             self.set_parameters(sp)
-            self.delay_sim_time(1)
+            self.delay_sim_time(1, reason="sensor state to update in log")
             mlog = self.dfreader_for_current_onboard_log()
             success = False
             while True:
@@ -11783,7 +11783,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.set_parameter("ARMING_SKIPCHK", -1)
 
         # delay 12 sec to allow EKF to lose altitude estimate
-        self.delay_sim_time(12)
+        self.delay_sim_time(12, reason="EKF to lose altitude estimate")
 
         self.change_mode("ALT_HOLD")
         self.assert_prearm_failure("Need Alt Estimate")
@@ -12142,7 +12142,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.change_mode('LOITER')
         self.wait_ready_to_arm()
         self.arm_vehicle()
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="GPS blend data to accumulate in log")
         self.disarm_vehicle()
 
         # inspect generated log for messages:
@@ -12437,7 +12437,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             self.context_pop()
             self.hover()
             self.change_mode('ALT_HOLD')
-            self.delay_sim_time(1)
+            self.delay_sim_time(1, reason="attitude to stabilise in alt_hold")
 
             def verify_rollpitch(mav, m):
                 if m.get_type() != 'ATTITUDE':
@@ -12454,9 +12454,9 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             self.install_message_hook_context(verify_rollpitch)
             for i in range(5):
                 self.set_rc(4, 2000)
-                self.delay_sim_time(0.5)
+                self.delay_sim_time(0.5, reason="yaw input to take effect")
                 self.set_rc(4, 1500)
-                self.delay_sim_time(5)
+                self.delay_sim_time(5, reason="attitude to settle after yaw")
             self.context_pop()
 
             self.do_RTL()
@@ -12652,7 +12652,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             if home and not reachedHome:
                 reachedHome = True
                 self.progress("Reached home - holding")
-                self.delay_sim_time(20)
+                self.delay_sim_time(20, reason="RTL hold at home")
                 continue
 
             if reachedHome:
@@ -12979,7 +12979,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.takeoff(alt_min=10, mode='GUIDED')
         self.hover()
         self.change_mode("CIRCLE")
-        self.delay_sim_time(1300)
+        self.delay_sim_time(1300, reason="SmartRTL to fill breadcrumb buffer")
         self.change_mode("SMART_RTL")
         self.wait_disarmed()
 
@@ -13006,7 +13006,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 compass_learn_set = True
 
             self.check_attitudes_match()
-            self.delay_sim_time(1)
+            self.delay_sim_time(1, reason="poll interval")
 
         self.do_RTL()
         self.context_pop()
@@ -13033,7 +13033,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         })
         self.wait_ready_to_arm()
         self.test_adsb_send_threatening_adsb_message(here)
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="ADSB threat to be detected")
         self.try_arm(result=False,
                      expect_msg="ADSB threat detected")
 
@@ -13396,7 +13396,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         for mot_id_to_kill in 1, 2:
             self.progress("Turning ESC=%u off" % mot_id_to_kill)
             self.set_parameter("SIM_FTOWESC_POW", mask & ~(1 << mot_id_to_kill))
-            self.delay_sim_time(1)
+            self.delay_sim_time(1, reason="ESC power-off to be detected")
             self.assert_prearm_failure("are not running")
             self.progress("Turning it back on")
             self.set_parameter("SIM_FTOWESC_POW", mask)
@@ -13404,7 +13404,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
             self.progress("Turning ESC=%u off (again)" % mot_id_to_kill)
             self.set_parameter("SIM_FTOWESC_POW", mask & ~(1 << mot_id_to_kill))
-            self.delay_sim_time(1)
+            self.delay_sim_time(1, reason="ESC power-off to be detected")
             self.assert_prearm_failure("are not running")
             self.progress("Turning it back on")
             self.set_parameter("SIM_FTOWESC_POW", mask)
@@ -13412,7 +13412,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.progress("Turning all ESCs off")
         self.set_parameter("SIM_FTOWESC_POW", 0)
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="ESC power-off to be detected")
         self.assert_prearm_failure("are not running")
         self.progress("Turning them back on")
         self.set_parameter("SIM_FTOWESC_POW", mask)
@@ -13424,7 +13424,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.context_push()
         self.set_parameter("SERVO_FTW_MASK", mask)
         self.reboot_sitl()
-        self.delay_sim_time(12)  # allow accels/gyros to be happy
+        self.delay_sim_time(12, reason="accels/gyros to be happy")  # allow accels/gyros to be happy
         tstart = self.get_sim_time()
         while True:
             if self.get_sim_time_cached() - tstart > 20:
@@ -13433,7 +13433,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 self.assert_prearm_failure("Invalid motor mask")
                 break
             except NotAchievedException:
-                self.delay_sim_time(1)
+                self.delay_sim_time(1, reason="poll interval")
         self.context_pop()
         self.reboot_sitl()
 
@@ -13510,7 +13510,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.set_parameter('SCHED_OPTIONS', 1)  # enable gathering
         # sometimes we need to trigger collection....
         content = self.fetch_file_via_ftp("@SYS/tasks.txt")
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="scheduler perf data to accumulate")
         content = self.fetch_file_via_ftp("@SYS/tasks.txt")
         self.progress("Got content (%s)" % str(content))
 
@@ -14101,7 +14101,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             p3=-30,            # pitch rate deg/s
             p4=0,              # yaw rate deg/s
         )
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="mount to slew at rate to target angle")
         # expect pitch around -60
         _, mount_pitch, _, _ = self.get_mount_roll_pitch_yaw_deg()
         if abs(mount_pitch - (-60)) > 20:
@@ -14265,9 +14265,9 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         # until the context pop happens, all received PID_TUNINGS will be verified as good
         self.arm_vehicle()
         self.set_rc(3, 1500)
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="motors to spool up")
         self.set_rc(2, 1250)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="PID data to accumulate")
         self.assert_receive_message('PID_TUNING', timeout=5)
         self.set_rc_default()
         self.zero_throttle()
@@ -14322,9 +14322,9 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         # until the context pop happens, all received PID_TUNINGS will be verified as good
         self.arm_vehicle()
         self.set_rc(3, 1500)
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="motors to spool up")
         self.set_rc(2, 1250)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="PID data to accumulate")
         self.assert_receive_message('PID_TUNING', timeout=5)
         self.set_rc_default()
         self.zero_throttle()
@@ -14894,34 +14894,34 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.reboot_sitl()
 
         self.set_rc(6, RC6_MIN)
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="RC6 change to update parameter")
         self.assert_parameter_value("LOIT_SPEED_MS", TUNE_MIN)
 
         self.set_rc(6, RC6_MAX)
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="RC6 change to update parameter")
         self.assert_parameter_value("LOIT_SPEED_MS", TUNE_MAX)
         self.set_rc(6, RC6_MIN)
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="RC6 change to update parameter")
         self.assert_parameter_value("LOIT_SPEED_MS", TUNE_MIN)
 
         self.set_rc(6, int((RC6_MIN+RC6_MAX)/2))
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="RC6 change to update parameter")
         # note that this check is also used below ("RC6 is unaffected")
         self.assert_parameter_value("LOIT_SPEED_MS", int((TUNE_MIN+TUNE_MAX)/2), epsilon=1)
 
         self.set_rc(7, RC7_MIN)
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="RC7 change to update parameter")
         self.assert_parameter_value("PSC_NE_VEL_I", TUNE2_MIN)
 
         self.set_rc(7, RC7_MAX)
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="RC7 change to update parameter")
         self.assert_parameter_value("PSC_NE_VEL_I", TUNE2_MAX)
 
         # make sure RC6 is unaffected:
         self.assert_parameter_value("LOIT_SPEED_MS", int((TUNE_MIN+TUNE_MAX)/2), epsilon=1)
 
         self.set_rc(7, int((RC7_MIN+RC7_MAX)/2))
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="RC7 change to update parameter")
         self.assert_parameter_value("PSC_NE_VEL_I", int((TUNE2_MIN+TUNE2_MAX)/2), epsilon=1)
 
     def PILOT_THR_BHV(self):
@@ -14979,7 +14979,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.change_mode('LOITER')
         self.set_rc(1, 1000)
         self.set_rc(2, 1000)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="vehicle to slow down in loiter")
         self.set_rc(12, 2000)
         gpis.append(self.assert_receive_message('GLOBAL_POSITION_INT'))
         gps_raws.append(self.assert_receive_message('GPS_RAW_INT'))
@@ -15183,7 +15183,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         expected_alt_abs = current_alt + expected_alt
 
         self.takeoff(expected_alt, mode='GUIDED')
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="EKF to stabilise at target altitude")
 
         self.set_parameter("SIM_BARO_DRIFT", 0.01)  # 1cm/second
 
@@ -15201,7 +15201,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.install_message_hook_context(check_altitude)
 
-        self.delay_sim_time(1500)
+        self.delay_sim_time(1500, reason="baro drift to accumulate while checking altitude hold")
 
         self.disarm_vehicle(force=True)
 
@@ -15217,7 +15217,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         })
         self.load_default_params_file("copter-optflow.parm")
         self.reboot_sitl()
-        self.delay_sim_time(30)
+        self.delay_sim_time(30, reason="EKF to initialise with optical flow")
         self.change_mode('GUIDED')
         self.arm_vehicle(force=True)
         self.takeoff(20, mode='GUIDED')
@@ -15233,7 +15233,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             dist = self.get_distance_int(startpos, self.sim_location_int())
             if dist > 10:
                 raise NotAchievedException("Wandered too far from start position")
-            self.delay_sim_time(1)
+            self.delay_sim_time(1, reason="poll interval")
 
         self.disarm_vehicle(force=True)
         self.reboot_sitl()
@@ -15255,7 +15255,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         expected_alt_abs = current_alt + expected_alt
 
         self.takeoff(expected_alt, mode='GUIDED')
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="EKF to stabilise at target altitude")
 
         def check_altitude(mav, m):
             m_type = m.get_type()
@@ -15270,7 +15270,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.install_message_hook_context(check_altitude)
 
-        self.delay_sim_time(1500)
+        self.delay_sim_time(1500, reason="OGN height mask to cause altitude change")
 
         self.disarm_vehicle(force=True)
 
@@ -15462,7 +15462,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.takeoff(mode='LOITER')
         self.set_rc(1, 1200)
-        self.delay_sim_time(1)  # build up some pilot desired stuff
+        self.delay_sim_time(1, reason="pilot desired input to build up")  # build up some pilot desired stuff
         self.change_mode('AUTO')
         self.wait_waypoint(2, 2, max_dist_to_final_wp_m=3)
         self.set_parameters({
@@ -15729,7 +15729,7 @@ RTL_ALT_M 111
         self.mavproxy_load_module(mavproxy, 'ftp')
         mavproxy.send(f"param ftpload {new_values_filepath.name}\n")
         mavproxy.expect("Loaded")
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="parameter write to be processed")
         self.stop_mavproxy(mavproxy)
 
         self.assert_parameter_value("DISARM_DELAY", 77)
@@ -15870,7 +15870,7 @@ RTL_ALT_M 111
         self.set_rc(1, 1450)
         for i in range(0, 5):  # we descend through all of this:
             self.change_mode('LOITER')
-            self.delay_sim_time(10)
+            self.delay_sim_time(10, reason="compass learn data to accumulate")
             self.change_mode('ALT_HOLD')
             self.change_mode('FLIP')
 
@@ -15879,7 +15879,7 @@ RTL_ALT_M 111
         for j in 1000, 2000:
             for i in 1, 2, 4:
                 self.set_rc(i, j)
-                self.delay_sim_time(10)
+                self.delay_sim_time(10, reason="compass learn data to accumulate")
         self.set_rc(1, 1500)
         self.set_rc(2, 1500)
         self.set_rc(4, 1500)
@@ -15905,7 +15905,7 @@ RTL_ALT_M 111
         self.wait_altitude(300, 20000, relative=True, timeout=10000)
         self.hover()
         self.set_rc(4, 1000)
-        self.delay_sim_time(11)
+        self.delay_sim_time(11, reason="confirming disarm by rudder does not trigger in flight")
         self.progress("Checking we are still armed")
         self.assert_armed()
 
@@ -15913,13 +15913,13 @@ RTL_ALT_M 111
         self.wait_altitude(300, 20000, relative=True)
         self.set_rc(3, 1000)
         self.set_rc(4, 1000)
-        self.delay_sim_time(11)
+        self.delay_sim_time(11, reason="rudder disarm to trigger")
         self.progress("Checking we disarm")
         self.wait_disarmed(timeout=5)
         self.set_rc(4, 1500)
         self.arm_vehicle()
         self.set_rc(3, 1600)
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="vehicle to climb to RTL altitude")
 
         self.do_RTL(timeout=600)
 
@@ -16158,7 +16158,7 @@ RTL_ALT_M 111
         self.arm_vehicle()
         self.progress("Takeoff throttle")
         rc3_value = 1800
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="throttle override to take effect")
         self.wait_altitude(20, 30, relative=True)
         self.progress("Neutral throttle")
         rc3_value = 1600
@@ -16215,7 +16215,7 @@ RTL_ALT_M 111
 
         self.set_parameter('RTL_OPTIONS', 1 << 2)
         self.set_rc(4, 2000)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="RTL to progress with yaw override")
         self.context_pop()
 
         self.wait_disarmed()
@@ -17005,7 +17005,7 @@ return update, 1000
         target_lat = home.latitude + 10000
         target_lon = home.longitude
         self.send_set_position_target_global_int(target_lat, target_lon, 20)
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="guided target to propagate to UTM message")
         m = self.assert_received_message_field_values("UTM_GLOBAL_POSITION", {
             "next_lat": target_lat,
             "next_lon": target_lon,
@@ -17160,22 +17160,22 @@ return update, 1000
             "BATT2_OPTIONS": 128,  # allow split auxinfo
         })
         self.reboot_sitl()
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="CAN battery backend to initialise")
         self.set_parameters({
             "BATT_MONITOR": 8,  # 8 is UAVCAN_BatteryInfo
             "BATT2_MONITOR": 4,  # 8 is UAVCAN_BatteryInfo
         })
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="battery monitor switch to take effect")
         self.set_parameters({
             "BATT_MONITOR": 4,  # 8 is UAVCAN_BatteryInfo
             "BATT2_MONITOR": 8,  # 8 is UAVCAN_BatteryInfo
         })
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="battery monitor switch to take effect")
         self.set_parameters({
             "BATT_MONITOR": 8,  # 8 is UAVCAN_BatteryInfo
             "BATT2_MONITOR": 4,  # 8 is UAVCAN_BatteryInfo
         })
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="battery monitor switch to take effect")
 
     def BattCANReplaceRuntime(self):
         '''test CAN battery periphs'''
@@ -17185,11 +17185,11 @@ return update, 1000
             "BATT_MONITOR": 11,  # 4 is analog volt+curr
         })
         self.reboot_sitl()
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="CAN battery backend to initialise")
         self.set_parameters({
             "BATT_MONITOR": 8,  # 4 is UAVCAN batterinfo
         })
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="battery monitor replacement to take effect")
 
     def testcanbatt(self):
         ret = ([

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -826,7 +826,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             raise NotAchievedException("Did not get good ext voltage (got=%f)" %
                                        (m.voltages_ext[0],))
         self.arm_vehicle()
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="battery log data to be written")
         self.disarm_vehicle()
         if not self.current_onboard_log_contains_message("BCL2"):
             raise NotAchievedException("Expected BCL2 message")
@@ -911,7 +911,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             p7=100,   # alt
             frame=mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT,
         )
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="vehicle to establish GUIDED position")
         self.progress("Ensuring initial speed is known and relatively constant")
         initial_speed = 22.0
         timeout = 15
@@ -929,7 +929,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.wait_groundspeed(new_target_groundspeed-2, new_target_groundspeed+2, timeout=80, minimum_duration=5)
             self.progress("Adding some wind, ensuring groundspeed holds")
             self.set_parameter("SIM_WIND_SPD", 5)
-            self.delay_sim_time(5)
+            self.delay_sim_time(5, reason="wind to take effect")
             self.wait_groundspeed(new_target_groundspeed-2, new_target_groundspeed+2, timeout=40, minimum_duration=5)
             self.set_parameter("SIM_WIND_SPD", 0)
 
@@ -959,7 +959,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             "SIM_WIND_SPD": 7,
             "SIM_WIND_DIR": 270,
         })
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="wind to take effect")
         timeout = 10
         tstart = self.get_sim_time()
         while True:
@@ -1094,7 +1094,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             raise PreconditionFailedException("SIM_MASK_PIN off")
 
         # allow time for the RC library to register initial value:
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="RC library to register initial value")
 
         self.set_rc(12, 2000)
         self.wait_heartbeat()
@@ -1137,7 +1137,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         takeoff_alt = 30
         self.takeoff(takeoff_alt)
         self.set_rc(12, 2000)
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="camera trigger to register")
         self.set_rc(12, 1000)
         x = self.mav.messages.get("CAMERA_FEEDBACK", None)
         if abs(x.alt_rel - takeoff_alt) > 10:
@@ -1159,7 +1159,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
         self.context_collect('CAMERA_FEEDBACK')
         self.set_rc(12, 2000)
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="camera trigger to register")
         self.set_rc(12, 1000)
         self.assert_received_message_field_values('CAMERA_FEEDBACK', {
             "roll": math.degrees(self.assert_receive_message('ATTITUDE').roll),
@@ -1210,7 +1210,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 #            raise NotAchievedException("Sensor healthy when it shouldn't be")
         self.set_parameter("SIM_RC_FAIL", 0)
         # have to allow time for RC to be fetched from SITL
-        self.delay_sim_time(0.5)
+        self.delay_sim_time(0.5, reason="RC to be fetched from SITL")
         self.do_timesync_roundtrip()
         m = self.assert_receive_message('SYS_STATUS')
         self.progress("Testing receiver enabled")
@@ -1247,7 +1247,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.set_parameter("SIM_RC_FAIL", 0)
         # have to allow time for RC to be fetched from SITL
         self.progress("Giving receiver time to recover")
-        self.delay_sim_time(0.5)
+        self.delay_sim_time(0.5, reason="receiver to recover")
         self.do_timesync_roundtrip()
         m = self.assert_receive_message('SYS_STATUS')
         self.progress("Testing receiver enabled")
@@ -1294,7 +1294,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             "THR_FAILSAFE": 2,
             "SIM_RC_FAIL": 1,  # no pulses
         })
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="failsafe to take effect")
         self.wait_attitude(desroll=0, timeout=5)
         self.assert_servo_channel_value(3, self.get_parameter("RC3_MIN"))
         self.set_parameters({
@@ -1341,7 +1341,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.progress("Failing receiver (throttle-to-950)")
         self.set_parameter("SIM_RC_FAIL", 2) # throttle-to-950
         self.wait_mode("CIRCLE")
-        self.delay_sim_time(1) # give
+        self.delay_sim_time(1, reason="fence status to update") # give
         self.do_timesync_roundtrip()
 
         self.progress("Checking fence is OK after receiver failure (bind-values)")
@@ -1368,7 +1368,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.wait_current_waypoint(2)
         self.progress("Disconnecting GCS")
         self.set_heartbeat_rate(0)
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="short failsafe window to pass")
         self.wait_mode("AUTO", timeout=10)
         self.set_heartbeat_rate(self.speedup)
         self.fly_home_land_and_disarm()
@@ -1435,7 +1435,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.wait_statustext("Auto disarmed", timeout=60)
 
     def assert_fence_sys_status(self, present, enabled, health):
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="fence status to propagate")
         self.do_timesync_roundtrip()
         m = self.assert_receive_message('SYS_STATUS')
         tests = [
@@ -1469,7 +1469,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.set_parameter('SIM_RC_FAIL', 0)
 
         self.progress("Ensuring we don't automatically revert mode")
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="mode to not automatically revert")
         self.assert_mode_is('RTL')
 
         self.progress("Ensuring MODE_SWITCH_RESET switch resets to pre-failsafe mode")
@@ -1536,7 +1536,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.set_parameter("FENCE_ALT_MIN", 50)
         self.set_parameter("FENCE_TYPE", 8) # Enables minimum altitude breaches
         self.do_fence_enable()
-        self.delay_sim_time(2) # Allow breach to propagate
+        self.delay_sim_time(2, reason="breach to propagate") # Allow breach to propagate
         self.assert_fence_enabled()
 
         self.try_arm(False, "Vehicle breaching Min Alt fence")
@@ -1554,10 +1554,10 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
                 mavutil.location(1.001, 1.000, 0, 0)
             ]
         )])
-        self.delay_sim_time(10) # let fence check run so it loads-from-eeprom
+        self.delay_sim_time(10, reason="fence check to run") # let fence check run so it loads-from-eeprom
         self.do_fence_enable()
         self.assert_fence_enabled()
-        self.delay_sim_time(2) # Allow breach to propagate
+        self.delay_sim_time(2, reason="breach to propagate") # Allow breach to propagate
         self.try_arm(False, "Vehicle breaching Polygon fence")
         self.do_fence_disable()
         self.clear_fence()
@@ -1574,10 +1574,10 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.upload_fences_from_locations([
             (mavutil.mavlink.MAV_CMD_NAV_FENCE_POLYGON_VERTEX_EXCLUSION, locs),
         ])
-        self.delay_sim_time(10) # let fence check run so it loads-from-eeprom
+        self.delay_sim_time(10, reason="fence check to run") # let fence check run so it loads-from-eeprom
         self.do_fence_enable()
         self.assert_fence_enabled()
-        self.delay_sim_time(2) # Allow breach to propagate
+        self.delay_sim_time(2, reason="breach to propagate") # Allow breach to propagate
         self.try_arm(False, "Vehicle breaching Polygon fence")
         self.do_fence_disable()
 
@@ -1672,7 +1672,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         ]
         self.upload_using_mission_protocol(mavutil.mavlink.MAV_MISSION_TYPE_FENCE,
                                            fence_return_mission_items)
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="fence upload to complete")
 
         # Grab a location for rally point, and upload it.
         rally_loc = self.home_relative_loc_ne(-50, 50)
@@ -1699,7 +1699,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.set_parameter("FENCE_ALT_MIN", 0) # Clear fence breach
 
         # 10 second fence min retrigger time
-        self.delay_sim_time(15)
+        self.delay_sim_time(15, reason="fence retrigger timeout")
 
         # Fly up before re-triggering fence breach. Fly to fence return point
         self.change_altitude(30, relative=True)
@@ -1935,22 +1935,22 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.takeoff(alt=50, mode='TAKEOFF')
         # simulate the effect of a blocked pitot tube
         self.set_parameter("ARSPD_RATIO", 0.1)
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="blocked pitot to be detected")
         if (self.get_parameter("ARSPD_USE") == 0):
             self.progress("Faulty Sensor Disabled")
         else:
             raise NotAchievedException("Airspeed Sensor Not Disabled")
-        self.delay_sim_time(20)
+        self.delay_sim_time(20, reason="sensor fault monitoring period")
         # simulate the effect of blockage partially clearing
         self.set_parameter("ARSPD_RATIO", 1.0)
-        self.delay_sim_time(60)
+        self.delay_sim_time(60, reason="partial blockage monitoring period")
         if (self.get_parameter("ARSPD_USE") == 0):
             self.progress("Faulty Sensor Remains Disabled")
         else:
             raise NotAchievedException("Fault Sensor Re-Enabled")
         # simulate the effect of blockage fully clearing
         self.set_parameter("ARSPD_RATIO", 2.0)
-        self.delay_sim_time(60)
+        self.delay_sim_time(60, reason="airspeed sensor to re-enable")
         if (self.get_parameter("ARSPD_USE") == 1):
             self.progress("Sensor Re-Enabled")
         else:
@@ -2030,12 +2030,12 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.progress("Orbit with GPS and learn wind")
             # allow longer to learn wind if there is no airspeed sensor
             if disable_airspeed_sensor:
-                self.delay_sim_time(180)
+                self.delay_sim_time(180, reason="wind learning without airspeed sensor")
             else:
-                self.delay_sim_time(20)
+                self.delay_sim_time(20, reason="wind learning in orbit")
             self.set_parameter("SIM_GPS1_ENABLE", 0)
             self.progress("Continue orbit without GPS")
-            self.delay_sim_time(20)
+            self.delay_sim_time(20, reason="dead reckoning data collection")
             self.change_mode("RTL")
             self.wait_distance_to_home(100, 200, timeout=200)
             # go into LOITER to create additional time for a GPS re-enable test
@@ -2048,11 +2048,11 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             if self.get_sim_time() < (t_enabled+9):
                 raise NotAchievedException("GPS use re-started too quickly")
             # wait for EKF and vehicle position to stabilise, then test response to jamming
-            self.delay_sim_time(20)
+            self.delay_sim_time(20, reason="EKF and position to stabilise")
 
             self.set_parameter("AHRS_OPTIONS", 1)
             self.set_parameter("SIM_GPS1_JAM", 1)
-            self.delay_sim_time(13)
+            self.delay_sim_time(13, reason="GPS jamming simulation")
             self.set_parameter("SIM_GPS1_JAM", 0)
             t_enabled = self.get_sim_time()
             # The EKF should wait for GPS checks to pass when we are still able to navigate using dead reckoning
@@ -2346,7 +2346,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.wait_ready_to_arm()
         here = self.mav.location()
         self.change_mode("FBWA")
-        self.delay_sim_time(2) # TODO: work out why this is required...
+        self.delay_sim_time(2, reason="mode change to settle") # TODO: work out why this is required...
         self.test_adsb_send_threatening_adsb_message(here)
         self.progress("Waiting for collision message")
         m = self.assert_receive_message('COLLISION', timeout=4)
@@ -2378,7 +2378,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
         self.progress("Disabling ADSB-avoidance with RC channel")
         self.set_rc(12, 1000)
-        self.delay_sim_time(1) # let the switch get polled
+        self.delay_sim_time(1, reason="RC switch to be polled") # let the switch get polled
         self.test_adsb_send_threatening_adsb_message(here)
         m = self.assert_not_receive_message('COLLISION', timeout=4)
 
@@ -2522,7 +2522,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.wait_altitude(initial_alt - 110, initial_alt - 90, timeout=90)
         # should not climb back at mid stick
         self.set_rc(2, 1500)
-        self.delay_sim_time(60)
+        self.delay_sim_time(60, reason="altitude hold verification")
         self.wait_altitude(initial_alt - 110, initial_alt - 90)
         # should climb at min stick
         self.set_rc(2, 1100)
@@ -2607,19 +2607,19 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.wait_altitude(alt_ctf-10, alt_ctf, timeout=600, relative=True)
 
         # Allow time to suppress throttle and start descent.
-        self.delay_sim_time(20)
+        self.delay_sim_time(20, reason="throttle to suppress after cutoff altitude")
 
         # Now set FBWB mode
         self.change_mode('FBWB')
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="FBWB mode to settle")
 
         # Now disable soaring (should hold altitude)
         self.set_parameter("SOAR_ENABLE", 0)
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="soaring disable to take effect")
 
         # And re-enable. This should force throttle-down
         self.set_parameter("SOAR_ENABLE", 1)
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="soaring re-enable to take effect")
 
         # Now wait for descent and check throttle up
         self.wait_altitude(alt_min-10, alt_min, timeout=600, relative=True)
@@ -2695,7 +2695,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.wait_altitude(390, 400, timeout=600, relative=True)
 
         # Wait 10s to stabilize.
-        self.delay_sim_time(30)
+        self.delay_sim_time(30, reason="flight to stabilise")
 
         # Enable soaring (no automatic thermalling)
         self.set_rc(rc_chan, 1500)
@@ -2707,7 +2707,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         })
 
         self.progress('Waiting a few seconds before determining the "trim" airspeed.')
-        self.delay_sim_time(20)
+        self.delay_sim_time(20, reason="trim airspeed to stabilise")
         m = self.assert_receive_message('VFR_HUD')
         trim_airspeed = m.airspeed
         self.progress("Using trim_airspeed=%f" % (trim_airspeed,))
@@ -2764,7 +2764,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             "SOAR_VSPEED": 1,
             "SIM_WIND_SPD": 1,
         })
-        self.delay_sim_time(20)
+        self.delay_sim_time(20, reason="airspeed to stabilise")
         m = self.assert_receive_message('VFR_HUD')
         mcready1_speed = m.airspeed
         self.progress("airspeed is %f" % mcready1_speed)
@@ -2966,7 +2966,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
                 last_terrain_report_pending = report.pending
                 tstart = now
 
-            self.delay_sim_time(1)
+            self.delay_sim_time(1, reason="terrain tile download")
 
         self.progress(self.dump_message_verbose(report))
 
@@ -3024,7 +3024,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         alt = 50
         self.takeoff(alt*0.9, alt*1.1, mode='TAKEOFF')
         self.change_mode('LOITER')
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="loiter to establish terrain following")
         self.change_mode('CIRCLE')
         self.wait_altitude(alt*0.9, alt*1.1, minimum_duration=10,
                            altitude_source="TERRAIN_REPORT.current_height")
@@ -3052,7 +3052,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             "INS_GYR_CAL": 1,
         })
         self.reboot_sitl()
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="external AHRS to initialise")
         self.progress("Running accelcal")
         self.run_cmd(
             mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION,
@@ -3173,7 +3173,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         # The SIM AHRS backend returns actual 3D SITL wind, but the
         # fallback logic prevents it being used until in flight.
         self.takeoff(20, mode='TAKEOFF')
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="wind estimate to establish")
 
         # Without the fix, speed == wind_spd (3D magnitude ~10 m/s).
         # With the fix, speed == horizontal component (~7.07 m/s).
@@ -3306,7 +3306,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             "INS_GYR_CAL": 1,
         })
         self.reboot_sitl()
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="external AHRS to initialise")
 
         self.progress("Running accelcal")
         self.run_cmd(
@@ -3344,7 +3344,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             "EAHRS_SENSORS": 13, # GPS is enabled
         })
         self.reboot_sitl()
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="external AHRS to initialise")
         self.progress("Running accelcal")
         self.run_cmd(
             mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION,
@@ -3367,7 +3367,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             "EAHRS_SENSORS": 13, # GPS is enabled
         })
         self.reboot_sitl()
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="external AHRS to initialise")
         self.progress("Running accelcal")
         self.run_cmd(
             mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION,
@@ -3483,7 +3483,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         for temp in test_temperatures:
             self.progress("Testing temperature %.1f" % temp)
             self.set_parameter("SIM_IMUT_FIXED", temp)
-            self.delay_sim_time(2)
+            self.delay_sim_time(2, reason="temperature to stabilise")
             for msg in ['RAW_IMU', 'SCALED_IMU2']:
                 m = self.assert_receive_message(msg, timeout=2)
                 temperature = m.temperature*0.01
@@ -3690,7 +3690,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
                 p7=50,    # alt
                 frame=mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT,
             )
-            self.delay_sim_time(5)
+            self.delay_sim_time(5, reason="position to reach")
             # create an airspeed sensor error by freezing to the
             # current airspeed then changing the airspeed demand
             # to a higher value and waiting for the TECS speed
@@ -4016,9 +4016,9 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
         self.progress("Toggle fence enable/disable")
         self.set_rc(7, 2000)
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="fence switch to register")
         self.set_rc(7, 1000)
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="fence switch to register")
 
         self.progress("Check fence is disabled")
         m = self.assert_receive_message('SYS_STATUS')
@@ -4123,7 +4123,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         }) # Turn fence off with aux function
 
         # wait to no longer be in breach
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="fence disable to take effect")
         self.assert_fence_disabled()
 
         self.fly_home_land_and_disarm(timeout=250)
@@ -4245,7 +4245,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.upload_fences_from_locations([
             (mavutil.mavlink.MAV_CMD_NAV_FENCE_POLYGON_VERTEX_INCLUSION, locs),
         ])
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="fence upload to complete")
         self.wait_ready_to_arm()
         self.takeoff(alt=50)
         self.change_mode("CRUISE")
@@ -4273,7 +4273,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.change_mode("LOITER")
 
         # Fly for 20 seconds and make sure still in LOITER mode
-        self.delay_sim_time(20)
+        self.delay_sim_time(20, reason="fence not to retrigger")
         if not self.mode_is("LOITER"):
             raise NotAchievedException("Fence should not re-trigger")
 
@@ -4305,7 +4305,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.upload_fences_from_locations([
             (mavutil.mavlink.MAV_CMD_NAV_FENCE_POLYGON_VERTEX_INCLUSION, locs),
         ])
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="fence upload to complete")
         self.wait_ready_to_arm()
         self.takeoff(alt=50)
         self.change_mode("CRUISE")
@@ -4315,7 +4315,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.do_fence_enable()
         self.assert_fence_enabled()
         self.wait_mode("GUIDED", timeout=120) # We should RTL because of fence breach
-        self.delay_sim_time(60)
+        self.delay_sim_time(60, reason="guided fence return to proceed")
 
         items = self.download_using_mission_protocol(mavutil.mavlink.MAV_MISSION_TYPE_FENCE)
         if len(items) != 4:
@@ -4373,7 +4373,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
         self.clear_fence()
 
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="fence clear to complete")
         self.wait_ready_to_arm()
         home_loc = self.mav.location()
         self.takeoff(alt=50)
@@ -4384,7 +4384,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.do_fence_enable()
         self.assert_fence_enabled()
         self.wait_mode("GUIDED") # We should RTL because of fence breach
-        self.delay_sim_time(30)
+        self.delay_sim_time(30, reason="guided fence return to proceed")
 
         items = self.download_using_mission_protocol(mavutil.mavlink.MAV_MISSION_TYPE_FENCE)
         if len(items) != 0:
@@ -4541,7 +4541,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
     def RCDisableAirspeedUse(self):
         '''Test RC DisableAirspeedUse option'''
         self.set_parameter("RC9_OPTION", 106)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="RC option to take effect")
         self.set_rc(9, 1000)
         self.wait_sensor_state(
             mavutil.mavlink.MAV_SYS_STATUS_SENSOR_DIFFERENTIAL_PRESSURE,
@@ -4699,7 +4699,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
                     # Center sticks to allow roll to return to neutral before starting pitch
                     self.set_rc(1, 1500)
                     self.set_rc(2, 1500)
-                    self.delay_sim_time(15)
+                    self.delay_sim_time(15, reason="vehicle to stabilise between tune axes")
 
                     # Reset toggle value so the initial input is in a consistent direction
                     rc_value = 1000
@@ -4710,7 +4710,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
                     raise ValueError("Bug: %s" % axis)
             except AutoTestTimeoutException:
                 pass
-            self.delay_sim_time(1)
+            self.delay_sim_time(1, reason="autotune iteration")
 
             if rc_value == 1000:
                 rc_value = 2000
@@ -4923,7 +4923,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.set_servo(7, 2000)
 
         # Ensure that TKOFF_THR_MAX_T is respected.
-        self.delay_sim_time(self.get_parameter("TKOFF_THR_MAX_T")-1)
+        self.delay_sim_time(self.get_parameter("TKOFF_THR_MAX_T")-1, reason="takeoff max throttle period")
         target_throttle = 1000+10*(self.get_parameter("TKOFF_THR_MAX"))
         self.assert_servo_channel_range(3, target_throttle-10, target_throttle+10)
 
@@ -4981,7 +4981,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.set_servo(7, 2000)
 
         # Ensure that TKOFF_THR_MAX_T is respected.
-        self.delay_sim_time(self.get_parameter("TKOFF_THR_MAX_T")-1)
+        self.delay_sim_time(self.get_parameter("TKOFF_THR_MAX_T")-1, reason="takeoff max throttle period")
         target_throttle = 1000+10*(self.get_parameter("TKOFF_THR_MAX"))
         self.assert_servo_channel_range(3, target_throttle-10, target_throttle+10)
 
@@ -5045,7 +5045,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.wait_altitude(target_alt-5, target_alt, relative=True)
 
         # Wait a bit for the Takeoff altitude to settle.
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="takeoff altitude to settle")
 
         self.fly_home_land_and_disarm()
 
@@ -5100,7 +5100,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.wait_altitude(target_alt-5, target_alt, relative=True)
 
         # Wait a bit for the Takeoff altitude to settle.
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="takeoff altitude to settle")
 
         self.fly_home_land_and_disarm()
 
@@ -5215,7 +5215,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.wait_altitude(target_alt-5, target_alt, relative=True)
 
         # Wait a bit for the Takeoff altitude to settle.
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="takeoff altitude to settle")
 
         self.fly_home_land_and_disarm()
 
@@ -5242,7 +5242,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.wait_altitude(target_alt-5, target_alt, relative=True)
 
         # Wait a bit for the Takeoff altitude to settle.
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="takeoff altitude to settle")
 
         bearing_margin = 35
         loc = self.mav.location()
@@ -5307,7 +5307,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         # Launch the catapult
         self.set_servo(6, 1000)
 
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="catapult launch to establish flight")
         self.change_mode('RTL')
 
         self.fly_home_land_and_disarm()
@@ -5344,7 +5344,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         target_alt = 50
         self.wait_altitude(target_alt-1, target_alt+1, relative=True, timeout=30)
 
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="altitude to settle")
 
         self.disarm_vehicle(force=True)
 
@@ -5376,7 +5376,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
         self.wait_altitude(tkoff_alt-10, tkoff_alt, relative=True)
         self.wait_level_flight(accuracy=10, timeout=1)  # Ensure we have roughly level-off.
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="level-off to confirm")
 
         self.change_mode('AUTOLAND')
         self.wait_disarmed(timeout=180)
@@ -5384,7 +5384,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
     def DCMFallback(self):
         '''Really annoy the EKF and force fallback'''
         self.reboot_sitl()
-        self.delay_sim_time(30)
+        self.delay_sim_time(30, reason="SITL to initialise after reboot")
 
         self.takeoff(50)
         self.change_mode('CIRCLE')
@@ -5769,7 +5769,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.change_mode("CRUISE")
 
         self.set_rc(9, 1000) # select first trick
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="trick selection to register")
         self.set_rc(7, 1500) # show selected trick
 
         self.wait_text("Trick 1 selected (SuperAirShow)", check_context=True)
@@ -6100,7 +6100,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.set_parameter("SIM_GPS1_GLTCH_Z", -47)
 
         self.progress("Waiting 10s for height update")
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="GPS altitude to update")
 
         self.wait_ready_to_arm()
         self.arm_vehicle()
@@ -6136,7 +6136,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.reboot_sitl()
         self.wait_statustext('No airspeed sensor', check_context=True)
         self.trigger_airspeed_cal()
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="airspeed calibration check period")
         if self.statustext_in_collections('Airspeed 1 calibrated'):
             raise NotAchievedException("Did not disable airspeed sensor?!")
         self.context_pop()
@@ -6200,7 +6200,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         # test for #24535
         self.start_subtest("switch to loiter and resume guided maintains home relative altitude")
         self.change_mode('LOITER')
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="loiter to stabilise altitude")
         self.change_mode('GUIDED')
         self.wait_altitude(
             height_diff+alt-3,  # NOTE: reuse of alt from above loop!
@@ -6220,11 +6220,11 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.wait_altitude(alt-3, alt+3, timeout=30, relative=False, minimum_duration=10)
 
         # let it settle so LOITER captures a constant altitude
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="altitude to settle for LOITER capture")
 
         # now switch to LOITER then back to GUIDED
         self.change_mode('LOITER')
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="loiter to capture altitude")
         self.change_mode('GUIDED')
         self.wait_altitude(
             alt-5,  # NOTE: reuse of alt from above CHANGE_ALTITUDE
@@ -6266,10 +6266,10 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             relative=False,
             altitude_source="TERRAIN_REPORT.current_height"
         )
-        self.delay_sim_time(30)
+        self.delay_sim_time(30, reason="terrain altitude to stabilise")
 
         self.change_mode('LOITER')
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="loiter to capture terrain altitude")
         self.change_mode('GUIDED')
         self.wait_altitude(
             alt-5,  # NOTE: reuse of alt from abovE
@@ -6338,7 +6338,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             altitude_source="TERRAIN_REPORT.current_height"
         )
 
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="terrain altitude to stabilise before landing")
         self.fly_home_land_and_disarm()
 
     def _MAV_CMD_PREFLIGHT_CALIBRATION(self, command):
@@ -6377,7 +6377,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         )
 
         # enforced delay between cals:
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="mandatory delay between calibrations")
 
         self.start_subtest("simple accel cal")
         command(
@@ -6633,7 +6633,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.install_message_hook_context(look_for_wiggle)
 
         # Wait for a bit to let message hook sample
-        self.delay_sim_time(60)
+        self.delay_sim_time(60, reason="message hook to sample servo outputs")
 
         self.context_pop()
 
@@ -6787,7 +6787,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.change_mode('GUIDED')
         self.context_push()
         self.set_parameter('SIM_GPS1_ENABLE', 0)
-        self.delay_sim_time(30)
+        self.delay_sim_time(30, reason="GPS disable to take effect")
         self.set_attitude_target()
         self.context_pop()
         self.fly_home_land_and_disarm()
@@ -6856,7 +6856,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             home = self.home_position_as_mav_location()
             target_alt = 20
             self.takeoff(target_alt, mode="TAKEOFF")
-            self.delay_sim_time(20)  # Give some time to altitude to stabilize.
+            self.delay_sim_time(20, reason="altitude to stabilise")  # Give some time to altitude to stabilize.
             self.set_rc(3, 1500)
             self.change_mode(mode)
             higher_home = copy.copy(home)
@@ -6878,7 +6878,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         target_alt = 20
         self.takeoff(target_alt, mode="TAKEOFF")
         self.change_mode("LOITER")
-        self.delay_sim_time(20) # Let the plane settle.
+        self.delay_sim_time(20, reason="plane to settle") # Let the plane settle.
 
         tstart = self.get_sim_time()
         test_time = 10 # Run the test for 10s.
@@ -6891,7 +6891,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.set_home(higher_home)
             if tnow-tstart > test_time:
                 break
-            self.delay_sim_time(1.0/pub_freq)
+            self.delay_sim_time(1.0/pub_freq, reason="home update interval")
 
         # Test if the altitude is still within bounds.
         self.wait_altitude(home.alt+target_alt-5, home.alt+target_alt+5, relative=False, minimum_duration=1, timeout=2)
@@ -6905,7 +6905,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         target_alt = 20
         self.takeoff(target_alt, mode="TAKEOFF")
         self.change_mode("LOITER")
-        self.delay_sim_time(20) # Let the plane settle.
+        self.delay_sim_time(20, reason="plane to settle") # Let the plane settle.
 
         higher_home = copy.copy(home)
         higher_home.alt += 40
@@ -7421,13 +7421,13 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
         # airspeed sensor never becomes unhealthy - we just stop using
         # it as EKF3 starts to reject, allow 10 seconds
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="EKF to reject failed airspeed sensor")
         if airspeed_active != [False, False]:
             raise NotAchievedException("Not using expected airspeed sensors %s" % str(airspeed_active))
 
         # Re-enable sensors, after some time the sensor should be re-enabled
         self.set_parameter("SIM_ARSPD_FAIL", 0)
-        self.delay_sim_time(60)
+        self.delay_sim_time(60, reason="airspeed sensor to be re-enabled")
         if airspeed_active != [True, False]:
             raise NotAchievedException("Not using expected airspeed sensors %s" % str(airspeed_active))
 
@@ -7435,13 +7435,13 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
         # Changing the primary should have no effect as the second sensor is not marked to use
         self.set_parameter("ARSPD_PRIMARY", 1)
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="primary airspeed change to take effect")
         if airspeed_active != [True, False]:
             raise NotAchievedException("Not using expected airspeed sensors %s" % str(airspeed_active))
 
         # Allowing the second sensor to be used should not result in a switch when armed despite the primary parameter
         self.set_parameter("ARSPD2_USE", 1)
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="airspeed sensor use to take effect")
         if airspeed_active != [True, False]:
             raise NotAchievedException("Not using expected airspeed sensors %s" % str(airspeed_active))
 
@@ -7449,13 +7449,13 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         # Now the second can be used it should switch
         self.set_parameter("ARSPD_PRIMARY", 0)
         self.set_parameter("ARSPD_PRIMARY", 1)
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="airspeed primary switch to take effect")
         if airspeed_active != [False, True]:
             raise NotAchievedException("Not using expected airspeed sensors %s" % str(airspeed_active))
 
         # Now stop using the second
         self.set_parameter("ARSPD2_USE", 0)
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="airspeed sensor disable to take effect")
         if airspeed_active != [True, False]:
             raise NotAchievedException("Not using expected airspeed sensors %s" % str(airspeed_active))
 
@@ -7472,7 +7472,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
         # Now the vehicle is disarmed, enabling use for the primary sensor should result in it being used
         self.set_parameter("ARSPD2_USE", 1)
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="airspeed sensor enable to take effect")
         if airspeed_active != [False, True]:
             raise NotAchievedException("Not using expected airspeed sensors %s" % str(airspeed_active))
 
@@ -7484,7 +7484,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             "RC4_REVERSED": 0,
         })
         self.reboot_sitl()
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="SITL to initialise after reboot")
         self.set_rc(4, 2000)
         w = vehicle_test_suite.WaitAndMaintainDisarmed(
             self,
@@ -7525,18 +7525,18 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.change_mode('FBWA')
         straight_and_level_text = "straight-and-level"
         self.send_statustext(straight_and_level_text)
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="straight-and-level flight data to log")
         self.progress("sticking servo with constant deflection")
         self.set_rc(1, 1400)
         self.change_mode('MANUAL')
-        self.delay_sim_time(0.5)
+        self.delay_sim_time(0.5, reason="servo deflection to establish")
         self.progress("Failing servo")
         self.set_parameter('SIM_VOLZ_FMASK', 1)
         self.set_rc(1, 1500)
         self.change_mode('FBWA')
         aileron_failed_text = "aileron has been failed"
         self.send_statustext(aileron_failed_text)
-        self.delay_sim_time(15)
+        self.delay_sim_time(15, reason="aileron failure data collection")
         self.set_parameter('SIM_VOLZ_FMASK', 0)
 
         log_filepath = self.current_onboard_log_filepath()
@@ -7758,9 +7758,9 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.takeoff(20)
         self.change_mode('FBWB')
         self.set_rc(2, 1000)  # full climb
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="climb rate to establish")
         self.set_rc(16, 2000)  # enable soaring
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="soaring climb rate data collection")
 
         self.set_rc(2, 1500)
         self.fly_home_land_and_disarm()
@@ -8241,7 +8241,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             p7=50,
             frame=mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT,
         )
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="reposition to register")
         m = self.assert_received_message_field_values("UTM_GLOBAL_POSITION", {
             "next_lat": target_lat,
             "next_lon": target_lon,
@@ -8306,7 +8306,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
         # suspend periodic resets so baro drift can accumulate
         self.set_parameter("HOME_RESET_ALT", -1)
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="baro drift to accumulate")
 
         # populate storedBaro with samples offset from where the
         # post-recalibration ground reference will sit.  4 s of
@@ -8314,13 +8314,13 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         # natural noise so any post-reset transient is unambiguous.
         drift_start_us = int(self.get_sim_time() * 1.0e6)
         self.set_parameter("SIM_BARO_DRIFT", 0.5)
-        self.delay_sim_time(4)
+        self.delay_sim_time(4, reason="baro buffer to fill with drift")
         self.set_parameter("SIM_BARO_DRIFT", 0)
 
         # re-enable periodic resets; the next 5 s tick fires
         # update_home -> resetHeightDatum
         self.set_parameter("HOME_RESET_ALT", 0)
-        self.delay_sim_time(8)
+        self.delay_sim_time(8, reason="home reset to trigger")
 
         # find the reset in the dataflash log: PD jumps by >0.5 m
         # between adjacent samples when resetHeightDatum fires

--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -169,7 +169,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.set_rc(Joystick.Throttle, pwm)
         self.wait_altitude(altitude_min=alt - 1, altitude_max=alt, relative=False, timeout=timeout)
         self.set_rc(Joystick.Throttle, 1500)
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="altitude to stabilise")
         self.progress("DIVE COMPLETE")
 
     def AltitudeHold(self):
@@ -182,7 +182,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.set_rc(Joystick.Throttle, 1500)
 
         # let the vehicle settle (momentum / stopping point shenanigans....)
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="vehicle to settle")
 
         self.watch_altitude_maintained()
 
@@ -191,7 +191,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.set_rc(Joystick.Throttle, 1500)
 
         # let the vehicle settle (momentum / stopping point shenanigans....)
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="vehicle to settle")
 
         self.watch_altitude_maintained()
 
@@ -200,7 +200,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.set_rc(Joystick.Throttle, 1500)
 
         # let the vehicle settle (momentum / stopping point shenanigans....)
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="vehicle to settle")
         self.watch_altitude_maintained()
 
         # Make sure the code can handle buoyancy changes
@@ -323,7 +323,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.set_rc(Joystick.Throttle, 1300)
         self.wait_altitude(altitude_min=-26, altitude_max=-25, relative=False, timeout=60)
         self.set_rc(Joystick.Throttle, 1500)
-        self.delay_sim_time(4)
+        self.delay_sim_time(4, reason="rangefinder target to settle")
         self.wait_statustext('rangefinder target is', check_context=True)
         self.context_clear_collection('STATUSTEXT')
         self.watch_distance_maintained()
@@ -332,13 +332,13 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.set_rc(Joystick.Throttle, 1300)
         self.wait_altitude(altitude_min=-31, altitude_max=-30, relative=False, timeout=60)
         self.set_rc(Joystick.Throttle, 1500)
-        self.delay_sim_time(4)
+        self.delay_sim_time(4, reason="rangefinder target to settle")
         self.wait_statustext('rangefinder target is', check_context=True)
         self.watch_distance_maintained()
 
         # Disarm, allowing the vehicle to drift up
         self.disarm_vehicle()
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="vehicle to drift upward")
 
         # Re-arm. The vehicle should get a new rangefinder target and maintain distance
         self.arm_vehicle()
@@ -497,27 +497,27 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         # dive a bit to make sure we are not surfaced
         self.change_mode('STABILIZE')
         self.set_rc(Joystick.Throttle, 1350)
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="vehicle to dive")
         self.set_rc(Joystick.Throttle, 1500)
-        self.delay_sim_time(3)
+        self.delay_sim_time(3, reason="vehicle to settle after dive")
         # start the test itself, go through some modes and check if anything changes
         previous_altitude = self.assert_receive_message('VFR_HUD').alt
         self.change_mode('ALT_HOLD')
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="ALT_HOLD to take effect")
         self.change_mode('POSHOLD')
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="POSHOLD to take effect")
         self.change_mode('STABILIZE')
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="STABILIZE to take effect")
         self.change_mode(21)
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="SURFTRAK to take effect")
         self.change_mode('ALT_HOLD')
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="ALT_HOLD to take effect")
         self.change_mode('STABILIZE')
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="STABILIZE to take effect")
         self.change_mode('ALT_HOLD')
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="ALT_HOLD to take effect")
         self.change_mode(21)
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="SURFTRAK to take effect")
         self.change_mode('MANUAL')
         self.disarm_vehicle()
         final_altitude = self.assert_receive_message('VFR_HUD').alt
@@ -537,16 +537,16 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
 
         # dive a little
         self.set_rc(Joystick.Throttle, 1300)
-        self.delay_sim_time(3)
+        self.delay_sim_time(3, reason="vehicle to dive")
         self.set_rc(Joystick.Throttle, 1500)
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="vehicle to settle")
 
         # Save starting point
         self.assert_receive_message('GLOBAL_POSITION_INT', timeout=5)
         start_pos = self.mav.location()
         # Hold in perfect conditions
         self.progress("Testing position hold in perfect conditions")
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="position hold measurement period")
         distance_m = self.get_distance(start_pos, self.mav.location())
         if distance_m > 1:
             raise NotAchievedException("Position Hold was unable to keep position in calm waters within 1 meter after 10 seconds, drifted {} meters".format(distance_m))  # noqa
@@ -555,7 +555,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.progress("Testing position hold in current")
         self.set_parameter("SIM_WIND_SPD", 1)
         self.set_parameter("SIM_WIND_T", 1)
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="drift measurement in 1m/s current")
         distance_m = self.get_distance(start_pos, self.mav.location())
         if distance_m > 1:
             raise NotAchievedException("Position Hold was unable to keep position in 1m/s current within 1 meter after 10 seconds, drifted {} meters".format(distance_m))  # noqa
@@ -564,7 +564,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         start_pos = self.mav.location()
         self.progress("Testing moving forward in position hold in 1m/s current")
         self.set_rc(Joystick.Forward, 1600)
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="forward movement")
         distance_m = self.get_distance(start_pos, self.mav.location())
         bearing = self.get_bearing(start_pos, self.mav.location())
         if distance_m < 2 or (bearing > 30 and bearing < 330):
@@ -896,7 +896,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.arm_vehicle()
         self.change_mode('AUTO')
         self.wait_waypoint(1, 4, max_dist_to_final_wp_m=5)
-        self.delay_sim_time(3)
+        self.delay_sim_time(3, reason="final waypoint to settle")
 
         # Expect sub to hover at final altitude
         self.assert_altitude(-36.0)
@@ -951,7 +951,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
 
         # This should set the EKF origin, write an ORGN msg to df and a GPS_GLOBAL_ORIGIN msg to MAVLink
         self.mav.mav.set_gps_global_origin_send(1, int(47.607584 * 1e7), int(-122.343911 * 1e7), 0)
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="EKF origin to be set")
 
         if not self.current_onboard_log_contains_message('ORGN'):
             raise NotAchievedException("Did not find expected ORGN message")
@@ -1012,10 +1012,10 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.wait_ready_to_arm()
         self.assert_mag_fusion_selection(MagFuseSel.FUSE_YAW)
         self.arm_vehicle()
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="mag fusion to switch to FUSE_MAG")
         self.assert_mag_fusion_selection(MagFuseSel.FUSE_MAG)
         self.disarm_vehicle()
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="mag fusion to revert to FUSE_YAW")
         self.assert_mag_fusion_selection(MagFuseSel.FUSE_YAW)
 
         # AFTER_FIRST_CLIMB: switch to FUSE_MAG after sub is armed and descends 0.5m; switch to FUSE_YAW on disarm
@@ -1030,7 +1030,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.set_rc(Joystick.Throttle, 1500)
         self.assert_mag_fusion_selection(MagFuseSel.FUSE_MAG)
         self.disarm_vehicle()
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="mag fusion to revert to FUSE_YAW")
         self.assert_mag_fusion_selection(MagFuseSel.FUSE_YAW)
 
         # ALWAYS
@@ -1096,7 +1096,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         dprev = 0
 
         while True:
-            self.delay_sim_time(1)
+            self.delay_sim_time(1, reason="movement measurement interval")
 
             dcurr = self.get_distance(lstart, self.mav.location())
 
@@ -1121,9 +1121,9 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
 
         # dive a little
         self.set_rc(Joystick.Throttle, 1300)
-        self.delay_sim_time(3)
+        self.delay_sim_time(3, reason="vehicle to dive")
         self.set_rc(Joystick.Throttle, 1500)
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="vehicle to settle")
 
         # hold position
         self.change_mode('POSHOLD')
@@ -1136,7 +1136,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
             for pwm in range(1700, 1901, 100):
                 self.progress('PILOT_SPEED %d, forward pwm %d' % (pilot_speed, pwm))
                 self.set_rc(Joystick.Forward, pwm)
-                self.delay_sim_time(3)
+                self.delay_sim_time(3, reason="forward movement")
                 self.set_rc(Joystick.Forward, 1500)
                 self.wait_for_stop()
 
@@ -1152,7 +1152,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.reboot_sitl()
         self.context_push()
         self.set_parameter('LOG_DISARMED', 1)
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="temperature data to be logged")
         self.context_pop()
 
         dfreader = self.dfreader_for_current_onboard_log()

--- a/Tools/autotest/helicopter.py
+++ b/Tools/autotest/helicopter.py
@@ -124,7 +124,7 @@ class AutoTestHelicopter(AutoTestCopter):
         self.set_current_waypoint(1)
 
         # wait for motor runup
-        self.delay_sim_time(20)
+        self.delay_sim_time(20, reason="rotor runup to complete")
 
         # switch into AUTO mode and raise throttle
         self.change_mode('AUTO')
@@ -171,7 +171,7 @@ class AutoTestHelicopter(AutoTestCopter):
             self.wait_servo_channel_value(8, 1659, timeout=10)
 
         # wait for motor runup
-        self.delay_sim_time(20)
+        self.delay_sim_time(20, reason="rotor runup to complete")
 
         if mode == 'GUIDED':
             self.user_takeoff(alt_min=alt_min)
@@ -244,7 +244,7 @@ class AutoTestHelicopter(AutoTestCopter):
         self.set_rc(8, 2000)
         self.progress("wait for rotor runup to complete")
         self.wait_servo_channel_value(8, 1659, timeout=10)
-        self.delay_sim_time(20)
+        self.delay_sim_time(20, reason="rotor runup to complete")
         # check we are still on the ground...
         max_relalt = 1  # metres
         relative_alt = self.get_altitude(relative=True)
@@ -254,7 +254,7 @@ class AutoTestHelicopter(AutoTestCopter):
 
         self.progress("Pushing collective past half-way")
         self.set_rc(3, 1600)
-        self.delay_sim_time(0.5)
+        self.delay_sim_time(0.5, reason="collective input to settle")
         self.hover()
 
         # make sure we haven't already reached alt:
@@ -280,7 +280,7 @@ class AutoTestHelicopter(AutoTestCopter):
         self.set_rc(8, 2000)
         self.progress("wait for rotor runup to complete")
         self.wait_servo_channel_value(8, 1659, timeout=10)
-        self.delay_sim_time(20)
+        self.delay_sim_time(20, reason="rotor runup to complete")
         # check we are still on the ground...
         relative_alt = self.get_altitude(relative=True)
         if abs(relative_alt) > 0.1:
@@ -303,7 +303,7 @@ class AutoTestHelicopter(AutoTestCopter):
         self.arm_vehicle()
         self.progress("Raising rotor speed")
         self.set_rc(8, 2000)
-        self.delay_sim_time(20)
+        self.delay_sim_time(20, reason="rotor to reach speed")
         self.change_mode("AUTO")
         self.set_rc(3, 1500)
         self.wait_disarmed(timeout=600)
@@ -328,7 +328,7 @@ class AutoTestHelicopter(AutoTestCopter):
         self.set_rc(8, 2000)
         self.progress("wait for rotor runup to complete")
         self.wait_servo_channel_value(8, 1659, timeout=10)
-        self.delay_sim_time(20)
+        self.delay_sim_time(20, reason="rotor runup to complete")
         self.set_rc(3, 2000)
         self.wait_altitude(start_alt - 1,
                            (start_alt + 5),
@@ -451,7 +451,7 @@ class AutoTestHelicopter(AutoTestCopter):
             self.progress("wait for rotor runup to complete")
             check_rsc_output(self, RSC_SETPOINT, RUNUP_TIME+1)
 
-            self.delay_sim_time(20)
+            self.delay_sim_time(20, reason="rotor runup to complete")
             self.set_rc(3, 2000)
             self.wait_altitude(100,
                                105,
@@ -476,7 +476,7 @@ class AutoTestHelicopter(AutoTestCopter):
             self.progress("RSC is outputting correct idle throttle")
 
             # Wait to establish autorotation.
-            self.delay_sim_time(2)
+            self.delay_sim_time(2, reason="autorotation to establish")
 
             # Re-engage interlock to start bailout sequence
             self.set_rc(8, 2000)
@@ -489,11 +489,11 @@ class AutoTestHelicopter(AutoTestCopter):
 
             # Give time for engine to power up
             self.set_rc(3, 1400)
-            self.delay_sim_time(2)
+            self.delay_sim_time(2, reason="engine to power up")
 
             self.progress("in-flight power recovery")
             self.set_rc(3, 1500)
-            self.delay_sim_time(5)
+            self.delay_sim_time(5, reason="power recovery to stabilise")
 
             # Initiate autorotation again
             self.set_rc(3, 1000)
@@ -783,7 +783,7 @@ class AutoTestHelicopter(AutoTestCopter):
         self.set_parameter("MNT1_NEUTRAL_X", retract_roll)
         self.progress("Killing RC")
         self.set_parameter("SIM_RC_FAIL", 2)
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="RC failsafe to trigger")
         want_servo_channel_value = int(1500 + 500*retract_roll/roll_limit)
         self.wait_servo_channel_value(roll_servo, want_servo_channel_value, epsilon=1)
 
@@ -806,7 +806,7 @@ class AutoTestHelicopter(AutoTestCopter):
         self.wait_ready_to_arm()
         self.arm_vehicle()
         self.set_rc(8, 2000)    # Raise rotor speed
-        self.delay_sim_time(20)
+        self.delay_sim_time(20, reason="rotor to reach speed")
         self.change_mode("AUTO")
         self.set_rc(3, 1500)
 
@@ -961,7 +961,7 @@ class AutoTestHelicopter(AutoTestCopter):
 
         # check that turbine start activates as designed (armed with interlock disabled)
         self.progress("Checking Turbine Start activates as designed (armed with interlock disabled)")
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="vehicle to fully disarm")
         self.arm_vehicle()
 
         self.set_rc(6, 2000)

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -138,14 +138,14 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.zero_throttle()
         self.arm_vehicle()
         self.progress("Waiting for Motor1 to spool up to SPIN_ARM")
-        self.delay_sim_time(spool_delay)
+        self.delay_sim_time(spool_delay, reason="motor spool-up")
         spin_arm_pwm = self.wait_servo_channel_value(5, min_pwm, comparator=operator.gt)
         self.progress("spin_arm_pwm: %d" % spin_arm_pwm)
         self.disarm_vehicle()
 
         """arm with switch, record Motor1 SPIN_MIN PWM output and disarm"""
         self.set_rc(8, 2000)
-        self.delay_sim_time(spool_delay)
+        self.delay_sim_time(spool_delay, reason="motor spool-up")
         self.progress("Waiting for Motor1 to spool up to SPIN_MIN")
         spin_min_pwm = self.wait_servo_channel_value(5, spin_arm_pwm, comparator=operator.gt)
         self.progress("spin_min_pwm: %d" % spin_min_pwm)
@@ -211,7 +211,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             self.progress("Arming with switch at zero throttle")
             self.arm_motors_with_switch(arm_ch)
             self.progress("Waiting for Motor1 to (not) speed up")
-            self.delay_sim_time(spool_delay)
+            self.delay_sim_time(spool_delay, reason="motor spool-up period")
             self.wait_servo_channel_value(5, spin_arm_pwm, comparator=operator.le)
             self.wait_servo_channel_value(6, spin_arm_pwm, comparator=operator.le)
             self.wait_servo_channel_value(7, spin_arm_pwm, comparator=operator.le)
@@ -764,7 +764,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.wait_mode('AUTO')
         self.reboot_sitl()
         self.wait_ready_to_arm()
-        self.delay_sim_time(20)
+        self.delay_sim_time(20, reason="EKF to initialise")
         self.assert_current_waypoint(1)
         self.arm_vehicle()
         self.wait_altitude(9, 11, relative=True)  # value from mission file is 10
@@ -802,7 +802,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
 
         self.takeoff(10, mode="QLOITER")
         self.set_rc(2, 1000)
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="forward movement into wind")
         # Check that it is using some forward throttle
         fwd_thr_pwm = self.get_servo_channel_value(3)
         if fwd_thr_pwm < 1150 :
@@ -813,10 +813,10 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         if abs(pitch + 3.0) > 0.5 :
             raise NotAchievedException("pitch should be -3.0 +- 0.5 deg, got %f" % (pitch))
         self.set_rc(2, 1500)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="position to stabilise")
         loc1 = self.mav.location()
         self.set_parameter("SIM_ENGINE_FAIL", 1 << 2) # simulate a complete loss of forward motor thrust
-        self.delay_sim_time(20)
+        self.delay_sim_time(20, reason="engine failure effect")
         self.change_mode('QLAND')
         self.wait_disarmed(timeout=60)
         loc2 = self.mav.location()
@@ -868,7 +868,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
                                       thr_min_pwm,
                                       timeout=30,
                                       comparator=operator.eq)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="motors to stop after transition")
         self.wait_servo_channel_value(5,
                                       thr_min_pwm,
                                       timeout=30,
@@ -953,7 +953,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.context_collect('STATUSTEXT')
         self.progress("Pitching up to %.0f degrees" % lim_pitch_up_deg)
         self.set_rc(3, 2000)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="pitch angle to build")
         self.change_mode('MANUAL')
         self.context_push()
         self.set_parameter("SIM_SPEEDUP", 1)
@@ -1201,7 +1201,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.progress("Starting LOITER")
         self.change_mode("LOITER")
         self.context_collect("STATUSTEXT")
-        self.delay_sim_time(20)  # Wait for the transition to be done and no longer assisting.
+        self.delay_sim_time(20, reason="transition to complete")  # Wait for the transition to be done and no longer assisting.
         servo_pwm = self.get_servo_channel_value(servo_under_test)
         if servo_pwm != min_pwm:
             raise NotAchievedException(f"The VTOL motor did not stop: {servo_pwm} != {min_pwm}")
@@ -1291,7 +1291,8 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             self.set_parameter("ICE_RPM_CHAN", 120) # Set to a non-existent sensor
             self.set_rc(rc_engine_start_chan, 2000)
             self.wait_statustext("Engine max crank attempts reached", check_context=True, timeout=30)
-            self.delay_sim_time(30) # wait for another 30 seconds to make sure the engine doesn't restart
+            # wait for another 30 seconds to make sure the engine doesn't restart
+            self.delay_sim_time(30, reason="engine restart check")
             messages = self.context_get().collections["STATUSTEXT"]
             self.context_stop_collecting("STATUSTEXT")
             # check for the exact number of starter attempts
@@ -1409,7 +1410,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             self.start_subtest("Check start chan control disable")
             old_start_channel_value = self.get_rc_channel_value(rc_engine_start_chan)
             self.set_rc(rc_engine_start_chan, 1000)
-            self.delay_sim_time(1) # Make sure the RC change has registered
+            self.delay_sim_time(1, reason="RC change to register") # Make sure the RC change has registered
             self.context_collect('STATUSTEXT')
             method(mavutil.mavlink.MAV_CMD_DO_ENGINE_CONTROL, p1=1, want_result=mavutil.mavlink.MAV_RESULT_FAILED)
             self.wait_statustext("start control disabled", check_context=True)
@@ -1517,7 +1518,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.start_flying_mission('mission.txt')
         self.wait_current_waypoint(4, timeout=240)
         self.assert_altitude(120, accuracy=5, relative=True)
-        self.delay_sim_time(30)
+        self.delay_sim_time(30, reason="altitude to remain stable")
         self.assert_altitude(120, accuracy=5, relative=True)
         self.set_current_waypoint(5)
         self.wait_altitude(altitude_min=65, altitude_max=75, relative=True)
@@ -1653,7 +1654,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             'SIM_ENGINE_FAIL': 1 << 0,
         })
 
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="engine failure effect")
 
         # and restore it
         self.set_parameter('SIM_ENGINE_MUL', 1)
@@ -1804,7 +1805,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
     def RCDisableAirspeedUse(self):
         '''check disabling airspeed using RC switch'''
         self.set_parameter("RC9_OPTION", 106)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="RC option to register")
         self.set_rc(9, 1000)
         self.wait_sensor_state(
             mavutil.mavlink.MAV_SYS_STATUS_SENSOR_DIFFERENTIAL_PRESSURE,
@@ -1925,7 +1926,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.arm_vehicle()
         self.wait_current_waypoint(2)
         # Wait for 5 seconds into the transition.
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="transition to progress")
         # Ensure TKOFF_THR_MIN is still respected.
         thr_min = self.get_parameter('TKOFF_THR_MIN')
         self.wait_servo_channel_value(3, 1000+thr_min*10, comparator=operator.eq)
@@ -2044,7 +2045,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
 
         # Switch to DCM
         self.set_parameter('AHRS_EKF_TYPE', 0)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="DCM to initialise")
 
         # Start Climbing
         self.set_rc(3, 2000)
@@ -2055,7 +2056,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             'SIM_GPS1_ENABLE': 0,
             'SIM_GPS2_ENABLE': 0,
         })
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="GPS disable to take effect")
 
         # Start Descending
         self.set_rc(3, 1000)
@@ -2136,9 +2137,9 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.reboot_sitl()
 
         self.wait_mode('FBWA')  # initial mode from parameter
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="FBWA log entries")
         self.change_mode('QHOVER')
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="QHOVER log entries")
 
         self.wait_ready_to_arm()
         self.arm_vehicle()
@@ -2150,10 +2151,10 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.wait_statustext('Transition started airspeed', check_context=True)
         self.wait_statustext('Transition airspeed reached', check_context=True)
         self.wait_statustext('Transition done', check_context=True)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="transition data to be logged")
         self.change_mode('QHOVER')
         self.wait_airspeed(0, 5)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="airspeed to drop")
         mlog_path = self.current_onboard_log_filepath()
         self.fly_home_land_and_disarm(timeout=600)
 
@@ -2317,7 +2318,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.change_mode('TAKEOFF')
         self.wait_ready_to_arm()
         self.arm_vehicle()
-        self.delay_sim_time(180)
+        self.delay_sim_time(180, reason="wind estimate data collection")
         mlog = self.dfreader_for_current_onboard_log()
         self.fly_home_land_and_disarm()
 
@@ -2408,7 +2409,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         NTESTS = 20
         for t in range(NTESTS):
             self.change_mode("FBWA")
-            self.delay_sim_time(3)
+            self.delay_sim_time(3, reason="mode change to stabilise")
             self.progress("Fast Recovery test %u" % t)
             self.arm_vehicle(force=True)
             self.wait_groundspeed(0, 2, timeout=15)
@@ -2437,7 +2438,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
 
         for t in range(NTESTS):
             self.change_mode("FBWA")
-            self.delay_sim_time(3)
+            self.delay_sim_time(3, reason="mode change to stabilise")
             self.progress("Slow Recovery test %u" % t)
             self.arm_vehicle(force=True)
             self.wait_attitude(desroll=0, despitch=0, timeout=10, tolerance=5)
@@ -2500,10 +2501,10 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         NTESTS = 20
         for t in range(NTESTS):
             self.change_mode("FBWA")
-            self.delay_sim_time(3)
+            self.delay_sim_time(3, reason="mode change to stabilise")
             self.progress("Fast CRUISE Recovery test %u" % t)
             self.arm_vehicle(force=True)
-            self.delay_sim_time(3)
+            self.delay_sim_time(3, reason="recovery to begin")
             # reset target alt and heading using stick inputs
             self.set_rc(2, 1600)
             self.set_rc(2, 1500)
@@ -2536,10 +2537,10 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
 
         for t in range(NTESTS):
             self.change_mode("FBWA")
-            self.delay_sim_time(3)
+            self.delay_sim_time(3, reason="mode change to stabilise")
             self.progress("Slow CRUISE Recovery test %u" % t)
             self.arm_vehicle(force=True)
-            self.delay_sim_time(3)
+            self.delay_sim_time(3, reason="recovery to begin")
             # reset target alt and heading using stick inputs
             self.set_rc(2, 1600)
             self.set_rc(2, 1500)
@@ -2581,7 +2582,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.progress("Go to inverted flight")
         self.run_auxfunc(43, 2)
         self.wait_roll(180, 3, absolute_value=True)
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="inverted flight to stabilise")
 
         initial_altitude = self.get_altitude(relative=True, timeout=2)
         self.change_mode('QHOVER')
@@ -2621,7 +2622,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             timeout=600,
             height_accuracy=10,
         )
-        self.delay_sim_time(20)
+        self.delay_sim_time(20, reason="terrain altitude to settle")
 
         self.wait_altitude(
             dest.alt-10,  # NOTE: reuse of alt from abovE
@@ -2684,7 +2685,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
                 timeout=600,
                 height_accuracy=10,
             )
-            self.delay_sim_time(10)
+            self.delay_sim_time(10, reason="terrain altitude to settle")
             self.wait_altitude(
                 loc.alt-5,
                 loc.alt+5,
@@ -2781,7 +2782,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
                 timeout=600,
                 height_accuracy=10,
             )
-            self.delay_sim_time(10)
+            self.delay_sim_time(10, reason="terrain altitude to settle")
             self.wait_altitude(
                 loc.alt-5,
                 loc.alt+5,
@@ -2967,7 +2968,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
                 last_terrain_report_pending = report.pending
                 tstart = now
 
-            self.delay_sim_time(1)
+            self.delay_sim_time(1, reason="terrain tile download interval")
 
         self.progress(self.dump_message_verbose(report))
         self.wait_ready_to_arm()
@@ -3145,7 +3146,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.set_parameter('SIM_WIND_SPD', 3)
         # The script runs every 1 simulated second; wait 30s to give it
         # enough iterations to detect any spurious warning
-        self.delay_sim_time(30)
+        self.delay_sim_time(30, reason="wind script to check threshold")
         if self.statustext_in_collections("Wind warning"):
             raise NotAchievedException("Got unexpected wind warning with wind=3m/s")
         if self.statustext_in_collections("Wind failsafe"):
@@ -3155,7 +3156,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         # Allow the EKF to converge at warning-level wind before exercising the
         # warning threshold; EKF wind estimation requires sustained fixed-wing flight
         self.set_parameter('SIM_WIND_SPD', 13)
-        self.delay_sim_time(200)
+        self.delay_sim_time(200, reason="EKF wind estimation to converge")
 
         self.start_subtest("Warning repeated approximately every 15 seconds, no failsafe")
         self.context_push()
@@ -3190,7 +3191,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.context_collect('STATUSTEXT')
         # SIM_WIND_SPD is 14 (restored by failsafe context_pop), in warning range;
         # wait more than one interval (15s) to confirm the script has stopped
-        self.delay_sim_time(35)
+        self.delay_sim_time(35, reason="wind script to confirm stopped")
         if self.statustext_in_collections("Wind warning"):
             raise NotAchievedException("Wind warning received after script should have exited")
         if self.statustext_in_collections("Wind failsafe"):

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -676,7 +676,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                     "on": value,
                 })
             self.context_pop()
-            self.delay_sim_time(3)
+            self.delay_sim_time(3, reason="relay state to propagate")
             self.assert_received_message_field_values('RELAY_STATUS', {
                 "on": 1,  # back to initial state
             })
@@ -996,7 +996,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
 
         self.progress("Ensuring timeout works")
         self.wait_rc_channel_value(ch, 1000, timeout=5)
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="RC override timeout")
 
         self.set_parameter("RC_OVERRIDE_TIME", 10)
         self.progress("Sending override message")
@@ -1044,7 +1044,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 raise NotAchievedException("Value reverted after %f seconds when it should not have (got=%u) (want=%u)" % (delta, m_value, ch_override_value))  # noqa
         self.set_parameter("RC_OVERRIDE_TIME", old)
 
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="RC override to revert")
 
         self.start_subtest("Checking higher-channel semantics")
         self.context_push()
@@ -1255,11 +1255,11 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.reboot_sitl()
         self.wait_mode(1)
         self.progress("Make sure we stay in this mode")
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="mode persistence check")
         self.wait_mode(1)
         # now change modes with a switch:
         self.set_rc(throttle_ch, 1100)
-        self.delay_sim_time(3)
+        self.delay_sim_time(3, reason="RC throttle to register")
         self.set_rc(mode_ch, mapping[5])
         self.wait_mode('STEERING')
 
@@ -1788,17 +1788,17 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             self.wait_ready_to_arm()
             self.arm_vehicle()
             self.set_rc(3, 2000)
-            self.delay_sim_time(5)
+            self.delay_sim_time(5, reason="vehicle to move")
             self.set_rc(3, 1500)
         # Trigger telemetry loss with failsafe disabled. Verify no action taken.
         self.start_subtest("GCS failsafe disabled test: FS_GCS_ENABLE=0 should take no failsafe action")
         self.setGCSfailsafe(0)
         go_somewhere()
         self.set_heartbeat_rate(0)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="GCS failsafe timeout")
         self.wait_mode("MANUAL")
         self.set_heartbeat_rate(self.speedup)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="heartbeat restoration")
         self.wait_mode("MANUAL")
         self.end_subtest("Completed GCS failsafe disabled test")
 
@@ -1841,10 +1841,10 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.setGCSfailsafe(2)
         self.load_mission("test_arming.txt")
         self.change_mode("AUTO")
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="mission waypoints to start")
         self.set_heartbeat_rate(0)
         self.wait_statustext("Failsafe - Continuing Auto Mode", timeout=60)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="failsafe continuation check")
         self.wait_mode("AUTO")
         self.set_heartbeat_rate(self.speedup)
         self.wait_statustext("GCS Failsafe Cleared", timeout=60)
@@ -1856,7 +1856,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.set_parameter("FS_GCS_TIMEOUT", new_gcs_timeout)
         go_somewhere()
         self.set_heartbeat_rate(0)
-        self.delay_sim_time(old_gcs_timeout + (new_gcs_timeout - old_gcs_timeout) / 2)
+        self.delay_sim_time(old_gcs_timeout + (new_gcs_timeout - old_gcs_timeout) / 2, reason="GCS timeout midpoint")
         self.assert_mode("MANUAL")
         self.wait_mode("RTL")
         self.wait_statustext("Reached destination", timeout=60)
@@ -2046,7 +2046,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         mavproxy = self.start_mavproxy()
         self.start_subsubtest("fence addcircle")
         self.clear_fence_using_mavproxy(mavproxy)
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="fence clear to propagate")
         radius = 20
         item = self.mav.mav.mission_item_int_encode(
             target_system,
@@ -2067,7 +2067,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         print("item is (%s)" % str(item))
         self.click_location_from_item(mavproxy, item)
         mavproxy.send("fence addcircle inc %u\n" % radius)
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="fence upload to complete")
         downloaded_items = self.download_using_mission_protocol(mavutil.mavlink.MAV_MISSION_TYPE_FENCE)
         print("downloaded items: %s" % str(downloaded_items))
         self.check_fence_items_same([item], downloaded_items)
@@ -2091,7 +2091,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             mavutil.mavlink.MAV_MISSION_TYPE_FENCE)
         self.click_location_from_item(mavproxy, item2)
         mavproxy.send("fence addcircle exc %f\n" % radius_exc)
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="fence upload to complete")
         downloaded_items = self.download_using_mission_protocol(mavutil.mavlink.MAV_MISSION_TYPE_FENCE)
         print("downloaded items: %s" % str(downloaded_items))
         self.check_fence_items_same([item, item2], downloaded_items)
@@ -2099,10 +2099,10 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
 
         self.start_subsubtest("fence addpoly")
         self.clear_fence_using_mavproxy(mavproxy)
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="fence clear to propagate")
         pointcount = 7
         mavproxy.send("fence addpoly inc 20 %u 37.2\n" % pointcount) # radius, pointcount, rotation
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="fence upload to complete")
         downloaded_items = self.download_using_mission_protocol(mavutil.mavlink.MAV_MISSION_TYPE_FENCE)
         if len(downloaded_items) != pointcount:
             raise NotAchievedException("Did not get expected number of points returned (want=%u got=%u)" %
@@ -2111,19 +2111,19 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
 
         self.start_subsubtest("fence movepolypoint")
         self.clear_fence_using_mavproxy(mavproxy)
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="fence clear to propagate")
         triangle = self.test_gcs_fence_boring_triangle(
             target_system=target_system,
             target_component=target_component)
         self.upload_using_mission_protocol(mavutil.mavlink.MAV_MISSION_TYPE_FENCE,
                                            triangle)
         mavproxy.send("fence list\n")
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="fence list to display")
         triangle[2].x += 500
         triangle[2].y += 700
         self.click_location_from_item(mavproxy, triangle[2])
         mavproxy.send("fence movepolypoint 0 2\n")
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="fence point move to propagate")
         downloaded_items = self.download_using_mission_protocol(mavutil.mavlink.MAV_MISSION_TYPE_FENCE)
         self.check_fence_items_same(triangle, downloaded_items)
         self.end_subsubtest("fence movepolypoint")
@@ -2225,7 +2225,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             mavutil.mavlink.MAV_MISSION_TYPE_FENCE,
             want_type=mavutil.mavlink.MAV_MISSION_INVALID_SEQUENCE,
         )
-        self.delay_sim_time(0.1)
+        self.delay_sim_time(0.1, reason="mission count collection")
         found = False
         for m in self.context_collection('MISSION_COUNT'):
             if m.mission_type != mavutil.mavlink.MAV_MISSION_TYPE_FENCE:
@@ -2483,13 +2483,13 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         # there are race conditions in MAVProxy.  Beware.
         mavproxy.send("click 1.0 1.0\n")
         mavproxy.send("rally add\n")
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="rally upload to propagate")
         mavproxy.send("click 2.0 2.0\n")
         mavproxy.send("rally add\n")
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="rally upload to propagate")
         mavproxy.send("click 3.0 3.0\n")
         mavproxy.send("rally add\n")
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="rally upload to complete")
         self.assert_mission_count_on_link(
             self.mav,
             3,
@@ -2516,7 +2516,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         mavproxy.send(f'click {lat_s} {lng_s}\n')
         self.drain_mav()
         mavproxy.send('rally add\n')
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="rally upload to propagate")
         downloaded_items = self.download_using_mission_protocol(mavutil.mavlink.MAV_MISSION_TYPE_RALLY)
         if len(downloaded_items) != 1:
             raise NotAchievedException("Unexpected count (got=%u want=1)" %
@@ -2606,7 +2606,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         mavproxy.send("rally add\n")
         mavproxy.send("click 2.0 2.0\n")
         mavproxy.send("rally add\n")
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="rally upload to propagate")
         self.assert_mission_count_on_link(
             self.mav,
             2,
@@ -2619,7 +2619,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.wait_heartbeat()
         self.wait_heartbeat()
         mavproxy.send("rally changealt 2 19.1\n")
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="rally alt change to propagate")
 
         downloaded_items = self.download_using_mission_protocol(mavutil.mavlink.MAV_MISSION_TYPE_RALLY)
         if len(downloaded_items) != 2:
@@ -2644,7 +2644,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
 
         self.progress("Now change two at once")
         mavproxy.send("rally changealt 1 17.3 2\n")
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="rally alt change to propagate")
         mavproxy.send('rally list\n')
         self.drain_mav()
         self.wait_heartbeat()
@@ -2679,7 +2679,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         mavproxy.send("rally add\n")
         mavproxy.send("click 2.0 2.0\n")
         mavproxy.send("rally add\n")
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="rally upload to propagate")
         self.assert_mission_count_on_link(
             self.mav,
             2,
@@ -2689,10 +2689,10 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         )
         mavproxy.send("click 3.0 3.0\n")
         mavproxy.send("rally move 2\n")
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="rally move to propagate")
         mavproxy.send("click 4.12345 4.987654\n")
         mavproxy.send("rally move 1\n")
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="rally move to propagate")
 
         downloaded_items = self.download_using_mission_protocol(mavutil.mavlink.MAV_MISSION_TYPE_RALLY)
         if len(downloaded_items) != 2:
@@ -2722,7 +2722,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         pure_items = self.download_using_mission_protocol(mavutil.mavlink.MAV_MISSION_TYPE_RALLY)
         self.progress("Removing last in list")
         mavproxy.send("rally remove 3\n")
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="rally remove to propagate")
         self.assert_mission_count_on_link(
             self.mav,
             2,
@@ -2739,7 +2739,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
 
         self.progress("Removing first in list")
         mavproxy.send("rally remove 1\n")
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="rally remove to propagate")
         self.assert_mission_count_on_link(
             self.mav,
             1,
@@ -2755,7 +2755,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
 
         self.progress("Removing remaining item")
         mavproxy.send("rally remove 1\n")
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="rally remove to propagate")
         self.assert_mission_count_on_link(
             self.mav,
             0,
@@ -2775,7 +2775,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         util.pexpect_drain(mavproxy)
         savelocal_path = self.buildlogs_path("rally-testing-tmp-local.txt")
         mavproxy.send('rally savelocal %s\n' % savelocal_path)
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="file save to complete")
         self.assert_rally_filepath_content(savelocal_path, '''QGC WPL 110
 0	0	3	5100	0.000000	0.000000	0.000000	0.000000	-5.678900	98.234100	87.000000	0
 ''')
@@ -2796,7 +2796,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         pure_items = self.download_using_mission_protocol(mavutil.mavlink.MAV_MISSION_TYPE_RALLY)
         self.progress("Removing first in list")
         mavproxy.send("rally remove 1\n")
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="rally remove to propagate")
         self.assert_mission_count_on_link(
             self.mav,
             2,
@@ -2805,7 +2805,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             mavutil.mavlink.MAV_MISSION_TYPE_RALLY,
         )
         mavproxy.send("rally undo\n")
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="rally undo to propagate")
         undone_items = self.download_using_mission_protocol(mavutil.mavlink.MAV_MISSION_TYPE_RALLY)
         self.check_rally_items_same(pure_items, undone_items)
 
@@ -2815,9 +2815,9 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         mavproxy.send("click 4.12345 4.987654\n")
         mavproxy.send("rally move 1\n")
         # move has already been tested, assume it works...
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="rally move to propagate")
         mavproxy.send("rally undo\n")
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="rally undo to propagate")
         undone_items = self.download_using_mission_protocol(mavutil.mavlink.MAV_MISSION_TYPE_RALLY)
         self.check_rally_items_same(pure_items, undone_items)
 
@@ -3509,7 +3509,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
 #        oldalt = downloaded_items[changealt_item].z
         want_newalt = 37.2
         mavproxy.send('wp changealt %u %f\n' % (changealt_item, want_newalt))
-        self.delay_sim_time(15)
+        self.delay_sim_time(15, reason="waypoint alt change to propagate")
         downloaded_items = self.download_using_mission_protocol(mavutil.mavlink.MAV_MISSION_TYPE_MISSION)
         if abs(downloaded_items[changealt_item].z - want_newalt) > 0.0001:
             raise NotAchievedException(
@@ -3522,7 +3522,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         new_home_lng = 2.71828
         mavproxy.send('click %f %f\n' % (new_home_lat, new_home_lng))
         mavproxy.send('wp sethome\n')
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="home waypoint to be set")
         # any way to close the loop on this one?
         # downloaded_items = self.download_using_mission_protocol(mavutil.mavlink.MAV_MISSION_TYPE_MISSION)
         # if abs(downloaded_items[0].x - new_home_lat) > 0.0001:
@@ -3534,7 +3534,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.start_subsubtest("wp slope")
         mavproxy.send('wp slope\n')
         mavproxy.expect("WP3: slope 0.1")
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="waypoint slope calculation")
         self.end_subsubtest("wp slope")
 
         if not self.mavproxy_can_do_mision_item_protocols():
@@ -3543,9 +3543,9 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
 
         self.start_subsubtest("wp split")
         mavproxy.send("wp clear\n")
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="waypoint clear to propagate")
         mavproxy.send("wp list\n")
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="waypoint list to display")
         items = [
             None,
             self.mav.mav.mission_item_int_encode(
@@ -3583,17 +3583,17 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         ]
         mavproxy.send("click 5 5\n") # space for home position
         mavproxy.send("wp add\n")
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="waypoint add to propagate")
         self.click_location_from_item(mavproxy, items[1])
         mavproxy.send("wp add\n")
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="waypoint add to propagate")
         self.click_location_from_item(mavproxy, items[2])
         mavproxy.send("wp add\n")
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="waypoint add to propagate")
         downloaded_items = self.download_using_mission_protocol(mavutil.mavlink.MAV_MISSION_TYPE_MISSION)
         self.check_mission_waypoint_items_same(items, downloaded_items)
         mavproxy.send("wp split 2\n")
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="waypoint split to propagate")
         items_with_split_in = [
             items[0],
             items[1],
@@ -3880,7 +3880,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.set_parameters({
             "FENCE_TYPE": 2,    # circle only
         })
-        self.delay_sim_time(5) # let breaches clear
+        self.delay_sim_time(5, reason="fence breaches to clear") # let breaches clear
         # FIXME: should we allow this?
         self.progress("Ensure we can arm with no poly in place")
         self.change_mode("GUIDED")
@@ -3941,7 +3941,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         ]
         self.upload_using_mission_protocol(mavutil.mavlink.MAV_MISSION_TYPE_FENCE,
                                            items)
-        self.delay_sim_time(5) # ArduPilot only checks for breaches @1Hz
+        self.delay_sim_time(5, reason="fence breach check") # ArduPilot only checks for breaches @1Hz
         self.drain_mav()
         self.assert_fence_breached()
         try:
@@ -3997,7 +3997,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         ]
         self.upload_using_mission_protocol(mavutil.mavlink.MAV_MISSION_TYPE_FENCE,
                                            items)
-        self.delay_sim_time(5) # ArduPilot only checks for breaches @1Hz
+        self.delay_sim_time(5, reason="fence breach check") # ArduPilot only checks for breaches @1Hz
         self.drain_mav()
         self.assert_fence_breached()
         try:
@@ -4033,7 +4033,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 self.offset_location_ne(here, 50, -50), # tl,
             ]),
         ])
-        self.delay_sim_time(5) # ArduPilot only checks for breaches @1Hz
+        self.delay_sim_time(5, reason="fence breach check") # ArduPilot only checks for breaches @1Hz
         self.drain_mav()
         self.assert_fence_breached()
         try:
@@ -4069,7 +4069,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 self.offset_location_ne(here, 50, -50), # tl,
             ]),
         ])
-        self.delay_sim_time(5) # ArduPilot only checks for breaches @1Hz
+        self.delay_sim_time(5, reason="fence breach check") # ArduPilot only checks for breaches @1Hz
         self.drain_mav()
         self.assert_fence_breached()
         try:
@@ -4332,7 +4332,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             # handy for getting pretty pictures
             self.mavproxy.send("fence list\n")
 
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="fence to be uploaded")
         self.progress("Drive outside top circle")
         fence_middle = self.offset_location_ne(here, -150, 0)
         self.drive_somewhere_breach_boundary_and_rtl(
@@ -4340,7 +4340,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             target_system=target_system,
             target_component=target_component)
 
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="RTL to complete")
         self.progress("Drive outside bottom circle")
         fence_middle = self.offset_location_ne(here, 150, 0)
         self.drive_somewhere_breach_boundary_and_rtl(
@@ -4368,7 +4368,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             }),
         ])
 
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="fence to be uploaded")
         if self.mavproxy is not None:
             self.mavproxy.send("fence list\n")
         self.progress("Drive outside polygon")
@@ -4378,7 +4378,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             target_system=target_system,
             target_component=target_component)
 
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="RTL to complete")
         self.progress("Drive outside circle")
         fence_middle = self.offset_location_ne(here, 150, 0)
         self.drive_somewhere_breach_boundary_and_rtl(
@@ -4401,7 +4401,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             ]),
         ])
 
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="fence to be uploaded")
         if self.mavproxy is not None:
             self.mavproxy.send("fence list\n")
         self.progress("Drive outside top polygon")
@@ -4411,7 +4411,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             target_system=target_system,
             target_component=target_component)
 
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="RTL to complete")
         self.progress("Drive outside bottom polygon")
         fence_middle = self.offset_location_ne(here, 150, 0)
         self.drive_somewhere_breach_boundary_and_rtl(
@@ -4441,7 +4441,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 "loc": self.offset_location_ne(here, -60, 0),
             }),
         ])
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="fence to be uploaded")
         if self.mavproxy is not None:
             self.mavproxy.send("fence list\n")
 
@@ -4452,7 +4452,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                                                      target_component=target_component)
 
         self.progress("delaying - hack to work around manual recovery bug")
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="manual recovery from breach")
 
         self.progress("Breach western boundary")
         fence_middle = self.offset_location_ne(here, 0, -30)
@@ -4461,7 +4461,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                                                      target_component=target_component)
 
         self.progress("delaying - hack to work around manual recovery bug")
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="manual recovery from breach")
 
         self.progress("Breach southern circle")
         fence_middle = self.offset_location_ne(here, -150, 0)
@@ -4479,7 +4479,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.progress("Driving North")
         self.reach_heading_manual(0)
         self.set_rc(3, 2000)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="vehicle to travel north")
         self.set_rc(3, 1000)
         self.wait_groundspeed(0, 1)
         loc = self.mav.location()
@@ -4487,7 +4487,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.set_rc(3, 2000)
         self.reach_heading_manual(90)
         self.set_rc(3, 2000)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="vehicle to travel east")
         self.set_rc(3, 1000)
 
         self.progress("Entering smartrtl")
@@ -4831,7 +4831,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.set_parameter("SCR_ENABLE", 1)
         self.install_example_script_context("simple_loop.lua")
         self.reboot_sitl()
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="Lua script to initialise")
 
         self.context_pop()
         self.reboot_sitl()
@@ -5101,7 +5101,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         )
 
     def send_obstacle_distances_expect_distance_sensor_messages(self, obstacle_distances_in, expect_distance_sensor_messages):
-        self.delay_sim_time(11)  # allow obstacles to time out
+        self.delay_sim_time(11, reason="obstacles to time out")  # allow obstacles to time out
         self.do_timesync_roundtrip()
         expect_distance_sensor_messages_copy = expect_distance_sensor_messages[:]
         last_sent = 0
@@ -5114,7 +5114,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             m = self.mav.recv_match(type='DISTANCE_SENSOR', blocking=True, timeout=1)
             self.progress("Got (%s)" % str(m))
             if m is None:
-                self.delay_sim_time(1)
+                self.delay_sim_time(1, reason="sensor message poll interval")
                 continue
             orientation = m.orientation
             found = False
@@ -5362,7 +5362,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             self.send_do_reposition(int(target.lat * 1e7), int(target.lng * 1e7))
             self.wait_location(target, accuracy=5, height_accuracy=None, timeout=60)
             self.progress("Dwelling at %s for 10s" % name)
-            self.delay_sim_time(10)
+            self.delay_sim_time(10, reason="heading stabilisation at waypoint")
 
         total = state['total_change']
         self.progress("Total yaw change %.0f deg over %u trips" % (total, trip + 1))
@@ -5663,7 +5663,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         # Wait for the rover to reach and begin the circle waypoint
         self.wait_current_waypoint(2, timeout=60)
 
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="circle waypoint traversal")
 
         # Check that POSITION_TARGET_GLOBAL_INT reports the correct AMSL
         # altitude
@@ -5888,7 +5888,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         # Set SIM parameter after reboot when AIS sim is loaded
         self.set_parameter("SIM_AIS_COUNT", 5)
 
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="AIS simulation to initialise")
 
         m = self.assert_receive_message('AIS_VESSEL', timeout=60)
 
@@ -6632,7 +6632,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 self.offset_location_ne(here, 50, -50), # tl,
             ]),
         ])
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="fence to be uploaded")
         self.wait_ready_to_arm()
 
         self.reboot_sitl()
@@ -7126,7 +7126,7 @@ return update()
         target_lat = home.latitude + 10000
         target_lon = home.longitude
         self.send_do_reposition(target_lat, target_lon)
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="reposition to register")
         m = self.assert_received_message_field_values("UTM_GLOBAL_POSITION", {
             "next_lat": target_lat,
             "next_lon": target_lon,

--- a/Tools/autotest/test_param_upgrade.py
+++ b/Tools/autotest/test_param_upgrade.py
@@ -99,7 +99,7 @@ class TestParamUpgradeTestSuiteSetParameters(TestParamUpgradeTestSuite):
         self.set_parameters(sets)
 
         # stopping SITL too soon can leave eeprom.bin corrupt!
-        self.delay_sim_time(2)  # FIXTHAT, should not be needed!
+        self.delay_sim_time(2, reason="EEPROM write to complete")  # FIXTHAT, should not be needed!
 
         self.stop_SITL()
 

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -3577,7 +3577,7 @@ class TestSuite(abc.ABC):
             raise NotAchievedException("Expected GPS to be OK")
         self.assert_sensor_state(mavutil.mavlink.MAV_SYS_STATUS_SENSOR_GPS, True, True, True)
         self.set_parameter("SIM_GPS1_TYPE", 0)
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="GPS disable to take effect")
         self.assert_sensor_state(mavutil.mavlink.MAV_SYS_STATUS_SENSOR_GPS, False, False, False)
         m = self.poll_message("HIGH_LATENCY2")
         self.progress(self.dump_message_verbose(m))
@@ -3586,7 +3586,7 @@ class TestSuite(abc.ABC):
 
         self.start_subtest("HIGH_LATENCY2 location")
         self.set_parameter("SIM_GPS1_TYPE", 1)
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="GPS to re-enable")
         m = self.poll_message("HIGH_LATENCY2")
         self.progress(self.dump_message_verbose(m))
         loc = mavutil.location(m.latitude, m.longitude, m.altitude, 0)
@@ -3675,7 +3675,7 @@ class TestSuite(abc.ABC):
 
                 self.start_subsubtest("Not get HIGH_LATENCY2 upon HL disable")
                 self.run_cmd_enable_high_latency(False, run_cmd=run_cmd)
-                self.delay_sim_time(10)
+                self.delay_sim_time(10, reason="HIGH_LATENCY2 to stop")
                 self.assert_not_receive_message('HIGH_LATENCY2', mav=self.mav, timeout=10)
                 self.drain_mav(mav2)
                 self.assert_not_receive_message('HIGH_LATENCY2', mav=mav2, timeout=10)
@@ -3698,7 +3698,7 @@ class TestSuite(abc.ABC):
 
             self.start_subsubtest("Not get HIGH_LATENCY2 after disabling after playing with rates")
             self.assert_not_receive_message('HIGH_LATENCY2', mav=self.mav, timeout=10)
-            self.delay_sim_time(1)
+            self.delay_sim_time(1, reason="HIGH_LATENCY2 drain period")
             self.drain_mav(mav2)
             self.assert_not_receive_message('HIGH_LATENCY2', mav=mav2, timeout=10)
 
@@ -3840,9 +3840,9 @@ class TestSuite(abc.ABC):
         def add_and_verify_log(test_log_num):
             self.wait_ready_to_arm()
             self.arm_vehicle()
-            self.delay_sim_time(1)
+            self.delay_sim_time(1, reason="log entry on arm")
             self.disarm_vehicle()
-            self.delay_sim_time(10)
+            self.delay_sim_time(10, reason="log file to be created")
             verify_logs(test_log_num + 1)
 
         def create_and_verify_logs(test_log_num, clear_logsdir=True):
@@ -3886,7 +3886,7 @@ class TestSuite(abc.ABC):
         for i in range(0, 10):
             self.wait_ready_to_arm()
             self.arm_vehicle()
-            self.delay_sim_time(1)
+            self.delay_sim_time(1, reason="log data to accumulate")
             self.disarm_vehicle()
         new_log_list = self.log_list()
         new_log_count = len(new_log_list) - len(original_log_list)
@@ -4094,7 +4094,7 @@ class TestSuite(abc.ABC):
         content = self.download_log(number)
         print(f"Content is of length {len(content)}")
         # current_log_filepath = self.current_onboard_log_filepath()
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="logging to restart")
         new_number = self.current_onboard_log_number()
         if number == new_number:
             raise NotAchievedException("Did not start logging again")
@@ -4159,11 +4159,11 @@ class TestSuite(abc.ABC):
     def save_wp(self, ch=7):
         """Trigger RC Aux to save waypoint."""
         self.set_rc(ch, 1000)
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="RC channel to go low")
         self.set_rc(ch, 2000)
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="RC channel to go high")
         self.set_rc(ch, 1000)
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="RC channel to go low")
 
     def correct_wp_seq_numbers(self, wps):
         # renumber the items:
@@ -4288,9 +4288,9 @@ class TestSuite(abc.ABC):
         """Trigger RC Aux to clear waypoint."""
         self.progress("Clearing waypoints")
         self.set_rc(ch, 1000)
-        self.delay_sim_time(0.5)
+        self.delay_sim_time(0.5, reason="RC channel to go low")
         self.set_rc(ch, 2000)
-        self.delay_sim_time(0.5)
+        self.delay_sim_time(0.5, reason="RC channel to go high")
         self.set_rc(ch, 1000)
         self.assert_mission_count(0)
 
@@ -4484,25 +4484,25 @@ class TestSuite(abc.ABC):
         original_list = self.log_list()
         self.progress("original list: %s" % str(original_list))
         self.set_parameter("LOG_DISARMED", 1)
-        self.delay_sim_time(1) # LOG_DISARMED is polled by the logger code
+        self.delay_sim_time(1, reason="LOG_DISARMED to take effect") # LOG_DISARMED is polled by the logger code
         new_list = self.log_list()
         self.progress("new list: %s" % str(new_list))
         if len(new_list) - len(original_list) != 1:
             raise NotAchievedException("Got more than one new log")
         self.set_parameter("LOG_DISARMED", 0)
-        self.delay_sim_time(1) # LOG_DISARMED is polled by the logger code
+        self.delay_sim_time(1, reason="LOG_DISARMED to be disabled") # LOG_DISARMED is polled by the logger code
         new_list = self.log_list()
         if len(new_list) - len(original_list) != 1:
             raise NotAchievedException("Got more or less than one new log after toggling LOG_DISARMED off")
 
         self.start_subtest("Ensuring toggling LOG_DISARMED on and off doesn't increase the number of files")
         self.set_parameter("LOG_DISARMED", 1)
-        self.delay_sim_time(1) # LOG_DISARMED is polled by the logger code
+        self.delay_sim_time(1, reason="LOG_DISARMED to take effect") # LOG_DISARMED is polled by the logger code
         new_new_list = self.log_list()
         if len(new_new_list) != len(new_list):
             raise NotAchievedException("Got extra files when toggling LOG_DISARMED")
         self.set_parameter("LOG_DISARMED", 0)
-        self.delay_sim_time(1) # LOG_DISARMED is polled by the logger code
+        self.delay_sim_time(1, reason="LOG_DISARMED to be disabled") # LOG_DISARMED is polled by the logger code
         new_new_list = self.log_list()
         if len(new_new_list) != len(new_list):
             raise NotAchievedException("Got extra files when toggling LOG_DISARMED to 0 again")
@@ -4527,7 +4527,7 @@ class TestSuite(abc.ABC):
         if len(post_disarmed_list) != len(post_armed_list):
             raise NotAchievedException("Log rotated immediately")
         self.progress("Allowing time for post-disarm-logging to occur if it will")
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="post-disarm logging to occur")
         post_disarmed_post_delay_list = self.log_list()
         if len(post_disarmed_post_delay_list) != len(post_disarmed_list):
             raise NotAchievedException("Got log rotation when we shouldn't have")
@@ -4541,7 +4541,7 @@ class TestSuite(abc.ABC):
         post_disarmed_list = self.log_list()
         if len(post_disarmed_list) != len(post_armed_list):
             raise NotAchievedException("Log rotated immediately")
-        self.delay_sim_time(30)
+        self.delay_sim_time(30, reason="HAL_LOGGER_ARM_PERSIST period")
         delayed_post_disarmed_list = self.log_list()
         # should *still* not get another log as LOG_DISARMED is false
         if len(post_disarmed_list) != len(delayed_post_disarmed_list):
@@ -4558,31 +4558,31 @@ class TestSuite(abc.ABC):
             raise NotAchievedException(
                 "Unexpected log detected (pre-delay) initial=(%s) restart=(%s)" %
                 (str(sorted(start_list)), str(sorted(restart_list))))
-        self.delay_sim_time(20)
+        self.delay_sim_time(20, reason="log rotation check")
         restart_list = self.log_list()
         if len(start_list) != len(restart_list):
             raise NotAchievedException("Unexpected log detected (post-delay)")
         self.set_parameter("LOG_DISARMED", 1)
-        self.delay_sim_time(5) # LOG_DISARMED is polled
+        self.delay_sim_time(5, reason="LOG_DISARMED to take effect") # LOG_DISARMED is polled
         post_log_disarmed_set_list = self.log_list()
         if len(post_log_disarmed_set_list) == len(restart_list):
             raise NotAchievedException("Did not get new log when LOG_DISARMED set")
         self.progress("Ensuring we get a new log after a reboot")
         self.reboot_sitl()
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="logging to start after reboot")
         post_reboot_log_list = self.log_list()
         if len(post_reboot_log_list) == len(post_log_disarmed_set_list):
             raise NotAchievedException("Did not get fresh log-disarmed log after a reboot")
         self.progress("Ensuring no log rotation when we toggle LOG_DISARMED off then on again")
         self.set_parameter("LOG_DISARMED", 0)
         current_log_filepath = self.current_onboard_log_filepath()
-        self.delay_sim_time(10) # LOG_DISARMED is polled
+        self.delay_sim_time(10, reason="LOG_DISARMED disable to take effect") # LOG_DISARMED is polled
         post_toggleoff_list = self.log_list()
         if len(post_toggleoff_list) != len(post_reboot_log_list):
             raise NotAchievedException("Shouldn't get new file yet")
         self.progress("Ensuring log does not grow when LOG_DISARMED unset...")
         current_log_filepath_size = os.path.getsize(current_log_filepath)
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="log to stop growing")
         current_log_filepath_new_size = os.path.getsize(current_log_filepath)
         if current_log_filepath_new_size != current_log_filepath_size:
             raise NotAchievedException(
@@ -4590,7 +4590,7 @@ class TestSuite(abc.ABC):
                 (current_log_filepath_new_size, current_log_filepath_size))
         self.progress("Turning LOG_DISARMED back on again")
         self.set_parameter("LOG_DISARMED", 1)
-        self.delay_sim_time(5) # LOG_DISARMED is polled
+        self.delay_sim_time(5, reason="LOG_DISARMED to take effect") # LOG_DISARMED is polled
         post_toggleon_list = self.log_list()
         if len(post_toggleon_list) != len(post_toggleoff_list):
             raise NotAchievedException("Log rotated when it shouldn't")
@@ -4634,7 +4634,7 @@ class TestSuite(abc.ABC):
         self.arm_vehicle(force=True)
         # we might be relying on a thread to actually create the log
         # file when doing forced-arming; give the file time to appear:
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="log file to appear after forced arm")
         post_arming_list = self.log_list()
         self.disarm_vehicle()
         if len(post_arming_list) <= len(pre_arming_list):
@@ -4689,7 +4689,7 @@ class TestSuite(abc.ABC):
         self.wait_ready_to_arm()
         for i in range(3):
             self.arm_vehicle()
-            self.delay_sim_time(5)
+            self.delay_sim_time(5, reason="log data to accumulate")
             path = self.current_onboard_log_filepath()
             self.disarm_vehicle()
             self.LoggingFormatSanityChecks(path)
@@ -4699,7 +4699,7 @@ class TestSuite(abc.ABC):
         for i in range(3):
             self.set_parameter("LOG_DISARMED", 1)
             self.reboot_sitl()
-            self.delay_sim_time(5)
+            self.delay_sim_time(5, reason="logging to start after reboot")
             path = self.current_onboard_log_filepath()
             self.set_parameter("LOG_DISARMED", 0)
             self.LoggingFormatSanityChecks(path)
@@ -4764,7 +4764,7 @@ class TestSuite(abc.ABC):
         # ensure the latest log file is very small:
         self.context_push()
         self.set_parameter('LOG_DISARMED', 1)
-        self.delay_sim_time(15)
+        self.delay_sim_time(15, reason="LOG_DISARMED to take effect")
         self.progress(f"Current onboard log filepath {self.current_onboard_log_filepath()}")
         self.context_pop()
 
@@ -5196,7 +5196,7 @@ class TestSuite(abc.ABC):
         mavproxy = self.start_mavproxy()
         mavproxy.send('rally load %s\n' % path)
         mavproxy.expect("Loaded")
-        self.delay_sim_time(10)  # allow transfer to complete
+        self.delay_sim_time(10, reason="rally point transfer to complete")  # allow transfer to complete
         self.stop_mavproxy(mavproxy)
 
     def load_sample_mission(self):
@@ -5575,7 +5575,7 @@ class TestSuite(abc.ABC):
         self.reboot_sitl()
         self.wait_ready_to_arm()
         self.set_parameter("LOG_DISARMED", 1)
-        self.delay_sim_time(20)
+        self.delay_sim_time(20, reason="LOG_DISARMED logging period")
         self.set_parameter("LOG_DISARMED", 0)
         path = self.current_onboard_log_filepath()
         self.progress("Rate sample log (%s)" % path)
@@ -5901,7 +5901,7 @@ class TestSuite(abc.ABC):
             )
         except ValueError as e:
             # statustexts are queued; give it a second to arrive:
-            self.delay_sim_time(5)
+            self.delay_sim_time(5, reason="statustext to arrive")
             raise e
         try:
             self.wait_armed()
@@ -8108,7 +8108,7 @@ class TestSuite(abc.ABC):
                           (parameter, v))
             if v == value:
                 return
-            self.delay_sim_time(0.1)
+            self.delay_sim_time(0.1, reason="parameter poll interval")
 
     def wait_parameter_values(self, parameters, timeout=10):
         need_to_see = copy.copy(parameters)
@@ -10573,7 +10573,7 @@ Also, ignores heartbeats not from our target system'''
             mavproxy.send("dataflash_logger set verbose 1\n")
             mavproxy.expect('logging started')
             mavproxy.send("dataflash_logger set verbose 0\n")
-            self.delay_sim_time(1)
+            self.delay_sim_time(1, reason="logging to initialise")
             self.do_timesync_roundtrip()  # drain COMMAND_ACK from that failed arm
             self.arm_vehicle()
             tstart = self.get_sim_time()
@@ -10645,15 +10645,15 @@ Also, ignores heartbeats not from our target system'''
             if self.is_copter() or self.is_plane():
                 self.set_autodisarm_delay(0)
             self.arm_vehicle()
-            self.delay_sim_time(5)
+            self.delay_sim_time(5, reason="log data to accumulate")
             self.disarm_vehicle()
             # First log created here
-            self.delay_sim_time(2)
+            self.delay_sim_time(2, reason="log to be created")
             self.arm_vehicle()
-            self.delay_sim_time(5)
+            self.delay_sim_time(5, reason="log data to accumulate")
             self.disarm_vehicle()
             # Second log created here
-            self.delay_sim_time(2)
+            self.delay_sim_time(2, reason="log to be created")
             mavproxy.send("log list\n")
             mavproxy.expect("Log ([0-9]+)  numLogs ([0-9]+) lastLog ([0-9]+) size ([0-9]+)", timeout=120)
             log_num = int(mavproxy.match.group(1))
@@ -10736,7 +10736,7 @@ Also, ignores heartbeats not from our target system'''
             mavproxy.send("log erase\n")
             mavproxy.expect("Chip erase complete")
             self.set_parameter("LOG_DISARMED", 1)
-            self.delay_sim_time(3)
+            self.delay_sim_time(3, reason="LOG_DISARMED to take effect")
             self.set_parameter("LOG_DISARMED", 0)
             mavproxy.send("log download 1 logs/dataflash-log-erase.BIN\n")
             mavproxy.expect("Finished downloading", timeout=120)
@@ -10751,18 +10751,18 @@ Also, ignores heartbeats not from our target system'''
             if self.is_copter() or self.is_plane():
                 self.set_autodisarm_delay(0)
             self.arm_vehicle()
-            self.delay_sim_time(30)
+            self.delay_sim_time(30, reason="log data for wrap test")
             self.disarm_vehicle()
             # roughly 4mb
             self.arm_vehicle()
-            self.delay_sim_time(30)
+            self.delay_sim_time(30, reason="log data for wrap test")
             self.disarm_vehicle()
             # roughly 9mb, should wrap around
             self.arm_vehicle()
-            self.delay_sim_time(50)
+            self.delay_sim_time(50, reason="log data for wrap test")
             self.disarm_vehicle()
             # make sure we have finished logging
-            self.delay_sim_time(15)
+            self.delay_sim_time(15, reason="logging to finish")
             mavproxy.send("log list\n")
             try:
                 mavproxy.expect("Log ([0-9]+)  numLogs ([0-9]+) lastLog ([0-9]+) size ([0-9]+)", timeout=120)
@@ -10808,7 +10808,7 @@ Also, ignores heartbeats not from our target system'''
     def ArmFeatures(self):
         '''Arm features'''
         # TEST ARMING/DISARM
-        self.delay_sim_time(12)  # wait for gyros/accels to be happy
+        self.delay_sim_time(12, reason="gyros and accels to stabilise")  # wait for gyros/accels to be happy
         if self.get_parameter("ARMING_SKIPCHK") != 0 and not self.is_sub():
             raise ValueError("Arming skipped checks should be 0")
         if not self.is_sub() and not self.is_tracker():
@@ -10865,7 +10865,7 @@ Also, ignores heartbeats not from our target system'''
             self.set_parameter("RC%d_OPTION" % arming_switch, 153)
             self.set_rc(arming_switch, 1000)
             # delay so a transition is seen by the RC switch code:
-            self.delay_sim_time(0.5)
+            self.delay_sim_time(0.5, reason="RC switch transition to register")
             self.arm_motors_with_switch(arming_switch)
             self.disarm_motors_with_switch(arming_switch)
             self.set_rc(arming_switch, 1000)
@@ -11261,7 +11261,7 @@ Also, ignores heartbeats not from our target system'''
         # 148 is AUTOPILOT_VERSION:
         self.context_collect('AUTOPILOT_VERSION')
         self.run_cmd_int(mavutil.mavlink.MAV_CMD_REQUEST_MESSAGE, 148)
-        self.delay_sim_time(2)
+        self.delay_sim_time(2, reason="AUTOPILOT_VERSION response")
         count = len(self.context_collection('AUTOPILOT_VERSION'))
         if count != 1:
             raise NotAchievedException(f"Did not get single AUTOPILOT_VERSION message (count={count}")
@@ -12667,7 +12667,7 @@ switch value'''
                                                    (str(count), str(expected_count), len(seen_ids.keys())))
                 elif attempt_count != 0:
                     self.progress("Download failed; retrying")
-                    self.delay_sim_time(1)
+                    self.delay_sim_time(1, reason="parameter retry interval")
                     debug = True
                 self.drain_mav()
                 self.mav.mav.param_request_list_send(target_system, target_component)
@@ -12959,7 +12959,7 @@ switch value'''
             "SIM_BARO_DISABLE": 1,
             "SIM_BAR2_DISABLE": 1,
         })
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="baro disable to take effect")
         self.start_subtest("Ensuring breaking GPS does now terminate")
         self.set_parameters({
             "SIM_GPS1_ENABLE": 0,
@@ -12970,7 +12970,7 @@ switch value'''
         tstart = self.get_sim_time_cached()
         while self.get_sim_time_cached() - tstart < seconds:
             self.drain_mav()
-            self.delay_sim_time(0.5)
+            self.delay_sim_time(0.5, reason="drain interval")
 
     def wait_gps_fix_type_gte(self, fix_type, timeout=30, message_type="GPS_RAW_INT", verbose=False):
         tstart = self.get_sim_time()
@@ -13220,7 +13220,7 @@ switch value'''
                     "EAHRS_SENSORS": 0xD,  # GPS|BARO|COMPASS (exclude IMU)
                 })
                 self.reboot_sitl()
-                self.delay_sim_time(5)
+                self.delay_sim_time(5, reason="AHRS to initialise")
                 self.progress("Running accelcal")
                 self.run_cmd(
                     mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION,
@@ -13265,7 +13265,7 @@ switch value'''
         '''AHRS trim testing'''
         self.start_subtest("Attitude Correctness")
         self.ahrstrim_attitude_correctness()
-        self.delay_sim_time(5)
+        self.delay_sim_time(5, reason="attitude trim test interval")
         self.start_subtest("Preflight Calibration")
         self.ahrstrim_preflight_cal()
 
@@ -13330,7 +13330,7 @@ switch value'''
             self.disarm_vehicle()
             # de-assert the pin:
             self.set_parameter("SIM_PIN_MASK", 0)
-            self.delay_sim_time(1)  # 5Hz update rate on Button library
+            self.delay_sim_time(1, reason="button library update")  # 5Hz update rate on Button library
             self.context_collect("STATUSTEXT")
             # try to arm the vehicle:
             self.run_cmd(
@@ -14441,13 +14441,13 @@ switch value'''
 
             self.progress("Writing vtx_frame")
             crsf.write_data_id(crsf.dataid_vtx_frame)
-            self.delay_sim_time(5)
+            self.delay_sim_time(5, reason="VTX frame to be processed")
             self.progress("Writing vtx_telem")
             crsf.write_data_id(crsf.dataid_vtx_telem)
-            self.delay_sim_time(5)
+            self.delay_sim_time(5, reason="VTX telem to be processed")
             self.progress("Writing vtx_unknown")
             crsf.write_data_id(crsf.dataid_vtx_unknown)
-            self.delay_sim_time(5)
+            self.delay_sim_time(5, reason="VTX data to be processed")
         except Exception as e:  # noqa: BLE001
             self.print_exception_caught(e)
             ex = e
@@ -14501,7 +14501,7 @@ switch value'''
         self.wait_ready_to_arm()
         original_imu = self.assert_receive_message("RAW_IMU", verbose=True)
         self.set_parameter("AHRS_ORIENTATION", 16)  # roll-90
-        self.delay_sim_time(2)  # we update this on a timer
+        self.delay_sim_time(2, reason="AHRS_ORIENTATION to update")  # we update this on a timer
         new_imu = self.assert_receive_message("RAW_IMU", verbose=True)
         delta_zacc = original_imu.zacc - new_imu.zacc
         delta_z_g = delta_zacc/1000.0  # milligravities -> gravities
@@ -14513,7 +14513,7 @@ switch value'''
             raise NotAchievedException("Magic AHRS_ORIENTATION update did not work (delta_y_g=%f)" % (delta_y_g,))
         self.context_pop()
         self.reboot_sitl()
-        self.delay_sim_time(2)  # we update orientation on a timer
+        self.delay_sim_time(2, reason="orientation update timer")  # we update orientation on a timer
 
     def GPSTypes(self):
         '''check each simulated GPS works'''
@@ -14688,7 +14688,7 @@ switch value'''
             raise NotAchievedException("alt moved unexpectedly")
         self.progress("Killing first GPS")
         self.set_parameter("SIM_GPS1_ENABLE", 0)
-        self.delay_sim_time(1)
+        self.delay_sim_time(1, reason="GPS failover to take effect")
         self.progress("Checking altitude now matches second GPS")
         m = self.assert_receive_message("GLOBAL_POSITION_INT")
         new_gpi_alt2 = m.alt
@@ -15098,7 +15098,7 @@ SERIAL5_BAUD 128
         # wait_disarmed is not sufficient here; it's actually the
         # *motors* being armed which causes the problem, not the
         # vehicle's arm state!  Could we use SYS_STATUS here instead?
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="motors to fully disarm")
         self.end_subtest("Testing PWM output")
 
         self.start_subtest("Testing percentage output")
@@ -15129,7 +15129,7 @@ SERIAL5_BAUD 128
         # wait_disarmed is not sufficient here; it's actually the
         # *motors* being armed which causes the problem, not the
         # vehicle's arm state!  Could we use SYS_STATUS here instead?
-        self.delay_sim_time(10)
+        self.delay_sim_time(10, reason="motors to fully disarm")
         self.end_subtest("Testing percentage output")
 
     def FenceRelative_fly_north_then_descend(self, north_m, timeout=120):


### PR DESCRIPTION
### Summary

Puts reasons on each delay call

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
### Description

It's useful to be able to disambigaute delays and whatnot in the output.

This should also allow us to eliminate some of these calls when we can instead look for something in the telemetry stream instead.
