### PR TITLE
AP_BattMonitor: INA2xx, INA239: add Increment metadata to SHUNT param

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_INA239.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_INA239.cpp
@@ -44,6 +44,7 @@ const AP_Param::GroupInfo AP_BattMonitor_INA239::var_info[] = {
     // @DisplayName: Battery monitor shunt resistor
     // @Description: This sets the shunt resistor used in the device
     // @Range: 0.0001 0.01
+    // @Increment: 0.0001
     // @Units: Ohm
     // @User: Advanced
     AP_GROUPINFO("SHUNT", 28, AP_BattMonitor_INA239, rShunt, HAL_BATTMON_INA239_SHUNT_RESISTANCE),

--- a/libraries/AP_BattMonitor/AP_BattMonitor_INA2xx.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_INA2xx.cpp
@@ -114,6 +114,7 @@ const AP_Param::GroupInfo AP_BattMonitor_INA2XX::var_info[] = {
     // @DisplayName: Battery monitor shunt resistor
     // @Description: This sets the shunt resistor used in the device
     // @Range: 0.0001 0.01
+    // @Increment: 0.0001
     // @Units: Ohm
     // @User: Advanced
     AP_GROUPINFO("SHUNT", 28, AP_BattMonitor_INA2XX, rShunt, DEFAULT_BATTMON_INA2XX_SHUNT),


### PR DESCRIPTION
## Summary

Adds `@Increment: 0.0001` to the `SHUNT` parameter docs for the INA2xx and INA239 battery monitor backends.

## Problem

Without an `@Increment` (or `@DecimalPlaces`) hint, ground stations fall back to a default of 3 decimal places when rendering the value. Typical shunt resistances are sub-mΩ (e.g. 0.0005 Ω), so the on-screen value rounds to `0.001` even though the stored float is correct. Reported on QGroundControl, but the root cause is missing parameter metadata — every GCS that derives display precision from the param docs is affected.

## Solution

Surface the natural increment (0.1 mΩ) in the parameter metadata so ground stations can pick an appropriate precision automatically. No behavioural change to the firmware; the stored value, range, and default are unchanged.