### PR TITLE
AP_AHRS: put HAGL in results object

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -1453,38 +1453,6 @@ bool AP_AHRS::get_vert_pos_rate_D(float &velocity) const
     return active_estimates->get_vert_pos_rate_D(velocity);
 }
 
-// get latest height above ground level estimate in metres and a validity flag
-bool AP_AHRS::get_hagl(float &height) const
-{
-    switch (active_EKF_type()) {
-#if AP_AHRS_DCM_ENABLED
-    case EKFType::DCM:
-        return false;
-#endif
-#if HAL_NAVEKF2_AVAILABLE
-    case EKFType::TWO:
-        return ekf2.get_hagl(height);
-#endif
-
-#if HAL_NAVEKF3_AVAILABLE
-    case EKFType::THREE:
-        return ekf3.get_hagl(height);
-#endif
-
-#if AP_AHRS_SIM_ENABLED
-    case EKFType::SIM:
-        return sim.get_hagl(height);
-#endif
-#if AP_AHRS_EXTERNAL_ENABLED
-    case EKFType::EXTERNAL: {
-        return false;
-    }
-#endif
-    }
-    // since there is no default case above, this is unreachable
-    return false;
-}
-
 /*
   return a relative NED position from the origin in meters
 */

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -109,7 +109,7 @@ public:
     bool get_location(Location &loc) const WARN_IF_UNUSED;
 
     // get latest altitude estimate above ground level in meters and validity flag
-    bool get_hagl(float &hagl) const WARN_IF_UNUSED;
+    bool get_hagl(float &hagl) const WARN_IF_UNUSED { return active_estimates->get_hagl(hagl); }
 
     // status reporting of estimated error
     float           get_error_rp() const;

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -53,6 +53,13 @@ public:
 
     // structure to retrieve results from backends:
     struct Estimates {
+        // allow backends to set the private members:
+        friend class AP_AHRS_DCM;
+        friend class AP_AHRS_SIM;
+        friend class AP_AHRS_External;
+        friend class AP_AHRS_NavEKF2;
+        friend class AP_AHRS_NavEKF3;
+
         // if attitude_valid is true then all of the
         // eulers/quaternion/matrix must be valid:
         bool attitude_valid;
@@ -112,6 +119,9 @@ public:
             return true;
         }
 
+        /*
+         * position estimates
+         */
         Location location;
         bool location_valid;
 
@@ -119,6 +129,15 @@ public:
             loc = location;
             return location_valid;
         };
+
+        bool get_hagl(float &height) const WARN_IF_UNUSED {
+            height = hagl;
+            return hagl_valid;
+        }
+
+    private:
+        bool hagl_valid;
+        float hagl;
     };
 
     // init sets up INS board orientation
@@ -157,9 +176,6 @@ public:
 
     // reset the current attitude, used on new IMU calibration
     virtual void reset() = 0;
-
-    // get latest altitude estimate above ground level in meters and validity flag
-    virtual bool get_hagl(float &height) const WARN_IF_UNUSED { return false; }
 
     // return a wind estimation vector, in m/s
     virtual bool wind_estimate(Vector3f &wind) const = 0;

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -167,7 +167,14 @@ void AP_AHRS_DCM::get_results(AP_AHRS_Backend::Estimates &results)
 
     results.vert_pos_rate_D_valid = get_vert_pos_rate_D(results.vert_pos_rate_D);
 
+    /*
+     * position estimates
+     */
     results.location_valid = get_location(results.location);
+
+    // hagl is not supplied:
+    // results.hagl_valid = false;
+    // results.hagl = 0;
 }
 
 /*

--- a/libraries/AP_AHRS/AP_AHRS_External.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_External.cpp
@@ -53,7 +53,14 @@ void AP_AHRS_External::get_results(AP_AHRS_Backend::Estimates &results)
     // ground velocity estimate in meters/second, in North/East order
     results.velocity_NE = AP::externalAHRS().get_groundspeed_vector();
 
+    /*
+     * position estimates
+     */
     results.location_valid = AP::externalAHRS().get_location(results.location);
+
+    // hagl is not supplied:
+    // results.hagl_valid = false;
+    // results.hagl = 0;
 }
 
 bool AP_AHRS_External::get_relative_position_NED_origin(Vector3p &vec) const

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF2.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF2.cpp
@@ -71,6 +71,8 @@ void AP_AHRS_NavEKF2::get_results(AP_AHRS_Backend::Estimates &results)
      * position estimates
      */
     results.location_valid = EKF2.getLLH(results.location);
+
+    results.hagl_valid = EKF2.getHAGL(results.hagl);
 }
 
 bool AP_AHRS_NavEKF2::pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF2.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF2.h
@@ -121,11 +121,6 @@ public:
         EKF2.requestYawReset();
     }
 
-    // get latest altitude estimate above ground level in meters and validity flag
-    bool get_hagl(float &hagl) const override WARN_IF_UNUSED {
-        return EKF2.getHAGL(hagl);
-    }
-
     // this is out here so parameters can be poked into it
     static NavEKF2 EKF2;
 

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
@@ -74,6 +74,8 @@ void AP_AHRS_NavEKF3::get_results(AP_AHRS_Backend::Estimates &results)
      * position estimates
      */
     results.location_valid = EKF3.getLLH(results.location);
+
+    results.hagl_valid = EKF3.getHAGL(results.hagl);
 }
 
 bool AP_AHRS_NavEKF3::pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF3.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF3.h
@@ -91,10 +91,6 @@ public:
     void request_yaw_reset() override {
         EKF3.requestYawReset();
     }
-    // get latest altitude estimate above ground level in meters and validity flag
-    bool get_hagl(float &hagl) const override WARN_IF_UNUSED {
-        return EKF3.getHAGL(hagl);
-    }
 
     bool pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const override;
 

--- a/libraries/AP_AHRS/AP_AHRS_SIM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_SIM.cpp
@@ -45,17 +45,6 @@ bool AP_AHRS_SIM::airspeed_EAS(uint8_t index, float &airspeed_ret) const
     return airspeed_EAS(airspeed_ret);
 }
 
-bool AP_AHRS_SIM::get_hagl(float &height) const
-{
-    if (_sitl == nullptr) {
-        return false;
-    }
-
-    height = _sitl->state.altitude - AP::ahrs().get_home().alt*0.01f;
-
-    return true;
-}
-
 bool AP_AHRS_SIM::get_relative_position_NED_origin(Vector3p &vec) const
 {
     if (_sitl == nullptr) {
@@ -219,7 +208,13 @@ void AP_AHRS_SIM::get_results(AP_AHRS_Backend::Estimates &results)
     results.vert_pos_rate_D_valid = true;
     results.vert_pos_rate_D = _sitl->state.speedD;
 
+    /*
+     * position estimates
+     */
     results.location_valid = get_location(results.location);
+
+    results.hagl_valid = true;
+    results.hagl = _sitl->state.altitude - AP::ahrs().get_home().alt*0.01f;
 
 #if HAL_NAVEKF3_AVAILABLE
     if (_sitl->odom_enable) {

--- a/libraries/AP_AHRS/AP_AHRS_SIM.h
+++ b/libraries/AP_AHRS/AP_AHRS_SIM.h
@@ -62,9 +62,6 @@ public:
     void            get_results(Estimates &results) override;
     void            reset() override { return; }
 
-    // get latest altitude estimate above ground level in meters and validity flag
-    bool get_hagl(float &hagl) const override WARN_IF_UNUSED;
-
     // return a wind estimation vector, in m/s
     bool wind_estimate(Vector3f &wind) const override;
 


### PR DESCRIPTION
### Summary

Moves HAGL into the backend results object rather than calling a virtual method to get result

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                 *                                                   
Durandal                            -40             0      *           -48     -32               -32    -40    -40
Hitec-Airspeed           *                                 *                                                   
KakuteH7-bdshot                     -32             -24    *           184     -24               144    -32    -16
MatekF405                           -8              -16    *           16      -24               -16    0      0
MatekH7A3                           -24             -32    *           -40     -40               -32    16     -56
Pixhawk1-1M-bdshot                  -32             -32                -152    -136              -72    -16    -24
SITL_x86_64_linux_gnu               -280            -272               -280    -280              -272   -272   -272
YJUAV_A6SE                          -48             -40    *           -120    0                 -184   -48    -16
f103-QiotekPeriph        *                                 *                                                   
f303-MatekGPS            *                                 *                                                   
f303-Universal           *                                 *                                                   
iomcu                                                                                *                         
mindpx-v2                           -32             72     *           -32     -8                -368   -16    -16
revo-mini                           -48             -48    *           -32     -40               -16    -56    -128
skyviper-v2450                                                         16                                      
speedybeef4                         -32             -32    *           24      56                80     -64    -56
```

### Description

Move HAGL into the backend results structure next to other position estimates.

Adds comments to start sectioning the results object better in some backends.
