### PR TITLE
Revert zero-velocity-fusion PR#32396

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -1843,104 +1843,6 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.context_pop()
         self.reboot_sitl()
 
-    def EK3_AccelBiasInhibitOnGroundMoving(self):
-        '''Test EKF3 inhibits accel bias learning when vehicle is moved on ground'''
-        # When a copter is on the ground and being moved (carried, on a ship),
-        # the EKF should not learn accel biases from the external motion.
-        # Without the fix (onGroundNotMoving check in dvelBiasAxisInhibit),
-        # the Z-axis bias is learnable on the ground (passes gravity alignment
-        # check), and GPS velocity innovations can drive incorrect bias learning
-        # during ground movement. With the fix, all bias learning is inhibited
-        # when onGround && !onGroundNotMoving.
-        self.context_push()
-
-        # Enable logging while disarmed so we capture ground-only EKF data
-        self.set_parameters({
-            "LOG_FILE_DSRMROT": 1,
-        })
-        self.reboot_sitl()
-        self.wait_ready_to_arm()
-
-        # Phase 1: Positive control - verify bias learning works when stationary
-        self.start_subtest("Positive control: verify bias learning works when stationary")
-        self.set_parameters({
-            'SIM_ACC2_BIAS_Z': 0.7,
-        })
-        self.delay_sim_time(30)
-        self.assert_dataflash_message_field_level_at(
-            "XKF2", "AZ", 0.7,
-            condition="XKF2.C==1",
-            maintain=1,
-        )
-
-        # Reset for next phase - reboot clears EKF state and starts a new log
-        self.set_parameters({
-            'SIM_ACC2_BIAS_Z': 0.0,
-        })
-        self.reboot_sitl()
-        self.wait_ready_to_arm()
-        self.delay_sim_time(5)
-
-        # Phase 2: Start ship movement, then inject bias - it should NOT be learned
-        self.start_subtest("Test: verify bias NOT learned during ground movement")
-        # Use a small circle to create sufficient centripetal acceleration and
-        # yaw rate so that onGroundNotMoving transitions to false.
-        # v=10 m/s, path_size=50m (r=25m) gives yaw_rate=0.4 rad/s which
-        # exceeds the gyro movement threshold.
-        self.set_parameters({
-            "SIM_SHIP_ENABLE": 1,
-            "SIM_SHIP_SPEED": 10,
-            "SIM_SHIP_PSIZE": 50,
-            "SIM_SHIP_DSIZE": 10,
-        })
-        # Wait for vehicle to be moving with the ship
-        self.wait_groundspeed(9, 11)
-        # Allow time for onGroundNotMoving to transition to false
-        self.delay_sim_time(5)
-
-        # Record timestamp, then inject Z-bias while vehicle is moving on ground
-        tstart_inject_us = self.get_sim_time() * 1.0e6
-        self.set_parameters({
-            'SIM_ACC2_BIAS_Z': 0.7,
-        })
-
-        # Wait for potential (unwanted) bias learning
-        self.delay_sim_time(30)
-
-        # Check that AZ stayed near 0 during the movement period.
-        # Skip the first 20s after injection to give time for any erroneous
-        # learning to manifest. Then require AZ near 0 for 5 consecutive seconds.
-        # With fix: AZ stays near 0 (learning inhibited) -> PASSES
-        # Without fix: AZ drifts toward 0.7 -> FAILS
-        tstart_check_us = tstart_inject_us + 20.0e6
-        self.assert_dataflash_message_field_level_at(
-            "XKF2", "AZ", 0.0,
-            condition="XKF2.C==1",
-            maintain=5,
-            tolerance=0.15,
-            dfreader_start_timestamp=tstart_check_us,
-        )
-
-        # Phase 3: Stop ship, verify bias learning resumes when stationary.
-        # After inhibition ends, the saved (small) variance is restored, so
-        # reconvergence is slow. Allow extra time and accept partial convergence.
-        self.start_subtest("Verify bias learning resumes after movement stops")
-        self.set_parameters({
-            "SIM_SHIP_ENABLE": 0,
-        })
-        self.wait_groundspeed(0, 2)
-
-        self.delay_sim_time(60)
-        self.assert_dataflash_message_field_level_at(
-            "XKF2", "AZ", 0.7,
-            condition="XKF2.C==1",
-            maintain=1,
-            tolerance=0.3,
-        )
-
-        self.context_pop()
-        self.reboot_sitl()
-
     # StabilityPatch - fly south, then hold loiter within 5m
     # position and altitude and reduce 1 motor to 60% efficiency
     def StabilityPatch(self,
@@ -13727,7 +13629,6 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
              self.BatteryMissing,
              self.VibrationFailsafe,
              self.EK3AccelBias,
-             self.EK3_AccelBiasInhibitOnGroundMoving,
              self.StabilityPatch,
              self.OBSTACLE_DISTANCE_3D,
              self.AC_Avoidance_Proximity,

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -1975,69 +1975,6 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.context_pop()
         self.reboot_sitl()
 
-    def EK3_ZeroVelFusionNotUsedWithGPS(self):
-        '''Test EKF3 zero velocity changes do not affect GPS-enabled setups'''
-        # Addresses review concern: does zero velocity fusion interfere
-        # with GPS-enabled configurations? This test places the vehicle on
-        # a fast-moving boat with GPS active and verifies:
-        # 1. EKF tracks GPS velocity (not pulled to zero)
-        # 2. Accel bias learning works via GPS velocity observations
-        #
-        # The ship uses a large circle (1000m diameter) at 15 m/s so
-        # motion is smooth enough that onGroundNotMoving stays TRUE once
-        # the ship reaches steady speed. Despite this, zero velocity
-        # fusion does NOT activate because GPS provides recent velocity
-        # data (haveRecentGpsVel is true in SelectVelPosFusion), so the
-        # condition for synthetic zero velocity injection is never met.
-
-        self.set_parameters({
-            "LOG_FILE_DSRMROT": 1,
-        })
-        self.reboot_sitl()
-        self.wait_ready_to_arm()
-
-        # Start ship with large radius to keep IMU motion below the
-        # on-ground-not-moving detection thresholds. At 15 m/s on
-        # 1000m diameter (r=500m) with EK3_OGNM_TEST_SF=2.0 (default):
-        #   angular rate = 0.03 rad/s (1.7 deg/s) vs 6 deg/s threshold
-        #   centripetal accel = 0.45 m/s^2 vs 2.0 m/s^2 threshold
-        # So onGroundNotMoving remains TRUE at steady state.
-        self.start_subtest("Verify EKF tracks GPS velocity on moving boat")
-        self.set_parameters({
-            "SIM_SHIP_ENABLE": 1,
-            "SIM_SHIP_SPEED": 15,
-            "SIM_SHIP_PSIZE": 1000,
-            "SIM_SHIP_DSIZE": 10,
-        })
-
-        # Wait for ship to reach speed and movement filters to settle.
-        # During initial acceleration onGroundNotMoving briefly goes
-        # false, but recovers once at constant speed.
-        self.wait_groundspeed(13, 17)
-        self.delay_sim_time(10)
-
-        # Verify EKF velocity matches GPS, not zero. If zero velocity
-        # fusion were incorrectly active, groundspeed would drift to 0.
-        self.wait_groundspeed(13, 17, timeout=10)
-
-        # Inject Z-bias and verify bias learning via GPS velocity.
-        # With onGroundNotMoving TRUE and gravity-aligned Z axis, the
-        # bias is observable. GPS velocity provides the Kalman filter
-        # measurement needed to converge the bias estimate.
-        self.start_subtest("Verify accel bias learned via GPS velocity")
-        self.set_parameters({
-            'SIM_ACC2_BIAS_Z': 0.7,
-        })
-        self.delay_sim_time(30)
-        self.assert_dataflash_message_field_level_at(
-            "XKF2", "AZ", 0.7,
-            condition="XKF2.C==1",
-            maintain=1,
-        )
-
-        # Confirm velocity still tracking GPS after bias convergence
-        self.wait_groundspeed(13, 17, timeout=10)
-
     # StabilityPatch - fly south, then hold loiter within 5m
     # position and altitude and reduce 1 motor to 60% efficiency
     def StabilityPatch(self,
@@ -13826,7 +13763,6 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
              self.EK3AccelBias,
              self.EK3_AccelBiasInhibitOnGroundMoving,
              self.EK3_AccelBiasZeroVelOptFlow,
-             self.EK3_ZeroVelFusionNotUsedWithGPS,
              self.StabilityPatch,
              self.OBSTACLE_DISTANCE_3D,
              self.AC_Avoidance_Proximity,

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -1852,6 +1852,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         # check), and GPS velocity innovations can drive incorrect bias learning
         # during ground movement. With the fix, all bias learning is inhibited
         # when onGround && !onGroundNotMoving.
+        self.context_push()
 
         # Enable logging while disarmed so we capture ground-only EKF data
         self.set_parameters({
@@ -1935,41 +1936,6 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             condition="XKF2.C==1",
             maintain=1,
             tolerance=0.3,
-        )
-
-    def EK3_AccelBiasZeroVelOptFlow(self):
-        '''Test EKF3 zero velocity fusion learns bias with optical flow config'''
-        # When optical flow is configured (AID_RELATIVE) but the vehicle is
-        # stationary on the ground, optical flow provides no velocity data.
-        # Without zero velocity fusion, there are no velocity observations and
-        # accel biases cannot converge. This test verifies that synthetic zero
-        # velocity fusion fills the gap, allowing Z-axis bias learning even
-        # when the only velocity source (optical flow) has no data.
-        self.context_push()
-
-        self.set_parameters({
-            "LOG_FILE_DSRMROT": 1,
-            "SIM_FLOW_ENABLE": 1,
-            "FLOW_TYPE": 10,
-        })
-        self.set_analog_rangefinder_parameters()
-        self.configure_EKFs_to_use_optical_flow_instead_of_GPS()
-
-        self.reboot_sitl()
-        self.wait_ready_to_arm(timeout=120, require_absolute=False)
-
-        # Inject Z-bias on IMU2 and wait for EKF to learn it via zero velocity
-        # fusion. In AID_RELATIVE with no flow data, only the synthetic zero
-        # velocity provides the observation needed to make Z-bias converge.
-        self.start_subtest("Verify Z-bias learned via zero velocity fusion with optical flow config")
-        self.set_parameters({
-            'SIM_ACC2_BIAS_Z': 0.7,
-        })
-        self.delay_sim_time(30)
-        self.assert_dataflash_message_field_level_at(
-            "XKF2", "AZ", 0.7,
-            condition="XKF2.C==1",
-            maintain=1,
         )
 
         self.context_pop()
@@ -13762,7 +13728,6 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
              self.VibrationFailsafe,
              self.EK3AccelBias,
              self.EK3_AccelBiasInhibitOnGroundMoving,
-             self.EK3_AccelBiasZeroVelOptFlow,
              self.StabilityPatch,
              self.OBSTACLE_DISTANCE_3D,
              self.AC_Avoidance_Proximity,

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -1388,12 +1388,13 @@ ftype NavEKF3_core::MagDeclination(void) const
 /*
   Update the on ground and not moving check.
   Should be called once per IMU update.
-  Used for yaw fusion strategy selection, zero velocity fusion gating,
-  and accel bias learning inhibition during ground movement.
+  Only updates when on ground and when operating without a magnetometer
 */
 void NavEKF3_core::updateMovementCheck(void)
 {
-    if (!onGround)
+    const bool runCheck = onGround && (yaw_source_last == AP_NavEKF_Source::SourceYaw::GPS || yaw_source_last == AP_NavEKF_Source::SourceYaw::GPS_COMPASS_FALLBACK ||
+                                       yaw_source_last == AP_NavEKF_Source::SourceYaw::EXTNAV || yaw_source_last == AP_NavEKF_Source::SourceYaw::GSF || !use_compass());
+    if (!runCheck)
     {
         onGroundNotMoving = false;
         return;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -666,8 +666,6 @@ void NavEKF3_core::SelectVelPosFusion()
     // If we are operating without any aiding, fuse in constant position of constant
     // velocity measurements to constrain tilt drift. This assumes a non-manoeuvring
     // vehicle. Do this to coincide with the height fusion.
-    fusingStationaryZeroVel = false;
-
     if (fuseHgtData && PV_AidingMode == AID_NONE) {
         if (assume_zero_sideslip() && tiltAlignComplete && motorsArmed) {
             // handle special case where we are launching a FW aircraft without magnetometer
@@ -696,60 +694,10 @@ void NavEKF3_core::SelectVelPosFusion()
             }
         } else {
             fusePosData = true;
-            // When stationary on ground or armed before takeoff, fuse zero velocity
-            // to constrain gyro bias and Z-axis accel bias learning. XY accel biases
-            // remain unobservable until the vehicle accelerates and are separately
-            // inhibited by dvelBiasAxisInhibit in CovariancePrediction.
-            // Use onGroundNotMoving to avoid fusing zero velocity when the vehicle
-            // is being moved (e.g. on a boat or carried by hand).
-            // takeoff_expected covers the armed-on-ground case before liftoff.
-            const bool onGroundNotFlying = onGroundNotMoving || dal.get_takeoff_expected();
-            if (onGroundNotFlying && tiltAlignComplete) {
-                fuseVelData = true;
-                fusingStationaryZeroVel = true;
-                velPosObs[0] = 0.0f;
-                velPosObs[1] = 0.0f;
-                velPosObs[2] = 0.0f;
-            } else {
-                fuseVelData = false;
-            }
+            fuseVelData = false;
+            fuseVelVertData = false;
             velPosObs[3] = lastKnownPositionNE.x;
             velPosObs[4] = lastKnownPositionNE.y;
-        }
-    }
-
-    // When in AID_RELATIVE or AID_ABSOLUTE mode but stationary on ground without velocity
-    // aiding, fuse synthetic zero velocity to constrain gyro bias and Z-axis accel bias
-    // learning. XY accel biases are unobservable on the ground and are inhibited by
-    // dvelBiasAxisInhibit. Without this, configurations like optical flow where
-    // PV_AidingMode is AID_RELATIVE but no velocity data is available when stationary
-    // have no velocity observations at all, causing unchecked bias drift. The timeout
-    // check on each velocity source ensures we only inject zero velocity when no real
-    // sensor data is being fused. Use onGroundNotMoving to avoid injecting zero velocity
-    // when the vehicle is being moved, and takeoff_expected for armed-on-ground.
-    // Gate behind fuseHgtData to limit fusion rate to baro rate (~10Hz) and avoid
-    // overconstraining the filter by fusing at IMU rate.
-    const bool onGroundNotFlying2 = onGroundNotMoving || dal.get_takeoff_expected();
-
-    if (fuseHgtData && PV_AidingMode != AID_NONE && onGroundNotFlying2) {
-        // Check if we have recent velocity aiding from any source
-        const uint32_t velAidTimeout_ms = 1000;
-        const bool haveRecentGpsVel = (imuSampleTime_ms - lastVelPassTime_ms < velAidTimeout_ms);
-#if EK3_FEATURE_OPTFLOW_FUSION
-        const bool haveRecentFlowVel = (imuSampleTime_ms - prevFlowFuseTime_ms < velAidTimeout_ms);
-#else
-        const bool haveRecentFlowVel = false;
-#endif
-        const bool haveRecentBodyVel = (imuSampleTime_ms - prevBodyVelFuseTime_ms < velAidTimeout_ms);
-
-        if (!haveRecentGpsVel && !haveRecentFlowVel && !haveRecentBodyVel) {
-            // No velocity aiding available while stationary - fuse synthetic zero velocity
-            // to constrain gyro bias and gravity-aligned accel bias
-            fuseVelData = true;
-            fusingStationaryZeroVel = true;
-            velPosObs[0] = 0.0f;
-            velPosObs[1] = 0.0f;
-            velPosObs[2] = 0.0f;
         }
     }
 
@@ -787,14 +735,7 @@ void NavEKF3_core::FuseVelPosNED()
         // estimate the velocity, horiz position and height measurement variances.
         // Use different errors if operating without external aiding using an assumed position or velocity of zero
         if (PV_AidingMode == AID_NONE) {
-            if (fusingStationaryZeroVel) {
-                // Synthetic zero velocity on ground: use 1 m/s noise (variance = 1 m^2/s^2).
-                // This is tighter than _noaidHorizNoise (default 10 m/s) used when armed,
-                // giving stronger velocity/bias convergence while we have high confidence
-                // the vehicle is stationary. Not as tight as a real sensor since
-                // the measurement is an assumption, not a physical observation.
-                R_OBS[0] = sq(1.0f);
-            } else if (tiltAlignComplete && motorsArmed) {
+            if (tiltAlignComplete && motorsArmed) {
                 // This is a compromise between corrections for gyro errors and reducing effect of manoeuvre accelerations on tilt estimate
                 R_OBS[0] = sq(constrain_ftype(frontend->_noaidHorizNoise, 0.5f, 50.0f));
             } else {
@@ -806,27 +747,6 @@ void NavEKF3_core::FuseVelPosNED()
             R_OBS[3] = R_OBS[0];
             R_OBS[4] = R_OBS[0];
             for (uint8_t i=0; i<=2; i++) R_OBS_DATA_CHECKS[i] = R_OBS[i];
-        } else if (fusingStationaryZeroVel) {
-            // Synthetic zero velocity in AID_RELATIVE or AID_ABSOLUTE mode when no
-            // velocity sensor data is available (e.g. GPS configured but not yet locked,
-            // or optical flow with no movement). Use 1 m/s noise for velocity — same
-            // rationale as the AID_NONE case above. Position observations may still be
-            // fused from real sensors so use their actual noise characteristics.
-            R_OBS[0] = sq(1.0f);
-            R_OBS[1] = R_OBS[0];
-            R_OBS[2] = R_OBS[0];
-            for (uint8_t i=0; i<=2; i++) R_OBS_DATA_CHECKS[i] = R_OBS[i];
-#if EK3_FEATURE_EXTERNAL_NAV
-            if (extNavUsedForPos) {
-                R_OBS[3] = sq(constrain_ftype(extNavDataDelayed.posErr, 0.01f, 10.0f));
-            } else
-#endif
-            if (gpsPosAccuracy > 0.0f) {
-                R_OBS[3] = sq(constrain_ftype(gpsPosAccuracy, frontend->_gpsHorizPosNoise, 100.0f));
-            } else {
-                R_OBS[3] = sq(constrain_ftype(frontend->_gpsHorizPosNoise, 0.1f, 10.0f));
-            }
-            R_OBS[4] = R_OBS[3];
         } else {
 #if EK3_FEATURE_EXTERNAL_NAV
             const bool extNavUsedForVel = extNavVelToFuse && frontend->sources.useVelXYSource(AP_NavEKF_Source::SourceXY::EXTNAV, core_index);
@@ -1090,7 +1010,8 @@ void NavEKF3_core::FuseVelPosNED()
         if (fuseVelData) {
             fuseData[0] = true;
             fuseData[1] = true;
-            if (fuseVelVertData || fusingStationaryZeroVel) {
+            // currently we do not support independant vertical velocity measurement fuision
+            if (fuseVelVertData) {
                 fuseData[2] = true;
             }
         }

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -793,7 +793,7 @@ void NavEKF3_core::FuseVelPosNED()
                 // giving stronger velocity/bias convergence while we have high confidence
                 // the vehicle is stationary. Not as tight as a real sensor since
                 // the measurement is an assumption, not a physical observation.
-                R_OBS[0] = sq(MIN(frontend->_noaidHorizNoise, 1.0f));
+                R_OBS[0] = sq(1.0f);
             } else if (tiltAlignComplete && motorsArmed) {
                 // This is a compromise between corrections for gyro errors and reducing effect of manoeuvre accelerations on tilt estimate
                 R_OBS[0] = sq(constrain_ftype(frontend->_noaidHorizNoise, 0.5f, 50.0f));

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -810,10 +810,8 @@ void NavEKF3_core::FuseVelPosNED()
             // Synthetic zero velocity in AID_RELATIVE or AID_ABSOLUTE mode when no
             // velocity sensor data is available (e.g. GPS configured but not yet locked,
             // or optical flow with no movement). Use 1 m/s noise for velocity — same
-            // rationale as the AID_NONE case above. Position noise uses actual sensor
-            // characteristics when available (extNav posErr, GPS accuracy), falling back
-            // to _gpsHorizPosNoise as a conservative default since it is the only
-            // position noise parameter available regardless of aiding source.
+            // rationale as the AID_NONE case above. Position observations may still be
+            // fused from real sensors so use their actual noise characteristics.
             R_OBS[0] = sq(1.0f);
             R_OBS[1] = R_OBS[0];
             R_OBS[2] = R_OBS[0];

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -729,9 +729,9 @@ void NavEKF3_core::SelectVelPosFusion()
     // when the vehicle is being moved, and takeoff_expected for armed-on-ground.
     // Gate behind fuseHgtData to limit fusion rate to baro rate (~10Hz) and avoid
     // overconstraining the filter by fusing at IMU rate.
-    const bool onGroundNotFlying = onGroundNotMoving || dal.get_takeoff_expected();
+    const bool onGroundNotFlying2 = onGroundNotMoving || dal.get_takeoff_expected();
 
-    if (fuseHgtData && PV_AidingMode != AID_NONE && onGroundNotFlying) {
+    if (fuseHgtData && PV_AidingMode != AID_NONE && onGroundNotFlying2) {
         // Check if we have recent velocity aiding from any source
         const uint32_t velAidTimeout_ms = 1000;
         const bool haveRecentGpsVel = (imuSampleTime_ms - lastVelPassTime_ms < velAidTimeout_ms);

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -1192,14 +1192,8 @@ void NavEKF3_core::CovariancePrediction(Vector3F *rotVarVecPtr)
         for (uint8_t stateIndex = 13; stateIndex <= 15; stateIndex++) {
             const uint8_t index = stateIndex - 13;
 
-            // Don't attempt learning of IMU delta velocity bias if on ground.
-            // In flight: all axes are observable from velocity/position aiding.
-            // On ground and stationary: only the gravity-aligned axis (Z for a level
-            // vehicle) is observable. XY biases remain unobservable until the vehicle
-            // accelerates horizontally in flight.
-            // On ground and moving (e.g. carried or on a boat): inhibit all axes
-            // to prevent learning biases from external motion accelerations.
-            const bool is_bias_observable = (fabsF(prevTnb[index][2]) > 0.8f && onGroundNotMoving) || !onGround;
+            // Don't attempt learning of IMU delta velocty bias if on ground and not aligned with the gravity vector
+            const bool is_bias_observable = (fabsF(prevTnb[index][2]) > 0.8f) || !onGround;
 
             if (!is_bias_observable && !dvelBiasAxisInhibit[index]) {
                 // store variances to be reinstated wben learning can commence later

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -269,7 +269,6 @@ void NavEKF3_core::InitialiseVariables()
     inFlight = false;
     prevInFlight = false;
     manoeuvring = false;
-    fusingStationaryZeroVel = false;
     inhibitWindStates = true;
     windStateIsObservable = false;
     treatWindStatesAsTruth = false;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -1126,7 +1126,6 @@ private:
     bool inFlight;                  // true when the vehicle is definitely flying
     bool prevInFlight;              // value inFlight from previous frame - used to detect transition
     bool manoeuvring;               // boolean true when the flight vehicle is performing horizontal changes in velocity
-    bool fusingStationaryZeroVel;   // true when fusing synthetic zero velocity while stationary on ground
     Vector6 innovVelPos;            // innovation output for a group of measurements
     Vector6 varInnovVelPos;         // innovation variance output for a group of measurements
     Vector6 velPosObs;              // observations for combined velocity and positon group of measurements (3x1 m , 3x1 m/s)


### PR DESCRIPTION
### Summary

Reverts PR#32396 which caused regression https://github.com/ArduPilot/ardupilot/issues/32980

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

The zero-velocity fusion PR introduced the linked regression, and a possible additional regression around quadplane takeoffs (`const bool onGroundNotFlying = onGroundNotMoving || dal.get_takeoff_expected();` does not gel with `When stationary on ground or armed before takeoff` as takeoff-expected can be true mid-air)

This PR simply reverts the original PR.

I would prefer we work through the issue rather than reverting, but there are strong reasons to get a fix into master ASAP (and there was definite agreement from other devs on DevCall that we should do this).

There is a [bunch of discussion on Discord](https://discord.com/channels/674039678562861068/1506212127155949699) as to other options - but (a) I said I would create this PR and (b) [my final question](https://discord.com/channels/674039678562861068/1506212127155949699/1506452262740820109) as to how we can be "taking off" mid-air with a conventional plane remains unanswered.

I had a feeling there must be something else in these patches which is problematic, apart from the onGroundNotMoving determination.  However there is a pre-existing bug (present both in master and on top of this branch) - probably the confounding factor for @andyp1per - which is that the "takeoffexpected" flag is being set by Plane when we enter FBWA mid-flight!

<img width="1981" height="921" alt="image" src="https://github.com/user-attachments/assets/e81806b2-5194-4774-8122-541298a91865" />

```
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -6783,6 +6783,11 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
     def GuidedAttitudeNoGPS(self):
         '''test that guided-attitude still works with no GPS'''
+        self.set_parameters({
+            "LOG_DISARMED": 1,
+            "LOG_REPLAY": 1,
+        })
+        self.reboot_sitl()
         self.takeoff(50)
         self.change_mode('GUIDED')
         self.context_push()
```
```
graph POS.Alt RFRN.Flags&64:2
```
