### PR TITLE
Scripting doc ci

### DIFF
--- a/.github/workflows/test_scripting.yml
+++ b/.github/workflows/test_scripting.yml
@@ -8,6 +8,8 @@ on:
       - '**.lua'
       - 'Tools/scripts/run_lua_language_check.py'
       - 'Tools/scripts/run_luacheck.sh'
+      - 'Tools/scripts/generate_lua_docs.sh'
+      - '.github/workflows/test_scripting.yml'
 
   pull_request:
     paths: # only run for scripting changes
@@ -16,6 +18,8 @@ on:
       - '**.lua'
       - 'Tools/scripts/run_lua_language_check.py'
       - 'Tools/scripts/run_luacheck.sh'
+      - 'Tools/scripts/generate_lua_docs.sh'
+      - '.github/workflows/test_scripting.yml'
 
   workflow_dispatch:
 
@@ -23,15 +27,18 @@ concurrency:
   group: ci-${{github.workflow}}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test-scripting:
-    runs-on: ubuntu-22.04
-    container: ardupilot/ardupilot-dev-base:v0.1.3
+    runs-on: ubuntu-slim
     steps:
       # git checkout the PR
       - uses: actions/checkout@v6
         with:
-          submodules: 'recursive'
+          submodules: false
+          persist-credentials: false
 
       - name: Register lua check problem matcher
         run: |
@@ -61,25 +68,23 @@ jobs:
           echo "::remove-matcher owner=Luacheck-problem-matcher::"
           echo "::remove-matcher owner=Lua-language-server-problem-matcher::"
 
-      - name: Generate docs md
+      - name: Generate lua markdown API docs
         shell: bash
         run: |
           ./Tools/scripts/generate_lua_docs.sh
 
-      - name: copy docs
+      - name: Copy current lua docs
         run: |
           PATH="/github/home/.local/bin:$PATH"
           mv "libraries/AP_Scripting/docs/docs.lua" "libraries/AP_Scripting/docs/current_docs.lua"
 
-      - name: build sitl # we don't really need to build the full code, just trigger docs re-gen with --scripting-docs, timeout after 10 seconds
+      - name: ReGenerate lua docs and annotations from code
         shell: bash
         run: |
-          git config --global --add safe.directory ${GITHUB_WORKSPACE}
-          PATH="/github/home/.local/bin:$PATH"
-          ./waf configure --board sitl
-          timeout 10 ./waf antennatracker --scripting-docs || code=$?; if [[ $code -ne 124 && $code -ne 0 ]]; then exit $code; fi
+          ./waf configure
+          ./waf scripting_docs
 
-      - name: run compare
+      - name: Compare Previous and current lua docs
         run: |
           PATH="/github/home/.local/bin:$PATH"
           python ./libraries/AP_Scripting/tests/docs_check.py "./libraries/AP_Scripting/docs/docs.lua" "./libraries/AP_Scripting/docs/current_docs.lua"

--- a/.github/workflows/test_scripting.yml
+++ b/.github/workflows/test_scripting.yml
@@ -40,6 +40,13 @@ jobs:
           submodules: false
           persist-credentials: false
 
+      - name: Checkout waf submodule
+        run: git submodule update --init --recursive --depth 1 modules/waf
+
+      - name: Install pip dependencies
+        run: |
+          python3 -m pip install github-release-downloader empy==3.3.4
+
       - name: Register lua check problem matcher
         run: |
           echo "::add-matcher::.github/problem-matchers/Lua.json"
@@ -60,7 +67,6 @@ jobs:
       - name: Language server check
         shell: bash
         run: |
-          python3 -m pip install github-release-downloader
           python3 ./Tools/scripts/run_lua_language_check.py --debugLogging
 
       - name: Remove problem matchers

--- a/Tools/completion/bash/_waf
+++ b/Tools/completion/bash/_waf
@@ -33,6 +33,7 @@ _waf()
     opts+=" distclean"
     opts+=" submodule_force_clean"
     opts+=" submodulesync"
+    opts+=" scripting_docs"
 
     # Prevent word reuse TODO: add -vvv case
     lim=$((COMP_CWORD - 1))

--- a/Tools/completion/zsh/_waf
+++ b/Tools/completion/zsh/_waf
@@ -90,6 +90,7 @@ _waf_cmds() {
     'configure:configures the project' \
     'clean:cleans the project' \
     'distclean:removes build folders and data' \
+    'scripting_docs:generates documentation for lua scripts' \
     'submodule_force_clean:removes all submodules, then checkouts all current submodules and synchronizes them' \
     'submodulesync:checkouts all current submodules and synchronizes them'
   )

--- a/Tools/scripts/generate_lua_docs.sh
+++ b/Tools/scripts/generate_lua_docs.sh
@@ -4,6 +4,8 @@
 cd "$(dirname "$0")"
 cd ../..
 
+mkdir -p lualogs
+
 if [ -n "$(ls -A lualogs)" ]; then
     echo "lualogs Not Empty"
     exit 1
@@ -19,7 +21,7 @@ fi
 CONFIG_PATH=$(realpath libraries/AP_Scripting/tests/docs.json)
 DOC_PATH=$(realpath libraries/AP_Scripting/docs/)
 
-${LLS_PATH} --configpath ${CONFIG_PATH}  --logpath lualogs --doc ${DOC_PATH}
+${LLS_PATH} --configpath "${CONFIG_PATH}"  --logpath lualogs --doc "${DOC_PATH}" --doc_out_path lualogs
 
 mv lualogs/doc.md ScriptingDocs.md
 rm -r lualogs

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -1,7 +1,7 @@
 ---@meta
 -- ArduPilot lua scripting documentation in EmmyLua Annotations
 -- This file should be auto generated and then manual edited
--- generate with --scripting-docs, eg  ./waf copter --scripting-docs
+-- generate with scripting-docs, eg  ./waf scripting-docs
 -- see: https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations
 -- luacheck: ignore 121 (Setting a read-only global variable)
 -- luacheck: ignore 122 (Setting a read-only field of a global variable)

--- a/libraries/AP_Scripting/generator/src/main.c
+++ b/libraries/AP_Scripting/generator/src/main.c
@@ -3055,7 +3055,7 @@ int main(int argc, char **argv) {
 
   fprintf(docs, "-- ArduPilot lua scripting documentation in EmmyLua Annotations\n");
   fprintf(docs, "-- This file should be auto generated and then manual edited\n");
-  fprintf(docs, "-- generate with --scripting-docs, eg  ./waf copter --scripting-docs\n");
+  fprintf(docs, "-- generate with scripting-docs, eg  ./waf scripting-docs\n");
   fprintf(docs, "-- see: https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations\n");
   fprintf(docs, "-- luacheck: ignore 121 (Setting a read-only global variable)\n");
   fprintf(docs, "-- luacheck: ignore 122 (Setting a read-only field of a global variable)\n");

--- a/wscript
+++ b/wscript
@@ -704,6 +704,20 @@ def collect_dirs_to_recurse(bld, globs, **kw):
 def list_boards(ctx):
     print(*boards.get_boards_names())
 
+
+class ScriptingDocsCtx(Build.BuildContext):
+    '''generate scripting docs'''
+    cmd = 'scripting_docs'
+    fun = 'scripting_docs'
+
+
+def scripting_docs(bld):
+    '''Generate Lua scripting docs by reusing the AP_Scripting build() tasks'''
+    bld.add_group('dynamic_sources')
+    bld.options.scripting_docs = True
+    bld.options.enable_scripting = True
+    bld.recurse('libraries/AP_Scripting', name='build')
+
 def list_ap_periph_boards(ctx):
     print(*boards.get_ap_periph_boards())
 


### PR DESCRIPTION
### Summary

Fix scripting doc test. 
generate_lua_docs.sh output was broken : see https://github.com/ArduPilot/ardupilot/actions/runs/26430401963/job/77802316906 for example on upload docs and Generate docs md for the errors

Add small directive to waf to generate scripting docs without using a full vehicle.
Switch to Ubuntu-slim runner (time is sensibly the same)
Restrict permission to read-only

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request


