### PR TITLE
.github: test_scripts: restrict to read only, only update waf submodu…

### DIFF
--- a/.github/workflows/test_scripts.yml
+++ b/.github/workflows/test_scripts.yml
@@ -6,6 +6,9 @@ concurrency:
   group: ci-${{github.workflow}}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-slim
@@ -26,12 +29,16 @@ jobs:
       # git checkout the PR
       - uses: actions/checkout@v6
         with:
-          submodules: 'recursive'
-      - uses: actions/setup-python@v6
-        with:
-          python-version: 3.x
-          cache: pip  # caching pip dependencies
-          pip-install: flake8 lxml pexpect
+          submodules: false
+          persist-credentials: false
+
+      - name: checkout waf submodule
+        run: git submodule update --init --recursive --depth 1 modules/waf
+
+      - name: install pip dependencies
+        shell: bash
+        run: |
+          python3 -m pip install flake8 lxml pexpect
 
       - name: Install astyle
         if: matrix.config == 'astyle-cleanliness'


### PR DESCRIPTION
…le, don't use setup-python

### Summary

Make permission restricted to read only
don't pull all submodules , only waf is need : gain from 40s to 2min
Don't use setup-python: ubuntu-slim is ubuntu24.04 base and already got python 3.12 and pip installed. caching few package (7mb) is mostly useless

Best time on master on the latest 5 days was 7min25(https://github.com/ArduPilot/ardupilot/actions/runs/26445021367) for the whole workflow, PR is 2min32s (https://github.com/khancyr/ardupilot/actions/runs/26458941699)

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
