### PR TITLE
AP_AHRS: use active_backend_estimates in get_location

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -808,36 +808,8 @@ void AP_AHRS::reset()
 // dead-reckoning support
 bool AP_AHRS::_get_location(Location &loc) const
 {
-    switch (active_EKF_type()) {
-#if AP_AHRS_DCM_ENABLED
-    case EKFType::DCM:
-        return dcm_estimates.get_location(loc);
-#endif
-#if HAL_NAVEKF2_AVAILABLE
-    case EKFType::TWO:
-        if (ekf2_estimates.get_location(loc)) {
-            return true;
-        }
-        break;
-#endif
-
-#if HAL_NAVEKF3_AVAILABLE
-    case EKFType::THREE:
-        if (ekf3_estimates.get_location(loc)) {
-            return true;
-        }
-        break;
-#endif
-
-#if AP_AHRS_SIM_ENABLED
-    case EKFType::SIM:
-        return sim_estimates.get_location(loc);
-#endif
-
-#if AP_AHRS_EXTERNAL_ENABLED
-    case EKFType::EXTERNAL:
-        return external_estimates.get_location(loc);
-#endif
+    if (active_estimates->get_location(loc)) {
+        return true;
     }
 
 #if AP_AHRS_DCM_ENABLED


### PR DESCRIPTION
### Summary

Uses new infrastructure in place of a switch statement on active EKF type to get a locaiton

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                 *
Durandal                            -8              -16    *           -16     -8                -16    -16    -16
Hitec-Airspeed           *                                 *
KakuteH7-bdshot                     -16             -8     *           -16     -16               -16    -16    -16
MatekF405                           -16             -16    *           -8      -16               -16    -16    -16
MatekH7A3                           -16             -16    *           -16     -8                -8     -8     -16
Pixhawk1-1M-bdshot                  -8              -16                -8      -8                -16    -8     -8
SITL_x86_64_linux_gnu               0               0                  0       0                 0      0      0
YJUAV_A6SE                          -32             -32    *           -32     -32               -32    -32    -32
f103-QiotekPeriph        *                                 *
f303-MatekGPS            *                                 *
f303-Universal           *                                 *
iomcu                                                                                *
mindpx-v2                           -16             -16    *           -16     -16               -8     -8     -16
revo-mini                           -16             -8     *           -8      -16               -16    -16    -16
skyviper-v2450                                                         -8
speedybeef4                         -8              -8     *           -16     -16               -16    -8     -8
```

### Description

Fairly major change in behaviour when using ExternalAHRS for your primary source in that if the external source fails then we will now start to fall back to DCM (and into the future hopefully a configured secondary estimator).  Only applicable on vehicles that `always_use_EKF()` returns false (e.g. Plane); Copter will still not fall back to DCM even when using an external estimator.
