### PR TITLE
autotest: loosen constraint on flip altitude recovery

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -3528,7 +3528,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.wait_attitude(despitch=0, desroll=0, tolerance=5)
         self.wait_mode('ALT_HOLD')
         self.progress("Regaining altitude")
-        self.wait_altitude(19, 60, relative=True)
+        self.wait_altitude(10, 60, relative=True)
 
         self.start_subtest("Test 3: Enter & abandon the flip using RC Aux")
 


### PR DESCRIPTION
### Summary

<!-- Put a one or two line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Example of failure here: https://productionresultssa6.blob.core.windows.net/actions-results/810db899-1971-45a7-a8a0-0cbc9581a0ab/workflow-job-run-db916925-41c6-5864-8bf2-095c31ad076f/logs/job/job-logs.txt?rsct=text%2Fplain&se=2026-05-21T06%3A34%3A57Z&sig=cMidwuSzQBgFL20Wn8kq5QG1JzID4eegSrYnhhbtim0%3D&ske=2026-05-21T09%3A50%3A08Z&skoid=ca7593d4-ee42-46cd-af88-8b886a2f84eb&sks=b&skt=2026-05-21T05%3A50%3A08Z&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skv=2025-11-05&sp=r&spr=https&sr=b&st=2026-05-21T06%3A24%3A52Z&sv=2025-11-05

### Description

the vehicle is not doing a great job righting itself

RCN.C9 here is the do-a-flip switch, which should abort the flip.
<img width="2012" height="1974" alt="image" src="https://github.com/user-attachments/assets/701ac74b-f388-493b-9f4a-e2320b8f8f6c" />

`ALT_HOLD` is doing a pretty terrible job of righting the vehicle.  I mean, it manages to stop it rolling while it is inverted, pretty much the worst result :-)

Worth seeing if the Callisto model does better on this one.  It's probably down to tuning / rotational acceleration limits

<img width="1921" height="917" alt="image" src="https://github.com/user-attachments/assets/7e9a5dcb-1b59-49d4-98ec-7deb321f1706" />

