### PR TITLE
AP_AHRS: combine copy_estimates_from_backend_estimates and update_state

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -438,7 +438,9 @@ void AP_AHRS::reset_gyro_drift(void)
 }
 
 /*
-  update state structure after each update()
+ * copy results from a backend over AP_AHRS canonical results.
+ * This updates member variables like roll and pitch, as well as
+ * updating derived values like sin_roll and sin_pitch.
  */
 void AP_AHRS::update_state(void)
 {
@@ -458,6 +460,22 @@ void AP_AHRS::update_state(void)
     state.airspeed_EAS_ok = _airspeed_EAS(state.airspeed_EAS, state.airspeed_estimate_type);
     state.airspeed_TAS_ok = _airspeed_TAS(state.airspeed_TAS);
     state.airspeed_TAS_vec_ok = _airspeed_TAS(state.airspeed_TAS_vec);
+
+    roll = active_estimates->roll_rad;
+    pitch = active_estimates->pitch_rad;
+    yaw = active_estimates->yaw_rad;
+
+    state.dcm_matrix = active_estimates->dcm_matrix;
+
+    state.gyro_estimate = active_estimates->gyro_estimate;
+    state.gyro_drift = active_estimates->gyro_drift;
+
+    state.accel_ef = active_estimates->accel_ef;
+    state.accel_bias = active_estimates->accel_bias;
+
+    update_cd_values();
+    update_trig();
+
     state.quat_ok = active_estimates->get_quaternion(state.quat);
     state.secondary_attitude_ok = _get_secondary_attitude(state.secondary_attitude);
     state.secondary_quat_ok = _get_secondary_quaternion(state.secondary_quat);
@@ -572,10 +590,8 @@ void AP_AHRS::update(bool skip_ins_update)
     }
 #endif // HAL_GCS_ENABLED
 
-    // update published state
+    // update published state, including copying state from the active backend:
     update_state();
-
-    copy_estimates_from_backend_estimates(*active_estimates);
 
 #if AP_MODULE_SUPPORTED
     // call AHRS_update hook if any
@@ -605,29 +621,6 @@ void AP_AHRS::update(bool skip_ins_update)
         hal.scheduler->delay_microseconds(random() % sitl->loop_time_jitter_us);
     }
 #endif
-}
-
-/*
- * copy results from a backend over AP_AHRS canonical results.
- * This updates member variables like roll and pitch, as well as
- * updating derived values like sin_roll and sin_pitch.
- */
-void AP_AHRS::copy_estimates_from_backend_estimates(const AP_AHRS_Backend::Estimates &results)
-{
-    roll = results.roll_rad;
-    pitch = results.pitch_rad;
-    yaw = results.yaw_rad;
-
-    state.dcm_matrix = results.dcm_matrix;
-
-    state.gyro_estimate = results.gyro_estimate;
-    state.gyro_drift = results.gyro_drift;
-
-    state.accel_ef = results.accel_ef;
-    state.accel_bias = results.accel_bias;
-
-    update_cd_values();
-    update_trig();
 }
 
 #if AP_AHRS_DCM_ENABLED

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -924,13 +924,6 @@ private:
     // poke AP_Notify based on values from status
     void update_notify_from_filter_status(const nav_filter_status &status);
 
-    /*
-     * copy results from a backend over AP_AHRS canonical results.
-     * This updates member variables like roll and pitch, as well as
-     * updating derived values like sin_roll and sin_pitch.
-     */
-    void copy_estimates_from_backend_estimates(const AP_AHRS_Backend::Estimates &results);
-
     // write out secondary estimates:
     void Write_AHRS2(void) const;
     // write POS (canonical vehicle position) message out:


### PR DESCRIPTION
### Summary

Combines two methods to keep the logic together

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                 *
Durandal                            -24             -16    *           -16     -24               -16    -24    -16
Hitec-Airspeed           *                                 *
KakuteH7-bdshot                     -16             -16    *           -24     -16               -24    -24    -16
MatekF405                           -24             -16    *           -16     -16               -24    -24    -16
MatekH7A3                           -24             -24    *           -24     -24               -16    -24    -16
Pixhawk1-1M-bdshot                  -24             -16                -24     -24               -24    -16    -24
SITL_x86_64_linux_gnu               0               0                  0       0                 0      0      0
YJUAV_A6SE                          -16             -16    *           -16     -16               -16    -16    -16
f103-QiotekPeriph        *                                 *
f303-MatekGPS            *                                 *
f303-Universal           *                                 *
iomcu                                                                                *
mindpx-v2                           -16             -24    *           -24     -16               -24    -24    -16
revo-mini                           -16             -16    *           -24     -16               -24    -24    -24
skyviper-v2450                                                         -16
speedybeef4                         -16             -24    *           -24     -24               -24    -24    -16
```

### Description

gets all of the same logic into the same method.  They were both already updating global state and state state

The method may eventually be replaced with a simple assignment (or eliminated as everything is fetched from the relevant backend estimates pointer)
