### PR TITLE
GCS_MAVLink: bound DEVICE_OP_WRITE count to prevent OOB read of packet.data

### DIFF
--- a/libraries/GCS_MAVLink/GCS_DeviceOp.cpp
+++ b/libraries/GCS_MAVLink/GCS_DeviceOp.cpp
@@ -119,6 +119,13 @@ void GCS_MAVLINK::handle_device_op_write(const mavlink_message_t &msg)
         retcode = 2;
         goto fail;
     }
+    if (packet.count > sizeof(packet.data)) {
+        // bound count against the payload buffer to prevent OOB read
+        // from packet.data[i] in the register write loop and OOB read
+        // in the raw transfer_bank() path below.
+        retcode = 5;
+        goto fail;
+    }
     if (!dev->get_semaphore()->take(10)) {
         retcode = 3;
         goto fail;        


### PR DESCRIPTION
### Summary

Avoids a buffer-overread caused by a bad packet arriving from the GCS

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
CubeOrange,16
```

### Description

Extracted from https://github.com/ArduPilot/ardupilot/pull/33147 as a faster merge

Similar fix to https://github.com/ArduPilot/ardupilot/commit/ee7c410b14e1af4e451912172200a35806272293

handle_device_op_read() correctly rejects packet.count > sizeof(data) (retcode = 5) before reading the payload buffer. The matching write path handle_device_op_write() was missing the same check.

packet.count is a uint8_t (max 255) but packet.data is fixed at 128 bytes per the MAVLink DEVICE_OP_WRITE definition. A malicious or malformed GCS that sets count > 128 caused:

  - write_bank_register loop: packet.data[i] reads up to 127 bytes beyond the payload buffer on the message-decode stack frame
  - transfer_bank raw path: same OOB read, then those bytes are pushed onto the I2C/SPI bus to the targeted peripheral

Both are information-disclosure vectors (stack contents leak onto a hardware bus, observable to anyone tapping the bus) and an integrity risk for the targeted device.

Add the same bound check the read handler uses, immediately after the device-resolution step.

Found via offensive-security benchmark on ArduPilot Plane 4.6.3 (ESL / claude-mythos amp-optimized prompt run, 2026-05-21).

Amp-Thread-ID: https://ampcode.com/threads/T-019e4710-85bb-77d1-b50a-ba871a28d82b
