### PR TITLE
AP_BattMonitor: Add 0x40 INA2XX probe addresses

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_INA2xx.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_INA2xx.cpp
@@ -82,7 +82,7 @@ extern const AP_HAL::HAL& hal;
 #endif
 
 // list of addresses to probe if I2C_ADDR is zero
-const uint8_t AP_BattMonitor_INA2XX::i2c_probe_addresses[] { 0x41, 0x44, 0x45 };
+const uint8_t AP_BattMonitor_INA2XX::i2c_probe_addresses[] { 0x40, 0x41, 0x44, 0x45 };
 
 const AP_Param::GroupInfo AP_BattMonitor_INA2XX::var_info[] = {
 
@@ -96,7 +96,7 @@ const AP_Param::GroupInfo AP_BattMonitor_INA2XX::var_info[] = {
 
     // @Param: I2C_ADDR
     // @DisplayName: Battery monitor I2C address
-    // @Description: Battery monitor I2C address. If this is zero then probe list of supported addresses
+    // @Description: Battery monitor I2C address in decimal. If this is zero then probe list of supported addresses
     // @Range: 0 127
     // @User: Advanced
     // @RebootRequired: True


### PR DESCRIPTION
### Summary

This PR adds ``0x40`` to the list of automatically-probed i2c addresses for the INA2xx line of power sensors.

``0x40`` is a commonly-used address (like on the Adafruit modules https://www.adafruit.com/product/4226), as it corresponds to the INA2XX's address pins (A0, A1) both being connected to GND (see Page 18 of the datasheet - https://www.ti.com/lit/ds/symlink/ina260.pdf?ts=1779400618908 for example)

Tested with an INA260 connected to a CubeOrange

I also added a clarification to the ``BATT_I2C_ADDR`` that it must be entered in decimal format (not the usual hex), as it did trip me up.

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [] Tested manually, description below (e.g. SITL)
- [X] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
