### PR TITLE
AC_Avoidance: set dest_to_next_dest_clear when OA not required

### DIFF
--- a/libraries/AC_Avoidance/AP_OAPathPlanner.cpp
+++ b/libraries/AC_Avoidance/AP_OAPathPlanner.cpp
@@ -403,6 +403,14 @@ void AP_OAPathPlanner::avoidance_thread()
 
         } // switch
 
+        // when avoidance is not required the path to the next
+        // destination is clear.  Only Dijkstra's sets
+        // dest_to_next_dest_clear; BendyRuler leaves it false which
+        // causes AC_WPNav_OA to force-stop at every waypoint.
+        if (res == OA_NOT_REQUIRED) {
+            dest_to_next_dest_clear = true;
+        }
+
         {
             // give the main thread the avoidance result
             WITH_SEMAPHORE(_rsem);


### PR DESCRIPTION
### Summary

Fix BendyRuler (OA_TYPE=1) causing vehicle to stop at every waypoint by setting dest_to_next_dest_clear when OA returns OA_NOT_REQUIRED.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

Tested in SITL Copter with OA_TYPE=1 and proximity sensor. Multi-waypoint AUTO mission through clear airspace. Before fix: vehicle stops at every waypoint (speed drops to 0). After fix: smooth waypoint transitions at cruise speed.

### Description

When BendyRuler is the active OA path planner (OA_TYPE=1), `dest_to_next_dest_clear` is initialised `false` in `avoidance_thread()` and only Dijkstra's planner ever sets it to `true`. BendyRuler never touches it.

In `AC_WPNav_OA::update_wpnav()`, `force_stop_at_next_wp()` is called on every iteration when `dest_to_next_dest_clear` is false. This clears `fast_waypoint` and sets the destination speed to zero, forcing the vehicle to stop and hover at every waypoint — even when no obstacles are detected.

The fix: after the avoidance planner switch statement, when `res == OA_NOT_REQUIRED`, set `dest_to_next_dest_clear = true`. If no avoidance is required, the path to the next destination is clear by definition.

This affects any vehicle using BendyRuler (OA_TYPE=1) with multi-waypoint missions. Dijkstra (OA_TYPE=2) and combined (OA_TYPE=3) are not affected because Dijkstra explicitly sets this flag.

I discovered this while developing a synthetic LiDAR obstacle avoidance system (Balliyang) for urban drone navigation. The stopping behaviour was consistent across all missions in SITL and initially appeared to be an S-Curve or spline issue before tracing it to this flag.