### PR TITLE
AP_HAL_SITL: avoid calling fcntl on -1

### DIFF
--- a/libraries/AP_HAL_SITL/UARTDriver.cpp
+++ b/libraries/AP_HAL_SITL/UARTDriver.cpp
@@ -200,8 +200,6 @@ void UARTDriver::_begin(uint32_t baud, uint16_t rxSpace, uint16_t txSpace)
         _readbuffer.clear();
         _writebuffer.clear();
     }
-
-    _set_nonblocking(_fd);
 }
 
 void UARTDriver::_end()
@@ -734,11 +732,6 @@ bool UARTDriver::_select_check(int fd)
     return false;
 }
 
-void UARTDriver::_set_nonblocking(int fd)
-{
-    unsigned v = fcntl(fd, F_GETFL, 0);
-    fcntl(fd, F_SETFL, v | O_NONBLOCK);
-}
 
 bool UARTDriver::set_unbuffered_writes(bool on) {
     if (_fd == -1) {

--- a/libraries/AP_HAL_SITL/UARTDriver.h
+++ b/libraries/AP_HAL_SITL/UARTDriver.h
@@ -108,7 +108,7 @@ private:
     void _udp_start_multicast(const char *address, uint16_t port);
     void _check_connection(void);
     static bool _select_check(int );
-    static void _set_nonblocking(int );
+
     bool set_speed(int speed) const;
 
     SITL_State *_sitlState;


### PR DESCRIPTION
### Summary

Stops SITL calling fcntl on an invalid file descriptor.  Shuts valgrind up about it.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

in-line the method to make setting non-blocking on _fd more proximate to where the thing is opened