### PR TITLE
ArduCopter: reflect commanded yaw in POSITION_TARGET_LOCAL_NED

### DIFF
--- a/ArduCopter/GCS_MAVLink_Copter.cpp
+++ b/ArduCopter/GCS_MAVLink_Copter.cpp
@@ -132,34 +132,48 @@ void GCS_MAVLINK_Copter::send_position_target_local_ned()
     case ModeGuided::SubMode::WP:
     case ModeGuided::SubMode::Pos:
         type_mask = POSITION_TARGET_TYPEMASK_VX_IGNORE | POSITION_TARGET_TYPEMASK_VY_IGNORE | POSITION_TARGET_TYPEMASK_VZ_IGNORE |
-                    POSITION_TARGET_TYPEMASK_AX_IGNORE | POSITION_TARGET_TYPEMASK_AY_IGNORE | POSITION_TARGET_TYPEMASK_AZ_IGNORE |
-                    POSITION_TARGET_TYPEMASK_YAW_IGNORE| POSITION_TARGET_TYPEMASK_YAW_RATE_IGNORE; // ignore everything except position
+                    POSITION_TARGET_TYPEMASK_AX_IGNORE | POSITION_TARGET_TYPEMASK_AY_IGNORE | POSITION_TARGET_TYPEMASK_AZ_IGNORE; // ignore everything except position
         target_pos_ned_m = copter.mode_guided.get_target_pos_NED_m().tofloat();
         break;
     case ModeGuided::SubMode::PosVelAccel:
-        type_mask = POSITION_TARGET_TYPEMASK_YAW_IGNORE| POSITION_TARGET_TYPEMASK_YAW_RATE_IGNORE; // ignore everything except position, velocity & acceleration
+        // ignore nothing except yaw (handled below): position, velocity & acceleration are all valid
         target_pos_ned_m = copter.mode_guided.get_target_pos_NED_m().tofloat();
         target_vel_ned_ms = copter.mode_guided.get_target_vel_NED_ms();
         target_accel_ned_mss = copter.mode_guided.get_target_accel_NED_mss();
         break;
     case ModeGuided::SubMode::VelAccel:
-        type_mask = POSITION_TARGET_TYPEMASK_X_IGNORE | POSITION_TARGET_TYPEMASK_Y_IGNORE | POSITION_TARGET_TYPEMASK_Z_IGNORE |
-                    POSITION_TARGET_TYPEMASK_YAW_IGNORE| POSITION_TARGET_TYPEMASK_YAW_RATE_IGNORE; // ignore everything except velocity & acceleration
+        type_mask = POSITION_TARGET_TYPEMASK_X_IGNORE | POSITION_TARGET_TYPEMASK_Y_IGNORE | POSITION_TARGET_TYPEMASK_Z_IGNORE; // ignore everything except velocity & acceleration
         target_vel_ned_ms = copter.mode_guided.get_target_vel_NED_ms();
         target_accel_ned_mss = copter.mode_guided.get_target_accel_NED_mss();
         break;
     case ModeGuided::SubMode::Accel:
         type_mask = POSITION_TARGET_TYPEMASK_X_IGNORE | POSITION_TARGET_TYPEMASK_Y_IGNORE | POSITION_TARGET_TYPEMASK_Z_IGNORE |
-                    POSITION_TARGET_TYPEMASK_VX_IGNORE | POSITION_TARGET_TYPEMASK_VY_IGNORE | POSITION_TARGET_TYPEMASK_VZ_IGNORE |
-                    POSITION_TARGET_TYPEMASK_YAW_IGNORE| POSITION_TARGET_TYPEMASK_YAW_RATE_IGNORE; // ignore everything except velocity & acceleration
+                    POSITION_TARGET_TYPEMASK_VX_IGNORE | POSITION_TARGET_TYPEMASK_VY_IGNORE | POSITION_TARGET_TYPEMASK_VZ_IGNORE; // ignore everything except acceleration
         target_accel_ned_mss = copter.mode_guided.get_target_accel_NED_mss();
         break;
+    }
+
+    // reflect the yaw / yaw-rate that was actually commanded rather than always
+    // reporting "ignored" with a zero value (issue #13932)
+    float yaw_rad = 0.0f;
+    float yaw_rate_rads = 0.0f;
+    if (copter.mode_guided.reported_yaw_is_ignored()) {
+        type_mask |= POSITION_TARGET_TYPEMASK_YAW_IGNORE;
+    } else {
+        yaw_rad = copter.mode_guided.get_reported_yaw_rad();
+    }
+    if (copter.mode_guided.reported_yaw_rate_is_ignored()) {
+        type_mask |= POSITION_TARGET_TYPEMASK_YAW_RATE_IGNORE;
+    } else {
+        yaw_rate_rads = copter.mode_guided.get_reported_yaw_rate_rads();
     }
 
     mavlink_msg_position_target_local_ned_send(
         chan,
         AP_HAL::millis(), // time boot ms
-        MAV_FRAME_LOCAL_NED, 
+        // the reported targets are always converted to earth-frame NED, so the
+        // frame is LOCAL_NED regardless of the frame used in the original request
+        MAV_FRAME_LOCAL_NED,
         type_mask,
         target_pos_ned_m.x,     // x in metres
         target_pos_ned_m.y,     // y in metres
@@ -170,8 +184,8 @@ void GCS_MAVLINK_Copter::send_position_target_local_ned()
         target_accel_ned_mss.x, // afx in m/s/s
         target_accel_ned_mss.y, // afy in m/s/s
         target_accel_ned_mss.z, // afz in m/s/s NED frame
-        0.0f,                   // yaw
-        0.0f);                  // yaw_rate
+        yaw_rad,                // yaw setpoint (rad)
+        yaw_rate_rads);         // yaw rate setpoint (rad/s)
 #endif
 }
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1138,6 +1138,14 @@ public:
     const Vector3f& get_target_vel_NED_ms() const;
     const Vector3f& get_target_accel_NED_mss() const;
 
+    // get the last commanded yaw / yaw-rate (earth-frame, radians) so the
+    // POSITION_TARGET_LOCAL_NED telemetry message can echo the requested yaw.
+    // *_is_ignored() return true when no yaw / yaw-rate has been commanded.
+    float get_reported_yaw_rad() const { return _reported_yaw_rad; }
+    float get_reported_yaw_rate_rads() const { return _reported_yaw_rate_rads; }
+    bool reported_yaw_is_ignored() const { return _reported_yaw_ignore; }
+    bool reported_yaw_rate_is_ignored() const { return _reported_yaw_rate_ignore; }
+
     // returns true if GUIDED_OPTIONS param suggests SET_ATTITUDE_TARGET's "thrust" field should be interpreted as thrust instead of climb rate
     bool set_attitude_target_provides_thrust() const;
     bool stabilizing_pos_NE() const;
@@ -1239,6 +1247,15 @@ private:
 
     // guided mode is paused or not
     bool _paused;
+
+    // last yaw state commanded via set_yaw_state_rad(), recorded so the
+    // POSITION_TARGET_LOCAL_NED telemetry message can echo the requested
+    // yaw / yaw-rate rather than reporting zero (issue #13932). Yaw is stored
+    // in earth-frame radians (body-relative requests are converted on input).
+    float _reported_yaw_rad = 0.0f;
+    float _reported_yaw_rate_rads = 0.0f;
+    bool  _reported_yaw_ignore = true;
+    bool  _reported_yaw_rate_ignore = true;
 };
 
 #if AP_SCRIPTING_ENABLED

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -44,6 +44,13 @@ bool ModeGuided::init(bool ignore_checks)
     // clear pause state when entering guided mode
     _paused = false;
 
+    // no yaw has been commanded yet, so report it as ignored in
+    // POSITION_TARGET_LOCAL_NED until a target sets it (issue #13932)
+    _reported_yaw_ignore = true;
+    _reported_yaw_rate_ignore = true;
+    _reported_yaw_rad = 0.0f;
+    _reported_yaw_rate_rads = 0.0f;
+
     return true;
 }
 

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -1039,6 +1039,14 @@ void ModeGuided::angle_control_run()
 // helper function to set yaw state and targets
 void ModeGuided::set_yaw_state_rad(bool use_yaw, float yaw_rad, bool use_yaw_rate, float yaw_rate_rads, bool relative_angle)
 {
+    // record the commanded yaw / yaw-rate so POSITION_TARGET_LOCAL_NED telemetry
+    // can echo what was requested (issue #13932). Store yaw in earth-frame by
+    // resolving body-relative requests against the current heading.
+    _reported_yaw_ignore = !use_yaw;
+    _reported_yaw_rate_ignore = !use_yaw_rate;
+    _reported_yaw_rad = (use_yaw && relative_angle) ? wrap_PI(copter.ahrs.get_yaw_rad() + yaw_rad) : yaw_rad;
+    _reported_yaw_rate_rads = use_yaw_rate ? yaw_rate_rads : 0.0f;
+
     if (use_yaw && relative_angle) {
         auto_yaw.set_fixed_yaw_rad(yaw_rad, 0.0f, 0, relative_angle);
     } else if (use_yaw && use_yaw_rate) {

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -6270,14 +6270,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             target_yaw_rad, # yaw
             0, # yawrate
         )
-        m = self.assert_receive_message('POSITION_TARGET_LOCAL_NED', timeout=2)
-        self.progress("Received local target with yaw: %s" % str(m))
-
-        if m.type_mask & MAV_POS_TARGET_TYPE_MASK.YAW_IGNORE:
-            raise NotAchievedException("YAW_IGNORE should be clear when a yaw is commanded: got mask=%u" % m.type_mask)
-
-        if abs(m.yaw - target_yaw_rad) > math.radians(1):
-            raise NotAchievedException("Did not receive commanded yaw: wanted=%f got=%f" % (target_yaw_rad, m.yaw))
+        self.wait_position_target_yaw(target_yaw_rad)
 
     def test_guided_local_velocity_target(self, vx, vy, vz_up, timeout=3):
         " Check local target velocity being received by vehicle "
@@ -6383,6 +6376,64 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.assert_not_receiving_message('POSITION_TARGET_LOCAL_NED')
 
         self.progress("Did not receive any POSITION_TARGET_LOCAL_NED message in LOITER mode. Success")
+
+    def wait_position_target_yaw(self, target_yaw_rad, timeout=2):
+        '''wait for POSITION_TARGET_LOCAL_NED to reflect a commanded yaw'''
+        tstart = time.time()
+        last_msg = None
+        while time.time() - tstart < timeout:
+            last_msg = self.assert_receive_message('POSITION_TARGET_LOCAL_NED', timeout=timeout)
+            self.progress("Received local target with yaw: %s" % str(last_msg))
+            if last_msg.type_mask & MAV_POS_TARGET_TYPE_MASK.YAW_IGNORE:
+                continue
+            if abs(last_msg.yaw - target_yaw_rad) <= math.radians(1):
+                return last_msg
+
+        raise NotAchievedException("Did not receive commanded yaw: wanted=%f last=%s" % (target_yaw_rad, last_msg))
+
+    def wait_position_target_yaw_ignored(self, timeout=2):
+        '''wait for POSITION_TARGET_LOCAL_NED to report yaw ignored'''
+        tstart = time.time()
+        last_msg = None
+        while time.time() - tstart < timeout:
+            last_msg = self.assert_receive_message('POSITION_TARGET_LOCAL_NED', timeout=timeout)
+            self.progress("Received local target with ignored yaw: %s" % str(last_msg))
+            if not (last_msg.type_mask & MAV_POS_TARGET_TYPE_MASK.YAW_IGNORE):
+                continue
+            if abs(last_msg.yaw) <= math.radians(1):
+                return last_msg
+
+        raise NotAchievedException("Did not receive ignored yaw target: last=%s" % last_msg)
+
+    def test_guided_yaw_target_reset_on_entry(self):
+        '''ensure POSITION_TARGET_LOCAL_NED reports yaw as ignored after
+        re-entering guided, until a new target commands it (issue #13932)'''
+        self.change_mode('GUIDED')
+        self.set_message_rate_hz(mavutil.mavlink.MAVLINK_MSG_ID_POSITION_TARGET_LOCAL_NED, 10)
+
+        # command a yaw so the reported yaw state becomes non-ignored
+        target_typemask = (MAV_POS_TARGET_TYPE_MASK.VEL_IGNORE |
+                           MAV_POS_TARGET_TYPE_MASK.ACC_IGNORE |
+                           MAV_POS_TARGET_TYPE_MASK.YAW_RATE_IGNORE)
+        self.mav.mav.set_position_target_local_ned_send(
+            0, 1, 1,
+            mavutil.mavlink.MAV_FRAME_LOCAL_NED,
+            target_typemask | MAV_POS_TARGET_TYPE_MASK.LAST_BYTE,
+            5, 5, -10,        # x, y, z
+            0, 0, 0,          # vx, vy, vz
+            0, 0, 0,          # afx, afy, afz
+            math.radians(42), # yaw
+            0,                # yawrate
+        )
+        self.wait_position_target_yaw(math.radians(42))
+
+        # leave and re-enter guided; the reported yaw should reset to ignored
+        # rather than reporting the stale target from the previous session
+        self.change_mode('LOITER')
+        self.change_mode('GUIDED')
+        self.set_message_rate_hz(mavutil.mavlink.MAVLINK_MSG_ID_POSITION_TARGET_LOCAL_NED, 10)
+
+        self.wait_position_target_yaw_ignored()
 
     def earth_to_body(self, vector):
         r = mavextra.rotation(self.mav.messages["ATTITUDE"]).invert()
@@ -6671,6 +6722,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.test_guided_local_position_target(5, 5, 10)
         self.test_guided_local_velocity_target(2, 2, 1)
         self.test_position_target_message_mode()
+        self.test_guided_yaw_target_reset_on_entry()
 
         self.do_RTL()
 

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -6245,6 +6245,40 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         if z_up - (-m.z) > 0.1:
             raise NotAchievedException("Did not receive proper target position z: wanted=%f got=%f" % (z_up, -m.z))
 
+        # check that a commanded yaw is reflected back rather than reported as
+        # ignored/zero (issue #13932)
+        target_yaw_rad = math.radians(42)
+        # position + yaw (velocity, acceleration and yaw-rate ignored)
+        target_typemask = (MAV_POS_TARGET_TYPE_MASK.VEL_IGNORE |
+                           MAV_POS_TARGET_TYPE_MASK.ACC_IGNORE |
+                           MAV_POS_TARGET_TYPE_MASK.YAW_RATE_IGNORE)
+        self.mav.mav.set_position_target_local_ned_send(
+            0, # timestamp
+            1, # target system_id
+            1, # target component id
+            mavutil.mavlink.MAV_FRAME_LOCAL_NED,
+            target_typemask | MAV_POS_TARGET_TYPE_MASK.LAST_BYTE,
+            x, # x
+            y, # y
+            -z_up, # z
+            0, # vx
+            0, # vy
+            0, # vz
+            0, # afx
+            0, # afy
+            0, # afz
+            target_yaw_rad, # yaw
+            0, # yawrate
+        )
+        m = self.assert_receive_message('POSITION_TARGET_LOCAL_NED', timeout=2)
+        self.progress("Received local target with yaw: %s" % str(m))
+
+        if m.type_mask & MAV_POS_TARGET_TYPE_MASK.YAW_IGNORE:
+            raise NotAchievedException("YAW_IGNORE should be clear when a yaw is commanded: got mask=%u" % m.type_mask)
+
+        if abs(m.yaw - target_yaw_rad) > math.radians(1):
+            raise NotAchievedException("Did not receive commanded yaw: wanted=%f got=%f" % (target_yaw_rad, m.yaw))
+
     def test_guided_local_velocity_target(self, vx, vy, vz_up, timeout=3):
         " Check local target velocity being received by vehicle "
         self.progress("Setting local NED velocity target: (%f, %f, %f)" % (vx, vy, -vz_up))


### PR DESCRIPTION
### Summary

Make Copter's `POSITION_TARGET_LOCAL_NED` telemetry reflect the yaw / yaw-rate commanded via `SET_POSITION_TARGET_LOCAL_NED` instead of always reporting zero with the ignore bits set (fixes #13932).

### Classification & Testing

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Verified with the existing `Copter.GuidedSubModeChange` autotest, extended here to command a non-zero yaw and assert it is echoed back with `YAW_IGNORE` cleared. The streamed message now reports `yaw: 0.733` (= 42 deg, exactly commanded) where it previously reported `0.0` / ignored.

### Description

`GCS_MAVLINK_Copter::send_position_target_local_ned()` always reported `yaw` and `yaw_rate` as `0` with the `YAW_IGNORE` / `YAW_RATE_IGNORE` bits set, regardless of what was requested via `SET_POSITION_TARGET_LOCAL_NED`. A GCS / companion reading back the active guided target could therefore never see the commanded heading.

- `ModeGuided::set_yaw_state_rad()` now records the last commanded yaw / yaw-rate and their ignore flags. This is the single chokepoint all guided yaw commands pass through, so it also covers `SET_POSITION_TARGET_GLOBAL_INT` and scripting sources. Body-relative yaw requests are resolved to earth-frame on input.
- `send_position_target_local_ned()` echoes the recorded yaw / yaw-rate and sets the `YAW_IGNORE` / `YAW_RATE_IGNORE` bits only when a yaw / yaw-rate is actually being ignored. The per-submode masking of position/velocity/acceleration is unchanged.

**On the `frame` field:** the issue also notes the message always reports `MAV_FRAME_LOCAL_NED`. I deliberately kept it: the reported `x/y/z` targets are always converted to earth-frame NED before being stored, so `LOCAL_NED` is the correct frame for the reported coordinates even when the original request used a body / offset frame. Echoing the request frame would mislabel the coordinates. Happy to revisit if reviewers disagree.

### AI assistance

I used an AI coding assistant to help inspect the code, debug the autotest failure, and prepare this update. I reviewed and take responsibility for the final changes.