### PR TITLE
Copter/Plane/Blimp/Rover: Avoid float division in high latency wind direction

### DIFF
--- a/ArduCopter/GCS_MAVLink_Copter.cpp
+++ b/ArduCopter/GCS_MAVLink_Copter.cpp
@@ -1334,7 +1334,7 @@ uint8_t GCS_MAVLINK_Copter::high_latency_wind_direction() const
     if (AP::ahrs().airspeed_vector_TAS(airspeed_vec_bf)) {
         wind = AP::ahrs().wind_estimate();
         // need to convert -180->180 to 0->360/2
-        return wrap_360(degrees(atan2f(-wind.y, -wind.x))) / 2;
+        return wrap_360(degrees(atan2f(-wind.y, -wind.x))) * 0.5f;
     }
     return 0;
 }

--- a/ArduPlane/GCS_MAVLink_Plane.cpp
+++ b/ArduPlane/GCS_MAVLink_Plane.cpp
@@ -1240,7 +1240,7 @@ uint8_t GCS_MAVLINK_Plane::high_latency_wind_direction() const
 
     // return units are deg/2
     // need to convert -180->180 to 0->360/2
-    return wrap_360(degrees(atan2f(-wind.y, -wind.x))) / 2;
+    return wrap_360(degrees(atan2f(-wind.y, -wind.x))) * 0.5f;
 }
 #endif // HAL_HIGH_LATENCY2_ENABLED
 

--- a/Blimp/GCS_MAVLink_Blimp.cpp
+++ b/Blimp/GCS_MAVLink_Blimp.cpp
@@ -360,7 +360,7 @@ uint8_t GCS_MAVLINK_Blimp::high_latency_wind_direction() const
     }
     const Vector3f wind = AP::ahrs().wind_estimate();
     // need to convert -180->180 to 0->360/2
-    return wrap_360(degrees(atan2f(-wind.y, -wind.x))) / 2;
+    return wrap_360(degrees(atan2f(-wind.y, -wind.x))) * 0.5f;
 }
 #endif // HAL_HIGH_LATENCY2_ENABLED
 

--- a/Rover/GCS_MAVLink_Rover.cpp
+++ b/Rover/GCS_MAVLink_Rover.cpp
@@ -922,7 +922,7 @@ uint8_t GCS_MAVLINK_Rover::high_latency_wind_direction() const
 {
     if (rover.g2.windvane.enabled()) {
         // return units are deg/2
-        return wrap_360(degrees(rover.g2.windvane.get_true_wind_direction_rad())) / 2;
+        return wrap_360(degrees(rover.g2.windvane.get_true_wind_direction_rad())) * 0.5f;
     }
     return 0;
 }


### PR DESCRIPTION
### Summary

Replace division by 2 with multiplication by 0.5 in HAL code.

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [X] Non-functional change
- [X] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [ ] AI-assisted contribution

 Tested:

- `./waf configure --board fmuv3`
- `./waf copter`
- `./waf plane`
- `./waf blimp`
- `./waf rover`
  
### Description

This PR changes a HAL calculation from dividing by `2` to multiplying by `0.5`.

The intended behavior is unchanged. This keeps the calculation equivalent while avoiding an explicit division operation.

This contribution was AI-assisted. The AI helped draft the PR description; the final change and testing responsibility remain with the human author.