### PR TITLE
Tools: environment_install.py: support Resolute Raccoon

### DIFF
--- a/.github/workflows/test_environment.yml
+++ b/.github/workflows/test_environment.yml
@@ -32,6 +32,8 @@ jobs:
             name: jammy
           - os: ubuntu
             name: noble
+          - os: ubuntu
+            name: resolute
           - os: archlinux
             name: latest
           - os: debian

--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -115,7 +115,8 @@ case "${RELEASE_CODENAME}" in
     jammy)    ;&
     noble)    ;&
     plucky)   ;&
-    questing)
+    questing) ;&
+    resolute)
         echo "${RELEASE_CODENAME} is supported"
         ;;
 
@@ -153,6 +154,11 @@ elif [ ${RELEASE_CODENAME} == 'plucky' ]; then
 elif [ ${RELEASE_CODENAME} == 'questing' ]; then
     SITLFML_VERSION="2.6"
     SITLCFML_VERSION="2.6"
+    PYTHON_V="python3"
+    PIP="python3 -m pip"
+elif [ ${RELEASE_CODENAME} == 'resolute' ]; then
+    SITLFML_VERSION="3.0"
+    SITLCFML_VERSION="3.0"
     PYTHON_V="python3"
     PIP="python3 -m pip"
 elif [ ${RELEASE_CODENAME} == 'bullseye' ]; then
@@ -212,6 +218,7 @@ if [ ${RELEASE_CODENAME} == 'trixie' ] ||
    [ ${RELEASE_CODENAME} == 'noble' ] ||
    [ ${RELEASE_CODENAME} == 'plucky' ] ||
    [ ${RELEASE_CODENAME} == 'questing' ] ||
+   [ ${RELEASE_CODENAME} == 'resolute' ] ||
    false; then
     # on Ubuntu 23.04 Lunar (and presumably later releases), we install in venv, below
     PYTHON_PKGS+=" numpy pyparsing psutil"
@@ -227,6 +234,7 @@ if [[ $SKIP_AP_GRAPHIC_ENV -ne 1 ]]; then
        [ ${RELEASE_CODENAME} == 'noble' ] ||
        [ ${RELEASE_CODENAME} == 'plucky' ] ||
        [ ${RELEASE_CODENAME} == 'questing' ] ||
+       [ ${RELEASE_CODENAME} == 'resolute' ] ||
        false; then
         PYTHON_PKGS+=" matplotlib scipy opencv-python pyyaml"
         SITL_PKGS+=" xterm xfonts-base libcsfml-dev libcsfml-audio${SITLCFML_VERSION} libcsfml-dev libcsfml-graphics${SITLCFML_VERSION} libcsfml-network${SITLCFML_VERSION} libcsfml-system${SITLCFML_VERSION} libcsfml-window${SITLCFML_VERSION} libsfml-audio${SITLFML_VERSION} libsfml-dev libsfml-graphics${SITLFML_VERSION} libsfml-network${SITLFML_VERSION} libsfml-system${SITLFML_VERSION} libsfml-window${SITLFML_VERSION}"
@@ -316,6 +324,7 @@ elif [ ${RELEASE_CODENAME} == 'bookworm' ]; then
 elif [ ${RELEASE_CODENAME} != 'noble' ] &&
      [ ${RELEASE_CODENAME} != 'plucky' ] &&
      [ ${RELEASE_CODENAME} != 'questing' ] &&
+     [ ${RELEASE_CODENAME} != 'resolute' ] &&
      true; then
     if apt-cache search python-argparse | grep argp; then
         SITL_PKGS+=" python-argparse"
@@ -342,6 +351,9 @@ if [[ $SKIP_AP_GRAPHIC_ENV -ne 1 ]]; then
   elif [ ${RELEASE_CODENAME} == 'questing' ]; then
     SITL_PKGS+=" libgtk-3-dev libwxgtk3.2-dev "
     # see below
+  elif [ ${RELEASE_CODENAME} == 'resolute' ]; then
+    SITL_PKGS+=" libgtk-3-dev libwxgtk3.2-dev "
+    # see below
   elif apt-cache search python-wxgtk3.0 | grep wx; then
       SITL_PKGS+=" python-wxgtk3.0"
   elif apt-cache search python3-wxgtk4.0 | grep wx; then
@@ -364,6 +376,7 @@ if [[ $SKIP_AP_GRAPHIC_ENV -ne 1 ]]; then
   elif [ ${RELEASE_CODENAME} == 'noble' ] ||
        [ ${RELEASE_CODENAME} == 'plucky' ] ||
        [ ${RELEASE_CODENAME} == 'questing' ] ||
+       [ ${RELEASE_CODENAME} == 'resolute' ] ||
        false; then
       PYTHON_PKGS+=" wxpython opencv-python"
       SITL_PKGS+=" python3-wxgtk4.0"
@@ -423,6 +436,7 @@ if [ ${RELEASE_CODENAME} == 'bookworm' ] ||
      [ ${RELEASE_CODENAME} == 'noble' ] ||
      [ ${RELEASE_CODENAME} == 'plucky' ] ||
      [ ${RELEASE_CODENAME} == 'questing' ] ||
+     [ ${RELEASE_CODENAME} == 'resolute' ] ||
      false; then
     $APT_GET install python3-venv
 
@@ -473,6 +487,7 @@ if [ ${RELEASE_CODENAME} == 'trixie' ] ||
    [ ${RELEASE_CODENAME} == 'noble' ] ||
    [ ${RELEASE_CODENAME} == 'plucky' ] ||
    [ ${RELEASE_CODENAME} == 'questing' ] ||
+   [ ${RELEASE_CODENAME} == 'resolute' ] ||
    false; then
     # must do this ahead of wxPython pip3 run :-/
     $PIP install $PIP_USER_ARGUMENT --upgrade attrdict3


### PR DESCRIPTION
### Summary

Adds support for installing on Resolute

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Tested on a fresh real machine.

### Description

Known-broken is all of the sfml stuff that sim_vehicle.py gives you.  This is not a fault with the install script but of the firmware itself; the SFML that comes with Resolute requires C++-17 support which ArduPilot does not have at the moment.
