### PR TITLE
Security: 3 small fixes (signed-firmware fail-open, DEVICE_OP_WRITE OOB, @SYS lseek OOB)

### DIFF
--- a/libraries/AP_CheckFirmware/AP_CheckFirmware_secure_command.cpp
+++ b/libraries/AP_CheckFirmware/AP_CheckFirmware_secure_command.cpp
@@ -189,6 +189,14 @@ bool AP_CheckFirmware::write_bootloader(const struct bl_data *bld)
 
 /*
   check signature in a command against bootloader public keys
+
+  When no public keys are provisioned yet, allow only the
+  SECURE_COMMAND_SET_PUBLIC_KEYS operation through unsigned. This
+  preserves the ability to do first-time provisioning while preventing
+  an attacker from issuing arbitrary signed-firmware operations
+  (GET_SESSION_KEY / REMOVE_PUBLIC_KEYS / future ops) on a board that
+  was built with AP_SIGNED_FIRMWARE but never had keys installed (or
+  had them wiped via REMOVE_PUBLIC_KEYS).
  */
 bool AP_CheckFirmware::check_signature(const mavlink_secure_command_t &pkt)
 {
@@ -197,8 +205,11 @@ bool AP_CheckFirmware::check_signature(const mavlink_secure_command_t &pkt)
         return false;
     }
     if (all_zero_keys(sec_data)) {
-        // allow through if no keys are setup
-        return true;
+        // no keys provisioned: allow ONLY the bootstrap operation that
+        // installs the first key. Every other operation is denied so
+        // that a missing/wiped keystore cannot be used to flash or to
+        // exfiltrate the session key.
+        return pkt.operation == SECURE_COMMAND_SET_PUBLIC_KEYS;
     }
     if (pkt.sig_length != 64) {
         // monocypher signatures are 64 bytes

--- a/libraries/AP_Filesystem/AP_Filesystem_Sys.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_Sys.cpp
@@ -200,12 +200,35 @@ int32_t AP_Filesystem_Sys::lseek(int fd, int32_t offset, int seek_from)
         return -1;
     }
     struct rfile &r = file[fd];
+    const uint32_t length = r.str->get_length();
     switch (seek_from) {
     case SEEK_SET:
-        r.file_ofs = MIN(offset, int32_t(r.str->get_length()));
+        // Reject negative absolute offsets. The previous code stored
+        // a negative int32_t directly into the uint32_t file_ofs via
+        // MIN(int32_t,int32_t), so an attacker-supplied negative
+        // offset produced file_ofs == 0xFFFFFFFF. The subsequent
+        // read() did MIN(count, length - 0xFFFFFFFF) which underflows
+        // to a huge value and memcpy()'d from get_string()+0xFFFFFFFF
+        // - a wild OOB read whose buffer base can be host RAM
+        // (storage.bin) or 0x08000000 flash (flash.bin).
+        if (offset < 0) {
+            errno = EINVAL;
+            return -1;
+        }
+        r.file_ofs = MIN(uint32_t(offset), length);
         break;
     case SEEK_CUR:
-        r.file_ofs = MIN(r.str->get_length(), offset+r.file_ofs);
+        // Compute the new offset in signed 64-bit space and clamp
+        // to [0, length] so neither overflow nor underflow can
+        // land file_ofs outside the buffer.
+        {
+            const int64_t new_ofs = int64_t(r.file_ofs) + int64_t(offset);
+            if (new_ofs < 0) {
+                errno = EINVAL;
+                return -1;
+            }
+            r.file_ofs = MIN(uint32_t(MIN<int64_t>(new_ofs, length)), length);
+        }
         break;
     case SEEK_END:
         errno = EINVAL;

--- a/libraries/GCS_MAVLink/GCS_DeviceOp.cpp
+++ b/libraries/GCS_MAVLink/GCS_DeviceOp.cpp
@@ -119,6 +119,13 @@ void GCS_MAVLINK::handle_device_op_write(const mavlink_message_t &msg)
         retcode = 2;
         goto fail;
     }
+    if (packet.count > sizeof(packet.data)) {
+        // bound count against the payload buffer to prevent OOB read
+        // from packet.data[i] in the register write loop and OOB read
+        // in the raw transfer_bank() path below.
+        retcode = 5;
+        goto fail;
+    }
     if (!dev->get_semaphore()->take(10)) {
         retcode = 3;
         goto fail;        


### PR DESCRIPTION
## Summary

Three small, independent security fixes surfaced by an offensive-security benchmark we ran on ArduPilot Plane 4.6.3. Each commit is self-contained and follows ArduPilot's preference for **bug fixes that don't change default operator workflow**. No new parameters, no API changes, no behaviour regression for legitimate use.

| # | Subsystem | Class | Commit |
|---|---|---|---|
| 1 | `AP_CheckFirmware` | Auth bypass (fail-open in `check_signature`) | `544689c4b0` |
| 2 | `GCS_MAVLink` | OOB read (`DEVICE_OP_WRITE` count not bounded) | `5efb802cce` |
| 3 | `AP_Filesystem` | OOB read (`@SYS` lseek with negative offset) | `fb4410db2c` |

If a maintainer prefers, I'm happy to split this into three PRs — they're already in three separate, atomic commits, so cherry-picking is trivial.

---

## 1 · `AP_CheckFirmware`: refuse SECURE_COMMAND ops when no public keys provisioned

**File:** `libraries/AP_CheckFirmware/AP_CheckFirmware_secure_command.cpp`

`check_signature()` returned `true` for every operation whenever the bootloader's public-key area was all-zero:

```c
// before
if (all_zero_keys(sec_data)) {
    // allow through if no keys are setup
    return true;
}
```

This is needed to allow the first-time provisioning call (`SECURE_COMMAND_SET_PUBLIC_KEYS`), but it also accepted every other operation — `GET_SESSION_KEY`, `REMOVE_PUBLIC_KEYS`, and any future op — on boards built with `AP_SIGNED_FIRMWARE` that have not yet been (or no longer are) provisioned.

```c
// after
if (all_zero_keys(sec_data)) {
    // no keys provisioned: allow ONLY the bootstrap operation that
    // installs the first key. Every other operation is denied so
    // that a missing/wiped keystore cannot be used to flash or to
    // exfiltrate the session key.
    return pkt.operation == SECURE_COMMAND_SET_PUBLIC_KEYS;
}
```

Bootstrap still works (the first `SET_PUBLIC_KEYS` is allowed unsigned). All subsequent operations, including additional `SET_PUBLIC_KEYS` calls, require valid Ed25519 signatures.

---

## 2 · `GCS_MAVLink`: bound `DEVICE_OP_WRITE` count

**File:** `libraries/GCS_MAVLink/GCS_DeviceOp.cpp`

`handle_device_op_read()` correctly rejects `packet.count > sizeof(data)`:

```c
if (packet.count > sizeof(data)) {
    retcode = 5;
    goto fail;
}
```

The matching write handler `handle_device_op_write()` was missing this check. `packet.count` is `uint8_t` (max 255) but `packet.data` is fixed at 128 bytes per the MAVLink `DEVICE_OP_WRITE` message definition. With `count` set to e.g. 255:

- `write_bank_register` loop reads up to 127 bytes past the payload buffer and writes them onto the I2C/SPI bus to the targeted peripheral
- the raw `transfer_bank(packet.data, packet.count, ...)` path does the same in one shot

Both leak stack contents onto a hardware bus (observable to anyone tapping the bus) and corrupt the targeted device's register space.

Fix mirrors the read-handler's check.

---

## 3 · `AP_Filesystem_Sys`: reject negative `lseek` offsets

**File:** `libraries/AP_Filesystem/AP_Filesystem_Sys.cpp`

`rfile::file_ofs` is `uint32_t`, but `lseek()`'s `offset` is `int32_t`. The previous SEEK_SET path:

```c
// before
case SEEK_SET:
    r.file_ofs = MIN(offset, int32_t(r.str->get_length()));
    break;
```

`MIN(int32_t -1, int32_t length)` returns `-1`, which then assigns into the `uint32_t` slot as `0xFFFFFFFF`. The subsequent `read()` computes:

```c
count = MIN(count, r.str->get_length() - r.file_ofs);
memcpy(buf, &r.str->get_string()[r.file_ofs], count);
```

`length - 0xFFFFFFFF` underflows to a huge value, `count` becomes huge, and `memcpy` reads from `get_string() + 0xFFFFFFFF` — a wild address relative to the underlying buffer.

This matters because `@SYS/storage.bin`'s backing buffer is the live storage pointer from `hal.storage->get_storage_ptr()`, and `@SYS/flash.bin` points at `0x08000000` internal flash. Either path leaks adjacent memory (potentially including the MAVLink2 signing key stored in EEPROM) over MAVFTP.

The fix rejects negative SEEK_SET offsets and computes SEEK_CUR in `int64_t` to detect underflow/overflow before clamping into `[0, length]`.

---

## Testing

- All three fixes are minimal, additive, and preserve every legitimate API call.
- Build verified locally on `master` (`waf configure --board sitl && waf plane`).
- No autotest changes required; the fixes are bound-checks and a one-line predicate. Happy to add unit tests for any/all if maintainers prefer — say the word and I'll push them.

## Discovery

Found while benchmarking three LLM coding agents (Amp, Claude Code, Factory Droid) against a security-audit prompt on the ArduPilot codebase, in the course of a research study comparing prompt-design strategies. Full methodology and finding-by-finding write-up:

- Standalone benchmark repo: <https://github.com/zuwasi/claude-mythos-amp>
- Prompt fork PR: <https://github.com/anshug/claude-mythos/pull/1>

The benchmark surfaced additional issues that are out-of-scope for this PR because they reflect ArduPilot's intentional design (operator-trusted MAVLink/DDS links); those are documented in the linked write-up but not submitted here.

## Disclosure note

Fix #1 (`check_signature` fail-open) is the most security-sensitive of the three. If the maintainers would prefer it routed through ArduPilot's security-disclosure process instead of a public PR, please let me know and I will split it out and resubmit privately.
