### PR TITLE
hwdef: ARKV6X-IOMCU: new IOMCU variant of ARKV6X

### DIFF
--- a/Tools/scripts/size_compare_branches.py
+++ b/Tools/scripts/size_compare_branches.py
@@ -202,6 +202,7 @@ class SizeCompareBranches(BuildScriptBase):
             'TBS-L431-CurrMon',  # uses USE_BOOTLOADER_FROM_BOARD
             'TBS-L431-PWM',  # uses USE_BOOTLOADER_FROM_BOARD
             'ARKV6X-bdshot',  # uses USE_BOOTLOADER_FROM_BOARD
+            'ARKV6X-IOMCU',  # uses USE_BOOTLOADER_FROM_BOARD
 
             'MatekL431-ADSB',  # uses USE_BOOTLOADER_FROM_BOARD
             'MatekL431-Airspeed',  # uses USE_BOOTLOADER_FROM_BOARD

--- a/libraries/AP_HAL_ChibiOS/hwdef/ARKV6X-IOMCU/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ARKV6X-IOMCU/hwdef.dat
@@ -1,0 +1,18 @@
+# ARKV6X variant for carriers that have an IO MCU on USART6
+# (e.g. ARK Jetson PAB V3 Carrier, Holybro Pixhawk6X carrier).
+#
+# Same board ID and bootloader as ARKV6X; the difference is purely
+# in how USART6 is wired downstream of the FMU.
+
+include ../ARKV6X/hwdef.dat
+
+USE_BOOTLOADER_FROM_BOARD ARKV6X
+
+# move USART6 out of the user-visible serial list; it is owned by the IO MCU
+SERIAL_ORDER OTG1 UART7 UART5 USART1 UART8 USART2 UART4 USART3 OTG2
+
+# SERIAL8 is now OTG2, not the USART6 RC input; drop the inherited default
+undef DEFAULT_SERIAL8_PROTOCOL
+
+IOMCU_UART USART6
+ROMFS io_firmware.bin Tools/IO_Firmware/iofirmware_lowpolh.bin

--- a/libraries/AP_HAL_ChibiOS/hwdef/ARKV6X/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ARKV6X/hwdef.dat
@@ -26,11 +26,11 @@ env USE_ALT_RAM_MAP 1
 FLASH_SIZE_KB 2048
 
 
-# order of UARTs (and USB) no IO MCU
+# order of UARTs (and USB)
+# USART6 is the RC input on carriers without an IO MCU. For carriers
+# with an IO MCU on USART6 (e.g. ARK Jetson PAB V3 Carrier, Holybro
+# Pixhawk6X carrier), build the ARKV6X-IOMCU board instead.
 SERIAL_ORDER OTG1 UART7 UART5 USART1 UART8 USART2 UART4 USART3 USART6 OTG2
-
-# order of UARTs (and USB) with IO MCU
-# SERIAL_ORDER OTG1 UART7 UART5 USART1 UART8 USART2 UART4 USART3 OTG2
 
 # debug console
 STDOUT_SERIAL SD3
@@ -82,13 +82,10 @@ PH14 UART4_RX UART4
 PD8 USART3_TX USART3
 PD9 USART3_RX USART3
 
-# used for RC SBUS
+# used for RC SBUS (carriers without an IO MCU)
 PC6 USART6_TX USART6
 PC7 USART6_RX USART6
 define DEFAULT_SERIAL8_PROTOCOL SerialProtocol_RCIN
-
-# Uncomment this line for carriers boards with an IO MCU
-# IOMCU_UART USART6
 
 # Ethernet
 PB11 ETH_RMII_TX_EN     ETH1
@@ -335,8 +332,6 @@ DMA_PRIORITY SDMMC* USART6* ADC* UART* USART* SPI* TIM*
 
 # enable FAT filesystem support (needs a microSD defined via SDMMC)
 define HAL_OS_FATFS_IO 1
-
-ROMFS io_firmware.bin Tools/IO_Firmware/iofirmware_lowpolh.bin
 
 # enable DFU reboot for installing bootloader
 # note that if firmware is build with --secure-bl then DFU is


### PR DESCRIPTION
## Summary
Supersedes #33103.

Add `ARKV6X-IOMCU` as a dedicated build for ARKV6X-based FMUs sitting on a carrier with an on-board IO MCU on USART6 (e.g. ARK Jetson PAB V3 Carrier, Holybro Pixhawk6X carrier).

## Problem
The base `ARKV6X` hwdef left IOMCU support as commented-out lines plus an unconditional `ROMFS io_firmware.bin` that added ~30 KB of unused iofirmware to every default build. Enabling IOMCU required hand-editing the hwdef in three different places.

## Solution
Per @peterbarker's first counter-proposal on #33103, introduce a second board rather than a toggle. `ARKV6X-IOMCU` includes the base hwdef, inherits the bootloader and board ID via `USE_BOOTLOADER_FROM_BOARD ARKV6X`, moves USART6 to `IOMCU_UART`, and pulls in `iofirmware_lowpolh.bin`. With it in place, the base `ARKV6X` drops the commented-out toggles and the unused ROMFS.