### PR TITLE
AP_InertialSensor: ADIS16607 IMU support sync clock input

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_ADIS16607.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_ADIS16607.cpp
@@ -35,6 +35,7 @@
 #define REG_USER_GPIO_CFG1      0x2F
 #define REG_SPI_FULLDUPLEX_KEY  0x31
 #define REG_SPI_HALFDUPLEX_KEY  0x32
+#define REG_USER_SYNC           0x33
 
 #define REG_USER_DATA_CFG               0x34
 #define USER_DATA_CFG_X_ACCEL_EN        (1U<<0)
@@ -107,32 +108,11 @@ AP_InertialSensor_ADIS16607::probe(AP_InertialSensor &imu,
 
 void AP_InertialSensor_ADIS16607::start()
 {
-    if (!_imu.register_accel(accel_instance, expected_sample_rate_hz, dev->get_bus_id_devtype(DEVTYPE_INS_ADIS16607)) ||
-        !_imu.register_gyro(gyro_instance, expected_sample_rate_hz, dev->get_bus_id_devtype(DEVTYPE_INS_ADIS16607))) {
+    // pre-fetch instance numbers for checking fast sampling settings
+    if (!_imu.get_gyro_instance(gyro_instance) || !_imu.get_accel_instance(accel_instance)) {
         return;
     }
-
-    // setup sensor rotations from probe()
-    set_gyro_orientation(gyro_instance, rotation);
-    set_accel_orientation(accel_instance, rotation);
-
-    fifo_buffer = hal.util->malloc_type(ADIS16607_FIFO_BUFFER_LEN * ADIS16607_FIFO_SAMPLE_SIZE + 2, AP_HAL::Util::MEM_DMA_SAFE);
-
-    if (fifo_buffer == nullptr) {
-        AP_HAL::panic("ADIS16607: Unable to allocate FIFO buffer");
-    }
-
-    periodic_handle = dev->register_periodic_callback((1000000UL / backend_rate_hz),
-                                                      FUNCTOR_BIND_MEMBER(&AP_InertialSensor_ADIS16607::read_sensor_fifo, void));
-}
-
-/**
- * @brief Check dev ID
- */
-bool AP_InertialSensor_ADIS16607::check_dev_id()
-{
-    // Lock the SPI mode
-    write_reg16(REG_SPI_HALFDUPLEX_KEY, 0xB4B4, false);
+    WITH_SEMAPHORE(dev->get_semaphore());
 
     backend_rate_hz = 1000;
     if (enable_fast_sampling(accel_instance) && (get_fast_sampling_rate() > 1) && (dev->bus_type() == AP_HAL::Device::BUS_TYPE_SPI)) {
@@ -149,11 +129,15 @@ bool AP_InertialSensor_ADIS16607::check_dev_id()
         backend_rate_hz *= fast_sampling_rate;
     }
 
-    if (read_reg16(REG_DEV_ID) == DEV_ID_16607) {
-        accel_scale = GRAVITY_MSS / 200000.0f;  // Accel: Dynamic Range ±40g. 24-bit data format 200000.0 LSB/g
-        gyro_scale = radians(1.0 / 4000.0);     // Gyro: ADIS16607-3, 24-bit data format 4000.0 LSB/°/sec
-        _clip_limit = 39.5f * GRAVITY_MSS;
+#if defined (ADIS16607_SYNC_INPUT_CLOCK_HZ) && defined (ADIS16607_SYNC_INPUT_BITMASK)
+    if (ADIS16607_SYNC_INPUT_BITMASK & (1U << accel_instance)) {
+        calc_sample_and_dec_rate();
 
+        // Configure GPIO2 as SYNC
+        write_reg16(REG_USER_GPIO_CFG1, 0x0040, false);
+    } else
+#endif
+    {
         switch (backend_rate_hz) {
             case 2000:
                 expected_sample_rate_hz = 2390;
@@ -173,6 +157,97 @@ bool AP_InertialSensor_ADIS16607::check_dev_id()
                 break;
         }
 
+        write_reg16(REG_USER_GPIO_CFG1, 0x0000, false);
+    }
+
+    /**
+     * Bring rate down
+     * The actual decimation rate, D, is the DEC_RATE+1. Note that when changing the decimation rate, it is 
+     * recommended to first reset DEC_RATE to 0x000 before entering the new value. This 
+     * allows the decimation accumulator to reset.
+     */
+    if (!write_reg16(REG_DEC_RATE, 0, true)) {
+        return;
+    }
+
+    if (!write_reg16(REG_DEC_RATE, dec_rate, true)) {
+        return;
+    }
+
+    // Clear FIFO data
+    if (!write_reg16(REG_USER_FIFO_CFG, USER_FIFO_CFG_CLEAR_FIFO_B | (ADIS16607_FIFO_THRESHOLD << 0), false)) {
+        return;
+    }
+
+    // Write lock
+    write_reg16(REG_WRITE_LOCK, 0x5555, false);
+    write_reg16(REG_WRITE_LOCK, 0xAAAA, false);
+
+    if (read_reg16(REG_WRITE_LOCK) != 1U) {
+        return;
+    }
+
+    if ((read_reg16(REG_DIAG_STAT) & 0xFBFF) != 0x0000) {
+        return;
+    }
+
+    dev->set_speed(AP_HAL::Device::SPEED_HIGH);
+
+    if (!_imu.register_accel(accel_instance, expected_sample_rate_hz, dev->get_bus_id_devtype(DEVTYPE_INS_ADIS16607)) ||
+        !_imu.register_gyro(gyro_instance, expected_sample_rate_hz, dev->get_bus_id_devtype(DEVTYPE_INS_ADIS16607))) {
+        return;
+    }
+
+    // setup sensor rotations from probe()
+    set_gyro_orientation(gyro_instance, rotation);
+    set_accel_orientation(accel_instance, rotation);
+
+    fifo_buffer = hal.util->malloc_type(ADIS16607_FIFO_BUFFER_LEN * ADIS16607_FIFO_SAMPLE_SIZE + 2, AP_HAL::Util::MEM_DMA_SAFE);
+
+    if (fifo_buffer == nullptr) {
+        AP_HAL::panic("ADIS16607: Unable to allocate FIFO buffer");
+    }
+
+    periodic_handle = dev->register_periodic_callback((1000000UL / backend_rate_hz),
+                                                      FUNCTOR_BIND_MEMBER(&AP_InertialSensor_ADIS16607::read_sensor_fifo, void));
+}
+
+#if defined (ADIS16607_SYNC_INPUT_CLOCK_HZ) && defined (ADIS16607_SYNC_INPUT_BITMASK)
+void AP_InertialSensor_ADIS16607::calc_sample_and_dec_rate()
+{
+    const uint16_t sync_clk = ADIS16607_SYNC_INPUT_CLOCK_HZ;
+
+    if (backend_rate_hz >= sync_clk) {
+        dec_rate = 0;
+        expected_sample_rate_hz = sync_clk;
+    } else {
+        int16_t min_error = INT16_MAX;
+        for (uint8_t i = 0; i < 9; i++) {
+            uint16_t error_abs = abs((sync_clk / (i + 1)) - backend_rate_hz);
+            if (error_abs < min_error) {
+                min_error = error_abs;
+                dec_rate = i;
+                expected_sample_rate_hz = (uint16_t)(sync_clk / (i + 1));
+            } else {
+                break;
+            }
+        }
+    }
+}
+#endif
+
+/**
+ * @brief Check dev ID
+ */
+bool AP_InertialSensor_ADIS16607::check_dev_id()
+{
+    // Lock the SPI mode
+    write_reg16(REG_SPI_HALFDUPLEX_KEY, 0xB4B4, false);
+
+    if (read_reg16(REG_DEV_ID) == DEV_ID_16607) {
+        accel_scale = GRAVITY_MSS / 200000.0f;  // Accel: Dynamic Range ±40g. 24-bit data format 200000.0 LSB/g
+        gyro_scale = radians(1.0 / 4000.0);     // Gyro: ADIS16607-3, 24-bit data format 4000.0 LSB/°/sec
+        _clip_limit = 39.5f * GRAVITY_MSS;
         return true;
     }
 
@@ -198,9 +273,18 @@ bool AP_InertialSensor_ADIS16607::init()
         return false;
     }
 
+    /**
+     * Ensure that the "BOOTLOAD_BUSY" bit (Bit 0) is low
+     * Otherwise, REG_DIAG_STAT may not be able to be cleared when we have a SYNC clock signal.
+     */
+    tries = 10;
+    while ((read_reg16(REG_DIGITAL_STATUS) & 0x01) && --tries) {
+        hal.scheduler->delay(10);
+    }
+
     // Ensure DIGITAL_STATUS is 0x0000 for clear possible false errors
     tries = 10;
-    while ((read_reg16(REG_DIAG_STAT) != 0x0000) && --tries) {
+    while (((read_reg16(REG_DIAG_STAT) & 0xFBFF) != 0x0000) && --tries) {
         hal.scheduler->delay(10);
     }
 
@@ -218,9 +302,6 @@ bool AP_InertialSensor_ADIS16607::init()
         return false;
     }
 
-    // Configure GPIO pins(GPIO3 as DR)
-    write_reg16(REG_USER_GPIO_CFG1, 0x0200, false);
-
     // Init USER_DATA_CFG register if we use burst read mode
     const uint16_t user_data_cfg = USER_DATA_CFG_X_ACCEL_EN | USER_DATA_CFG_Y_ACCEL_EN | USER_DATA_CFG_Z_ACCEL_EN |
                                    USER_DATA_CFG_X_GYRO_EN | USER_DATA_CFG_Y_GYRO_EN | USER_DATA_CFG_Z_GYRO_EN |
@@ -234,39 +315,6 @@ bool AP_InertialSensor_ADIS16607::init()
     if (!write_reg16(REG_MSC_CTRL, 0x100, true)) {
         return false;
     }
-
-    /**
-     * Bring rate down
-     * The actual decimation rate, D, is the DEC_RATE+1. Note that when changing the decimation rate, it is 
-     * recommended to first reset DEC_RATE to 0x000 before entering the new value. This 
-     * allows the decimation accumulator to reset.
-     */
-    if (!write_reg16(REG_DEC_RATE, 0, true)) {
-        return false;
-    }
-
-    if (!write_reg16(REG_DEC_RATE, dec_rate, true)) {
-        return false;
-    }
-
-    // Clear FIFO data
-    if (!write_reg16(REG_USER_FIFO_CFG, USER_FIFO_CFG_CLEAR_FIFO_B | (ADIS16607_FIFO_THRESHOLD << 0), false)) {
-        return false;
-    }
-
-    // Write lock
-    write_reg16(REG_WRITE_LOCK, 0x5555, false);
-    write_reg16(REG_WRITE_LOCK, 0xAAAA, false);
-
-    if (read_reg16(REG_WRITE_LOCK) != 1U) {
-        return false;
-    }
-
-    if (read_reg16(REG_DIAG_STAT) != 0x0000) {
-        return false;
-    }
-
-    dev->set_speed(AP_HAL::Device::SPEED_HIGH);
 
     return true;
 }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_ADIS16607.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_ADIS16607.cpp
@@ -20,6 +20,21 @@
 
 #include "AP_InertialSensor_ADIS16607.h"
 
+#if defined(ADIS16607_SYNC_INPUT_CLOCK_HZ)
+#if (ADIS16607_SYNC_INPUT_CLOCK_HZ < 1000) || (ADIS16607_SYNC_INPUT_CLOCK_HZ > 8000)
+#error "Invalid ADIS16607 sync input clock range!"
+#endif
+
+#ifndef ADIS16607_SYNC_INPUT_BITMASK
+#error "Use ADIS16607_SYNC_INPUT_BITMASK macro to define sync clock IMU instances."
+#endif
+
+#else
+#if defined(ADIS16607_SYNC_INPUT_BITMASK)
+#error "Use ADIS16607_SYNC_INPUT_CLOCK_HZ macro to define sync clock frequency."
+#endif  // defined(ADIS16607_SYNC_INPUT_BITMASK)
+#endif  // defined(ADIS16607_SYNC_INPUT_CLOCK_HZ)
+
 /*
   device registers
  */
@@ -127,23 +142,34 @@ void AP_InertialSensor_ADIS16607::start()
         backend_rate_hz *= fast_sampling_rate;
     }
 
-    switch (backend_rate_hz) {
-    case 2000:
-        expected_sample_rate_hz = 2390;
-        dec_rate = DEC_RATE_2390HZ;
-        break;
-    case 4000:
-        expected_sample_rate_hz = 4780;
-        dec_rate = DEC_RATE_4780HZ;
-        break;
-    case 8000:
-        expected_sample_rate_hz = 9560;
-        dec_rate = DEC_RATE_9560HZ;
-        break;
-    default:
-        expected_sample_rate_hz = 1195;
-        dec_rate = DEC_RATE_1195HZ;
-        break;
+    uint16_t gpio_cfg1 = 0x0000;
+#if defined (ADIS16607_SYNC_INPUT_CLOCK_HZ) && defined (ADIS16607_SYNC_INPUT_BITMASK)
+    if (ADIS16607_SYNC_INPUT_BITMASK & (1U << accel_instance)) {
+        calc_sample_and_dec_rate();
+
+        // Configure GPIO2 as SYNC
+        gpio_cfg1 = 0x0040;
+    } else
+#endif
+    {
+        switch (backend_rate_hz) {
+        case 2000:
+            expected_sample_rate_hz = 2390;
+            dec_rate = DEC_RATE_2390HZ;
+            break;
+        case 4000:
+            expected_sample_rate_hz = 4780;
+            dec_rate = DEC_RATE_4780HZ;
+            break;
+        case 8000:
+            expected_sample_rate_hz = 9560;
+            dec_rate = DEC_RATE_9560HZ;
+            break;
+        default:
+            expected_sample_rate_hz = 1195;
+            dec_rate = DEC_RATE_1195HZ;
+            break;
+        }
     }
 
     if (!_imu.register_accel(accel_instance, expected_sample_rate_hz, dev->get_bus_id_devtype(DEVTYPE_INS_ADIS16607)) ||
@@ -157,6 +183,9 @@ void AP_InertialSensor_ADIS16607::start()
         // Enable SPI Writes to Register Map
         write_reg16(REG_WRITE_LOCK, 0xAAAA, false);
         write_reg16(REG_WRITE_LOCK, 0x5555, false);
+
+        // Configure GPIO pins
+        const bool gpio_cfg_ok = write_reg16(REG_USER_GPIO_CFG1, gpio_cfg1, true);
 
         /**
          * Bring rate down
@@ -173,8 +202,22 @@ void AP_InertialSensor_ADIS16607::start()
         write_reg16(REG_WRITE_LOCK, 0x5555, false);
         write_reg16(REG_WRITE_LOCK, 0xAAAA, false);
 
-        if (!rate_ok) {
+        if (!rate_ok || !gpio_cfg_ok) {
+            DEV_PRINTF("ADIS16607: Rate/GPIO config error\n");
             return;
+        }
+
+        if (read_reg16(REG_WRITE_LOCK) != 1U) {
+            DEV_PRINTF("ADIS16607: Register lock failed\n");
+            return;
+        }
+
+        // Read DIAG_STAT twice to ensure clearing possible false errors.
+        if (read_reg16(REG_DIAG_STAT) != 0x0000) {
+            if (read_reg16(REG_DIAG_STAT) != 0x0000) {
+                DEV_PRINTF("ADIS16607: Diag status error\n");
+                return;
+            }
         }
     }
 
@@ -191,6 +234,34 @@ void AP_InertialSensor_ADIS16607::start()
     periodic_handle = dev->register_periodic_callback((1000000UL / backend_rate_hz),
                                                       FUNCTOR_BIND_MEMBER(&AP_InertialSensor_ADIS16607::read_sensor_fifo, void));
 }
+
+#if defined (ADIS16607_SYNC_INPUT_CLOCK_HZ) && defined (ADIS16607_SYNC_INPUT_BITMASK)
+/**
+ * @brief Calculate the DEC_RATE and expected_sample_rate_hz parameters
+ *        when using an external synchronization clock.
+ */
+void AP_InertialSensor_ADIS16607::calc_sample_and_dec_rate()
+{
+    const uint16_t sync_clk = ADIS16607_SYNC_INPUT_CLOCK_HZ;
+
+    if (backend_rate_hz >= sync_clk) {
+        dec_rate = 0;
+        expected_sample_rate_hz = sync_clk;
+    } else {
+        int16_t min_error = INT16_MAX;
+        for (uint8_t i = 0; i < 9; i++) {
+            uint16_t error_abs = abs((sync_clk / (i + 1)) - backend_rate_hz);
+            if (error_abs < min_error) {
+                min_error = error_abs;
+                dec_rate = i;
+                expected_sample_rate_hz = (uint16_t)(sync_clk / (i + 1));
+            } else {
+                break;
+            }
+        }
+    }
+}
+#endif
 
 /**
  * @brief Check dev ID
@@ -230,17 +301,10 @@ bool AP_InertialSensor_ADIS16607::init()
         return false;
     }
 
-    // Ensure DIGITAL_STATUS is 0x0000 for clear possible false errors
-    tries = 10;
-    while ((read_reg16(REG_DIAG_STAT) != 0x0000) && --tries) {
-        hal.scheduler->delay(10);
-    }
-
-    if (tries == 0) {
-        return false;
-    }
-
-    // Ensure that the "BOOTLOAD_BUSY" bit (Bit 0) is low
+    /**
+     * Ensure that the "BOOTLOAD_BUSY" bit (Bit 0) is low
+     * Otherwise, REG_DIAG_STAT may not be able to be cleared in some case.
+     */
     tries = 10;
     while ((read_reg16(REG_DIGITAL_STATUS) & 0x01) && --tries) {
         hal.scheduler->delay(10);
@@ -250,8 +314,25 @@ bool AP_InertialSensor_ADIS16607::init()
         return false;
     }
 
-    // Configure GPIO pins(GPIO3 as DR)
-    write_reg16(REG_USER_GPIO_CFG1, 0x0200, false);
+    // Ensure DIAG_STAT is 0x0000 for clear possible false errors
+    tries = 10;
+    while ((read_reg16(REG_DIAG_STAT) != 0x0000) && --tries) {
+        hal.scheduler->delay(10);
+    }
+
+    if (tries == 0) {
+        return false;
+    }
+
+    // Ensure again that the "BOOTLOAD_BUSY" bit (Bit 0) is low
+    tries = 10;
+    while ((read_reg16(REG_DIGITAL_STATUS) & 0x01) && --tries) {
+        hal.scheduler->delay(10);
+    }
+
+    if (tries == 0) {
+        return false;
+    }
 
     // Init USER_DATA_CFG register if we use burst read mode
     const uint16_t user_data_cfg = USER_DATA_CFG_X_ACCEL_EN | USER_DATA_CFG_Y_ACCEL_EN | USER_DATA_CFG_Z_ACCEL_EN |
@@ -280,8 +361,11 @@ bool AP_InertialSensor_ADIS16607::init()
         return false;
     }
 
+    // If DIAG_STAT is not 0x0000, read twice.
     if (read_reg16(REG_DIAG_STAT) != 0x0000) {
-        return false;
+        if (read_reg16(REG_DIAG_STAT) != 0x0000) {
+            return false;
+        }
     }
 
     dev->set_speed(AP_HAL::Device::SPEED_HIGH);

--- a/libraries/AP_InertialSensor/AP_InertialSensor_ADIS16607.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_ADIS16607.h
@@ -62,6 +62,7 @@ private:
     bool check_dev_id();
     void accumulate_samples(const struct adis_fifo_data *fifo, const uint8_t num);
     void read_sensor_fifo(void);
+    void calc_sample_and_dec_rate();
 
     // read a 16 bit register
     uint16_t read_reg16(uint8_t regnum) const;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_ADIS16607.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_ADIS16607.h
@@ -62,6 +62,9 @@ private:
     bool check_dev_id();
     void accumulate_samples(const struct adis_fifo_data *fifo, const uint8_t num);
     void read_sensor_fifo(void);
+#if defined (ADIS16607_SYNC_INPUT_CLOCK_HZ) && defined (ADIS16607_SYNC_INPUT_BITMASK)
+    void calc_sample_and_dec_rate();
+#endif
 
     // read a 16 bit register
     uint16_t read_reg16(uint8_t regnum) const;


### PR DESCRIPTION
### Summary

This PR add sync clock input support for ADIS16607 IMU.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [x] Logs attached
- [x] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

This sensor has a different sampling frequency for each individual unit. With a synchronous clock input, we can achieve a more consistent sampling frequency.

This defines two macros: `ADIS16607_SYNC_INPUT_BITMASK` and `ADIS16607_SYNC_INPUT_CLOCK_HZ` to enable the sync clock input function.
`ADIS16607_SYNC_INPUT_BITMASK` specifies which IMU instance to be enabled.
`ADIS16607_SYNC_INPUT_CLOCK_HZ` specifies the input clock frequency.

Here are the sampling frequency test data logs with/without 8kHz sync clock input:
8kHz sync clock input and downsampling to 2kHz:
<img width="1128" height="459" alt="sync_clock_2k" src="https://github.com/user-attachments/assets/ed426c7d-556a-453e-ac62-41bfdccc2f7c" />

No sync clock and downsampling to 2kHz::
<img width="1135" height="507" alt="no_sync_clock" src="https://github.com/user-attachments/assets/ebc4809c-8ae1-40b3-b756-29dfd85cd62c" />

Log file:
[sync_clock.zip](https://github.com/user-attachments/files/28340985/sync_clock.zip)
[no_sync_clock.zip](https://github.com/user-attachments/files/28340993/no_sync_clock.zip)
