### PR TITLE
Tools: logger_metadata: include NVAL logs

### DIFF
--- a/Tools/autotest/logger_metadata/parse.py
+++ b/Tools/autotest/logger_metadata/parse.py
@@ -47,9 +47,11 @@ re_units_define = re.compile(r'#define\s+(\w+_UNITS)\s+"([\w\-#?%]+)"')
 re_mults_define = re.compile(r'#define\s+(\w+_MULTS)\s+"([\w\-#?%]+)"')
 
 # Regular expressions for finding message definitions in Write calls
-re_start_writecall = re.compile(r"\s*[AP:]*logger[\(\)]*.Write[StreamingCrcl]*\(")
+# AP::logger().Write and logger->Write (singleton pointer) are both used
+re_logger_write = r'(?:[AP:]*logger[\(\)]*|logger->)Write[StreamingCrcl]*\('
+re_start_writecall = re.compile(r'\s*' + re_logger_write)
 re_writefield = r'\s*"([\w\-#?%,]+)"\s*'
-re_full_writecall = re.compile(r'\s*[AP:]*logger[\(\)]*.Write[StreamingCrcl]*\(' +
+re_full_writecall = re.compile(r'\s*' + re_logger_write +
                                f'{re_writefield},{re_writefield},{re_writefield},({re_writefield},{re_writefield})?',
                                re.MULTILINE)
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3902,6 +3902,14 @@ void GCS_MAVLINK::handle_named_value(const mavlink_message_t &msg) const
     mavlink_msg_named_value_float_decode(&msg, &p);
     char s[11] {};
     strncpy(s, p.name, sizeof(s)-1);
+// @LoggerMessage: NVAL
+// @Description: Named values received via MAVLink NAMED_VALUE_FLOAT
+// @Field: TimeUS: Time since system startup
+// @Field: TimeBootMS: Time since boot from the incoming message
+// @Field: Name: Name of value
+// @Field: Value: Float value
+// @Field: SSys: MAVLink source system ID
+// @Field: SCom: MAVLink source component ID
     logger->Write("NVAL", "TimeUS,TimeBootMS,Name,Value,SSys,SCom", "ss#---", "FC----", "QINfBB",
                   AP_HAL::micros64(),
                   p.time_boot_ms,


### PR DESCRIPTION
### Summary

Adds handling and documentation for `NVAL` logs (received MAVLink `NAMED_VALUE_FLOAT` messages).

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

Realised `NVAL` log messages aren't included in the documentation.

1. Added handling for the `logger->Write` pattern
2. Added relevant comment documentation where the NVAL message logging occurs

Tested by running manually for Sub, and confirmed the NVAL section + table does indeed appear as expected.
[LogMessages.md](https://github.com/user-attachments/files/28324007/LogMessages.md)