### PR TITLE
AP_SurfaceDistance: Copter: gate glitch detector and terrain LPF on alt_healthy

### DIFF
--- a/ArduCopter/sensors.cpp
+++ b/ArduCopter/sensors.cpp
@@ -53,11 +53,15 @@ bool Copter::rangefinder_up_ok() const
 // terrain offset is the terrain's height above the EKF origin
 void Copter::update_rangefinder_terrain_offset()
 {
-    float terrain_u_m = rangefinder_state.ref_pos_u_m - rangefinder_state.alt_glitch_protected_m;
-    rangefinder_state.terrain_u_m += (terrain_u_m - rangefinder_state.terrain_u_m) * (copter.G_Dt / MAX(copter.g2.surftrak_tc, copter.G_Dt));
+    if (rangefinder_state.alt_healthy) {
+        const float terrain_u_m = rangefinder_state.ref_pos_u_m - rangefinder_state.alt_glitch_protected_m;
+        rangefinder_state.terrain_u_m += (terrain_u_m - rangefinder_state.terrain_u_m) * (copter.G_Dt / MAX(copter.g2.surftrak_tc, copter.G_Dt));
+    }
 
-    terrain_u_m = rangefinder_up_state.ref_pos_u_m + rangefinder_up_state.alt_glitch_protected_m;
-    rangefinder_up_state.terrain_u_m += (terrain_u_m - rangefinder_up_state.terrain_u_m) * (copter.G_Dt / MAX(copter.g2.surftrak_tc, copter.G_Dt));
+    if (rangefinder_up_state.alt_healthy) {
+        const float terrain_u_m = rangefinder_up_state.ref_pos_u_m + rangefinder_up_state.alt_glitch_protected_m;
+        rangefinder_up_state.terrain_u_m += (terrain_u_m - rangefinder_up_state.terrain_u_m) * (copter.G_Dt / MAX(copter.g2.surftrak_tc, copter.G_Dt));
+    }
 
     if (rangefinder_state.alt_healthy || rangefinder_state.data_stale()) {
         wp_nav->set_rangefinder_terrain_U_m(rangefinder_state.enabled, rangefinder_state.alt_healthy, rangefinder_state.terrain_u_m);

--- a/libraries/AP_SurfaceDistance/AP_SurfaceDistance.cpp
+++ b/libraries/AP_SurfaceDistance/AP_SurfaceDistance.cpp
@@ -75,24 +75,26 @@ void AP_SurfaceDistance::update()
     // are considered a glitch and glitch_count becomes non-zero
     // glitches clear after RANGEFINDER_GLITCH_NUM_SAMPLES samples in a row.
     // glitch_cleared_ms is set so surface tracking (or other consumers) can trigger a target reset
-    const float glitch_m = alt_m - alt_glitch_protected_m;
     bool reset_terrain = false;
-    if (glitch_m >= RANGEFINDER_GLITCH_ALT_M) {
-        glitch_count = MAX(glitch_count+1, 1);
-        status |= (uint8_t)Surface_Distance_Status::Glitch_Detected;
-    } else if (glitch_m <= -RANGEFINDER_GLITCH_ALT_M) {
-        glitch_count = MIN(glitch_count-1, -1);
-        status |= (uint8_t)Surface_Distance_Status::Glitch_Detected;
-    } else {
-        glitch_count = 0;
-        alt_glitch_protected_m = alt_m;
-    }
-    if (abs(glitch_count) >= RANGEFINDER_GLITCH_NUM_SAMPLES) {
-        // clear glitch and record time so consumers (i.e. surface tracking) can reset their target altitudes
-        glitch_count = 0;
-        alt_glitch_protected_m = alt_m;
-        glitch_cleared_ms = now;
-        reset_terrain = true;
+    if (alt_healthy && isfinite(alt_m)) {
+        const float glitch_m = alt_m - alt_glitch_protected_m;
+        if (glitch_m >= RANGEFINDER_GLITCH_ALT_M) {
+            glitch_count = MAX(glitch_count+1, 1);
+            status |= (uint8_t)Surface_Distance_Status::Glitch_Detected;
+        } else if (glitch_m <= -RANGEFINDER_GLITCH_ALT_M) {
+            glitch_count = MIN(glitch_count-1, -1);
+            status |= (uint8_t)Surface_Distance_Status::Glitch_Detected;
+        } else {
+            glitch_count = 0;
+            alt_glitch_protected_m = alt_m;
+        }
+        if (abs(glitch_count) >= RANGEFINDER_GLITCH_NUM_SAMPLES) {
+            // clear glitch and record time so consumers (i.e. surface tracking) can reset their target altitudes
+            glitch_count = 0;
+            alt_glitch_protected_m = alt_m;
+            glitch_cleared_ms = now;
+            reset_terrain = true;
+        }
     }
 
     // filter rangefinder altitude


### PR DESCRIPTION
## Summary

The glitch detector in `AP_SurfaceDistance::update()` runs unconditionally, so when a rangefinder reports OutOfRangeHigh with `range == sensor_max` (per DroneCAN DSDL), `alt_glitch_protected_m` is overwritten after `RANGEFINDER_GLITCH_NUM_SAMPLES` cycles. The FAST_TASK terrain-offset LPF then drags `terrain_u_m` toward `ref_pos_u_m - sensor_max`, contaminating the terrain estimate that reaches the position controller on recovery.

Gate the glitch detector on `alt_healthy` (with an `isfinite` belt-and-braces) and gate both the downward and upward terrain-offset LPFs on `alt_healthy` so the filter pauses while inputs are unreliable.