### PR TITLE
AntennaTracker: fortify pressure comparison logic

### DIFF
--- a/AntennaTracker/tracking.cpp
+++ b/AntennaTracker/tracking.cpp
@@ -166,8 +166,12 @@ void Tracker::tracking_update_pressure(const mavlink_scaled_pressure_t &msg)
     float local_pressure = barometer.get_pressure();
     float aircraft_pressure = msg.press_abs*100.0f;
 
+    // if both tracker and target pressures make sense
     // calculate altitude difference based on difference in barometric pressure
-    float alt_diff = barometer.get_altitude_difference(local_pressure, aircraft_pressure);
+    float alt_diff = NAN;
+    if (local_pressure > 0 && aircraft_pressure > 0) {
+        alt_diff = barometer.get_altitude_difference(local_pressure, aircraft_pressure);
+    }
     if (!isnan(alt_diff) && !isinf(alt_diff)) {
         nav_status.alt_difference_baro = alt_diff + nav_status.altitude_offset;
 


### PR DESCRIPTION
### Summary

Protects the Tracker code against spurious intenal errors whenever either of the pressures in the pressure comparison are zero.

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [X] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

I was running into rare random errors with Tracker whenever the target UAV was powered before the tracker itself. In particular I got this:
```
AP: PreArm: Internal errors 0x100000 l:167 flow_of_ctrl
```

Of all the sources for my version, this line corresponds to the following: https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Baro/AP_Baro_atmosphere.cpp#L167

What I assume is happening, we get a pressure mavlink packet before the baro calibration / initialization of any kind is over and thus we end up supplying a zero input to `AP_Baro::get_altitude_from_pressure` which of course leads to the internal error branch. I've added a bunch of logging to validate and indeed the error happens on zero input to this particular method. I didn't really test if it was the Tracker's own pressure or the incoming one from mavlink, since in my opinion, badly formed mavlink shouldn't result in the Tracker going into an intenal error state. If anything the error would be external in this case. The code is pretty trivial so I haven't tested it on HW yet (will report here when I do), but it shouldn't really break a thing. The fact I'm only getting this error on Tracker and only if the plane was powered first implies I'm looking at the right issue I think.

I believe this issue was masked in previous releases (e.g. 4.5.x) because the atmosphere code only appeared "recently" in 4.6 so the internal error clause wasn't there before.