### PR TITLE
ArduPlane: fix units in high_latency_tgt_dist()

### DIFF
--- a/ArduPlane/GCS_MAVLink_Plane.cpp
+++ b/ArduPlane/GCS_MAVLink_Plane.cpp
@@ -1206,18 +1206,22 @@ uint8_t GCS_MAVLINK_Plane::high_latency_tgt_heading() const
         return wrap_360_cd(nav_controller->target_bearing_cd() ) / 200;
 }
 
-// return units are dm
+// return units are dam (decameters), per MAVLink HIGH_LATENCY2 spec
 uint16_t GCS_MAVLINK_Plane::high_latency_tgt_dist() const
 {
 #if HAL_QUADPLANE_ENABLED
     const QuadPlane &quadplane = plane.quadplane;
     if (quadplane.show_vtol_view()) {
-        bool wp_nav_valid = quadplane.using_wp_nav();
-        return (wp_nav_valid ? MIN(quadplane.wp_nav->get_wp_distance_to_destination_cm(), UINT16_MAX) : 0) / 10;
+        if (!quadplane.using_wp_nav()) {
+            return 0;
+        }
+        // cm -> dam (divide first to avoid the clamp truncating long distances)
+        return MIN(quadplane.wp_nav->get_wp_distance_to_destination_cm() / 1000.0f, (float)UINT16_MAX);
     }
-    #endif
+#endif
 
-    return MIN(plane.auto_state.wp_distance, UINT16_MAX) / 10;
+    // m -> dam
+    return MIN(plane.auto_state.wp_distance / 10.0f, (float)UINT16_MAX);
 }
 
 uint8_t GCS_MAVLINK_Plane::high_latency_tgt_airspeed() const


### PR DESCRIPTION
## Summary

Fixes #32838.

The MAVLink [HIGH_LATENCY2](https://mavlink.io/en/messages/common.html#HIGH_LATENCY2) spec defines `target_distance` in **dam** (decameters, = 10 m). The function had two problems:

1. The QuadPlane (VTOL view) branch divided centimeters by 10, producing **decimeters** instead of decameters — reporting the distance to the GCS **100x too large**.
2. The doc comment said `// return units are dm`, matching the (incorrect) implementation rather than the spec.

The non-VTOL Plane branch was already correct (`m / 10 = dam`), as @stephendade confirmed on the issue.

This PR:

- Changes the QuadPlane branch from `cm / 10` to `cm / 1000` so both branches return `dam`.
- Fixes the doc comment to say `dam` and references the spec.
- Reorders the clamp to apply *after* the divide, so the full `uint16` range is usable. Previously the input was clamped to `UINT16_MAX` before the divide, which artificially capped the reported distance at ~655 m on the QuadPlane branch and ~65 km on the Plane branch. After this change both branches can report up to `UINT16_MAX` dam (~655 km), which fits HIGH_LATENCY long-range telemetry use cases.

## Classification & Testing

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [x] Bug fix
- [ ] Automated test(s) verify changes
- [x] Tested manually, description below
- [ ] Tested on hardware

Built ArduPlane SITL on macOS (arm64) — change compiles cleanly. Have not exercised the HIGH_LATENCY2 path in a running SITL session.