### PR TITLE
add : Gps spoof flag with lua bindings

### DIFF
--- a/libraries/AP_DAL/AP_DAL_GPS.cpp
+++ b/libraries/AP_DAL/AP_DAL_GPS.cpp
@@ -47,6 +47,8 @@ void AP_DAL_GPS::start_frame()
         RGPI.speed_accuracy_returncode = gps.speed_accuracy(i, RGPJ.sacc);
         RGPI.gps_yaw_deg_returncode = gps.gps_yaw_deg(i, RGPJ.yaw_deg, RGPJ.yaw_accuracy_deg, RGPJ.yaw_deg_time_ms);
 
+        RGPI.is_spoofed = gps.is_spoofed(i);
+
         WRITE_REPLAY_BLOCK_IFCHANGED(RGPI, RGPI, old_RGPI);
         WRITE_REPLAY_BLOCK_IFCHANGED(RGPJ, RGPJ, old_RGPJ);
 

--- a/libraries/AP_DAL/AP_DAL_GPS.h
+++ b/libraries/AP_DAL/AP_DAL_GPS.h
@@ -40,6 +40,13 @@ public:
         return vertical_accuracy(primary_sensor(), vacc);
     }
 
+    bool is_spoofed(uint8_t instance) const {
+        return _RGPI[instance].is_spoofed;
+    }
+    bool is_spoofed() const {
+        return is_spoofed(primary_sensor());
+    }
+
     uint16_t get_hdop(uint8_t instance) const {
         return _RGPJ[instance].hdop;
     }

--- a/libraries/AP_DAL/LogStructure.h
+++ b/libraries/AP_DAL/LogStructure.h
@@ -303,6 +303,7 @@ struct log_RGPI {
     uint8_t get_lag_returncode:1;
     uint8_t speed_accuracy_returncode:1;
     uint8_t gps_yaw_deg_returncode:1;
+    uint8_t is_spoofed:1;
     uint8_t status;
     uint8_t num_sats;
     uint8_t instance;

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -415,6 +415,16 @@ uint8_t AP_GPS::num_sensors(void) const
     return num_instances;
 }
 
+void AP_GPS::set_spoofing_flag(uint8_t instance, bool spoofed)
+{
+    if (instance >= GPS_MAX_INSTANCES) {
+        return;
+    }
+    WITH_SEMAPHORE(rsem);
+    spoofing_override[instance] = spoofed;
+}
+
+
 bool AP_GPS::speed_accuracy(uint8_t instance, float &sacc) const
 {
     if (state[instance].have_speed_accuracy) {

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -239,6 +239,7 @@ public:
         float relPosD;                     ///< Reported Vertical distance in meters
         float accHeading;                  ///< Reported Heading Accuracy in degrees
         uint32_t relposheading_ts;        ///< True if new data has been received since last time it was false
+        bool spoofing_detected;            ///< GPS spoofing detected by receiver
     };
 
     /// Startup initialisation.
@@ -401,6 +402,21 @@ public:
     uint8_t num_sats() const {
         return num_sats(primary_instance);
     }
+
+    // GPS spoofing detection
+    bool is_spoofed(uint8_t instance) const {
+        if (instance >= GPS_MAX_INSTANCES) {
+            return false;
+        }
+        return state[instance].spoofing_detected || spoofing_override[instance];
+    }
+    bool is_spoofed() const {
+        return is_spoofed(primary_instance);
+    }
+
+    // override spoofing flag from GCS/companion
+    void set_spoofing_flag(uint8_t instance, bool spoofed);
+
 
     // GPS time of week in milliseconds
     uint32_t time_week_ms(uint8_t instance) const {
@@ -669,6 +685,7 @@ private:
     GPS_State state[GPS_MAX_INSTANCES];
     AP_GPS_Backend *drivers[GPS_MAX_INSTANCES];
     AP_HAL::UARTDriver *_port[GPS_MAX_RECEIVERS];
+    bool spoofing_override[GPS_MAX_INSTANCES] = {};
 
     /// primary GPS instance
     uint8_t primary_instance;

--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -1541,6 +1541,12 @@ AP_GPS_UBLOX::_parse_gps(void)
               _buffer.status.fix_status,
               _buffer.status.fix_type);
         _check_new_itow(_buffer.status.itow);
+        if (_payload_length >= sizeof(ubx_nav_status)) {
+            const uint8_t spoof_state = (_buffer.status.flags2 >> 3) & 0x03;
+            state.spoofing_detected = (spoof_state >= 2);
+        } else {
+            state.spoofing_detected = false;
+        }
         if (havePvtMsg) {
             // when we have PVT we don't need status, just change the rate for STATUS to zero
             _unconfigured_messages &= ~CONFIG_RATE_STATUS;
@@ -1674,6 +1680,12 @@ AP_GPS_UBLOX::_parse_gps(void)
         Debug("MSG_PVT");
 
         havePvtMsg = true;
+        
+        {
+            const uint8_t spoof_state = (_buffer.pvt.flags2 >> 3) & 0x03;
+            state.spoofing_detected = (spoof_state >= 2);
+        }
+
 
         // if we have PVT we don't want MSG_STATUS
         _unconfigured_messages &= ~CONFIG_RATE_STATUS;

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -332,7 +332,7 @@ private:
         uint8_t fix_type;
         uint8_t fix_status;
         uint8_t differential_status;
-        uint8_t res;
+        uint8_t flags2;
         uint32_t time_to_first_fix;
         uint32_t uptime;                                // milliseconds
     };

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -3420,6 +3420,12 @@ gps.GPS_OK_FIX_2D = enum_integer
 gps.NO_FIX = enum_integer
 gps.NO_GPS = enum_integer
 
+--- Returns true if the specified GPS instance is currently reporting a spoofed state.
+---@param instance integer
+---@return boolean
+function gps:is_spoofed(instance) end
+
+
 -- get unix time
 ---@param instance integer -- instance number
 ---@return uint64_t_ud -- unix time microseconds

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -157,6 +157,7 @@ singleton AP_GPS method first_unconfigured_gps boolean uint8_t'Null
 singleton AP_GPS method gps_yaw_deg boolean uint8_t 0 ud->num_sensors() float'Null float'Null uint32_t'Null
 singleton AP_GPS method time_epoch_usec uint64_t uint8_t 0 ud->num_sensors()
 singleton AP_GPS manual inject_data lua_gps_inject_data 1 0
+singleton AP_GPS method is_spoofed boolean uint8_t 0 ud->num_sensors()
 
 include AP_Math/AP_Math.h
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -50,6 +50,7 @@
 #include <AP_VisualOdom/AP_VisualOdom.h>
 #include <AP_Baro/AP_Baro.h>
 #include <AP_EFI/AP_EFI.h>
+#include <AP_GPS/AP_GPS.h>
 #include <AP_Proximity/AP_Proximity.h>
 #include <AP_Scripting/AP_Scripting.h>
 #include <SRV_Channel/SRV_Channel.h>
@@ -5886,6 +5887,21 @@ MAV_RESULT GCS_MAVLINK::handle_command_int_packet(const mavlink_command_int_t &p
 
     case MAV_CMD_GET_MESSAGE_INTERVAL:
         return handle_command_get_message_interval(packet);
+
+#if AP_GPS_ENABLED
+    case MAV_CMD_USER_1: {
+        const int32_t instance = (int32_t)packet.param2;
+        if (instance < 0 || instance >= GPS_MAX_INSTANCES) {
+            return MAV_RESULT_DENIED;
+        }
+        const bool spoofed = packet.param1 >= 0.5f;
+        AP::gps().set_spoofing_flag(static_cast<uint8_t>(instance), spoofed);
+        return MAV_RESULT_ACCEPTED;
+    }
+#else
+    case MAV_CMD_USER_1:
+        return MAV_RESULT_UNSUPPORTED;
+#endif
 
     case MAV_CMD_REQUEST_MESSAGE:
         return handle_command_request_message(packet);


### PR DESCRIPTION
### Summary

Adds a GPS spoofing flag to `AP_GPS` that can be injected via MAVLink  or by u-blox hardware flags , and exposes it to Lua scripts, allowing companion computers and users to implement custom spoofing failsafes.

### Classification & Testing (

* [x] Checked by a human programmer
* [ ] Non-functional change
* [ ] No-binary change
* [ ] Infrastructure change (e.g. unit tests, helper scripts)
* [ ] Automated test(s) verify changes (e.g. unit test, autotest)
* [x] Tested manually, description below (e.g. SITL)
* [ ] Tested on hardware
* [ ] Logs attached
* [ ] Logs available on request

### Description

Resolves **Fixes #11239** (Ublox GPS spoofing indicator).
With the rise of GPS spoofing, there is a need for  ML-based anomaly detection or RF spectrum analysis to detect spoofing . It also supports parsing Ublox GPS spoofing indicator .  This PR provides a direct pipeline for a companion computer to flag the core system via MAVLink, and exposes that flag to Lua so users can script custom, mission-specific failsafe behaviors .


1. **Ublox spoofing indicator:** Parses `UBX-NAV-STATUS` packet containing  a `spoofDetState` bitfield with 4 states:
  - 0: Unknown or deactivated
  - 1: No spoofing indicated
  - 2: Spoofing indicated
  - 3: Multiple spoofing indications
2. **GCS_MAVLink:** Accepts `MAV_CMD_USER_1` (`param1`=spoofed state, `param2`=GPS instance) from a GCS or companion computer (via MAVROS) to override the spoofing state in `AP_GPS`.
3. **AP_Scripting:** Adds the `gps:is_spoofed(uint8_t instance)` binding to `bindings.desc`, safely exposing the state to the Lua sandbox.



**Testing Evidence**
Tested locally using `sim_vehicle.py` (Copter). The Lua example script was loaded, and the spoofing state was successfully toggled via the MAVProxy console using the MAVLink command injection.


*Test lua script*

```lua
-- spoof_test.lua
-- Runs at 1Hz to test the new gps:is_spoofed() binding

local RUN_INTERVAL_MS = 1000
local was_spoofed = false

function check_spoofing()
    local primary_instance = gps:primary_sensor()
    
    -- CALLING YOUR NEW BINDING HERE:
    local is_spoofed = gps:is_spoofed(primary_instance)

    if is_spoofed and not was_spoofed then
        gcs:send_text(2, "LUA ALERT: GPS Spoofing Detected! (State: TRUE)")
        was_spoofed = true
    elseif not is_spoofed and was_spoofed then
        gcs:send_text(5, "LUA INFO: GPS Spoofing Cleared. (State: FALSE)")
        was_spoofed = false
    end

    return check_spoofing, RUN_INTERVAL_MS
end

gcs:send_text(6, "Spoof test script initialized...")
return check_spoofing()
```
*SITL Console Output:*

```text
AP: EKF3 IMU0 is using GPS
AP: EKF3 IMU1 is using GPS

STABILIZE> 
STABILIZE> long 31010 1 0 0 0 0 0 0
STABILIZE> Got COMMAND_ACK: USER_1: ACCEPTED
AP: LUA ALERT: GPS Spoofing Detected! (State: TRUE)

STABILIZE> long 31010 0 0 0 0 0 0 0
STABILIZE> Got COMMAND_ACK: USER_1: ACCEPTED
AP: LUA INFO: GPS Spoofing Cleared. (State: FALSE)

STABILIZE> Flight battery 100 percent 

```

**AI Disclosure**
This contribution was AI-assisted. An AI assistant was used to write the test lua script. 