### PR TITLE
Ap logger async stop logging

### DIFF
--- a/libraries/AP_Logger/AP_Logger_File.cpp
+++ b/libraries/AP_Logger/AP_Logger_File.cpp
@@ -711,16 +711,31 @@ uint16_t AP_Logger_File::get_num_logs()
  */
 void AP_Logger_File::stop_logging(void)
 {
+    // cancel any pending async stop so we don't double-close
+    stop_log_pending = false;
     // best-case effort to avoid annoying the IO thread
     const bool have_sem = write_fd_semaphore.take(hal.util->get_soft_armed()?1:20);
     if (_write_fd != -1) {
         int fd = _write_fd;
         _write_fd = -1;
+        last_io_operation = "close";
         AP::FS().close(fd);
+        last_io_operation = "";
     }
     if (have_sem) {
         write_fd_semaphore.give();
     }
+}
+
+/*
+  request that the IO thread close the log file. This avoids blocking
+  the main thread on a potentially slow filesystem close() call, which
+  can stall the scheduler long enough to cause GPS UART buffer overflows
+  and EKF variance explosions (especially with LOG_FILE_DSRMROT=1).
+ */
+void AP_Logger_File::stop_logging_async(void)
+{
+    stop_log_pending = true;
 }
 
 /*
@@ -915,6 +930,11 @@ void AP_Logger_File::io_timer(void)
     if (start_new_log_pending) {
         start_new_log();
         start_new_log_pending = false;
+    }
+
+    if (stop_log_pending) {
+        stop_log_pending = false;
+        stop_logging();
     }
 
     if (erase.log_num != 0) {

--- a/libraries/AP_Logger/AP_Logger_File.h
+++ b/libraries/AP_Logger/AP_Logger_File.h
@@ -123,6 +123,7 @@ private:
     uint32_t _get_log_time(const uint16_t log_num);
 
     void stop_logging(void) override;
+    void stop_logging_async(void) override;
 
     uint32_t last_messagewrite_message_sent;
 
@@ -158,6 +159,8 @@ private:
     const char *last_io_operation = "";
 
     bool start_new_log_pending;
+    // stop_logging() was requested asynchronously; io_timer() will close the fd
+    bool stop_log_pending;
 };
 
 #endif // HAL_LOGGING_FILESYSTEM_ENABLED


### PR DESCRIPTION
### Summary

Move AP_Logger_File::stop_logging() to the IO thread to avoid blocking the main scheduler on disarm. (when LOG_FILE_DSRMROT=1)

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

  Using a Cube Orange plus with the log rotation on disarm set to true we are seeing the EKF diverge while closing the old log (the estimated altitude either climbs or descends by about 200m before recovering) 

This goal of this fix is to move the closing to be asynchronous so it doesn't block the main loop and cause the EKF to diverge
<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
