### PR TITLE
AP_HAL: enable BLHeli / serial-RCOut feature set under SITL

### DIFF
--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -418,7 +418,15 @@ void AP_BLHeli::msp_process_command(void)
     case MSP_UID:
         // MCU identifier
         debug("MSP_UID");
+#ifdef UDID_START
         msp_send_reply(msp.cmdMSP, (const uint8_t *)UDID_START, 12);
+#else
+        {
+            // boards without a fixed UID address (e.g. SITL) reply with zeros
+            const uint8_t zero_uid[12] = {0};
+            msp_send_reply(msp.cmdMSP, zero_uid, sizeof(zero_uid));
+        }
+#endif
         break;
 
         // a literal "4" is used for the PWMType here to allow Rover
@@ -1504,7 +1512,7 @@ void AP_BLHeli::init(uint32_t mask, AP_HAL::RCOutput::output_mode otype)
         }
     }
     motor_mask = mask;
-    debug("ESC: %u motors mask=0x%08lx", num_motors, digital_mask);
+    debug("ESC: %u motors mask=0x%08lx", num_motors, (unsigned long)digital_mask);
 
     // check if we have a combination of reversible and normal
     mixed_type = (mask != (mask & channel_reversible_mask.get())) && (channel_reversible_mask.get() != 0);

--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -418,15 +418,9 @@ void AP_BLHeli::msp_process_command(void)
     case MSP_UID:
         // MCU identifier
         debug("MSP_UID");
-#ifdef UDID_START
-        msp_send_reply(msp.cmdMSP, (const uint8_t *)UDID_START, 12);
-#else
-        {
-            // boards without a fixed UID address (e.g. SITL) reply with zeros
-            const uint8_t zero_uid[12] = {0};
-            msp_send_reply(msp.cmdMSP, zero_uid, sizeof(zero_uid));
-        }
-#endif
+      uint8_t uid[12] {};
+      hal.util->get_system_id_unformatted(uid, sizeof(uid));
+      msp_send_reply(msp.cmdMSP, uid, sizeof(uid));
         break;
 
         // a literal "4" is used for the PWMType here to allow Rover

--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -25,10 +25,6 @@
 
 #if HAVE_AP_BLHELI_SUPPORT
 
-#if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
-#include <hal.h>
-#endif
-
 #include <AP_Math/crc.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 #if APM_BUILD_TYPE(APM_BUILD_Rover)
@@ -415,11 +411,15 @@ void AP_BLHeli::msp_process_command(void)
         blheli.connected[blheli.chan] = false;
         break;
 
-    case MSP_UID:
+    case MSP_UID: {
         // MCU identifier
         debug("MSP_UID");
-        msp_send_reply(msp.cmdMSP, (const uint8_t *)UDID_START, 12);
+        uint8_t uid[12] {};
+        uint8_t len = sizeof(uid);
+        hal.util->get_system_id_unformatted(uid, len);
+        msp_send_reply(msp.cmdMSP, uid, sizeof(uid));
         break;
+    }
 
         // a literal "4" is used for the PWMType here to allow Rover
         // to use the same number for the same protocol.  At time of
@@ -1504,7 +1504,7 @@ void AP_BLHeli::init(uint32_t mask, AP_HAL::RCOutput::output_mode otype)
         }
     }
     motor_mask = mask;
-    debug("ESC: %u motors mask=0x%08lx", num_motors, digital_mask);
+    debug("%u motors mask=0x%08lx", num_motors, (unsigned long)digital_mask);
 
     // check if we have a combination of reversible and normal
     mixed_type = (mask != (mask & channel_reversible_mask.get())) && (channel_reversible_mask.get() != 0);

--- a/libraries/AP_HAL/board/sitl.h
+++ b/libraries/AP_HAL/board/sitl.h
@@ -7,6 +7,11 @@
 #define HAL_MEM_CLASS HAL_MEM_CLASS_1000
 #define HAL_OS_SOCKETS 1
 
+// build AP_BLHeli under SITL so the SERVO_BLH_* params exist; serial passthrough and DShot reversing are no-ops here
+#ifndef HAL_SUPPORT_RCOUT_SERIAL
+#define HAL_SUPPORT_RCOUT_SERIAL 1
+#endif
+
 #define AP_FLASHSTORAGE_TYPE 3
 
 #if AP_FLASHSTORAGE_TYPE == 1

--- a/libraries/AP_HAL/board/sitl.h
+++ b/libraries/AP_HAL/board/sitl.h
@@ -7,6 +7,11 @@
 #define HAL_MEM_CLASS HAL_MEM_CLASS_1000
 #define HAL_OS_SOCKETS 1
 
+// build AP_BLHeli for the SERVO_BLH_* params; passthrough is unsupported here
+#ifndef HAL_SUPPORT_RCOUT_SERIAL
+#define HAL_SUPPORT_RCOUT_SERIAL 1
+#endif
+
 #define AP_FLASHSTORAGE_TYPE 3
 
 #if AP_FLASHSTORAGE_TYPE == 1


### PR DESCRIPTION
### Summary

Make AP_BLHeli build under SITL and register the SERVO_BLH_* parameters, so the ESC and motor-direction tooling that depends on them can be exercised in the simulator instead of only on hardware.

### Classification & Testing

- [x] Checked by a human programmer
- [x] Non-functional change on hardware

AP_BLHeli.cpp compiles clean under -Werror for SITL (x86-64) and for a ChibiOS H7 target, and the SERVO_BLH_* parameters register under SITL. No autotest covers them yet.

### Description

Two changes:

- The MSP_UID handler read the MCU serial number by dereferencing UDID_START, which only exists on ChibiOS, and the motor-mask debug line used a %08lx specifier on a uint32_t - correct on arm-none-eabi, where uint32_t is unsigned long, and wrong everywhere else. Neither is portable, so the library only built for ChibiOS targets. Use hal.util->get_system_id_unformatted() instead: on ChibiOS it performs the same memcpy from UDID_START, so the reply is byte-identical there, and it works on any HAL. The reply stays a fixed 12 bytes, zero padded, matching what AP_MSP_Telem_Backend already sends for MSP_UID.

- Define HAL_SUPPORT_RCOUT_SERIAL for SITL so AP_BLHeli compiles and the parameters register. Serial passthrough and DShot reversing are no-ops there, and nothing needs implementing for them: the RCOutput serial methods are non-pure virtuals that return false.

The same define drives AP_NOTIFY_DSHOT_LED_ENABLED, so NTF_LED_TYPES gains the DShot LED bit under SITL. It is not in the default set, and the backend is a no-op there because SITL does not override get_dshot_esc_type(). sitl_periph sets the define to 0 in its own hwdef and that still wins, since hwdef.h is included before the guard.
