### PR TITLE
AP_AHRS: DCM: ignore uninitialised GPS location in drift_correction

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -770,8 +770,11 @@ AP_AHRS_DCM::drift_correction(float deltat)
         _last_airspeed_TAS = MAX(airspeed.x, 0);
     }
 
-    if (have_gps()) {
-        // use GPS for positioning with any fix, even a 2D fix
+    // allow positioning from any fix (even 2D), but require an initialised
+    // Location -- some backends (notably DroneCAN GPSes during cold start)
+    // briefly publish status>=FIX_2D with lat=lng=0, which would latch
+    // (0,0) as the dead-reckoning origin.
+    if (have_gps() && _gps.location().initialised()) {
         _last_lat = _gps.location().lat;
         _last_lng = _gps.location().lng;
         _last_pos_ms = AP_HAL::millis();


### PR DESCRIPTION
## Summary

Stop `AP_AHRS_DCM` from latching `(0,0)` as the dead-reckoning origin when a GPS backend transiently publishes `status>=FIX_2D` with `lat=lng=0`. Supersedes #33135 (which patched the downstream consumer instead of the root cause).

## Problem

`drift_correction()` latches `_gps.location().lat/lng` into `_last_lat/_last_lng` and sets `_have_position=true` whenever `have_gps()` returns true. `have_gps()` only requires `status > NONE`, but the AP_GPS contract does not guarantee `status>=FIX_2D` implies an initialised `Location`. Several backends violate this transiently: `AP_GPS_DroneCAN` faithfully relays whatever the CAN module publishes (a peripheral in cold start under jamming/spoofing conditions can advertise `FIX_2D` with lan/lon set to 0), `AP_GPS_MAV` writes status and coords from a `GPS_INPUT` packet with no guard, `AP_GPS_NMEA` can update status from GGA while location is still zero from earlier, and `AP_GPS_Blended` picks the max status across instances but copies location from a single weighted instance.

Once latched, `_have_position` is sticky: `get_location()` returns `(0,0)+offsets` with success, which trips the SITL panic at `AP_AHRS.cpp:465` (`location_ok` with uninitialised `Location`) and in production seeds an AP_Terrain cache slot at grid `(0,0)`, driving the ~12 Hz `TERRAIN_REQUEST` spam for the Null Island tile reported in #33135.

## Solution

Gate the latch on `_gps.location().initialised()` in addition to `have_gps()`. When the backend publishes junk coords, we fall through to the existing offset-accumulation branch, leaving `_last_lat/_last_lng` and `_have_position` untouched — so a previously-good fix continues to anchor dead-reckoning, and a fresh boot keeps `_have_position=false` until a real fix arrives. Audited the other 23 `gps.location()` callsites in-tree; none pair these checks because every other consumer either gates on `status>=FIX_3D` directly or reads through `AHRS::get_location()`, which transitively benefits from this fix.