### PR TITLE
autotest: skip helicopter tests when running Copter frame

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -12543,6 +12543,8 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             'heli': "wrong binary, different takeoff regime",
             'heli-gas': "wrong binary, different takeoff regime",
             'heli-blade360': "wrong binary, different takeoff regime",
+            'heli-ddvptail': "wrong binary, different takeoff regime",
+            'heli-ddfptail': "wrong binary, different takeoff regime",
             "quad-can" : "needs CAN periph",
         }
         for frame in sorted(copter_vinfo_options["frames"].keys()):


### PR DESCRIPTION
### Summary

Fixes regression caused by https://github.com/ArduPilot/ardupilot/pull/33187 causing CI to fail

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

We probably need to have a better solution for this.

Probably upending things completely and having required_binaries or something in vehicleinfo.json
