### PR TITLE
Allow ArduPilot to focus cameras on a per-instance basis

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -7630,6 +7630,66 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             if trigger_counts[cam] != 1:
                 raise NotAchievedException(f"Incorrect trigger count for cam{cam}")
 
+        # Test per-camera zoom and focus levels
+        camera_settings_by_compid = {}
+
+        def camera_settings_hook(mav, m):
+            if m.get_type() != 'CAMERA_SETTINGS':
+                return
+            camera_settings_by_compid[m.get_srcComponent()] = m
+
+        self.install_message_hook_context(camera_settings_hook)
+
+        cam1_compid = mavutil.mavlink.MAV_COMP_ID_CAMERA
+        cam2_compid = mavutil.mavlink.MAV_COMP_ID_CAMERA + 1  # MAV_COMP_ID_CAMERA2
+
+        self.progress("Test setting different zoom levels on each camera")
+        self.run_cmd_int(
+            mavutil.mavlink.MAV_CMD_SET_CAMERA_ZOOM,
+            p1=mavutil.mavlink.ZOOM_TYPE_RANGE,
+            p2=30,  # 30%
+            p3=1,   # camera instance 1
+        )
+        self.run_cmd_int(
+            mavutil.mavlink.MAV_CMD_SET_CAMERA_ZOOM,
+            p1=mavutil.mavlink.ZOOM_TYPE_RANGE,
+            p2=70,  # 70%
+            p3=2,   # camera instance 2
+        )
+        self.delay_sim_time(2, "allow CAMERA_SETTINGS to come through")
+        for compid, want_zoom in [(cam1_compid, 30), (cam2_compid, 70)]:
+            if compid not in camera_settings_by_compid:
+                raise NotAchievedException(
+                    f"Did not see CAMERA_SETTINGS from compid {compid}")
+            got = camera_settings_by_compid[compid].zoomLevel
+            if abs(got - want_zoom) > 0.5:
+                raise NotAchievedException(
+                    f"compid {compid} zoom wrong: want={want_zoom} got={got}")
+
+        self.progress("Test setting different focus levels on each camera")
+        camera_settings_by_compid.clear()
+        self.run_cmd_int(
+            mavutil.mavlink.MAV_CMD_SET_CAMERA_FOCUS,
+            p1=mavutil.mavlink.FOCUS_TYPE_RANGE,
+            p2=20,  # 20%
+            p3=1,   # camera instance 1
+        )
+        self.run_cmd_int(
+            mavutil.mavlink.MAV_CMD_SET_CAMERA_FOCUS,
+            p1=mavutil.mavlink.FOCUS_TYPE_RANGE,
+            p2=80,  # 80%
+            p3=2,   # camera instance 2
+        )
+        self.delay_sim_time(2, "allow CAMERA_SETTINGS to come through")
+        for compid, want_focus in [(cam1_compid, 20), (cam2_compid, 80)]:
+            if compid not in camera_settings_by_compid:
+                raise NotAchievedException(
+                    f"Did not see CAMERA_SETTINGS from compid {compid}")
+            got = camera_settings_by_compid[compid].focusLevel
+            if abs(got - want_focus) > 0.5:
+                raise NotAchievedException(
+                    f"compid {compid} focus wrong: want={want_focus} got={got}")
+
     def assert_mount_rpy(self, r, p, y, tolerance=1):
         '''assert mount atttiude in degrees'''
         got_r, got_p, got_y, yaw_is_absolute = self.get_mount_roll_pitch_yaw_deg()

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -7573,9 +7573,8 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         })
         self.customise_SITL_commandline(["--serial5=sim:avt_cm62_gimbal:"])
 
-    def MountAVTCM62Dual(self):
-        '''test two simultaneous MAVLink (Gimbal Protocol v2) gimbals using
-        two SIM_AVT_CM62 simulators on separate serial ports'''
+    def _setup_avt_cm62_dual(self):
+        '''configure two SIM_AVT_CM62 simulators on serial5 and serial6'''
         self.set_parameters({
             "MNT1_TYPE": 6,         # MAVLink
             "MNT2_TYPE": 6,         # MAVLink
@@ -7588,6 +7587,12 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             "--serial5=sim:avt_cm62_gimbal:",
             "--serial6=sim:avt_cm62_gimbal:",
         ])
+        self.delay_sim_time(12, "wait for MAVLink camera backends to initialise")
+
+    def MountAVTCM62Dual(self):
+        '''test two simultaneous MAVLink (Gimbal Protocol v2) gimbals using
+        two SIM_AVT_CM62 simulators on separate serial ports'''
+        self._setup_avt_cm62_dual()
 
         # note that CAMERA_FEEDBACK uses instance numbers starting from 0
         trigger_counts = {}
@@ -7600,7 +7605,6 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             trigger_counts[m.cam_idx] += 1
 
         self.install_message_hook_context(trig_counter)
-        self.delay_sim_time(12, "wait for MAVLink camera backends to initialise")
         self.progress("Test triggering of the two cameras")
         self.run_cmd_int(
             mavutil.mavlink.MAV_CMD_DO_SET_CAM_TRIGG_DIST,
@@ -7682,6 +7686,82 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         )
         self.delay_sim_time(2, "allow CAMERA_SETTINGS to come through")
         for compid, want_focus in [(cam1_compid, 20), (cam2_compid, 80)]:
+            if compid not in camera_settings_by_compid:
+                raise NotAchievedException(
+                    f"Did not see CAMERA_SETTINGS from compid {compid}")
+            got = camera_settings_by_compid[compid].focusLevel
+            if abs(got - want_focus) > 0.5:
+                raise NotAchievedException(
+                    f"compid {compid} focus wrong: want={want_focus} got={got}")
+
+    def MountAVTCM62DualMission(self):
+        '''test dual AVT CM62 cameras with zoom and focus controlled via
+        mission items (MAV_CMD_SET_CAMERA_ZOOM and MAV_CMD_SET_CAMERA_FOCUS)'''
+        self._setup_avt_cm62_dual()
+
+        cam1_compid = mavutil.mavlink.MAV_COMP_ID_CAMERA
+        cam2_compid = mavutil.mavlink.MAV_COMP_ID_CAMERA + 1  # MAV_COMP_ID_CAMERA2
+
+        camera_settings_by_compid = {}
+
+        def camera_settings_hook(mav, m):
+            if m.get_type() != 'CAMERA_SETTINGS':
+                return
+            camera_settings_by_compid[m.get_srcComponent()] = m
+
+        self.install_message_hook_context(camera_settings_hook)
+
+        self.set_parameter("AUTO_OPTIONS", 3)
+
+        mission_items = [
+            (mavutil.mavlink.MAV_CMD_NAV_TAKEOFF, 0, 0, 20),
+            self.create_MISSION_ITEM_INT(
+                mavutil.mavlink.MAV_CMD_SET_CAMERA_ZOOM,
+                p1=mavutil.mavlink.ZOOM_TYPE_RANGE,
+                p2=25,   # cam1 → 25%
+                p3=1,    # camera instance 1
+                autocontinue=1,
+            ),
+            self.create_MISSION_ITEM_INT(
+                mavutil.mavlink.MAV_CMD_SET_CAMERA_ZOOM,
+                p1=mavutil.mavlink.ZOOM_TYPE_RANGE,
+                p2=75,   # cam2 → 75%
+                p3=2,    # camera instance 2
+                autocontinue=1,
+            ),
+            self.create_MISSION_ITEM_INT(
+                mavutil.mavlink.MAV_CMD_SET_CAMERA_FOCUS,
+                p1=mavutil.mavlink.FOCUS_TYPE_RANGE,
+                p2=40,   # cam1 → 40%
+                p3=1,    # camera instance 1
+                autocontinue=1,
+            ),
+            self.create_MISSION_ITEM_INT(
+                mavutil.mavlink.MAV_CMD_SET_CAMERA_FOCUS,
+                p1=mavutil.mavlink.FOCUS_TYPE_RANGE,
+                p2=80,   # cam2 → 80%
+                p3=2,    # camera instance 2
+                autocontinue=1,
+            ),
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 30, 0, 20),
+            (mavutil.mavlink.MAV_CMD_NAV_RETURN_TO_LAUNCH, 0, 0, 0),
+        ]
+
+        self.fly_simple_relhome_mission(mission_items)
+        self.delay_sim_time(2, "allow CAMERA_SETTINGS to come through after mission")
+
+        self.progress("Verify per-camera zoom levels set by mission items")
+        for compid, want_zoom in [(cam1_compid, 25), (cam2_compid, 75)]:
+            if compid not in camera_settings_by_compid:
+                raise NotAchievedException(
+                    f"Did not see CAMERA_SETTINGS from compid {compid}")
+            got = camera_settings_by_compid[compid].zoomLevel
+            if abs(got - want_zoom) > 0.5:
+                raise NotAchievedException(
+                    f"compid {compid} zoom wrong: want={want_zoom} got={got}")
+
+        self.progress("Verify per-camera focus levels set by mission items")
+        for compid, want_focus in [(cam1_compid, 40), (cam2_compid, 80)]:
             if compid not in camera_settings_by_compid:
                 raise NotAchievedException(
                     f"Did not see CAMERA_SETTINGS from compid {compid}")
@@ -17465,6 +17545,7 @@ return update, 1000
             self.MountViewPro,
             self.MountAVTCM62,
             self.MountAVTCM62Dual,
+            self.MountAVTCM62DualMission,
             self.MountRCFailAngle,
             self.MountRCFailRate,
             self.FlyMissionTwice,

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -6776,6 +6776,9 @@ class TestSuite(abc.ABC):
     def sysid_thismav(self):
         return 1
 
+    def compid_thismav(self):
+        return 1
+
     def create_MISSION_ITEM_INT(
             self,
             t,
@@ -8801,7 +8804,8 @@ Also, ignores heartbeats not from our target system'''
             m = self.mav.wait_heartbeat(*args, **x)
             if m is None:
                 continue
-            if m.get_srcSystem() == self.sysid_thismav():
+            if (m.get_srcSystem() == self.sysid_thismav() and
+                    m.get_srcComponent() == self.compid_thismav()):
                 return m
 
     def wait_ekf_happy(self, require_absolute=True, **kwargs):

--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -351,6 +351,56 @@ MAV_RESULT AP_Camera::handle_mav_SET_CAMERA_ZOOM(uint8_t instance_id, CAMERA_ZOO
 
     return result;
 }
+
+MAV_RESULT AP_Camera::handle_mav_SET_CAMERA_FOCUS(uint8_t instance_id, SET_FOCUS_TYPE mav_focus_type, float focus_value)
+{
+    // note: focus_value can be modified before it is used
+
+    FocusType focus_type;
+    switch (mav_focus_type) {
+    case FOCUS_TYPE_AUTO:
+    case FOCUS_TYPE_AUTO_SINGLE:
+    case FOCUS_TYPE_AUTO_CONTINUOUS:
+        // accept any of the auto focus types
+        focus_type = FocusType::AUTO;
+        focus_value = 0;
+        break;
+    case FOCUS_TYPE_CONTINUOUS:
+        // accept continuous manual focus
+        focus_type = FocusType::RATE;
+        break;
+    case FOCUS_TYPE_RANGE:
+        // accept focus as percentage
+        focus_type = FocusType::PCT;
+        break;
+    case SET_FOCUS_TYPE_ENUM_END:
+    case FOCUS_TYPE_STEP:
+    case FOCUS_TYPE_METERS:
+    default:  // mav_focus_type comes off the wire so could be anything
+        // unsupported focus (bad parameter)
+        return MAV_RESULT_DENIED;
+    }
+
+    MAV_RESULT result = MAV_RESULT_ACCEPTED;
+    for (uint8_t i=0; i<AP_CAMERA_MAX_INSTANCES; i++) {
+        if (_backends[i] == nullptr) {
+            continue;
+        }
+        // honour packet instance number:
+        if (instance_id != 0 && i+1 != instance_id) {
+            continue;
+        }
+        // all backends must succeed.  If any fail we pass back the
+        // result from the last camera that failed.
+        const SetFocusResult backend_result = _backends[i]->set_focus(focus_type, focus_value);
+        if (backend_result != SetFocusResult::ACCEPTED) {
+            // for now FocusResult can just be cast into MAV_RESULT:
+            result = (MAV_RESULT)backend_result;
+        }
+    }
+
+    return result;
+}
 #endif  // HAL_MAVLINK_BINDINGS_ENABLED
 
 // handle command_long mavlink messages
@@ -376,25 +426,11 @@ MAV_RESULT AP_Camera::handle_command(const mavlink_command_int_t &packet)
             packet.param2                    // zoom level
         );
     case MAV_CMD_SET_CAMERA_FOCUS:
-        // accept any of the auto focus types
-        switch ((SET_FOCUS_TYPE)packet.param1) {
-        case FOCUS_TYPE_AUTO:
-        case FOCUS_TYPE_AUTO_SINGLE:
-        case FOCUS_TYPE_AUTO_CONTINUOUS:
-            return (MAV_RESULT)set_focus(FocusType::AUTO, 0);
-        case FOCUS_TYPE_CONTINUOUS:
-        // accept continuous manual focus
-            return (MAV_RESULT)set_focus(FocusType::RATE, packet.param2);
-        // accept focus as percentage
-        case FOCUS_TYPE_RANGE:
-            return (MAV_RESULT)set_focus(FocusType::PCT, packet.param2);
-        case SET_FOCUS_TYPE_ENUM_END:
-        case FOCUS_TYPE_STEP:
-        case FOCUS_TYPE_METERS:
-            // unsupported focus (bad parameter)
-            break;
-        }
-        return MAV_RESULT_DENIED;
+        return handle_mav_SET_CAMERA_FOCUS(
+            packet.param3,                   // instance
+            SET_FOCUS_TYPE(packet.param1),   // focus type
+            packet.param2                    // focus value
+        );
 
 #if AP_CAMERA_SET_CAMERA_SOURCE_ENABLED
     case MAV_CMD_SET_CAMERA_SOURCE:

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -105,6 +105,7 @@ public:
     // methods to handle mavlink-style instance-id (0 meaning all cameras)
     MAV_RESULT handle_mav_DO_SET_CAM_TRIGG_DISTANCE(uint8_t instance_id, bool trigger, float dist_m);
     MAV_RESULT handle_mav_SET_CAMERA_ZOOM(uint8_t instance_id, CAMERA_ZOOM_TYPE mav_zoom_type, float zoom_value);
+    MAV_RESULT handle_mav_SET_CAMERA_FOCUS(uint8_t instance_id, SET_FOCUS_TYPE mav_focus_type, float focus_value);
 #endif  // HAL_MAVLINK_BINDINGS_ENABLED
 
     // select which instance to send on the next deferred MSG_CAMERA_INFORMATION send

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -1453,6 +1453,7 @@ MAV_MISSION_RESULT AP_Mission::mavlink_int_to_mission_cmd(const mavlink_mission_
     case MAV_CMD_SET_CAMERA_FOCUS:
         cmd.content.set_camera_focus.focus_type = packet.param1;
         cmd.content.set_camera_focus.focus_value = packet.param2;
+        cmd.content.set_camera_focus.camera_id = packet.param3;
         break;
 
     case MAV_CMD_SET_CAMERA_SOURCE:
@@ -1977,6 +1978,7 @@ bool AP_Mission::mission_cmd_to_mavlink_int(const AP_Mission::Mission_Command& c
     case MAV_CMD_SET_CAMERA_FOCUS:
         packet.param1 = cmd.content.set_camera_focus.focus_type;
         packet.param2 = cmd.content.set_camera_focus.focus_value;
+        packet.param3 = cmd.content.set_camera_focus.camera_id;
         break;
 
     case MAV_CMD_SET_CAMERA_SOURCE:

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -285,6 +285,7 @@ public:
     struct PACKED set_camera_focus_Command {
         uint8_t focus_type;
         float focus_value;
+        uint8_t camera_id;
     };
 
     // MAV_CMD_SET_CAMERA_SOURCE support

--- a/libraries/AP_Mission/AP_Mission_Commands.cpp
+++ b/libraries/AP_Mission/AP_Mission_Commands.cpp
@@ -147,22 +147,13 @@ bool AP_Mission::start_command_camera(const AP_Mission::Mission_Command& cmd)
             (CAMERA_ZOOM_TYPE)cmd.content.set_camera_zoom.zoom_type,
             cmd.content.set_camera_zoom.zoom_value
         ) == MAV_RESULT_ACCEPTED;
+
     case MAV_CMD_SET_CAMERA_FOCUS:
-        // accept any of the auto focus types
-        if ((cmd.content.set_camera_focus.focus_type == FOCUS_TYPE_AUTO) ||
-            (cmd.content.set_camera_focus.focus_type == FOCUS_TYPE_AUTO_SINGLE) ||
-            (cmd.content.set_camera_focus.focus_type == FOCUS_TYPE_AUTO_CONTINUOUS)) {
-            return camera->set_focus(FocusType::AUTO, 0) == SetFocusResult::ACCEPTED;
-        }
-        // accept continuous manual focus
-        if (cmd.content.set_camera_focus.focus_type == FOCUS_TYPE_CONTINUOUS) {
-            return camera->set_focus(FocusType::RATE, cmd.content.set_camera_focus.focus_value) == SetFocusResult::ACCEPTED;
-        }
-        // accept range manual focus
-        if (cmd.content.set_camera_focus.focus_type == FOCUS_TYPE_RANGE) {
-            return camera->set_focus(FocusType::PCT, cmd.content.set_camera_focus.focus_value) == SetFocusResult::ACCEPTED;
-        }
-        return false;
+        return camera->handle_mav_SET_CAMERA_FOCUS(
+            cmd.content.set_camera_focus.camera_id,
+            (SET_FOCUS_TYPE)cmd.content.set_camera_focus.focus_type,
+            cmd.content.set_camera_focus.focus_value
+        ) == MAV_RESULT_ACCEPTED;
 
 #if AP_CAMERA_SET_CAMERA_SOURCE_ENABLED
     case MAV_CMD_SET_CAMERA_SOURCE:

--- a/libraries/SITL/SIM_AVT_CM62.h
+++ b/libraries/SITL/SIM_AVT_CM62.h
@@ -48,7 +48,11 @@ private:
     const char *get_camera_vendor_name()      const override { return "AVTA"; }
     const char *get_camera_model_name()       const override { return "SIM_AVTA_CAM"; }
     uint32_t    get_camera_firmware_version() const override { return (3U << 16) | (2U << 8) | 1U; }
-    uint32_t    get_camera_cap_flags()        const override { return CAMERA_CAP_FLAGS_CAPTURE_IMAGE; }
+    uint32_t    get_camera_cap_flags()        const override {
+        return CAMERA_CAP_FLAGS_CAPTURE_IMAGE |
+               CAMERA_CAP_FLAGS_HAS_BASIC_ZOOM |   // speculative: unverified on real hardware
+               CAMERA_CAP_FLAGS_HAS_BASIC_FOCUS;   // speculative: unverified on real hardware
+    }
 
     void camera_send_mavlink_message(const mavlink_message_t &msg) override {
         send_mavlink_message(msg);

--- a/libraries/SITL/SIM_Camera.h
+++ b/libraries/SITL/SIM_Camera.h
@@ -18,8 +18,16 @@ public:
     void     trigger_shutter() { _shot_count++; }
     uint16_t shot_count() const { return _shot_count; }
 
+    void  set_zoom_pct(float pct)  { _zoom_pct = pct; }
+    float zoom_pct()   const       { return _zoom_pct; }
+
+    void  set_focus_pct(float pct) { _focus_pct = pct; }
+    float focus_pct()  const       { return _focus_pct; }
+
 private:
     uint16_t _shot_count {};
+    float    _zoom_pct   {NAN};
+    float    _focus_pct  {NAN};
 };
 
 }  // namespace SITL

--- a/libraries/SITL/SIM_MAVLinkCamV2.cpp
+++ b/libraries/SITL/SIM_MAVLinkCamV2.cpp
@@ -56,6 +56,8 @@ void MAVLinkCamV2::handle_message(const mavlink_message_t &msg)
                                 MAV_CMD_IMAGE_START_CAPTURE, MAV_RESULT_ACCEPTED);
         break;
     default:
+        send_camera_command_ack(msg.sysid, msg.compid, (MAV_CMD)cmd.command,
+                                MAV_RESULT_UNSUPPORTED);
         break;
     }
 }

--- a/libraries/SITL/SIM_MAVLinkCamV2.cpp
+++ b/libraries/SITL/SIM_MAVLinkCamV2.cpp
@@ -46,6 +46,13 @@ void MAVLinkCamV2::handle_message(const mavlink_message_t &msg)
             send_camera_information(msg.sysid, msg.compid);
             send_camera_command_ack(msg.sysid, msg.compid,
                                     MAV_CMD_REQUEST_MESSAGE, MAV_RESULT_ACCEPTED);
+        } else if ((uint32_t)cmd.param1 == MAVLINK_MSG_ID_CAMERA_SETTINGS) {
+            send_camera_settings();
+            send_camera_command_ack(msg.sysid, msg.compid,
+                                    MAV_CMD_REQUEST_MESSAGE, MAV_RESULT_ACCEPTED);
+        } else {
+            send_camera_command_ack(msg.sysid, msg.compid,
+                                    MAV_CMD_REQUEST_MESSAGE, MAV_RESULT_DENIED);
         }
         break;
     case MAV_CMD_IMAGE_START_CAPTURE:
@@ -54,6 +61,32 @@ void MAVLinkCamV2::handle_message(const mavlink_message_t &msg)
                  (unsigned)_camera_compid, (unsigned)_camera.shot_count());
         send_camera_command_ack(msg.sysid, msg.compid,
                                 MAV_CMD_IMAGE_START_CAPTURE, MAV_RESULT_ACCEPTED);
+        break;
+    case MAV_CMD_SET_CAMERA_ZOOM:
+        if ((uint32_t)cmd.param1 == ZOOM_TYPE_RANGE) {
+            _camera.set_zoom_pct(cmd.param2);
+            ::printf("MAVLinkCamV2[compid=%u]: zoom set to %.1f%%\n",
+                     (unsigned)_camera_compid, (double)cmd.param2);
+            send_camera_command_ack(msg.sysid, msg.compid,
+                                    MAV_CMD_SET_CAMERA_ZOOM, MAV_RESULT_ACCEPTED);
+            send_camera_settings();
+        } else {
+            send_camera_command_ack(msg.sysid, msg.compid,
+                                    MAV_CMD_SET_CAMERA_ZOOM, MAV_RESULT_DENIED);
+        }
+        break;
+    case MAV_CMD_SET_CAMERA_FOCUS:
+        if ((uint32_t)cmd.param1 == FOCUS_TYPE_RANGE) {
+            _camera.set_focus_pct(cmd.param2);
+            ::printf("MAVLinkCamV2[compid=%u]: focus set to %.1f%%\n",
+                     (unsigned)_camera_compid, (double)cmd.param2);
+            send_camera_command_ack(msg.sysid, msg.compid,
+                                    MAV_CMD_SET_CAMERA_FOCUS, MAV_RESULT_ACCEPTED);
+            send_camera_settings();
+        } else {
+            send_camera_command_ack(msg.sysid, msg.compid,
+                                    MAV_CMD_SET_CAMERA_FOCUS, MAV_RESULT_DENIED);
+        }
         break;
     default:
         send_camera_command_ack(msg.sysid, msg.compid, (MAV_CMD)cmd.command,
@@ -93,6 +126,21 @@ void MAVLinkCamV2::send_camera_information(uint8_t target_sysid, uint8_t target_
     mavlink_msg_camera_information_encode_status(
         camera_vehicle_sysid(), _camera_compid,
         &camera_mav_status(), &msg, &info);
+    camera_send_mavlink_message(msg);
+}
+
+void MAVLinkCamV2::send_camera_settings()
+{
+    mavlink_camera_settings_t settings {};
+    settings.time_boot_ms = AP_HAL::millis();
+    settings.mode_id      = CAMERA_MODE_IMAGE;
+    settings.zoomLevel    = _camera.zoom_pct();
+    settings.focusLevel   = _camera.focus_pct();
+
+    mavlink_message_t msg;
+    mavlink_msg_camera_settings_encode_status(
+        camera_vehicle_sysid(), _camera_compid,
+        &camera_mav_status(), &msg, &settings);
     camera_send_mavlink_message(msg);
 }
 

--- a/libraries/SITL/SIM_MAVLinkCamV2.h
+++ b/libraries/SITL/SIM_MAVLinkCamV2.h
@@ -44,6 +44,7 @@ protected:
 private:
     void send_camera_heartbeat();
     void send_camera_information(uint8_t target_sysid, uint8_t target_compid);
+    void send_camera_settings();
     void send_camera_command_ack(uint8_t target_sysid, uint8_t target_compid,
                                   MAV_CMD cmd, MAV_RESULT result);
 


### PR DESCRIPTION
### Summary

Extends support for focussing cameras so multiple can be targetted according to the mavlink spec.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board,antennatracker,blimp,bootloader,copter,heli,plane,rover,sub
CubeOrangePlus,8,16,*,16,8,24,16,16
```

Added tests that not only verify that the new focus commands work when sent by the GCS, but also that taking photos, zooming and focusing specific cameras can all be done with mission items.

### Description

Allows cameras to be individually addressed for focussing

Small bugfix to filter out heartbeats from the autopilot component which is not the flight controller (presumptively)
