### PR TITLE
Avoid over-reading valid data in an array

### DIFF
--- a/libraries/Filter/HarmonicNotchFilter.cpp
+++ b/libraries/Filter/HarmonicNotchFilter.cpp
@@ -491,13 +491,14 @@ void HarmonicNotchFilter<T>::log_notch_centers(uint8_t instance, uint64_t now_us
     float centers[6] {};
     float first_harmonic[6] {};
 
+    // filters are ordered: f1h1, f2h1, ..., fNh1, f1h2, f2h2, ..., fNh2, ...
+    const uint16_t second_harmonic_offset = num_sources * _composite_notches;
     for (uint8_t i=0; i<num_sources; i++) {
-        /*
-          note the ordering of the filters from update() above:
-            f1h1, f2h1, f3h1, f4h1, f1h2, f2h2, f3h2, f4h2 etc
-         */
         centers[i] = _filters[i*_composite_notches].logging_frequency();
-        first_harmonic[i] = _filters[num_sources*_composite_notches + i*_composite_notches].logging_frequency();
+        const uint16_t h2_idx = second_harmonic_offset + i*_composite_notches;
+        if (h2_idx < _num_filters) {
+            first_harmonic[i] = _filters[h2_idx].logging_frequency();
+        }
     }
 
     if (num_sources > 1) {


### PR DESCRIPTION
### Summary

Avoid valid-data-overread in harmonic notch logging.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Closes https://github.com/ArduPilot/ardupilot/issues/33230

This is a blunt approach to avoiding a valid-buffer-data-overread which the issue explains.

I have not done any sort of deep-dive into these harmonic-notch arrays to see whether there actually really, really should be valid data written to the offsets which are causing problems - it may actually be that the correct fix is not to constrain the read here but to work out why there's no valid data at these offsets to be read!  If the latter really is the problem it could be a rather more serious bug than reported.  i.e. I don't trust claude's appraisal here.

Either I need to find time to deep-dive this code or someone who is more familiar with it will need to weigh in.

Valgrind doesn't pick this up because the space *is* allocated appropriately.  ASAN *does* pick the problem up as no valid data is written there.  I'm going to bring patches to allow `--asan` to `autotest.py` - which does fail the autotest which picked this problem up as well as at least one more test.
