### PR TITLE
Avoid buffer over-read when passed extreme offset in FTP packet

### DIFF
--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -3272,6 +3272,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             self.ScriptedArmingChecksApplet,
             self.TerrainAvoidApplet,
             self.TakeoffCheck,
+            self.MAVFTPBadReadOffset,
             self.FenceRelativePreArms,
             self.FenceRelativeToHomeMaxAlt,
             self.FenceRelativeToHomeMinAlt,

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -15152,6 +15152,54 @@ switch value'''
 
         self.progress(f"param.pck: {len(pdata.params)} params OK")
 
+    def MAVFTPBadReadOffset(self):
+        '''ask for a very large offset'''
+
+        # reset sessions
+        op = FTP_OP(
+            seq=0, session=0, opcode=mavftp_op.OP_ResetSessions,
+            size=0, req_opcode=0, burst_complete=0,
+            offset=0, payload=None,
+        )
+        self.ftp_send(op)
+        reply = self.ftp_recv(timeout=5)
+        if reply is None:
+            raise NotAchievedException("No reply to ResetSessions")
+        seq = reply.seq
+
+        # open file read-only
+        path = "@SYS/storage.bin"
+        path_bytes = bytearray(path.encode('utf-8')) + bytearray([0])
+        op = FTP_OP(
+            seq=seq, session=0, opcode=mavftp_op.OP_OpenFileRO,
+            size=len(path_bytes), req_opcode=0, burst_complete=0,
+            offset=0, payload=path_bytes,
+        )
+        self.ftp_send(op)
+        reply = self.ftp_recv(timeout=5)
+        if reply is None:
+            raise NotAchievedException("No reply to OpenFileRO")
+        if reply.opcode != mavftp_op.OP_Ack:
+            raise NotAchievedException(f"OpenFileRO failed: opcode={reply.opcode}")
+        seq = reply.seq
+
+        # send burst read request
+        op = FTP_OP(
+            seq=seq, session=0, opcode=mavftp_op.OP_BurstReadFile,
+            size=0, req_opcode=0, burst_complete=0,
+            offset=4294967294, payload=None,
+        )
+        self.ftp_send(op)
+
+        reply = self.ftp_recv(timeout=5)
+
+        if reply is None:
+            raise NotAchievedException("No reply to BurstReadFile with bad offset")
+        if reply.opcode != mavftp_op.OP_Nack:
+            raise NotAchievedException(f"Expected Nack, got opcode={reply.opcode}")
+
+        self.progress("if we got to here we didn't die :-)")
+
     def write_content_to_filepath(self, content, filepath):
         '''write biunary content to filepath'''
         if not isinstance(content, bytes):

--- a/libraries/AP_Filesystem/AP_Filesystem_Sys.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_Sys.cpp
@@ -216,6 +216,7 @@ int32_t AP_Filesystem_Sys::lseek(int fd, int32_t offset, int seek_from)
         break;
     }
 
+    // special semantics for Sysfs - don't allow seeking outside the file
     if (new_ofs < 0 || new_ofs > r.str->get_length()) {
         errno = EINVAL;
         return -1;

--- a/libraries/AP_Filesystem/AP_Filesystem_Sys.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_Sys.cpp
@@ -200,40 +200,32 @@ int32_t AP_Filesystem_Sys::lseek(int fd, int32_t offset, int seek_from)
         return -1;
     }
     struct rfile &r = file[fd];
-    const uint32_t length = r.str->get_length();
+
+    int64_t new_ofs = -1;  // -1 being invalid
     switch (seek_from) {
     case SEEK_SET:
-        // Reject negative absolute offsets. The previous code stored
-        // a negative int32_t directly into the uint32_t file_ofs via
-        // MIN(int32_t,int32_t), so an attacker-supplied negative
-        // offset produced file_ofs == 0xFFFFFFFF. The subsequent
-        // read() did MIN(count, length - 0xFFFFFFFF) which underflows
-        // to a huge value and memcpy()'d from get_string()+0xFFFFFFFF
-        // - a wild OOB read whose buffer base can be host RAM
-        // (storage.bin) or 0x08000000 flash (flash.bin).
-        if (offset < 0) {
-            errno = EINVAL;
-            return -1;
-        }
-        r.file_ofs = MIN(uint32_t(offset), length);
+        new_ofs = offset;
         break;
     case SEEK_CUR:
-        // Compute the new offset in signed 64-bit space and clamp
-        // to [0, length] so neither overflow nor underflow can
-        // land file_ofs outside the buffer.
-        {
-            const int64_t new_ofs = int64_t(r.file_ofs) + int64_t(offset);
-            if (new_ofs < 0) {
-                errno = EINVAL;
-                return -1;
-            }
-            r.file_ofs = MIN(uint32_t(MIN<int64_t>(new_ofs, length)), length);
-        }
+        // Compute the new offset in signed 64-bit space to avoid
+        // 32-bit overflows:
+        new_ofs = int64_t(r.file_ofs) + int64_t(offset);
         break;
     case SEEK_END:
+        // we don't support this, leave new_ofs at -1 meaning "invalid"
+        break;
+    }
+
+    if (new_ofs < 0 || new_ofs > r.str->get_length()) {
         errno = EINVAL;
         return -1;
     }
+
+    r.file_ofs = (uint32_t)new_ofs;
+
+    // note conversion from uint32_t to int32_t in return value here.
+    // Above we clamp to r.str->get_length(), so in practise no
+    // truncation can occur here.
     return r.file_ofs;
 }
 

--- a/libraries/AP_Filesystem/AP_Filesystem_Sys.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_Sys.cpp
@@ -200,12 +200,35 @@ int32_t AP_Filesystem_Sys::lseek(int fd, int32_t offset, int seek_from)
         return -1;
     }
     struct rfile &r = file[fd];
+    const uint32_t length = r.str->get_length();
     switch (seek_from) {
     case SEEK_SET:
-        r.file_ofs = MIN(offset, int32_t(r.str->get_length()));
+        // Reject negative absolute offsets. The previous code stored
+        // a negative int32_t directly into the uint32_t file_ofs via
+        // MIN(int32_t,int32_t), so an attacker-supplied negative
+        // offset produced file_ofs == 0xFFFFFFFF. The subsequent
+        // read() did MIN(count, length - 0xFFFFFFFF) which underflows
+        // to a huge value and memcpy()'d from get_string()+0xFFFFFFFF
+        // - a wild OOB read whose buffer base can be host RAM
+        // (storage.bin) or 0x08000000 flash (flash.bin).
+        if (offset < 0) {
+            errno = EINVAL;
+            return -1;
+        }
+        r.file_ofs = MIN(uint32_t(offset), length);
         break;
     case SEEK_CUR:
-        r.file_ofs = MIN(r.str->get_length(), offset+r.file_ofs);
+        // Compute the new offset in signed 64-bit space and clamp
+        // to [0, length] so neither overflow nor underflow can
+        // land file_ofs outside the buffer.
+        {
+            const int64_t new_ofs = int64_t(r.file_ofs) + int64_t(offset);
+            if (new_ofs < 0) {
+                errno = EINVAL;
+                return -1;
+            }
+            r.file_ofs = MIN(uint32_t(MIN<int64_t>(new_ofs, length)), length);
+        }
         break;
     case SEEK_END:
         errno = EINVAL;


### PR DESCRIPTION
### Summary

Avoids a buffer-overread (confirmed in SITL via a segfault) when bad offsets are used

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board,plane
CubeOrangePlus,8
```

(included autotest does nasty things before, passes afterwards)

### Description

Based on a patch extracted from https://github.com/ArduPilot/ardupilot/pull/33147/changes

Changes the results of lseek to more-closely match POSIX standards.
