### PR TITLE
Copter: RTL may ignore pilot yaw during descent

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1316,6 +1316,7 @@ public:
     bool controlling_position() const { return control_position; }
 
     void set_land_pause(bool new_value) { land_pause = new_value; }
+    bool use_pilot_yaw() const override;
 
     // parameter accessors
     float get_land_speed_ms() const { return land_speed_ms.get(); }

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -668,10 +668,19 @@ void PayloadPlace::start_descent()
 // returns true if pilot's yaw input should be used to adjust vehicle's heading
 bool ModeAuto::use_pilot_yaw(void) const
 {
-    const bool allow_yaw_option = !option_is_enabled(Option::IgnorePilotYaw);
-    const bool rtl_allow_yaw = (_mode == SubMode::RTL) && copter.mode_rtl.use_pilot_yaw();
-    const bool landing = _mode == SubMode::LAND;
-    return allow_yaw_option || rtl_allow_yaw || landing;
+    // use option bit except during land and RTL
+    switch (_mode) {
+        case SubMode::LAND:
+            return copter.mode_land.use_pilot_yaw();
+        case SubMode::RTL:
+            return copter.mode_rtl.use_pilot_yaw();
+#if AC_NAV_GUIDED
+        case SubMode::NAVGUIDED:
+            return copter.mode_guided.use_pilot_yaw();
+#endif
+        default:
+            return !option_is_enabled(Option::IgnorePilotYaw);
+    }
 }
 
 bool ModeAuto::set_speed_NE_ms(float speed_ne_ms)

--- a/ArduCopter/mode_land.cpp
+++ b/ArduCopter/mode_land.cpp
@@ -201,6 +201,13 @@ void ModeLand::do_not_use_GPS()
     control_position = false;
 }
 
+// returns true if pilot's yaw input should be used to adjust vehicle's heading
+bool ModeLand::use_pilot_yaw() const
+{
+    // only accept yaw input if repositioning is enabled
+    return g.land_repositioning;
+}
+
 // set_mode_land_with_pause - sets mode to LAND and triggers 4 second delay before descent starts
 //  this is always called from a failsafe so we trigger notification to pilot
 void Copter::set_mode_land_with_pause(ModeReason reason)

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -613,10 +613,11 @@ float ModeRTL::wp_bearing_deg() const
 // returns true if pilot's yaw input should be used to adjust vehicle's heading
 bool ModeRTL::use_pilot_yaw(void) const
 {
-    const bool allow_yaw_option = !option_is_enabled(Option::IgnorePilotYaw);
-    const bool land_repositioning = g.land_repositioning && (_state == SubMode::FINAL_DESCENT);
-    const bool final_landing = _state == SubMode::LAND;
-    return allow_yaw_option || land_repositioning || final_landing;
+    // use land mode setting during descent
+    if (_state == SubMode::FINAL_DESCENT || _state == SubMode::LAND) {
+        return copter.mode_land.use_pilot_yaw();
+    }
+    return !option_is_enabled(Option::IgnorePilotYaw);
 }
 
 bool ModeRTL::set_speed_NE_ms(float speed_ne_ms)


### PR DESCRIPTION
### Summary

This resolves issue https://github.com/ArduPilot/ardupilot/issues/33168 and some related issues I found during testing.  The two issues reported [during 4.7 beta testing](https://discuss.ardupilot.org/t/rc-options-to-1-make-copter-yaw-spinning/142948/16) were:

- Even if the user sets [RTL_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#rtl-options-rtl-mode-options) = 4 (Ignore Pilot Yaw) the pilot's yaw input is still consumed during the landing stage of RTL
- If an auto mission includes a Land command, even if [AUTO_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#auto-options-auto-mode-options) = 4  (Ignore Pilot Yaw) and/or [LAND_REPOSITION](https://ardupilot.org/copter/docs/parameters.html#land-reposition-land-repositioning) = 1, the pilot's yaw input in always consumed

This PR makes a few changes to the use of [AUTO_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#auto-options-auto-mode-options), [RTL_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#rtl-options-rtl-mode-options), [GUID_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#guid-options-guided-mode-options) and [LAND_REPOSITION](https://ardupilot.org/copter/docs/parameters.html#land-reposition-land-repositioning) which resolves the issue.


1. Land mode uses LAND_REPOSITION to decide if pilot yaw input is consumed in LAND mode.  There was previously no way to disable the pilot's yaw input in Land mode.
2. RTL mode uses RTL_OPTIONS to decide if pilot yaw is consumed except during the final Land or Descent stages where it falls back to land mode's use_pilot_yaw() method (which checks LAND_REPOSITION)
3. Auto mode uses AUTO_OPTIONS to decide if pilot yaw is consumed except when executing RTL, Land and NavGuided commands in which case it falls back to the corresponding flight mode's use_pilot_yaw() method.

Overall this change allows pilot yaw input to be ignored in more situations.  The current logic added in PR https://github.com/ArduPilot/ardupilot/pull/21651 was actually more restrictive than what was there before so in some ways this is a continuation of that change.

Note1: I purposely have not fallen back to Circle mode's use-pilot-yaw method when executing LOITER_TURNS because I don't think this is what users would want or expect.  Same for the loiter and loiter-to-alt commands.
Note2: I have not changed the PayloadPlace submode which should probably act like the Land submode.  I leave that to a future PR.

I've extensively tested this in SITL to confirm the pilot input is consumed as described above including testing the Auto, Guided, Land, RTL flight modes and also each mode as run by a command within Auto

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request
