### PR TITLE
.markdownlint-cli2.jsonc: ignore lua-language-server

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -4,7 +4,8 @@
   "ignores": [
     "libraries/AP_GyroFFT/CMSIS_5/**",
     "libraries/AP_ADSB/sagetech-sdk/**",
-    "modules/**"
+    "modules/**",
+    "lua-language-server/**"
   ],
   "config": {
     // Disable rules that are currently violated in the codebase


### PR DESCRIPTION
### Summary

If you want to run the markdown check locally and have run the scripting check it pulls up all the readme's in the locally copy of the language server.

<!-- Put a one or two line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->

Example of failing checks:

<img width="1180" height="287" alt="image" src="https://github.com/user-attachments/assets/c622460d-7c65-4656-9e61-4fab09ad94af" />
