### PR TITLE
ASAN fixes and autotest integration

### DIFF
--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -719,9 +719,10 @@ arducopter and upload it to my board".
 
     g.add_option('--asan',
         action='store_true',
-        help='''Build using the macOS clang Address Sanitizer. In order to run with
-Address Sanitizer support llvm-symbolizer is required to be on the PATH.
-This option is only supported on macOS versions of clang.
+        help='''Build using the clang Address Sanitizer (Linux and macOS). Requires
+clang to be selected via the CXX/CC environment variables, e.g.:
+  CXX=clang++-19 CC=clang-19 ./waf configure --board sitl --asan
+llvm-symbolizer must be on the PATH for symbolised reports.
 ''')
 
     g.add_option('--ubsan',

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -875,7 +875,9 @@ class SITLBoard(Board):
                 '-O3',
             ]
 
-        if 'clang++' in cfg.env.COMPILER_CXX and cfg.options.asan:
+        if cfg.options.asan:
+            if not cfg.env.DEBUG:
+                cfg.fatal('--asan requires --debug for reliable instrumentation')
             env.CXXFLAGS += [
                 '-fsanitize=address',
                 '-fno-omit-frame-pointer',
@@ -890,8 +892,8 @@ class SITLBoard(Board):
 
         env.LINKFLAGS += ['-pthread',]
 
-        if cfg.env.DEBUG and 'clang++' in cfg.env.COMPILER_CXX and cfg.options.asan:
-             env.LINKFLAGS += ['-fsanitize=address']
+        if 'clang++' in cfg.env.COMPILER_CXX and cfg.options.asan:
+            env.LINKFLAGS += ['-fsanitize=address']
 
         env.AP_LIBRARIES += [
             'AP_HAL_SITL',

--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -427,6 +427,7 @@ def run_step(step):
         "ubsan_abort" : opts.ubsan_abort,
         "num_aux_imus" : opts.num_aux_imus,
         "dronecan_tests" : opts.dronecan_tests,
+        "asan" : opts.asan,
     }
 
     if opts.Werror:
@@ -509,6 +510,7 @@ def run_step(step):
         "use_map": opts.map,
         "valgrind": opts.valgrind,
         "callgrind": opts.callgrind,
+        "asan": opts.asan,
         "gdb": opts.gdb,
         "gdb_no_tui": opts.gdb_no_tui,
         "lldb": opts.lldb,
@@ -987,6 +989,10 @@ if __name__ == "__main__":
                          default=False,
                          action='store_true',
                          help='run ArduPilot binaries under valgrind')
+    group_sim.add_option("--asan",
+                         default=False,
+                         action='store_true',
+                         help='enable ASAN error checking (binary must be built with --asan --debug)')
     group_sim.add_option("", "--callgrind",
                          action='store_true',
                          default=False,
@@ -1067,6 +1073,8 @@ if __name__ == "__main__":
             opts.timeout *= 10
         elif opts.callgrind:
             opts.timeout *= 10
+        elif opts.asan:
+            opts.timeout *= 2
         elif opts.gdb:
             opts.timeout = None
 

--- a/Tools/autotest/pysim/util.py
+++ b/Tools/autotest/pysim/util.py
@@ -45,7 +45,7 @@ def reltopdir(path):
     return os.path.normpath(os.path.join(topdir(), path))
 
 
-def run_cmd(cmd, directory=".", show=True, output=False, checkfail=True):
+def run_cmd(cmd, directory=".", show=True, output=False, checkfail=True, env=None):
     """Run a shell command."""
     shell = False
     if not isinstance(cmd, list):
@@ -54,11 +54,11 @@ def run_cmd(cmd, directory=".", show=True, output=False, checkfail=True):
     if show:
         print("Running: (%s) in (%s)" % (cmd_as_shell(cmd), directory,))
     if output:
-        return subprocess.Popen(cmd, shell=shell, stdout=subprocess.PIPE, cwd=directory).communicate()[0]
+        return subprocess.Popen(cmd, shell=shell, stdout=subprocess.PIPE, cwd=directory, env=env).communicate()[0]
     elif checkfail:
-        return subprocess.check_call(cmd, shell=shell, cwd=directory)
+        return subprocess.check_call(cmd, shell=shell, cwd=directory, env=env)
     else:
-        return subprocess.call(cmd, shell=shell, cwd=directory)
+        return subprocess.call(cmd, shell=shell, cwd=directory, env=env)
 
 
 def rmfile(path):
@@ -92,7 +92,8 @@ def waf_configure(board,
                   ubsan_abort=False,
                   num_aux_imus=0,
                   dronecan_tests=False,
-                  extra_defines: dict | None = None):
+                  extra_defines: dict | None = None,
+                  asan=False):
 
     if extra_args is None:
         extra_args = []
@@ -129,7 +130,41 @@ def waf_configure(board,
     pieces = [shlex.split(x) for x in extra_args]
     for piece in pieces:
         cmd_configure.extend(piece)
-    run_cmd(cmd_configure, directory=topdir(), checkfail=True)
+
+    configure_env = None
+    if asan:
+        cmd_configure.append('--asan')
+        if not debug:
+            cmd_configure.append('--debug')  # waf enforces this; be explicit
+        # Resolve the clang compiler. Honour CXX/CC if already set by the
+        # caller; otherwise search for a versioned clang++ by counting down
+        # from a high version number so we pick the newest one available.
+        # The unversioned 'clang++' is tried last as a fallback.
+        import shutil
+        cxx = os.environ.get('CXX')
+        if not cxx:
+            for ver in range(99, 13, -1):
+                candidate = 'clang++-%u' % ver
+                if shutil.which(candidate):
+                    cxx = candidate
+                    break
+            if not cxx and shutil.which('clang++'):
+                cxx = 'clang++'
+        cc = os.environ.get('CC')
+        if not cc:
+            # Derive cc from the cxx version we found so both compilers are
+            # from the same toolchain (e.g. clang++-19 → clang-19).
+            if cxx and cxx != 'clang++':
+                cc = cxx.replace('clang++', 'clang')
+            elif shutil.which('clang'):
+                cc = 'clang'
+        if not cxx or not cc:
+            raise RuntimeError("--asan requires clang; install clang or set CXX/CC environment variables")
+        configure_env = dict(os.environ)
+        configure_env['CXX'] = cxx
+        configure_env['CC'] = cc
+
+    run_cmd(cmd_configure, directory=topdir(), checkfail=True, env=configure_env)
 
 
 def waf_clean():
@@ -161,6 +196,7 @@ def build_SITL(
         ubsan_abort=False,
         num_aux_imus=0,
         dronecan_tests=False,
+        asan=False,
 ):
     if extra_configure_args is None:
         extra_configure_args = []
@@ -182,7 +218,8 @@ def build_SITL(
                       extra_defines=extra_defines,
                       num_aux_imus=num_aux_imus,
                       dronecan_tests=dronecan_tests,
-                      extra_args=extra_configure_args,)
+                      extra_args=extra_configure_args,
+                      asan=asan,)
 
     # then clean
     if clean:
@@ -300,7 +337,8 @@ def build_tests(board,
                 ubsan_abort=False,
                 num_aux_imus=0,
                 dronecan_tests=False,
-                extra_configure_args: list | None = None):
+                extra_configure_args: list | None = None,
+                asan=False):
     if extra_configure_args is None:
         extra_configure_args = []
 
@@ -318,7 +356,8 @@ def build_tests(board,
                       ubsan_abort=ubsan_abort,
                       num_aux_imus=num_aux_imus,
                       dronecan_tests=dronecan_tests,
-                      extra_args=extra_configure_args,)
+                      extra_args=extra_configure_args,
+                      asan=asan,)
 
     # then clean
     if clean:
@@ -399,6 +438,13 @@ def valgrind_log_filepath(binary, model):
     if model is None:
         model = 'None'
     return make_safe_filename('%s-%s-valgrind.log' % (os.path.basename(binary), model,))
+
+
+def asan_log_filepath(binary, model):
+    if model is None:
+        model = 'None'
+    # ASAN appends .<pid> to this path; glob with asan_log_filepath(...)+".*"
+    return make_safe_filename('%s-%s-asan' % (os.path.basename(binary), model))
 
 
 def kill_screen_gdb():
@@ -484,6 +530,7 @@ def start_SITL(binary,
                enable_fgview=False,
                supplementary=False,
                stdout_prefix=None,
+               asan=False,
                ):
     """Launch a SITL instance."""
 
@@ -667,7 +714,18 @@ def start_SITL(binary,
 
         first = cmd[0]
         rest = cmd[1:]
-        child = pexpect.spawn(str(first), rest, logfile=pexpect_logfile, encoding='ascii', timeout=5, cwd=cwd)
+        spawn_env = None
+        if asan:
+            spawn_env = dict(os.environ)
+            log_base = asan_log_filepath(binary=binary, model=model)
+            existing = spawn_env.get('ASAN_OPTIONS', '')
+            # Append our options after any inherited ones so that our
+            # log_path and verbosity=0 take precedence (last value wins).
+            # verbosity=0 suppresses startup noise that would make the log
+            # non-empty even when no errors are detected.
+            our_opts = 'log_path=%s:symbolize=1:verbosity=0' % log_base
+            spawn_env['ASAN_OPTIONS'] = (existing + ':' + our_opts) if existing else our_opts
+        child = pexpect.spawn(str(first), rest, logfile=pexpect_logfile, encoding='ascii', timeout=5, cwd=cwd, env=spawn_env)
         pexpect_autoclose(child)
     if gdb or lldb:
         # if we run GDB we do so in an xterm.  "Waiting for

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -2555,6 +2555,7 @@ class TestSuite(abc.ABC):
             "BATT2_MONITOR": 4,   # AP_BattMonitor: instance 1 (Analog V+I)
             "FILT1_TYPE": 1,      # AP_Filter: NotchFilter backend
             "TEMP1_TYPE": 8,      # AP_TemperatureSensor: SHT3X (simulated in SITL)
+            "TEMP1_ADDR": 0x44,   # SHT3X I2C address (avoid conflicting with TSYS01 at 0x77)
             "GEN_TYPE": 1,        # AP_Generator: IE_650_800 backend
             "CC_TYPE": 2,         # AC_CustomControl: PID backend (ArduCopter)
         }

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -1924,6 +1924,16 @@ class ValgrindFailedResult(Result):
         return "Valgrind error detected"
 
 
+class ASANFailedResult(Result):
+    '''a custom Result to allow passing of ASAN failures around'''
+    def __init__(self):
+        super(ASANFailedResult, self).__init__(None)
+        self.passed = False
+
+    def __str__(self):
+        return "ASAN error detected"
+
+
 class TestSuite(abc.ABC):
     """Base abstract class.
     It implements the common function for all vehicle types.
@@ -1959,6 +1969,7 @@ class TestSuite(abc.ABC):
                  build_opts: dict | None = None,
                  enable_fgview=False,
                  move_logs_on_test_failure: bool = False,
+                 asan=False,
                  ):
         if breakpoints is None:
             breakpoints = []
@@ -1975,6 +1986,8 @@ class TestSuite(abc.ABC):
         self.binary = binary
         self.valgrind = valgrind
         self.callgrind = callgrind
+        self.asan = asan
+        self.known_corefiles = set()
         self.gdb = gdb
         self.gdb_no_tui = gdb_no_tui
         self.lldb = lldb
@@ -9327,12 +9340,12 @@ Also, ignores heartbeats not from our target system'''
             util.pexpect_close(self._mavproxy)
             self._mavproxy = None
 
-        corefiles = []
-        corefiles.extend(glob.glob("core*"))
-        corefiles.extend(glob.glob("ap-*.core"))
-        if corefiles:
-            self.progress('Corefiles detected: %s' % str(corefiles))
+        all_corefiles = set(glob.glob("core*") + glob.glob("ap-*.core"))
+        new_corefiles = all_corefiles - self.known_corefiles
+        if new_corefiles:
+            self.progress('New corefiles detected: %s' % sorted(new_corefiles))
             passed = False
+            self.known_corefiles |= new_corefiles
 
         if len(self.contexts) != old_contexts_length:
             self.progress("context count mismatch (want=%u got=%u); popping extras" %
@@ -9404,6 +9417,8 @@ Also, ignores heartbeats not from our target system'''
         pexpect_timeout = 60
         if self.valgrind or self.callgrind:
             pexpect_timeout *= 10
+        elif self.asan:
+            pexpect_timeout *= 2
 
         if sitl_rcin_port is None:
             sitl_rcin_port = self.sitl_rcin_port()
@@ -9459,6 +9474,7 @@ Also, ignores heartbeats not from our target system'''
             "speedup": self.speedup,
             "valgrind": self.valgrind,
             "callgrind": self.callgrind,
+            "asan": self.asan,
             "wipe": True,
             "enable_fgview": self.enable_fgview,
         }
@@ -9524,6 +9540,7 @@ Also, ignores heartbeats not from our target system'''
             "speedup": self.speedup,
             "valgrind": self.valgrind,
             "callgrind": self.callgrind,
+            "asan": self.asan,
             "wipe": True,
         }
         for i in range(len(self.sup_binaries)):
@@ -12785,6 +12802,20 @@ switch value'''
                 valgrind_failed = True
         if valgrind_failed:
             result_list.append(ValgrindFailedResult())
+
+        if self.asan:
+            asan_log_base = util.asan_log_filepath(binary=self.binary, model=self.frame)
+            files = glob.glob(asan_log_base + ".*")  # ASAN appends .<pid>
+            asan_failed = False
+            for f in files:
+                os.chmod(f, 0o644)
+                if os.path.getsize(f) > 0:
+                    target = self.buildlogs_path("%s-%s" % (self.log_name(), os.path.basename(f)))
+                    self.progress("ASAN log: moving %s to %s" % (f, target))
+                    shutil.move(f, target)
+                    asan_failed = True
+            if asan_failed:
+                result_list.append(ASANFailedResult())
 
         return result_list
 

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
@@ -561,6 +561,11 @@ void AP_FETtecOneWire::pack_fast_throttle_command(const uint16_t *motor_values, 
     uint8_t mot = 0;
     uint8_t bits_remaining_in_this_pwm = 7;
     for (uint8_t out_byte_offset = 2; out_byte_offset<length; out_byte_offset++) {
+        if (mot >= _esc_count) {
+            // all motor bits consumed; remaining bytes are padding before CRC
+            fast_throttle_command[out_byte_offset] = 0;
+            continue;
+        }
         if (bits_remaining_in_this_pwm >= 8) {
             // const uint8_t mask = 0xFF << (11-bits_remaining_in_this_pwm);
             fast_throttle_command[out_byte_offset] = (motor_values[mot] >> (bits_remaining_in_this_pwm-8)) & 0xFF;

--- a/libraries/Filter/HarmonicNotchFilter.cpp
+++ b/libraries/Filter/HarmonicNotchFilter.cpp
@@ -491,13 +491,14 @@ void HarmonicNotchFilter<T>::log_notch_centers(uint8_t instance, uint64_t now_us
     float centers[6] {};
     float first_harmonic[6] {};
 
+    // filters are ordered: f1h1, f2h1, ..., fNh1, f1h2, f2h2, ..., fNh2, ...
+    const uint16_t second_harmonic_offset = num_sources * _composite_notches;
     for (uint8_t i=0; i<num_sources; i++) {
-        /*
-          note the ordering of the filters from update() above:
-            f1h1, f2h1, f3h1, f4h1, f1h2, f2h2, f3h2, f4h2 etc
-         */
         centers[i] = _filters[i*_composite_notches].logging_frequency();
-        first_harmonic[i] = _filters[num_sources*_composite_notches + i*_composite_notches].logging_frequency();
+        const uint16_t h2_idx = second_harmonic_offset + i*_composite_notches;
+        if (h2_idx < _num_filters) {
+            first_harmonic[i] = _filters[h2_idx].logging_frequency();
+        }
     }
 
     if (num_sources > 1) {

--- a/libraries/SITL/SIM_Temperature_TSYS01.cpp
+++ b/libraries/SITL/SIM_Temperature_TSYS01.cpp
@@ -34,8 +34,15 @@ int SITL::TSYS01::rdwr(I2C::i2c_rdwr_ioctl_data *&data)
             if (data->msgs[1].len != 2) {
                 AP_HAL::panic("Unexpected prom read length");
             }
-            uint8_t offs = ARRAY_SIZE(_k)-((uint8_t(command) - uint8_t(Command::READ_PROM0))/2);
-            const uint16_t k = _k[offs];
+            const uint8_t prom_idx = (uint8_t(command) - uint8_t(Command::READ_PROM0))/2;
+            if (prom_idx == 0) {
+                // PROM0 is the unused CRC register; not requested by the driver
+                data->msgs[1].buf[0] = 0;
+                data->msgs[1].buf[1] = 0;
+                break;
+            }
+            // prom_idx 1..5 → _k[5].._k[1] (reversed to match driver's read_prom ordering)
+            const uint16_t k = _k[ARRAY_SIZE(_k) - prom_idx];
             data->msgs[1].buf[0] = k >> 8;
             data->msgs[1].buf[1] = k & 0xFF;
             break;


### PR DESCRIPTION
### Summary

Fixes three bugs found by ASAN, and allows autotests to be run under `--asan`

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Allows someone to run the autotest suite under ASAN.

I did so today and some fixes are included here:
 - off-by-one problem in the TSYS01 (trying to be too clever)
 - problem when packing motor values (missing checks that there was actually still valid motor data to pack!)
 - harmonic notch filter buffer overread (there's [an issue](https://github.com/ArduPilot/ardupilot/issues/33230) and a [pre-existing PR](https://github.com/ArduPilot/ardupilot/pull/33232) for this one


... the i2c addr deconfliction is a bonus extra that fixes a race condition in the Sub parameters test

