### PR TITLE
Replace primary_accel and primary_gyro with primary_IMU

### DIFF
--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -698,7 +698,7 @@ bool AC_PrecLand::construct_pos_meas_using_rangefinder(float rangefinder_alt_m, 
             }
 
             // Compute camera position relative to IMU
-            const Vector3f accel_pos_ned_m = _inertial_data_delayed->Tbn * AP::ins().get_imu_pos_offset(AP::ahrs().get_primary_accel_index());
+            const Vector3f accel_pos_ned_m = _inertial_data_delayed->Tbn * AP::ins().get_imu_pos_offset(AP::ahrs().get_primary_IMU_index());
             const Vector3f cam_pos_ned_rel_imu_ned_m = cam_pos_ned_m - accel_pos_ned_m;
 
             // Compute target position relative to IMU
@@ -736,7 +736,7 @@ void AC_PrecLand::run_output_prediction()
     const AP_AHRS &_ahrs = AP::ahrs();
 
     const Matrix3f& Tbn = (*_inertial_history)[_inertial_history->available()-1]->Tbn;
-    Vector3f accel_body_offset = AP::ins().get_imu_pos_offset(_ahrs.get_primary_accel_index());
+    Vector3f accel_body_offset = AP::ins().get_imu_pos_offset(_ahrs.get_primary_IMU_index());
 
     // Apply position correction for CG offset from IMU
     Vector3f imu_pos_ned = Tbn * accel_body_offset;

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -442,16 +442,14 @@ void AP_AHRS::reset_gyro_drift(void)
  */
 void AP_AHRS::update_state(void)
 {
-    const uint8_t primary_gyro = _get_primary_gyro_index();
+    const uint8_t primary_IMU = _get_primary_IMU_index();
 #if AP_INERTIALSENSOR_ENABLED
     // tell the IMUS about primary changes
-    if (primary_gyro != state.primary_gyro) {
-        AP::ins().set_primary(primary_gyro);
+    if (primary_IMU != state.primary_IMU) {
+        AP::ins().set_primary(primary_IMU);
     }
 #endif
-    state.primary_IMU = _get_primary_IMU_index();
-    state.primary_gyro = primary_gyro;
-    state.primary_accel = _get_primary_accel_index();
+    state.primary_IMU = primary_IMU;
     state.primary_core = _get_primary_core_index();
     state.wind_estimate_ok = active_backend->wind_estimate(state.wind_estimate);
     state.EAS2TAS = AP_AHRS_Backend::get_EAS2TAS();
@@ -2874,18 +2872,6 @@ int8_t AP_AHRS::_get_primary_core_index() const
     // we should never get here
     INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
     return -1;
-}
-
-// get the index of the current primary accelerometer sensor
-uint8_t AP_AHRS::_get_primary_accel_index(void) const
-{
-    return _get_primary_IMU_index();
-}
-
-// get the index of the current primary gyro sensor
-uint8_t AP_AHRS::_get_primary_gyro_index(void) const
-{
-    return _get_primary_IMU_index();
 }
 
 // see if EKF lane switching is possible to avoid EKF failsafe

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -449,11 +449,8 @@ public:
     // return the index of the primary core or -1 if no primary core selected
     int8_t get_primary_core_index() const { return state.primary_core; }
 
-    // get the index of the current primary accelerometer sensor
-    uint8_t get_primary_accel_index(void) const { return state.primary_accel; }
-
-    // get the index of the current primary gyro sensor
-    uint8_t get_primary_gyro_index(void) const { return state.primary_gyro; }
+    // get the index of the current primary IMU sensor
+    uint8_t get_primary_IMU_index(void) const { return state.primary_IMU; }
 
     // see if EKF lane switching is possible to avoid EKF failsafe
     void check_lane_switch(void);
@@ -688,7 +685,7 @@ public:
 
     // return primary accels
     const Vector3f &get_accel(void) const {
-        return AP::ins().get_accel(_get_primary_accel_index());
+        return AP::ins().get_accel(state.primary_IMU);
     }
 
     // return primary accel bias. This should be subtracted from
@@ -982,12 +979,6 @@ private:
     // return the index of the primary core or -1 if no primary core selected
     int8_t _get_primary_core_index() const;
 
-    // get the index of the current primary accelerometer sensor
-    uint8_t _get_primary_accel_index(void) const;
-
-    // get the index of the current primary gyro sensor
-    uint8_t _get_primary_gyro_index(void) const;
-
     // get the index of the current primary IMU
     uint8_t _get_primary_IMU_index(void) const;
 
@@ -1016,8 +1007,6 @@ private:
     struct {
         EKFType active_EKF_type;
         uint8_t primary_IMU;
-        uint8_t primary_gyro;
-        uint8_t primary_accel;
         uint8_t primary_core;
         Vector3f gyro_estimate;
         Matrix3f dcm_matrix;

--- a/libraries/AP_AHRS/AP_AHRS_Backend.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.cpp
@@ -34,8 +34,8 @@ void AP_AHRS_Backend::init()
 // return a smoothed and corrected gyro vector using the latest ins data (which may not have been consumed by the EKF yet)
 Vector3f AP_AHRS::get_gyro_latest(void) const
 {
-    const uint8_t primary_gyro = get_primary_gyro_index();
-    return AP::ins().get_gyro(primary_gyro) + get_gyro_drift();
+    const uint8_t primary_IMU = get_primary_IMU_index();
+    return AP::ins().get_gyro(primary_IMU) + get_gyro_drift();
 }
 
 // set_trim

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -143,16 +143,6 @@ public:
     // init sets up INS board orientation
     virtual void init();
 
-    // get the index of the current primary IMU, as determined by good
-    // gyro sensor
-    virtual uint8_t get_primary_IMU_index(void) const {
-#if AP_INERTIALSENSOR_ENABLED
-        return AP::ins().get_first_usable_gyro();
-#else
-        return 0;
-#endif
-    }
-
     // Methods
     virtual void update() = 0;
 

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -143,8 +143,9 @@ public:
     // init sets up INS board orientation
     virtual void init();
 
-    // get the index of the current primary gyro sensor
-    virtual uint8_t get_primary_gyro_index(void) const {
+    // get the index of the current primary IMU, as determined by good
+    // gyro sensor
+    virtual uint8_t get_primary_IMU_index(void) const {
 #if AP_INERTIALSENSOR_ENABLED
         return AP::ins().get_first_usable_gyro();
 #else

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF2.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF2.cpp
@@ -30,11 +30,11 @@ void AP_AHRS_NavEKF2::get_results(AP_AHRS_Backend::Estimates &results)
     /*
      * rotational rate estimates:
      */
-    // Use the primary EKF to select the primary gyro
+    // Use the primary EKF to select the primary IMU, falling back to
+    // the IMU with the first usable gyro
     const AP_InertialSensor &_ins = AP::ins();
-    const int8_t primary_imu = EKF2.getPrimaryCoreIMUIndex();
-    const uint8_t primary_gyro = primary_imu>=0?primary_imu:_ins.get_first_usable_gyro();
-    const uint8_t primary_accel = primary_imu>=0?primary_imu:_ins.get_first_usable_accel();
+    const int8_t primary_core = EKF2.getPrimaryCoreIMUIndex();
+    const uint8_t primary_IMU = primary_core>=0?primary_core:_ins.get_first_usable_gyro();
 
     // get gyro bias for primary EKF and change sign to give gyro drift
     // Note sign convention used by EKF is bias = measurement - truth
@@ -43,7 +43,7 @@ void AP_AHRS_NavEKF2::get_results(AP_AHRS_Backend::Estimates &results)
     results.gyro_drift = -drift;
 
     // use the same IMU as the primary EKF and correct for gyro drift
-    results.gyro_estimate = _ins.get_gyro(primary_gyro) + results.gyro_drift;
+    results.gyro_estimate = _ins.get_gyro(primary_IMU) + results.gyro_drift;
 
     /*
      * acceleration estimates
@@ -51,8 +51,8 @@ void AP_AHRS_NavEKF2::get_results(AP_AHRS_Backend::Estimates &results)
     // get z accel bias estimate from active EKF (this is usually for the primary IMU)
     EKF2.getAccelZBias(results.accel_bias.z);
 
-    // This EKF is currently using primary_imu, and a bias applies to only that IMU
-    Vector3f accel = _ins.get_accel(primary_accel);
+    // This EKF is currently using primary_IMU, and a bias applies to only that IMU
+    Vector3f accel = _ins.get_accel(primary_IMU);
     accel.z -= results.accel_bias.z;
     results.accel_ef = results.dcm_matrix * AP::ahrs().get_rotation_autopilot_body_to_vehicle_body() * accel;
 

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
@@ -33,10 +33,10 @@ void AP_AHRS_NavEKF3::get_results(AP_AHRS_Backend::Estimates &results)
      */
     const AP_InertialSensor &_ins = AP::ins();
 
-    // Use the primary EKF to select the primary gyro
-    const int8_t primary_imu = EKF3.getPrimaryCoreIMUIndex();
-    const uint8_t primary_gyro = primary_imu>=0?primary_imu:_ins.get_first_usable_gyro();
-    const uint8_t primary_accel = primary_imu>=0?primary_imu:_ins.get_first_usable_accel();
+    // Use the primary EKF to select the primary IMU, falling back to
+    // the IMU with the first usable gyro
+    const int8_t primary_core = EKF3.getPrimaryCoreIMUIndex();
+    const uint8_t primary_IMU = primary_core>=0?primary_core:_ins.get_first_usable_gyro();
 
     // get gyro bias for primary EKF and change sign to give gyro drift
     // Note sign convention used by EKF is bias = measurement - truth
@@ -45,7 +45,7 @@ void AP_AHRS_NavEKF3::get_results(AP_AHRS_Backend::Estimates &results)
     results.gyro_drift = -drift;
 
     // use the same IMU as the primary EKF and correct for gyro drift
-    results.gyro_estimate = _ins.get_gyro(primary_gyro) + results.gyro_drift;
+    results.gyro_estimate = _ins.get_gyro(primary_IMU) + results.gyro_drift;
 
     /*
      * acceleration estimates
@@ -55,7 +55,7 @@ void AP_AHRS_NavEKF3::get_results(AP_AHRS_Backend::Estimates &results)
     EKF3.getAccelBias(-1, results.accel_bias);
 
     // use the primary IMU for accel earth frame
-    Vector3f accel = _ins.get_accel(primary_accel);
+    Vector3f accel = _ins.get_accel(primary_IMU);
     accel -= results.accel_bias;
     results.accel_ef = results.dcm_matrix * AP::ahrs().get_rotation_autopilot_body_to_vehicle_body() * accel;
 

--- a/libraries/AP_DDS/AP_DDS_Client.cpp
+++ b/libraries/AP_DDS/AP_DDS_Client.cpp
@@ -671,10 +671,9 @@ void AP_DDS_Client::update_topic(sensor_msgs_msg_Imu& msg)
         initialize(msg.orientation);
     }
 
-    uint8_t accel_index = ahrs.get_primary_accel_index();
-    uint8_t gyro_index = ahrs.get_primary_gyro_index();
-    const Vector3f accel_data = imu.get_accel(accel_index);
-    const Vector3f gyro_data = imu.get_gyro(gyro_index);
+    const uint8_t imu_index = ahrs.get_primary_IMU_index();
+    const Vector3f accel_data = imu.get_accel(imu_index);
+    const Vector3f gyro_data = imu.get_gyro(imu_index);
 
     // Populate the message fields
     msg.linear_acceleration.x = accel_data.x;

--- a/libraries/AP_InertialSensor/FastRateBuffer.cpp
+++ b/libraries/AP_InertialSensor/FastRateBuffer.cpp
@@ -76,7 +76,7 @@ bool AP_InertialSensor::is_rate_loop_gyro_enabled(uint8_t instance) const
     if (!fast_rate_buffer_enabled || fast_rate_buffer == nullptr) {
         return false;
     }
-    return fast_rate_buffer->use_rate_loop_gyro_samples() && instance == AP::ahrs().get_primary_gyro_index();
+    return fast_rate_buffer->use_rate_loop_gyro_samples() && instance == AP::ahrs().get_primary_IMU_index();
 }
 
 // whether or not to use the dynamic fifo

--- a/libraries/AP_Module/AP_Module.cpp
+++ b/libraries/AP_Module/AP_Module.cpp
@@ -203,8 +203,9 @@ void AP_Module::call_hook_AHRS_update(const AP_AHRS &ahrs)
     state.accel_ef[1] = accel_ef[0];
     state.accel_ef[2] = accel_ef[0];
 
-    state.primary_accel = ahrs.get_primary_accel_index();
-    state.primary_gyro = ahrs.get_primary_gyro_index();
+    const uint8_t primary_imu_index = ahrs.get_primary_IMU_index();
+    state.primary_accel = primary_imu_index;
+    state.primary_gyro = primary_imu_index;
 
     const Vector3f &gyro_bias = ahrs.get_gyro_drift();
     state.gyro_bias[0] = gyro_bias[0];


### PR DESCRIPTION
### Summary

Start to just assume we have a "primary IMU" rather than the possibility of  a primary gyro and a primary accel.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                 *                                                   
Durandal                            -48             -32    *           -24     -48               -248   -8     -56
Hitec-Airspeed           *                                 *                                                   
KakuteH7-bdshot                     -64             -72    *           -88     -64               -72    -64    -56
MatekF405                           -64             -48    *           -56     -72               -56    -40    -72
MatekH7A3                           -56             -56    *           -56     -56               -56    -56    -48
Pixhawk1-1M-bdshot                  -48             -48                -56     -56               -56    -56    -48
SITL_x86_64_linux_gnu               -136            -136               -136    -136              -192   -144   -136
YJUAV_A6SE                          -80             -64    *           -80     -136              -120   -80    -192
f103-QiotekPeriph        *                                 *                                                   
f303-MatekGPS            *                                 *                                                   
f303-Universal           *                                 *                                                   
iomcu                                                                                *                         
mindpx-v2                           -64             -48    *           -56     -304              -88    -56    -40
revo-mini                           -48             -48    *           -56     -56               -72    -56    -48
skyviper-v2450                                                         -88                                     
speedybeef4                         -40             -40    *           -48     -48               -64    -56    -40
```

### Description

We decided at DevCall that if we ever did get something which was just e.g. a stand-alone gyro that it would flog accel data from somewhere else.

Also removes unused `AP_AHRS_Backend::get_primary_gyro_index` - there's a switch statement which never moved to calling backend methods, and the primary_IMU uint8_t will be moving into the results structure.
