### PR TITLE
Sub: eliminate pointless climb_rate member

### DIFF
--- a/ArduSub/Log.cpp
+++ b/ArduSub/Log.cpp
@@ -51,7 +51,7 @@ void Sub::Log_Write_Control_Tuning()
         rangefinder_alt           : rangefinder_state.alt,
         terr_alt            : terr_alt,
         target_climb_rate   : (int16_t)pos_control.get_vel_target_U_cms(),
-        climb_rate          : climb_rate
+        climb_rate          : int16_t(pos_control.get_vel_estimate_U_ms() * 100.0f)
     };
     logger.WriteBlock(&pkt, sizeof(pkt));
 }

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -281,10 +281,6 @@ private:
 
     AP_Arming_Sub arming;
 
-    // Altitude
-    // The cm/s we are moving up or down based on filtered data - Positive = UP
-    int16_t climb_rate;
-
     // Turn counter
     int32_t quarter_turn_count;
     uint8_t last_turn_state;

--- a/ArduSub/inertia.cpp
+++ b/ArduSub/inertia.cpp
@@ -19,8 +19,4 @@ void Sub::read_inertia()
     }
 
     current_loc.alt = pos_control.get_pos_estimate_U_m() * 100.0f;
-
-    // get velocity, altitude is always absolute frame, referenced from
-    // water's surface
-    climb_rate = pos_control.get_vel_estimate_U_ms() * 100.0f;
 }


### PR DESCRIPTION
### Summary

Removes a member populated in inertia.cpp but not used for anything but logging

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

We'd like to get rid of inertia library...


<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
