### PR TITLE
ArduSub: add prearm initialization check

### DIFF
--- a/ArduSub/AP_Arming_Sub.cpp
+++ b/ArduSub/AP_Arming_Sub.cpp
@@ -32,6 +32,12 @@ bool AP_Arming_Sub::pre_arm_checks(bool display_failure)
     if (armed) {
         return true;
     }
+
+    if (!hal.scheduler->is_system_initialized()) {
+        check_failed(display_failure, "System not initialised");
+        return false;
+    }
+
     // don't allow arming unless there is a disarm button configured
     if (!has_disarm_function()) {
         check_failed(display_failure, "Must assign a disarm or arm_toggle button or disarm aux function");


### PR DESCRIPTION
### Summary

Fixes #33204, a bug where running a prearm check before initialization allows dereferencing an uninitialized GPS pointer.

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [X] Automated test(s) verify changes (e.g. unit test, autotest)
- [X] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [X] Logs available on request

Passed automated test `./Tools/autotest/autotest.py build.Sub test.Sub`.

Manual SITL testing involved running the reproducible test from the bug report and confirming that prearm checks will not pass until after initialization using `sim_vehicle.py` with gdb.

### Description

This change checks if the system is initialized before proceeding with the prearm check, preventing it from running before GPS has initialized.

This same system initialization check currently exists on other vehicles which prevented this issue, so the same check was added here.
