### PR TITLE
Revert ".github: avoid use of pull_request_target"

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,7 +1,7 @@
 name: ci
 
 on:
-  pull_request:
+  pull_request_target:  # pull_request_target, NOT pull_request
     types: [opened, synchronize, reopened]
 
 jobs:


### PR DESCRIPTION
### Summary

Reverts a commit which caused the "label by languages" CI test to fail with a permission error

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

This reverts commit 6c8c99c8a52510fca384268ccb2c855e91a4e1c5.

Looks like we really do need pull_request_target - we need the permssions of the repository (the very thing I was trying to get rid of!) to do the labelling

```
POST /repos/ArduPilot/ardupilot/issues/32955/labels - 403 with id 1340:126B67:4AED39D:121E3ED7:6A0C08EC in 177ms Error: Unhandled error: HttpError: Resource not accessible by integration - https://docs.github.com/rest/issues/labels#add-labels-to-an-issue RequestError [HttpError]: Resource not accessible by integration - https://docs.github.com/rest/issues/labels#add-labels-to-an-issue
    at fetchWrapper (/home/runner/work/_actions/actions/github-script/v9/dist/index.js:61509:11)
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5) {
  status: 403,
  request: {
    method: 'POST',
    url: 'https://api.github.com/repos/ArduPilot/ardupilot/issues/32955/labels',
    headers: {
      accept: 'application/vnd.github.v3+json',
      'user-agent': 'actions/github-script actions_orchestration_id/903aba2b-2ade-441c-80e5-5d001e9af665.labels-by-language.__default octokit-core.js/7.0.6 Node.js/24',
      authorization: 'token [REDACTED]',
      'content-type': 'application/json; charset=utf-8'
    },
    body: [Object: null prototype] { labels: [Array] },
    request: {
      agent: [Agent],
      fetch: [Function: proxyFetch],
      hook: [Function: bound bound register]
    }
  },
  response: {
    url: 'https://api.github.com/repos/ArduPilot/ardupilot/issues/32955/labels',
    status: 403,
    headers: {
      'access-control-allow-origin': '*',
      'access-control-expose-headers': 'ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset',
      'content-encoding': 'gzip',
      'content-security-policy': "default-src 'none'",
      'content-type': 'application/json; charset=utf-8',
      date: 'Tue, 19 May 2026 06:53:33 GMT',
      'referrer-policy': 'origin-when-cross-origin, strict-origin-when-cross-origin',
      server: 'github.com',
      'strict-transport-security': 'max-age=31536000; includeSubdomains; preload',
      'transfer-encoding': 'chunked',
      vary: 'Accept-Encoding, Accept, X-Requested-With',
      'x-accepted-github-permissions': 'issues=write; pull_requests=write',
      'x-content-type-options': 'nosniff',
      'x-frame-options': 'deny',
      'x-github-api-version-selected': '2022-11-28',
      'x-github-media-type': 'github.v3; format=json',
      'x-github-request-id': '1340:126B67:4AED39D:121E3ED7:6A0C08EC',
      'x-ratelimit-limit': '5000',
      'x-ratelimit-remaining': '4998',
      'x-ratelimit-reset': '1779177212',
      'x-ratelimit-resource': 'core',
      'x-ratelimit-used': '2',
      'x-xss-protection': '0'
    },
    data: {
      message: 'Resource not accessible by integration',
      documentation_url: 'https://docs.github.com/rest/issues/labels#add-labels-to-an-issue',
      status: '403'
    }
  },
  [cause]: undefined
}
```
