### PR TITLE
Tools: autotest: param parse: json: don't clear existing dict

### DIFF
--- a/Tools/autotest/param_metadata/jsonemit.py
+++ b/Tools/autotest/param_metadata/jsonemit.py
@@ -32,7 +32,9 @@ class JSONEmit(Emit):
         # Copy content to avoid any modification
         g = copy.deepcopy(g)
 
-        self.content[g.name] = {}
+        # Make new dict if one does not already exist
+        if g.name not in self.content:
+            self.content[g.name] = {}
 
         # Check all params available
         for param in g.params:


### PR DESCRIPTION
### Summary

This fixes https://github.com/ArduPilot/ardupilot/issues/33150

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->

The problem is that there are top level params in both AP_Vehicle and the vehicle itself. They both have "" as the top level prefix in `g.name`. So we would drop all the AP Vehicle params. This only effected `FLTMODE_GCSBLOCK` because it is the only top level param in AP_Vehicle, all the others are subgroups.