### PR TITLE
.github: remove duplicate 'Bug Report' heading

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,14 +4,12 @@ about: If you are sure you have found a bug, then choose this to open a bug repo
 
 ---
 
-# Bug Report
+## Bug Report
 
 **IF YOU DON'T REMOVE THESE FOUR LINES, THEN YOUR REPORT WILL BE CLOSED AUTOMATICALLY**
 Questions and user problems should be directed at the [ArduPilot forum](http://discuss.ardupilot.org)
 _**Please be very sure you have found a bug when opening this issue**_
 If there was a previous discussion in the forum, link to it
-
-## Bug report
 
 ### Issue details
 
@@ -21,12 +19,12 @@ Please describe the problem
 What version was the issue encountered with
 
 **Platform**
-[  ] All
-[  ] AntennaTracker
-[  ] Copter
-[  ] Plane
-[  ] Rover
-[  ] Submarine
+[ ] All
+[ ] AntennaTracker
+[ ] Copter
+[ ] Plane
+[ ] Rover
+[ ] Submarine
 
 **Airframe type**
 _What type of airframe (flying wing, glider, hex, Y6, octa etc)_


### PR DESCRIPTION
### Summary

Removes duplicate heading (keeping the smaller one; there's an exception to our markup linting in these files to make Thomas happy ;-)

Also fixes the checkboxes to not have two spaces in them.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

keep the smaller one to make life nicer all around
