### PR TITLE
ArduSub: report target location in Guided_PosVel submode

### DIFF
--- a/ArduSub/GCS_MAVLink_Sub.cpp
+++ b/ArduSub/GCS_MAVLink_Sub.cpp
@@ -97,6 +97,28 @@ void GCS_MAVLINK_Sub::send_nav_controller_output() const
 // would head in an autonomous mode
 bool GCS_MAVLINK_Sub::get_target_location(Location &loc) const
 {
+    // in Guided mode, only Guided_WP uses wp_nav; the other submodes keep
+    // their own targets. Guided_WP breaks out to the wp_nav return below.
+    if (sub.flightmode->in_guided_mode()) {
+        switch (sub.guided_mode) {
+        case Guided_WP:
+            break;
+        case Guided_PosVel: {
+            Vector3f pos_neu_cm;
+            if (!sub.mode_guided.get_posvel_target_NEU_cm(pos_neu_cm)) {
+                return false;
+            }
+            loc = Location(pos_neu_cm, Location::AltFrame::ABOVE_ORIGIN);
+            return true;
+        }
+        case Guided_Velocity:
+        case Guided_Angle:
+            // no fixed position target to report
+            return false;
+        }
+    }
+
+    // for non-guided modes (Auto, etc.) fall back to wp_nav as before
     return sub.wp_nav.is_active() && sub.wp_nav.get_wp_destination_loc(loc);
 }
 

--- a/ArduSub/mode.h
+++ b/ArduSub/mode.h
@@ -274,6 +274,10 @@ public:
     void guided_set_velocity(const Vector3f& velocity);
     void guided_set_velocity(const Vector3f& velocity, bool use_yaw, float yaw_cd, bool use_yaw_rate, float yaw_rate_cds, bool relative_yaw);
     void guided_set_yaw_state(bool use_yaw, float yaw_cd, bool use_yaw_rate, float yaw_rate_cds, bool relative_angle);
+    // fills pos with the current Guided_PosVel position target (NEU cm
+    // relative to EKF origin). returns false if not in Guided_PosVel.
+    // velocity target not exposed; base GCS sends 0 with VX/VY/VZ_IGNORE.
+    bool get_posvel_target_NEU_cm(Vector3f &pos) const;
     float get_auto_heading();
     void guided_limit_clear();
     void set_auto_yaw_mode(autopilot_yaw_mode yaw_mode);

--- a/ArduSub/mode_guided.cpp
+++ b/ArduSub/mode_guided.cpp
@@ -297,6 +297,17 @@ void ModeGuided::guided_set_velocity(const Vector3f& velocity, bool use_yaw, flo
 
 }
 
+// expose the current Guided_PosVel position target so the GCS layer can
+// report POSITION_TARGET_GLOBAL_INT in that submode.
+bool ModeGuided::get_posvel_target_NEU_cm(Vector3f &pos) const
+{
+    if (sub.guided_mode != Guided_PosVel) {
+        return false;
+    }
+    pos = posvel_pos_target_cm.tofloat();
+    return true;
+}
+
 // set guided mode posvel target
 bool ModeGuided::guided_set_destination_posvel(const Vector3f& destination, const Vector3f& velocity)
 {


### PR DESCRIPTION
## Summary

Fixes #33098.

Sub's `GCS_MAVLINK_Sub::get_target_location()` only checked `wp_nav`, which is only used by the `Guided_WP` submode. The `Guided_PosVel` submode keeps its own position target in `posvel_pos_target_cm` (file-scope static in `mode_guided.cpp`), so `POSITION_TARGET_GLOBAL_INT` messages stopped being sent whenever a user controlled the vehicle via `SET_POSITION_TARGET_GLOBAL_INT` with the posvel typemask. External controllers had no way to verify their commands were being acted on.

This PR:

- Adds a public accessor `ModeGuided::get_posvel_target_NEU_cm()` so external code can read the PosVel target without exposing the file-scope static directly.
- Dispatches on `sub.guided_mode` in `get_target_location()`:
  - `Guided_WP` — existing behavior (`wp_nav.is_active() && wp_nav.get_wp_destination_loc(loc)`)
  - `Guided_PosVel` — returns the new accessor's value, converted to a `Location` with `AltFrame::ABOVE_ORIGIN`
  - `Guided_Velocity` / `Guided_Angle` — no fixed position target to report; returns false (`POSITION_TARGET_GLOBAL_INT` correctly omitted)
- Non-guided modes (Auto, etc.) keep the existing `wp_nav` fallback unchanged.

## Classification & Testing

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [x] Bug fix
- [ ] Automated test(s) verify changes
- [x] Tested manually, description below
- [ ] Tested on hardware

Built ArduSub SITL on macOS (arm64) — compiles cleanly. Did not exercise the message-sending path in a running SITL session; the issue's reporter (@clydemcqueen) has a SITL repro that should validate the fix.