### PR TITLE
AP_HAL: fix ftoa_engine hang on infinities

### DIFF
--- a/libraries/AP_HAL/tests/test_vsnprintf.cpp
+++ b/libraries/AP_HAL/tests/test_vsnprintf.cpp
@@ -117,5 +117,58 @@ TEST(vsnprintf_Test, SubnormalFormat)
         do_subnormal_format(0x00000000));
 }
 
+static const char* do_special_format(uint32_t val_hex) {
+    // format float represented as a hex number
+
+    static char buf[256];
+
+    float val;
+    static_assert(sizeof(uint32_t) == sizeof(float));
+    memcpy(&val, &val_hex, sizeof(float));
+
+    hal.util->snprintf(buf, ARRAY_SIZE(buf), "%f", val);
+
+    return buf;
+}
+
+TEST(vsnprintf_Test, SpecialFormat)
+{
+    // positive infinity
+    EXPECT_STREQ("inf", do_special_format(0x7F800000));
+
+    // negative infinity
+    EXPECT_STREQ("-inf", do_special_format(0xFF800000));
+
+    // signaling NaN with arbitrary payload A
+    EXPECT_STREQ("nan", do_special_format(0x7FF00800));
+
+    // signaling NaN with arbitrary payload B
+    EXPECT_STREQ("nan", do_special_format(0x7FF01230));
+
+    // quiet NaN with arbitrary payload A
+    EXPECT_STREQ("nan", do_special_format(0x7FB00800));
+
+    // quiet NaN with arbitrary payload B
+    EXPECT_STREQ("nan", do_special_format(0x7FB01230));
+
+    // negative signaling NaN with arbitrary payload A
+    EXPECT_STREQ("nan", do_special_format(0xFFF00800));
+
+    // negative signaling NaN with arbitrary payload B
+    EXPECT_STREQ("nan", do_special_format(0xFFF01230));
+
+    // negative quiet NaN with arbitrary payload A
+    EXPECT_STREQ("nan", do_special_format(0xFFB00800));
+
+    // negative quiet NaN with arbitrary payload B
+    EXPECT_STREQ("nan", do_special_format(0xFFB01230));
+
+    // largest NaN payload
+    EXPECT_STREQ("nan", do_special_format(0x7FFFFFFF));
+
+    // smallest NaN payload
+    EXPECT_STREQ("nan", do_special_format(0x7F800001));
+}
+
 
 AP_GTEST_MAIN()

--- a/libraries/AP_HAL/utility/ftoa_engine.cpp
+++ b/libraries/AP_HAL/utility/ftoa_engine.cpp
@@ -117,10 +117,12 @@ int16_t ftoa_engine(float val, char *buf, uint8_t precision, uint8_t maxDecimals
         } else { // Subnormal
             exp = 1; // Subnormal mantissa has same significance as exp=1
         }
-    } else if(exp==0xff) { // Infinity or NaN
-        if(frac==0) flags |= FTOA_INF; else flags |= FTOA_NAN;
-    } else { // Normal number
-        frac |= (1UL<<23); // The implicit leading 1 is made explicit
+    } else {
+        if(exp==0xff) { // Infinity or NaN
+            if(frac==0) flags |= FTOA_INF; else flags |= FTOA_NAN;
+        } // Else normal number
+        // Note this ensures infinities have a non-zero frac and don't hang!
+        frac |= (1UL<<23); // The implicit leading 1 is made explicit.
     }
 
     uint8_t idx = exp>>3;


### PR DESCRIPTION
### Summary

If any code or a script tried to use the `%f` format specifier (with any parameters) to format an infinity, it would hang and watchdog and result in sadness. This problem was introduced by my fixes in #30758 , sorry!

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [X] Automated test(s) verify changes (e.g. unit test, autotest)
- [X] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

There is a very gnarly explanation in the commit message. All of the conclusions in that original PR still hold, namely that this should probably be replaced. This problem exists in 4.6 too.

Fixes #33024 properly.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
