### PR TITLE
Tools: Fix autotest error for Copter Tests2b due to heli frames added under Arducopter builds

### DIFF
--- a/Tools/autotest/pysim/vehicleinfo.json
+++ b/Tools/autotest/pysim/vehicleinfo.json
@@ -204,44 +204,6 @@
                 ],
                 "external": true
             },
-            "heli": {
-                "waf_target": "bin/arducopter-heli",
-                "default_params_filename": "default_params/copter-heli.parm"
-            },
-            "heli-gas": {
-                "waf_target": "bin/arducopter-heli",
-                "default_params_filename": [
-                    "default_params/copter-heli.parm",
-                    "default_params/copter-heli-gas.parm"
-                ]
-            },
-            "heli-ddvptail": {
-                "waf_target": "bin/arducopter-heli",
-                "default_params_filename": [
-                    "default_params/copter-heli.parm",
-                    "default_params/copter-heli-ddvptail.parm"
-                ]
-            },
-            "heli-ddfptail": {
-                "waf_target": "bin/arducopter-heli",
-                "default_params_filename": [
-                    "default_params/copter-heli.parm",
-                    "default_params/copter-heli-ddfptail.parm"
-                ]
-            },
-            "heli-dual": {
-                "waf_target": "bin/arducopter-heli",
-                "default_params_filename": [
-                    "default_params/copter-heli.parm",
-                    "default_params/copter-heli-dual.parm"
-                ]
-            },
-            "heli-blade360": {
-                "waf_target": "bin/arducopter-heli",
-                "default_params_filename": [
-                    "default_params/copter-heli.parm"
-                ]
-            },
             "singlecopter": {
                 "waf_target": "bin/arducopter",
                 "default_params_filename": "default_params/copter-single.parm"


### PR DESCRIPTION
### Summary

removes all heli frames from the ArduCopter builds.  fixes failures of copter tests2b.  @peterbarker please add commit to remove the code that was the bandaid for this issue.

### Classification & Testing
- [x] Checked by a human programmer


