### PR TITLE
AP_AHRS: remove primary IMU

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -442,16 +442,17 @@ void AP_AHRS::reset_gyro_drift(void)
  */
 void AP_AHRS::update_state(void)
 {
-    const uint8_t primary_gyro = _get_primary_gyro_index();
+    const uint8_t primary_gyro = active_estimates->primary_gyro;
 #if AP_INERTIALSENSOR_ENABLED
     // tell the IMUS about primary changes
     if (primary_gyro != state.primary_gyro) {
         AP::ins().set_primary(primary_gyro);
     }
 #endif
-    state.primary_IMU = _get_primary_IMU_index();
     state.primary_gyro = primary_gyro;
-    state.primary_accel = _get_primary_accel_index();
+
+    state.primary_accel = active_estimates->primary_accel;
+
     state.primary_core = _get_primary_core_index();
     state.wind_estimate_ok = active_backend->wind_estimate(state.wind_estimate);
     state.EAS2TAS = AP_AHRS_Backend::get_EAS2TAS();
@@ -2804,42 +2805,6 @@ uint8_t AP_AHRS::get_active_airspeed_index() const
 #endif // AP_AIRSPEED_ENABLED
 }
 
-// get the index of the current primary IMU
-uint8_t AP_AHRS::_get_primary_IMU_index() const
-{
-    int8_t imu = -1;
-    switch (active_EKF_type()) {
-#if AP_AHRS_DCM_ENABLED
-    case EKFType::DCM:
-        break;
-#endif
-#if HAL_NAVEKF2_AVAILABLE
-    case EKFType::TWO:
-        // let EKF2 choose primary IMU
-        imu = ekf2.EKF2.getPrimaryCoreIMUIndex();
-        break;
-#endif
-#if HAL_NAVEKF3_AVAILABLE
-    case EKFType::THREE:
-        // let EKF2 choose primary IMU
-        imu = ekf3.EKF3.getPrimaryCoreIMUIndex();
-        break;
-#endif
-#if AP_AHRS_SIM_ENABLED
-    case EKFType::SIM:
-        break;
-#endif
-#if AP_AHRS_EXTERNAL_ENABLED
-    case EKFType::EXTERNAL:
-        break;
-#endif
-    }
-    if (imu == -1) {
-        imu = AP::ins().get_first_usable_gyro();
-    }
-    return imu;
-}
-
 // return the index of the primary core or -1 if no primary core selected
 int8_t AP_AHRS::_get_primary_core_index() const
 {
@@ -2874,18 +2839,6 @@ int8_t AP_AHRS::_get_primary_core_index() const
     // we should never get here
     INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
     return -1;
-}
-
-// get the index of the current primary accelerometer sensor
-uint8_t AP_AHRS::_get_primary_accel_index(void) const
-{
-    return _get_primary_IMU_index();
-}
-
-// get the index of the current primary gyro sensor
-uint8_t AP_AHRS::_get_primary_gyro_index(void) const
-{
-    return _get_primary_IMU_index();
 }
 
 // see if EKF lane switching is possible to avoid EKF failsafe

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -688,7 +688,7 @@ public:
 
     // return primary accels
     const Vector3f &get_accel(void) const {
-        return AP::ins().get_accel(_get_primary_accel_index());
+        return AP::ins().get_accel(get_primary_accel_index());
     }
 
     // return primary accel bias. This should be subtracted from
@@ -982,15 +982,6 @@ private:
     // return the index of the primary core or -1 if no primary core selected
     int8_t _get_primary_core_index() const;
 
-    // get the index of the current primary accelerometer sensor
-    uint8_t _get_primary_accel_index(void) const;
-
-    // get the index of the current primary gyro sensor
-    uint8_t _get_primary_gyro_index(void) const;
-
-    // get the index of the current primary IMU
-    uint8_t _get_primary_IMU_index(void) const;
-
     // get current location estimate
     bool _get_location(Location &loc) const;
 
@@ -1015,7 +1006,6 @@ private:
      */
     struct {
         EKFType active_EKF_type;
-        uint8_t primary_IMU;
         uint8_t primary_gyro;
         uint8_t primary_accel;
         uint8_t primary_core;

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -60,6 +60,9 @@ public:
         friend class AP_AHRS_NavEKF2;
         friend class AP_AHRS_NavEKF3;
 
+        // inertial sensor information
+        uint8_t primary_gyro;
+
         // if attitude_valid is true then all of the
         // eulers/quaternion/matrix must be valid:
         bool attitude_valid;
@@ -80,6 +83,9 @@ public:
 
         Vector3f gyro_estimate;
         Vector3f gyro_drift;
+
+        uint8_t primary_accel;
+
         Vector3f accel_ef;
         Vector3f accel_bias;
 

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -149,15 +149,6 @@ public:
     // init sets up INS board orientation
     virtual void init();
 
-    // get the index of the current primary gyro sensor
-    virtual uint8_t get_primary_gyro_index(void) const {
-#if AP_INERTIALSENSOR_ENABLED
-        return AP::ins().get_first_usable_gyro();
-#else
-        return 0;
-#endif
-    }
-
     // Methods
     virtual void update() = 0;
 

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -143,6 +143,10 @@ AP_AHRS_DCM::update()
 
 void AP_AHRS_DCM::get_results(AP_AHRS_Backend::Estimates &results)
 {
+    // not using a specific sensor:
+    results.primary_gyro = AP::ins().get_first_usable_gyro();
+    results.primary_accel = AP::ins().get_first_usable_accel();
+
     results.roll_rad = roll;
     results.pitch_rad = pitch;
     results.yaw_rad = yaw;

--- a/libraries/AP_AHRS/AP_AHRS_External.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_External.cpp
@@ -23,7 +23,14 @@ bool AP_AHRS_External::healthy() const {
 void AP_AHRS_External::get_results(AP_AHRS_Backend::Estimates &results)
 {
     auto &extahrs = AP::externalAHRS();
+
+#if AP_INERTIALSENSOR_ENABLED
     const AP_InertialSensor &_ins = AP::ins();
+    // not using specific sensors:
+    results.primary_gyro = _ins.get_first_usable_gyro();
+    results.primary_accel = _ins.get_first_usable_accel();
+#endif  // AP_INERTIALSENSOR_ENABLED
+
     if (!extahrs.get_quaternion(results.quaternion)) {
         results.attitude_valid = false;
         return;
@@ -34,12 +41,16 @@ void AP_AHRS_External::get_results(AP_AHRS_Backend::Estimates &results)
 
     results.gyro_drift.zero();
     if (!extahrs.get_gyro(results.gyro_estimate)) {
+#if AP_INERTIALSENSOR_ENABLED
         results.gyro_estimate = _ins.get_gyro();
+#endif  // AP_INERTIALSENSOR_ENABLED
     }
 
     Vector3f accel;
     if (!extahrs.get_accel(accel)) {
+#if AP_INERTIALSENSOR_ENABLED
         accel = _ins.get_accel();
+#endif  // AP_INERTIALSENSOR_ENABLED
     }
 
     const Vector3f accel_ef = results.dcm_matrix * AP::ahrs().get_rotation_autopilot_body_to_vehicle_body() * accel;

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF2.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF2.cpp
@@ -12,6 +12,31 @@ NavEKF2 AP_AHRS_NavEKF2::EKF2;
 
 void AP_AHRS_NavEKF2::get_results(AP_AHRS_Backend::Estimates &results)
 {
+    const AP_InertialSensor &_ins = AP::ins();
+
+    /*
+     * rotational rate estimates:
+     */
+
+    // The backend should tell us what gyro it is using right now.
+    // There's no API for that at the moment, so we assume the
+    // gyro corresponds to the IMU index.
+    const int8_t ek2_primary_gyro = EKF2.getPrimaryCoreIMUIndex();
+    if (ek2_primary_gyro == -1) {
+        results.primary_gyro = _ins.get_first_usable_gyro();
+    } else {
+        results.primary_gyro = ek2_primary_gyro;
+    }
+
+    // get gyro bias for primary EKF and change sign to give gyro drift
+    // Note sign convention used by EKF is bias = measurement - truth
+    Vector3f drift;
+    EKF2.getGyroBias(drift);
+    results.gyro_drift = -drift;
+
+    // use the same IMU as the primary EKF and correct for gyro drift
+    results.gyro_estimate = _ins.get_gyro(results.primary_gyro) + results.gyro_drift;
+
     /*
      * attitude estimates:
      */
@@ -28,31 +53,24 @@ void AP_AHRS_NavEKF2::get_results(AP_AHRS_Backend::Estimates &results)
     results.attitude_valid = started;
 
     /*
-     * rotational rate estimates:
-     */
-    // Use the primary EKF to select the primary gyro
-    const AP_InertialSensor &_ins = AP::ins();
-    const int8_t primary_imu = EKF2.getPrimaryCoreIMUIndex();
-    const uint8_t primary_gyro = primary_imu>=0?primary_imu:_ins.get_first_usable_gyro();
-    const uint8_t primary_accel = primary_imu>=0?primary_imu:_ins.get_first_usable_accel();
-
-    // get gyro bias for primary EKF and change sign to give gyro drift
-    // Note sign convention used by EKF is bias = measurement - truth
-    Vector3f drift;
-    EKF2.getGyroBias(drift);
-    results.gyro_drift = -drift;
-
-    // use the same IMU as the primary EKF and correct for gyro drift
-    results.gyro_estimate = _ins.get_gyro(primary_gyro) + results.gyro_drift;
-
-    /*
      * acceleration estimates
      */
+
+    // The backend should tell us what accelerometer it is using
+    // right now.  There's no API for that at the moment, so we assume
+    // the accelerometer corresponds to the IMU index.
+    const int8_t ek2_primary_accel = EKF2.getPrimaryCoreIMUIndex();
+    if (ek2_primary_accel == -1) {
+        results.primary_accel = _ins.get_first_usable_accel();
+    } else {
+        results.primary_accel = ek2_primary_accel;
+    }
+
     // get z accel bias estimate from active EKF (this is usually for the primary IMU)
     EKF2.getAccelZBias(results.accel_bias.z);
 
     // This EKF is currently using primary_imu, and a bias applies to only that IMU
-    Vector3f accel = _ins.get_accel(primary_accel);
+    Vector3f accel = _ins.get_accel(results.primary_accel);
     accel.z -= results.accel_bias.z;
     results.accel_ef = results.dcm_matrix * AP::ahrs().get_rotation_autopilot_body_to_vehicle_body() * accel;
 

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
@@ -12,6 +12,30 @@ NavEKF3 AP_AHRS_NavEKF3::EKF3;
 
 void AP_AHRS_NavEKF3::get_results(AP_AHRS_Backend::Estimates &results)
 {
+    const AP_InertialSensor &_ins = AP::ins();
+
+    /*
+     * rotational rate estimates:
+     */
+    // The backend should tell us what gyro it is using right now.
+    // There's no API for that at the moment, so we assume the
+    // gyro corresponds to the IMU index.
+    const int8_t ek3_primary_gyro = EKF3.getPrimaryCoreIMUIndex();
+    if (ek3_primary_gyro == -1) {
+        results.primary_gyro = _ins.get_first_usable_gyro();
+    } else {
+        results.primary_gyro = ek3_primary_gyro;
+    }
+
+    // get gyro bias for primary EKF and change sign to give gyro drift
+    // Note sign convention used by EKF is bias = measurement - truth
+    Vector3f drift;
+    EKF3.getGyroBias(-1, drift);
+    results.gyro_drift = -drift;
+
+    // use the same IMU as the primary EKF and correct for gyro drift
+    results.gyro_estimate = _ins.get_gyro(results.primary_gyro) + results.gyro_drift;
+
     /*
      * attitude estimates:
      */
@@ -29,33 +53,25 @@ void AP_AHRS_NavEKF3::get_results(AP_AHRS_Backend::Estimates &results)
     results.attitude_valid = started;
 
     /*
-     * rotational rate estimates:
-     */
-    const AP_InertialSensor &_ins = AP::ins();
-
-    // Use the primary EKF to select the primary gyro
-    const int8_t primary_imu = EKF3.getPrimaryCoreIMUIndex();
-    const uint8_t primary_gyro = primary_imu>=0?primary_imu:_ins.get_first_usable_gyro();
-    const uint8_t primary_accel = primary_imu>=0?primary_imu:_ins.get_first_usable_accel();
-
-    // get gyro bias for primary EKF and change sign to give gyro drift
-    // Note sign convention used by EKF is bias = measurement - truth
-    Vector3f drift;
-    EKF3.getGyroBias(-1, drift);
-    results.gyro_drift = -drift;
-
-    // use the same IMU as the primary EKF and correct for gyro drift
-    results.gyro_estimate = _ins.get_gyro(primary_gyro) + results.gyro_drift;
-
-    /*
      * acceleration estimates
      */
+
+    // The backend should tell us what accelerometer it is using
+    // right now.  There's no API for that at the moment, so we assume
+    // the accelerometer corresponds to the IMU index.
+    const int8_t ek3_primary_accel = EKF3.getPrimaryCoreIMUIndex();
+    if (ek3_primary_accel == -1) {
+        results.primary_accel = _ins.get_first_usable_accel();
+    } else {
+        results.primary_accel = ek3_primary_accel;
+    }
+
     // get 3-axis accel bias estimates for active EKF (this is usually
     // for the primary IMU)
     EKF3.getAccelBias(-1, results.accel_bias);
 
     // use the primary IMU for accel earth frame
-    Vector3f accel = _ins.get_accel(primary_accel);
+    Vector3f accel = _ins.get_accel(results.primary_accel);
     accel -= results.accel_bias;
     results.accel_ef = results.dcm_matrix * AP::ahrs().get_rotation_autopilot_body_to_vehicle_body() * accel;
 

--- a/libraries/AP_AHRS/AP_AHRS_SIM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_SIM.cpp
@@ -178,6 +178,10 @@ void AP_AHRS_SIM::get_results(AP_AHRS_Backend::Estimates &results)
         }
     }
 
+    // not using a specific sensor:
+    results.primary_gyro = AP::ins().get_first_usable_gyro();
+    results.primary_accel = AP::ins().get_first_usable_accel();
+
     const struct SITL::sitl_fdm &fdm = _sitl->state;
     const AP_InertialSensor &_ins = AP::ins();
 


### PR DESCRIPTION
### Summary

Removes the primary_IMU method and instead pushes the primary-imu/primary-gyro down into the results object.

Alternative to https://github.com/ArduPilot/ardupilot/pull/33223

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                 *                                                   
Durandal                            8               8      *           8       0                 8      0      8
Hitec-Airspeed           *                                 *                                                   
KakuteH7-bdshot                     0               0      *           -8      -8                -16    -8     0
MatekF405                           -16             -8     *           -16     -16               -8     -16    -8
MatekH7A3                           0               0      *           -8      -32               -24    0      -16
Pixhawk1-1M-bdshot                  0               0                  72      64                -88    -40    -96
SITL_x86_64_linux_gnu               -64             -64                -64     -64               -120   -72    -64
YJUAV_A6SE                          -16             -24    *           -8      -8                -40    0      16
f103-QiotekPeriph        *                                 *                                                   
f303-MatekGPS            *                                 *                                                   
f303-Universal           *                                 *                                                   
iomcu                                                                                *                         
mindpx-v2                           -8              -8     *           -16     -8                -16    -16    -8
revo-mini                           -16             -16    *           16      56                72     -80    -48
skyviper-v2450                                                         -8                                      
speedybeef4                         0               -8     *           -64     16                -64    0      -32
```

### Description

keep primary accel and primary gyro

Turns out we should be doing a lot better when reporting this information.

The EKFs will move to using first-usable if they're having issues with their allocated IMU:
```
    if (ins.use_accel(imu_index)) {
        accel_active = imu_index;
    } else {
        accel_active = ins.get_first_usable_accel();
    }
```
Something to fix into the future: we don't actually report that up the chain as we should... (that's a `_core` function, BTW)


