### PR TITLE
Tools: signing/README.md, add a note on accepting commands when no pubkeys

### DIFF
--- a/Tools/scripts/signing/README.md
+++ b/Tools/scripts/signing/README.md
@@ -140,7 +140,7 @@ public keys and one of your own public keys then X will be 4 in the
 above command.
 
 Re-run the 'securecommand getpublickeys' command again and check that "No public keys" is returned.
-This confirms that all keys have been removed.
+This confirms that all keys have been removed.  By design, ArduPilot accepts all SECURE_COMMANDs when there are no public keys present.
 
 Now exit MAVProxy and build a firmware using the normal bootloader but still using the --signed-fw option:
 


### PR DESCRIPTION
### Summary

Add a note that we allow any commands in when there are not pukeys

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request


### Description

In response to https://github.com/ArduPilot/ardupilot/pull/33147 - document that the behaviour is intended.  The suggestion made on that PR is non-sensical - this is acually part of the process of un-locking-down a board!
