### PR TITLE
GCS_MAVLink: fix RC_CHANNELS_OVERRIDE zero value handling for channels 1-8

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4210,7 +4210,7 @@ void GCS_MAVLINK::handle_rc_channels_override(const mavlink_message_t &msg)
 
     for (uint8_t i=0; i<8; i++) {
         // Per MAVLink spec a value of UINT16_MAX means to ignore this field.
-        if (override_data[i] != UINT16_MAX) {
+        if (override_data[i] != 0 && override_data[i] != UINT16_MAX) {
             RC_Channels::set_override(i, override_data[i], tnow);
         }
     }

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4209,7 +4209,7 @@ void GCS_MAVLINK::handle_rc_channels_override(const mavlink_message_t &msg)
     };
 
     for (uint8_t i=0; i<8; i++) {
-        // Per MAVLink spec a value of UINT16_MAX means to ignore this field.
+        // Per MAVLink spec a value of zero or UINT16_MAX means to ignore this field.
         if (override_data[i] != 0 && override_data[i] != UINT16_MAX) {
             RC_Channels::set_override(i, override_data[i], tnow);
         }


### PR DESCRIPTION
Fixes #33125

Channels 1-8 were missing the zero-value check in RC_CHANNELS_OVERRIDE
handling, unlike channels 9-16 which correctly ignored zero values.

## Root Cause
First loop (ch1-8) only checked for UINT16_MAX but not zero.
Second loop (ch9-16) correctly checked both zero AND UINT16_MAX.

## Fix
Added `override_data[i] != 0` check to first loop to match
MAVLink spec which states value of 0 means ignore this channel.

## Testing
- Built successfully with ./waf copter
- Tested in SITL with ArduCopter