### PR TITLE
AP_AHRS: privatise AP_AHRS_Backend::Estimates member variables to force access through accessors

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -1185,7 +1185,7 @@ bool AP_AHRS::_get_secondary_position(Location &loc) const
 #if AP_AHRS_DCM_ENABLED
     case EKFType::DCM:
         // return DCM position
-        loc = dcm_estimates.location;
+        UNUSED_RESULT(dcm_estimates.get_location(loc));
         // FIXME: we intentionally do not return whether location is
         // actually valid here so we continue to send mavlink messages
         // and log data:
@@ -1195,14 +1195,14 @@ bool AP_AHRS::_get_secondary_position(Location &loc) const
 #if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO:
         // EKF2 is secondary
-        ekf2_estimates.get_location(loc);
+        UNUSED_RESULT(ekf2_estimates.get_location(loc));
         return ekf2.started;
 #endif
 
 #if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
         // EKF3 is secondary
-        ekf3_estimates.get_location(loc);
+        UNUSED_RESULT(ekf3_estimates.get_location(loc));
         return ekf3.started;
 #endif
 

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -73,7 +73,7 @@ public:
         // frame.  A backend using the autopilot sensors will need to
         // rotate according to the TRIM parameters.  An ExternalAHRS
         // won't!
-        bool get_quaternion(Quaternion &quat) const {
+        bool get_quaternion(Quaternion &quat) const WARN_IF_UNUSED {
             quat = quaternion;
             return attitude_valid;
         }
@@ -83,9 +83,9 @@ public:
         Vector3f accel_ef;
         Vector3f accel_bias;
 
-        // a ground velocity in meters/second, North/East/Down
-        Vector3f velocity_NED;
-        bool velocity_NED_valid;
+        /*
+         * linear velocity estimates
+         */
         // return a ground velocity in meters/second, North/East/Down
         bool get_velocity_NED(Vector3f &vel) const WARN_IF_UNUSED {
             if (!velocity_NED_valid) {
@@ -97,21 +97,13 @@ public:
         // ground velocity estimate in meters/second, in North/East order
         Vector2f velocity_NE;
 
-        // a derivative of the vertical position in m/s which is
-        // kinematically consistent with the vertical position is
-        // required by some control loops.
-        // This is different to the vertical velocity from the EKF
-        // which is not always consistent with the vertical position
-        // due to the various errors that are being corrected for.
-        float vert_pos_rate_D;
-        bool vert_pos_rate_D_valid;
         // Get a derivative of the vertical position in m/s which is
         // kinematically consistent with the vertical position is
         // required by some control loops.
         // This is different to the vertical velocity from the EKF
         // which is not always consistent with the vertical position
         // due to the various errors that are being corrected for.
-        bool get_vert_pos_rate_D(float &velocity) const {
+        bool get_vert_pos_rate_D(float &velocity) const WARN_IF_UNUSED {
             if (!vert_pos_rate_D_valid) {
                 return false;
             }
@@ -122,10 +114,7 @@ public:
         /*
          * position estimates
          */
-        Location location;
-        bool location_valid;
-
-        bool get_location(Location &loc) const {
+        bool get_location(Location &loc) const WARN_IF_UNUSED {
             loc = location;
             return location_valid;
         };
@@ -136,6 +125,29 @@ public:
         }
 
     private:
+
+        /*
+         * linear velocity estimates
+         */
+        // a ground velocity in meters/second, North/East/Down
+        Vector3f velocity_NED;
+        bool velocity_NED_valid;
+
+        // a derivative of the vertical position in m/s which is
+        // kinematically consistent with the vertical position is
+        // required by some control loops.
+        // This is different to the vertical velocity from the EKF
+        // which is not always consistent with the vertical position
+        // due to the various errors that are being corrected for.
+        float vert_pos_rate_D;
+        bool vert_pos_rate_D_valid;
+
+        /*
+         * position estimates
+         */
+        Location location;
+        bool location_valid;
+
         bool hagl_valid;
         float hagl;
     };


### PR DESCRIPTION
### Summary

Moves data members into the private section, so only backends can see/set them.  AP_AHRS has to go through the accessors.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board,plane
CubeOrange,0
```

### Description

this may allow for lazy calculation of some derived values in the future, and is just nicer

Also sneaks in some `WARN_IF_UNUSED`, which pointed out some interesting places in `_get_seecondary_position` where we really need to fix the return values to match _get_position (IMO).
