### PR TITLE
AP_Terrain: ignore uninitialised AHRS locations

### DIFF
--- a/libraries/AP_Terrain/AP_Terrain.cpp
+++ b/libraries/AP_Terrain/AP_Terrain.cpp
@@ -118,6 +118,15 @@ bool AP_Terrain::height_amsl(const Location &loc, float &height, bool corrected)
         return false;
     }
 
+    // refuse to operate on uninitialised locations. AP_AHRS::update()
+    // asserts the same invariant in SITL but the check is compiled out
+    // of production, so a backend that violates it would otherwise
+    // cause us to seed a cache slot at (0,0) and spam TERRAIN_REQUEST
+    // for that tile.
+    if (!loc.initialised()) {
+        return false;
+    }
+
     const AP_AHRS &ahrs = AP::ahrs();
 
     // quick access for home altitude
@@ -370,9 +379,11 @@ void AP_Terrain::update(void)
     float height;
     height_amsl(ahrs.get_home(), height);
 
-    // update the cached current location height
+    // update the cached current location height. An uninitialised
+    // Location is treated as no fix so that update_surrounding_tiles()
+    // doesn't seed neighbour tiles around (0,0).
     Location loc;
-    bool pos_valid = ahrs.get_location(loc);
+    bool pos_valid = ahrs.get_location(loc) && loc.initialised();
     bool terrain_valid = pos_valid && height_amsl(loc, height);
     if (pos_valid && terrain_valid) {
         last_current_loc_height = height;

--- a/libraries/AP_Terrain/TerrainGCS.cpp
+++ b/libraries/AP_Terrain/TerrainGCS.cpp
@@ -119,9 +119,12 @@ void AP_Terrain::send_request(GCS_MAVLINK &link)
     schedule_disk_io();
 
     Location loc;
-    if (!AP::ahrs().get_location(loc)) {
-        // we don't know where we are. Request any cached blocks.
-        // this allows for download of mission items when we have no GPS lock
+    if (!AP::ahrs().get_location(loc) || !loc.initialised()) {
+        // we don't know where we are, or a backend returned an
+        // uninitialised Location. Request any cached blocks. This
+        // allows download of mission items when we have no GPS lock,
+        // and prevents seeding a (0,0) cache slot via find_grid_cache()
+        // when the AHRS reports a default-constructed Location.
         send_cache_request(link);
         return;
     }


### PR DESCRIPTION
## Summary
Stop AP_Terrain from sending TERRAIN_REQUEST(lat=0, lon=0) when an AHRS backend briefly returns `get_location()=true` with an uninitialised Location.

## Problem
`AP_AHRS::update()` asserts in SITL that backends must not return `location_ok=true` with an uninitialised Location (`libraries/AP_AHRS/AP_AHRS.cpp:464-468`), but the assertion is compiled out of production builds. A backend that violates the invariant — a GPS reporting FIX_3D at (0,0) before time-of-week sync, an external GPS_INPUT with default coords, brief windows during EKF startup — causes AP_Terrain to seed a cache slot at `grid_lat=0/grid_lon=0` via `height_amsl()` or `send_request()`. Once the disk read for `N00E000.DAT` completes (file missing, bitmap stays 0), every subsequent `send_request()` invocation fires a TERRAIN_REQUEST for the Null Island tile. The no-fix branch of `send_request()` (taken once the AHRS loses fix again) has no rate limit and drives the spam at the EXTRA3 stream rate — visible from the GCS side as ~12 Hz of inbound requests for tile (0,0).

## Solution
Treat an uninitialised AHRS location as "no fix" at the three points in AP_Terrain that consume one: the `pos_valid` gate in `update()` (so `update_surrounding_tiles()` doesn't seed neighbour tiles around (0,0)), the entry check in `send_request()` (so the rate-limited path doesn't create a (0,0) cache slot via `find_grid_cache(info)`), and the top of `height_amsl()` (so external callers like `height_above_terrain()` and `lookahead()` can't create one either). This matches the existing SITL invariant.