### PR TITLE
Tool script base statusg

### DIFF
--- a/Tools/scripts/build_script_base.py
+++ b/Tools/scripts/build_script_base.py
@@ -14,6 +14,9 @@ import subprocess
 import sys
 import time
 
+from abc import ABC
+from abc import abstractmethod
+
 import board_list
 
 # map from vehicle names to binary names
@@ -31,7 +34,7 @@ VEHICLE_MAP = {
 }
 
 
-class BuildScriptBase:
+class BuildScriptBase(ABC):
     """Base class for build scripts with common utilities for running programs"""
 
     def __init__(self):
@@ -231,6 +234,10 @@ class BuildScriptBase:
                     break
 
         return sorted(modified_board_names, key=lambda x: x.lower())
+
+    @abstractmethod
+    def progress_prefix(self) -> str:
+        '''return a short prefix string identifying this script in log output'''
 
     def progress(self, string):
         '''pretty-print progress'''

--- a/Tools/scripts/build_script_base.py
+++ b/Tools/scripts/build_script_base.py
@@ -91,7 +91,7 @@ class BuildScriptBase:
             except Exception:  # noqa: BLE001 — best-effort debug-file write
                 self.progress("Writing process failure file failed")
             raise subprocess.CalledProcessError(
-                returncode, cmd_list)
+                status, cmd_list)
         return output
 
     def find_current_git_branch_or_sha1(self):


### PR DESCRIPTION
### Summary

fix error on error on build_script_base.py, the return code is a Tuple ( waitpid return a tuple containing its process id and exit status indication) so we cannot use it directly as errorcode on CalledProcessError :
<img width="1258" height="794" alt="Capture d’écran du 2026-05-26 10-09-04" src="https://github.com/user-attachments/assets/cd4ad960-9e00-4cb4-9015-fef73f3b05f1" />

After PR:

<img width="1302" height="832" alt="Capture d’écran du 2026-05-26 10-09-14" src="https://github.com/user-attachments/assets/af974994-a961-48b8-83f6-6f517dc74915" />

Also make the base class abstract to make linter happy on progress_prefix() and mark it as virtual

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request


