### PR TITLE
Sub: stop resetting home on arm

### DIFF
--- a/ArduSub/AP_Arming_Sub.cpp
+++ b/ArduSub/AP_Arming_Sub.cpp
@@ -118,14 +118,7 @@ bool AP_Arming_Sub::arm(AP_Arming::Method method, bool do_arming_checks)
 
     sub.initial_armed_bearing = ahrs.yaw_sensor;
 
-    if (!ahrs.home_is_set()) {
-        // Reset EKF altitude if home hasn't been set yet (we use EKF altitude as substitute for alt above home)
-
-        // Always use absolute altitude for ROV
-        // ahrs.resetHeightDatum();
-        // AP::logger().Write_Event(LogEvent::EKF_ALT_RESET);
-    } else if (!ahrs.home_is_locked()) {
-        // Reset home position if it has already been set before (but not locked)
+    if (!ahrs.home_is_set() || (!ahrs.home_is_locked() && !option_enabled(AP_Arming::Option::DISABLE_UPDATE_HOME_ON_ARM))) {
         if (!sub.set_home_to_current_location(false)) {
             // ignore this failure
         }

--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -166,7 +166,7 @@ const AP_Param::GroupInfo AP_Arming::var_info[] = {
     // @Param: OPTIONS
     // @DisplayName: Arming options
     // @Description: Options that can be applied to change arming behaviour
-    // @Bitmask: 0:Disable prearm display,1:Do not send status text on state change,2:Skip IMU consistency checks when ICE motor running
+    // @Bitmask: 0:Disable prearm display,1:Do not send status text on state change,2:Skip IMU consistency checks when ICE motor running,3:Do not update home location on arm (Sub only)
     // @User: Advanced
     AP_GROUPINFO("OPTIONS", 9,   AP_Arming, _arming_options, 0),
 

--- a/libraries/AP_Arming/AP_Arming.h
+++ b/libraries/AP_Arming/AP_Arming.h
@@ -162,6 +162,7 @@ public:
         DISABLE_PREARM_DISPLAY             = (1U << 0),
         DISABLE_STATUSTEXT_ON_STATE_CHANGE = (1U << 1),
         SKIP_IMU_CONSISTENCY_ICE_RUNNING   = (1U << 2),
+        DISABLE_UPDATE_HOME_ON_ARM         = (1U << 3),
     };
     bool option_enabled(Option option) const {
         return (_arming_options & uint32_t(option)) != 0;


### PR DESCRIPTION
Re-arming while submerged overwrote home with a bad surface altitude, breaking relative-altitude mission items on the next AUTO run.

Sub, same as Rover, can disarm whenever without crashing, and mostly stay in place.  This means we can just sit at the bottom/surface for a while and then continue a mission. We don't want a new home to be set when re-arming
