### PR TITLE
mode_guided: run OA path planner in Pos submode

### DIFF
--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -767,7 +767,38 @@ void ModeGuided::pos_control_run()
     if (guided_is_terrain_alt) {
         terrain_margin_m = MIN(copter.wp_nav->get_terrain_margin_m(), 0.5 * fabsF(guided_pos_target_ned_m.z));
     }
-    pos_control->input_pos_NED_m(guided_pos_target_ned_m, terrain_d_m, terrain_margin_m);
+    // run object avoidance on the position target so that
+    // BendyRuler / Dijkstra can adjust the path.  Without this,
+    // GUIDED Pos submode sends the target straight to pos_control
+    // and bypasses wp_nav, so OA never runs.
+    Vector3p oa_target = guided_pos_target_ned_m;
+#if AP_OAPATHPLANNER_ENABLED
+    {
+        AP_OAPathPlanner *oa = AP_OAPathPlanner::get_singleton();
+        if (oa != nullptr) {
+            Location current_loc;
+            if (AP::ahrs().get_location(current_loc)) {
+                const Location target_loc = Location::from_ekf_offset_NED_m(
+                    guided_pos_target_ned_m,
+                    guided_is_terrain_alt ? Location::AltFrame::ABOVE_TERRAIN
+                                         : Location::AltFrame::ABOVE_ORIGIN);
+                Location oa_origin, oa_dest, oa_next;
+                bool dest_to_next_clear = true;
+                AP_OAPathPlanner::OAPathPlannerUsed planner_used;
+
+                const AP_OAPathPlanner::OA_RetState ret =
+                    oa->mission_avoidance(current_loc, current_loc,
+                                          target_loc, target_loc,
+                                          oa_origin, oa_dest, oa_next,
+                                          dest_to_next_clear, planner_used);
+                if (ret == AP_OAPathPlanner::OA_SUCCESS) {
+                    oa_dest.get_vector_from_origin_NED_m(oa_target);
+                }
+            }
+        }
+    }
+#endif
+    pos_control->input_pos_NED_m(oa_target, terrain_d_m, terrain_margin_m);
 
     // run position controllers
     pos_control->NE_update_controller();


### PR DESCRIPTION
## Summary

GUIDED mode's `pos_control_run()` (SubMode::Pos) sends the target position directly to `pos_control->input_pos_NED_m()`, bypassing `wp_nav` entirely. Since BendyRuler and Dijkstra OA live inside the `AC_WPNav_OA` wrapper, obstacle avoidance never runs in GUIDED Pos submode.

This means when a user clicks "Fly Here" in a GCS (which uses GUIDED Pos), the vehicle flies straight to the target with no obstacle avoidance, even when `OA_TYPE` is enabled and proximity sensors are active.

The fix calls `AP_OAPathPlanner::mission_avoidance()` on the target position before sending it to `pos_control`. If the OA planner returns an adjusted position (obstacle detected), that adjusted position is used instead. If OA is disabled or not required, the original target passes through unchanged.

The change is wrapped in `#if AP_OAPATHPLANNER_ENABLED` for zero overhead when OA is compiled out.

## How to reproduce

1. Configure ArduCopter with `OA_TYPE=1` (BendyRuler), proximity sensor active
2. Arm and take off
3. Use GCS "Fly Here" / "Go To" (GUIDED mode) toward a known obstacle
4. Vehicle flies straight through/into the obstacle — no avoidance

## After fix

- GUIDED Pos submode checks OA before sending position to controller
- BendyRuler deflects the target around obstacles
- GUIDED WP submode (which already uses wp_nav) is unaffected
- No change when OA is disabled (`OA_TYPE=0`)

## Affected vehicles/modes

- **Copter**: GUIDED mode, Pos submode (used by GCS "Fly Here")
- Does NOT affect GUIDED WP submode (already has OA via wp_nav)
- Does NOT affect AUTO mode (uses wp_nav)

## Testing

- SITL Copter with `OA_TYPE=1`, proximity sensor configured
- Click "Fly Here" toward a building/obstacle
- Before fix: vehicle flies straight to target, ignoring obstacles
- After fix: vehicle deflects around obstacles via BendyRuler