### PR TITLE
AP_Param: Purge param_overrides from default_list

### DIFF
--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -9,10 +9,12 @@ import copy
 import math
 import operator
 import os
+import tempfile
 
 import numpy
 
 from pymavlink import mavutil
+from pymavlink.mavftp import MAVFTP as MavFTP
 from pymavlink.rotmat import Vector3
 
 import vehicle_test_suite
@@ -3209,6 +3211,37 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.wait_disarmed(timeout=60)
         self.zero_throttle()
 
+    def HighServoFunctionDefault(self):
+        '''check that stale constructor set_default() is purged when param_overrides are loaded'''
+        k_motor1 = 33
+
+        defaults_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
+        defaults_file.write("SERVO_32_ENABLE 1\n")
+        defaults_file.write("SERVO17_FUNCTION %d\n" % k_motor1)
+        defaults_file.close()
+
+        self.customise_SITL_commandline([], defaults_filepath=defaults_file.name)
+        self.assert_parameter_values({"SERVO17_FUNCTION": k_motor1})
+
+        data, _ = self.ftp_burst_read("@PARAM/param.pck?withdefaults=1")
+
+        pdata = MavFTP.ftp_param_decode(bytes(data))
+        if pdata is None:
+            raise NotAchievedException("param.pck failed to decode")
+        if pdata.defaults is None:
+            raise NotAchievedException("param.pck has no defaults")
+
+        defaults = {name.decode('utf-8'): value for (name, value, ptype) in pdata.defaults}
+
+        if "SERVO17_FUNCTION" not in defaults:
+            raise NotAchievedException("SERVO17_FUNCTION not found in param defaults")
+
+        got = defaults["SERVO17_FUNCTION"]
+        if got != k_motor1:
+            raise NotAchievedException(
+                f"SERVO17_FUNCTION default: expected {k_motor1} got {got}"
+            )
+
     def tests(self):
         '''return list of all tests'''
 
@@ -3288,5 +3321,6 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             self.FenceRelativeToTerrainMaxAlt,
             self.FenceRelativeToTerrainMinAlt,
             self.PlaneWindFailsafe,
+            self.HighServoFunctionDefault,
         ])
         return ret

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -2460,6 +2460,10 @@ bool AP_Param::load_defaults_file(const char *filename, bool last_pass)
 
     num_param_overrides = num_defaults;
 
+#if AP_PARAM_DEFAULTS_ENABLED
+    purge_defaults_list_overrides();
+#endif
+
     return true;
 }
 #endif // AP_PARAM_DEFAULTS_FILE_PARSING_ENABLED
@@ -2589,6 +2593,10 @@ void AP_Param::load_param_defaults(const volatile char *ptr, int32_t length, boo
         }
     }
     num_param_overrides = num_defaults;
+
+#if AP_PARAM_DEFAULTS_ENABLED
+    purge_defaults_list_overrides();
+#endif
 }
 #endif // AP_PARAM_MAX_EMBEDDED_PARAM > 0 || defined(HAL_HAVE_AP_ROMFS_EMBEDDED_H)
 
@@ -2900,6 +2908,36 @@ void AP_Param::check_default(AP_Param *ap, float *default_value)
         }
     }
 }
+
+/*
+  Remove default_list entries that are in param_overrides.  Constructors may
+  call add_default() before param_overrides is populated, leaving stale nodes.
+ */
+#if AP_PARAM_DEFAULTS_ENABLED
+void AP_Param::purge_defaults_list_overrides(void)
+{
+    defaults_list **prev = &default_list;
+    defaults_list *item = default_list;
+    while (item != nullptr) {
+        bool found = false;
+        for (uint16_t i = 0; i < num_param_overrides; i++) {
+            if (item->ap == param_overrides[i].object_ptr) {
+                found = true;
+                break;
+            }
+        }
+        if (found) {
+            *prev = item->next;
+            defaults_list *to_delete = item;
+            item = item->next;
+            delete to_delete;
+        } else {
+            prev = &item->next;
+            item = item->next;
+        }
+    }
+}
+#endif // AP_PARAM_DEFAULTS_ENABLED
 
 void AP_Param::add_default(AP_Param *ap, float v)
 {

--- a/libraries/AP_Param/AP_Param.h
+++ b/libraries/AP_Param/AP_Param.h
@@ -873,6 +873,7 @@ private:
     };
     static defaults_list *default_list;
     static void check_default(AP_Param *ap, float *default_value);
+    static void purge_defaults_list_overrides(void);
 
     static bool eeprom_full;
 };


### PR DESCRIPTION
### Summary
Removes out of sync defaults from defaults_list that sneak in before the param_overrides[] is populated by embedded defaults. An example would be the servo constructor that sets SERVOx_FUNCTION for servo's >16 to -1. 

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [X] Tested manually, description below (e.g. SITL)
- [X] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request


### Description
Found this out by chasing down the servo_function problem with defaults but seems to fix the NET_IP params too.

Tested on cubeorange plus on bench with firmware for carbonix ottano which uses SERVOx_FUNCTION parameters >16 for motors. Before we would see -1 for defaults for all function params >16 now they correctly show the embedded defaults.
<img width="1477" height="1219" alt="image" src="https://github.com/user-attachments/assets/f0bd87f1-107b-4c4f-bd06-b4512f32058b" />


<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
