### PR TITLE
workflows: fix labels adder without pull_request_target

### DIFF
--- a/.github/workflows/labels-apply.yml
+++ b/.github/workflows/labels-apply.yml
@@ -1,0 +1,78 @@
+name: Labels Apply
+# High permissions Action that shouldn't be exposed to / directly runnable from user code.
+# Fetches which PR to apply to from an Artifact output by the PR-triggered labels-trigger Action.
+# Approach from https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
+
+on:
+  workflow_run:
+    workflows: ["Labels Trigger"]
+    types:
+      - completed
+
+jobs:
+  labels-by-language:
+    runs-on: ubuntu-slim
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    permissions:
+      pull-requests: write  # So we can add labels to the pull request
+    steps:  # Do NOT "uses: actions/checkout" here!
+      # All this to get the PR number...
+      - name: Download artifact
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const artifacts = await github.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{github.event.workflow_run.id }},
+            });
+            const matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "labels-trigger"
+            })[0];
+            const download = await github.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: 'zip',
+            });
+            const fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/pr.zip', Buffer.from(download.data));
+      - run: unzip pr.zip
+
+      - name: Retrieve PR Number
+        run: |
+          echo "PR=$(cat pr/pr/NR)" >> $GITHUB_ENV
+
+      # Ok, now for the actual workflow
+      - name: Apply Labels
+        uses: actions/github-script@v9
+        with:
+          script: |
+            // Fetches untrusted user input in a privileged environment - be careful!
+            const filenames = (await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: ${{ env.PR }},
+              per_page: 100,
+            })).map(file => file.filename);
+            console.log(filenames);
+
+            // Process the input into a predefined set of (non-sensitive) labels
+            const labels = new Set();
+            for (const filename of filenames) {
+              if (filename.endsWith('.lua')) labels.add('Scripting');
+              else if (filename.endsWith('.py')) labels.add('Python');
+            }
+            console.log(labels);
+
+            // Values have been sanitized, so can be applied to the PR
+            if (labels.size > 0) {
+              github.rest.issues.addLabels({
+                issue_number: ${{ env.PR }},
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                labels: Array.from(labels),
+              })
+            }

--- a/.github/workflows/labels-trigger.yml
+++ b/.github/workflows/labels-trigger.yml
@@ -1,0 +1,24 @@
+name: Labels Trigger
+# Avoid pull_request_target by running the PR-write-access-required part in a follow-on Action.
+# This one just triggers that one and tells it which PR to get filenames for.
+# Note that this decouples success of this Action from whether the labeller actually succeeded.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  build:
+    runs-on: ubuntu-slim
+    steps:
+      - name: Save PR number
+        run: |
+          mkdir -p ./pr
+          echo ${{ github.event.number }} > ./pr/NR
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: labels-trigger
+          path: |
+            pr/


### PR DESCRIPTION
### Summary

Fixes the broken labeller workflow, without reverting to using `pull_request_target`.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

Splits the initial labelling Action into a contributor-controlled workflow that runs in the limited `pull-request` context, which then triggers a separate privileged workflow to fetch relevant information about the pull request (in this case the names of the files), then converts them into sanitary values (labels) and performs the privilege-required act of applying them (to the original PR). This follows a pattern that is [suggested by GitHub's security team](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/), and which I have [used previously](https://github.com/bluerobotics/BlueOS-docs/pull/39) to generate hosted documentation previews, which needed to access an AWS API key that we didn't want to expose.

Note that this decouples the success of the first Action (and hence the PR approval status) from the completion of the desired work, but given this was a one-directional labelling task that seems fine - it wasn't doing any PR-blocking checks anyway.

*Note:* I haven't tested this PR (but I expect it will work, FWIW 🤷‍♂️). Because it's not reliant on external services (besides GitHub) I think it would be _possible_ to test by merging it to `master` in a fork, then making a PR against that fork and seeing if it runs successfully (assuming the fork supports the relevant labels). That could be sped up by disabling all the other workflows on that fork. I'm short on time at the moment but can potentially do that later in the week if it's decided as critical before merging.

~Closes #33123 (by replacement). Alternatively that can be merged for now, and~ we can hold off on merging this one until it's been properly tested.