### PR TITLE
AP_Scripting: EFI_DLA64: Fix temperature unit conversion

### DIFF
--- a/libraries/AP_Math/AP_Math.cpp
+++ b/libraries/AP_Math/AP_Math.cpp
@@ -506,7 +506,7 @@ float fixedwing_turn_rate(float bank_angle_deg, float airspeed)
     return degrees(GRAVITY_MSS*tanf(radians(bank_angle_deg))/MAX(airspeed,1));
 }
 
-// convert degrees farenheight to Kelvin
+// convert degrees fahrenheit to Kelvin
 float degF_to_Kelvin(float temp_f)
 {
     return (temp_f + 459.67) * 0.55556;

--- a/libraries/AP_Math/AP_Math.h
+++ b/libraries/AP_Math/AP_Math.h
@@ -410,7 +410,7 @@ uint16_t float2fixed(const float input, const uint8_t fractional_bits = 8);
  */
 float fixedwing_turn_rate(float bank_angle_deg, float airspeed);
 
-// convert degrees farenheight to Kelvin
+// convert degrees fahrenheit to Kelvin
 float degF_to_Kelvin(float temp_f);
 
 /*

--- a/libraries/AP_Scripting/drivers/EFI_DLA.lua
+++ b/libraries/AP_Scripting/drivers/EFI_DLA.lua
@@ -119,7 +119,7 @@ local function request_data()
    uart:write(0x61)
 end
 
-local function farenheight_to_C(v)
+local function fahrenheit_to_C(v)
    return (v + 459.67) * 0.55556
 end
 
@@ -136,8 +136,8 @@ local function update_EFI()
    -- 4.3.x incorrectly uses C instead of kelvin
    -- local C_TO_KELVIN = 273.2
 
-   cylinder_state:cylinder_head_temperature(farenheight_to_C(state.clt*0.1))
-   cylinder_state:exhaust_gas_temperature(farenheight_to_C(state.mat*0.1))
+   cylinder_state:cylinder_head_temperature(fahrenheit_to_C(state.clt*0.1))
+   cylinder_state:exhaust_gas_temperature(fahrenheit_to_C(state.mat*0.1))
    cylinder_state:ignition_timing_deg(state.adv_deg*0.1)
 
    local inj_time_ms = (state.pw1+state.pw2)*0.001
@@ -147,7 +147,7 @@ local function update_EFI()
 
    efi_state:atmospheric_pressure_kpa(state.baro*0.1)
    efi_state:intake_manifold_pressure_kpa(state.map*0.1)
-   efi_state:intake_manifold_temperature(farenheight_to_C(state.mat*0.1))
+   efi_state:intake_manifold_temperature(fahrenheit_to_C(state.mat*0.1))
    efi_state:throttle_position_percent(math.floor(state.tps*0.1))
    efi_state:ignition_voltage(state.batt*0.1)
 

--- a/libraries/AP_Scripting/drivers/EFI_DLA64.lua
+++ b/libraries/AP_Scripting/drivers/EFI_DLA64.lua
@@ -112,7 +112,7 @@ local function crc16(bytes)
     return crc
 end
 
-local function farenheight_to_Kelvin(v)
+local function fahrenheit_to_Kelvin(v)
    return (v - 32) / 1.8 + 273.15
 end
 
@@ -142,9 +142,9 @@ local function check_input()
    end
    state.rpm = string.unpack("<H", string.sub(payload, 16, 17))
    state.fcr = string.unpack("<H", string.sub(payload, 108, 109)) * 0.1
-   state.ctemp1 = farenheight_to_Kelvin(string.unpack("<H", string.sub(payload, 96, 97)) * 0.1)
-   state.ctemp2 = farenheight_to_Kelvin(string.unpack("<H", string.sub(payload, 102, 103)) * 0.1)
-   state.atemp = farenheight_to_Kelvin(string.unpack("<H", string.sub(payload, 30, 31)) * 0.1)
+   state.ctemp1 = fahrenheit_to_Kelvin(string.unpack("<H", string.sub(payload, 96, 97)) * 0.1)
+   state.ctemp2 = fahrenheit_to_Kelvin(string.unpack("<H", string.sub(payload, 102, 103)) * 0.1)
+   state.atemp = fahrenheit_to_Kelvin(string.unpack("<H", string.sub(payload, 30, 31)) * 0.1)
    state.apress_kPa = string.unpack("<H", string.sub(payload, 26, 27)) * 0.1
    state.bvolt = string.unpack("<H", string.sub(payload, 36, 37)) * 0.1
 

--- a/libraries/AP_Scripting/drivers/EFI_DLA64.lua
+++ b/libraries/AP_Scripting/drivers/EFI_DLA64.lua
@@ -113,7 +113,7 @@ local function crc16(bytes)
 end
 
 local function farenheight_to_Kelvin(v)
-   return (v + 459.67) * 0.55556 + 273.15
+   return (v - 32) / 1.8 + 273.15
 end
 
 --[[


### PR DESCRIPTION
### Summary

I don't know how we ended up with this formula in our codebase, but it looks very wrong!
A partner was reporting weird temperature readings when using this driver.

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
