### PR TITLE
Tools: fix duplicate GRF parameter parsing

### DIFF
--- a/Tools/autotest/param_metadata/param_parse.py
+++ b/Tools/autotest/param_metadata/param_parse.py
@@ -271,6 +271,7 @@ def applicable_to_vehicle(vehicle: str, vehicle_list: list) -> bool:
 def process_library(vehicle, library, pathprefix=None):
     '''process one library'''
     paths = library.Path.split(',')
+    processed_group_paths = set()  # tracks (group_name, path) tuples across all files
     for path in paths:
         path = path.strip()
         global current_file
@@ -412,7 +413,7 @@ def process_library(vehicle, library, pathprefix=None):
         group_matches = prog_groups.findall(p_text)
         debug("Found %u groups" % len(group_matches))
         debug(group_matches)
-        done_groups = dict()
+        done_groups = dict()  # per-file: handles same group declared twice in same file
         for group_match in group_matches:
             group = group_match[0].strip()
             debug("Group: %s" % group)
@@ -436,6 +437,14 @@ def process_library(vehicle, library, pathprefix=None):
                     setattr(p, field_name, field_value)
                 else:
                     error(f"unknown parameter metadata field '{field_name}'")
+
+            group_path_key = (group, getattr(lib, 'Path', None))
+            if group_path_key in processed_group_paths:
+                # Same group+path already processed in a previous file - skip duplicates
+                debug(f"Skipping duplicate group '{group}' with path '{getattr(lib, 'Path', None)}'")
+                continue
+
+            processed_group_paths.add(group_path_key)
             if not any(lib.Path == parsed_l.Path for parsed_l in libraries):
                 if do_append:
                     lib.set_name(library.name + lib.name)


### PR DESCRIPTION
### Summary

Rangefinder GRF show that we don't deduplicate parameters correctly as from the wiki build

```
/home/henryw/ardupilot_wiki/copter/source/docs/parameters.rst:101385: WARNING: Duplicate explicit target name: "parameters_rngfnd1_grf_".
/home/henryw/ardupilot_wiki/copter/source/docs/parameters.rst:101391: WARNING: Duplicate explicit target name: "rngfnd1_grf_ret".
/home/henryw/ardupilot_wiki/copter/source/docs/parameters.rst:101421: WARNING: Duplicate explicit target name: "rngfnd1_grf_st".
/home/henryw/ardupilot_wiki/copter/source/docs/parameters.rst:101441: WARNING: Duplicate explicit target name: "rngfnd1_grf_rate".
/home/henryw/ardupilot_wiki/copter/source/docs/parameters.rst:102193: WARNING: Duplicate explicit target name: "parameters_rngfnd2_grf_".
/home/henryw/ardupilot_wiki/copter/source/docs/parameters.rst:102199: WARNING: Duplicate explicit target name: "rngfnd2_grf_ret".
```

Used Claude help to find and correct the issues : 
add new check for same group+path already processed in a previous file, this allow skip duplicates


Check done : 

Using 
```
for v in Rover AntennaTracker ArduCopter ArduPlane ArduSub Blimp AP_Periph; do
    for t in json xml; do
        python3 Tools/autotest/param_metadata/param_parse.py --vehicle $v --format $t
        mv apm.pdef.$t ./params/apm.pdef_$v.$t
    done
    for t in html md rst; do
        python3 Tools/autotest/param_metadata/param_parse.py --vehicle $v --format $t
        mv Parameters.$t ./params/Parameters_$v.$t
    done

done
```
generate parameters for master and the PR.

<img width="1904" height="1027" alt="image" src="https://github.com/user-attachments/assets/2117d893-8a23-446e-9b7c-6e84ed53294d" />
<img width="1897" height="1079" alt="image" src="https://github.com/user-attachments/assets/37f2a45c-7a22-4a0d-b44f-c7ad35caa641" />

Result : only the culprit duplicate parameters are removed


### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [x] Logs attached
- [ ] Logs available on request


### Description

