### PR TITLE
AP_Compass: persist dev_id for newly-detected compasses

### DIFF
--- a/libraries/AP_Compass/AP_Compass_Backend.cpp
+++ b/libraries/AP_Compass/AP_Compass_Backend.cpp
@@ -220,6 +220,14 @@ bool AP_Compass_Backend::register_compass(int32_t dev_id)
 void AP_Compass_Backend::set_dev_id(uint32_t dev_id)
 {
     _compass._state[Compass::StateIndex(instance)].dev_id.set_and_notify(dev_id);
+    // Persist the dev_id of a newly-detected compass that fills a slot with no
+    // stored dev_id (e.g. a runtime DroneCAN mag), so the next boot's
+    // _reorder_compass_params() can map its priority back to this slot. Gated
+    // on the empty slot, not init_done, to avoid the DroneCAN/init() race.
+    if (!_compass.suppress_devid_save &&
+        _compass._state[Compass::StateIndex(instance)].expected_dev_id == 0) {
+        _compass._state[Compass::StateIndex(instance)].dev_id.save();
+    }
     _compass._state[Compass::StateIndex(instance)].detected_dev_id = dev_id;
 }
 


### PR DESCRIPTION
## Summary

`AP_Compass_Backend::set_dev_id()` only called `set_and_notify()`, so a compass that first appears on an already-configured vehicle never had its `COMPASS_DEV_IDn` written to EEPROM, even though `_update_priority_list()` had already persisted its `COMPASS_PRIOn_ID`. The motivating case is a DroneCAN GPS+mag detected at runtime and never calibrated.

When priorities are then re-ordered and the vehicle reboots, `_reorder_compass_params()` matches each `_priority_did_list[]` entry to a state slot via `_state[j].dev_id`. The runtime compass is in no saved slot, so it is skipped, and a later priority swaps the previously-calibrated compass out of slot 0 — leaving `COMPASS_DEV_ID = 0` with the saved offsets / scale_factor / diagonals in the wrong slot, after which mag-cal misbehaves.

Persist the dev_id from `set_dev_id()` when the compass fills a slot that held no stored dev_id at boot (`expected_dev_id == 0`). This is timing-independent: it fires whether the compass registers during `init()` or asynchronously at runtime, and it never matches the already-known compasses that `_reorder_compass_params()` has arranged into occupied slots, so it cannot clobber that arrangement.

The gate is deliberately not keyed off `init_done`: DroneCAN registration races with `init()` (`probe_dronecan_compasses()` runs inside `_detect_backends()`), so a CAN mag already publishing registers before `init_done` is set and a timing check would miss it.

## Testing

- `SixCompassCalibrationAndReordering` and `CompassReordering` pass (both failed with an earlier unconditional-save form of this patch; the empty-slot gate fixes that regression).
- `CANGPSCopterMission` passes.
- Verified in SITL that the dev_id is persisted only when a compass fills an empty slot — including when it registers during `init()`, covering the DroneCAN/`init()` race — and never for compasses already arranged by `_reorder_compass_params()`.
