### PR TITLE
AP_Proximity: Move RPLidarA2 defines and descriptors to header

### DIFF
--- a/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp
@@ -47,27 +47,6 @@
   #define Debug(level, fmt, args ...)
 #endif
 
-#define COMM_ACTIVITY_TIMEOUT_MS        200
-
-// Commands
-//-----------------------------------------
-
-// Commands without payload and response
-#define RPLIDAR_PREAMBLE               0xA5
-#define RPLIDAR_CMD_STOP               0x25
-#define RPLIDAR_CMD_SCAN               0x20
-#define RPLIDAR_CMD_FORCE_SCAN         0x21
-#define RPLIDAR_CMD_RESET              0x40
-
-// Commands without payload but have response
-#define RPLIDAR_CMD_GET_DEVICE_INFO    0x50
-#define RPLIDAR_CMD_GET_DEVICE_HEALTH  0x52
-
-#if AP_PROXIMITY_RPLIDAR_EXPRESSSCAN_ENABLED
-// Commands with payload and have response
-#define RPLIDAR_CMD_EXPRESS_SCAN       0x82
-#endif
-
 extern const AP_HAL::HAL& hal;
 
 void AP_Proximity_RPLidarA2::update(void)
@@ -323,21 +302,7 @@ void AP_Proximity_RPLidarA2::get_readings()
             if (_byte_count < sizeof(_descriptor)) {
                 return;
             }
-            // identify the payload data after the descriptor
-            static const _descriptor SCAN_DATA_DESCRIPTOR[] {
-                { RPLIDAR_PREAMBLE, 0x5A, 0x05, 0x00, 0x00, 0x40, 0x81 }
-            };
-            static const _descriptor HEALTH_DESCRIPTOR[] {
-                { RPLIDAR_PREAMBLE, 0x5A, 0x03, 0x00, 0x00, 0x00, 0x06 }
-            };
-            static const _descriptor DEVICE_INFO_DESCRIPTOR[] {
-                { RPLIDAR_PREAMBLE, 0x5A, 0x14, 0x00, 0x00, 0x00, 0x04 }
-            };
-#if AP_PROXIMITY_RPLIDAR_EXPRESSSCAN_ENABLED
-            static const _descriptor EXPRESS_DATA_DESCRIPTOR[] {
-                { RPLIDAR_PREAMBLE, 0x5A, 0x54, 0x00, 0x00, 0x40, 0x85 }
-            };
-#endif
+
             Debug(2,"LIDAR descriptor found");
             if (memcmp((void*)&_payload[0], SCAN_DATA_DESCRIPTOR, sizeof(_descriptor)) == 0) {
                 _state = State::AWAITING_SCAN_DATA;

--- a/libraries/AP_Proximity/AP_Proximity_RPLidarA2.h
+++ b/libraries/AP_Proximity/AP_Proximity_RPLidarA2.h
@@ -48,6 +48,27 @@ reboot
 
 #include "AP_Proximity_Backend_Serial.h"
 
+#define COMM_ACTIVITY_TIMEOUT_MS        200
+
+// Commands
+//-----------------------------------------
+
+// Commands without payload and response
+#define RPLIDAR_PREAMBLE               0xA5
+#define RPLIDAR_CMD_STOP               0x25
+#define RPLIDAR_CMD_SCAN               0x20
+#define RPLIDAR_CMD_FORCE_SCAN         0x21
+#define RPLIDAR_CMD_RESET              0x40
+
+// Commands without payload but have response
+#define RPLIDAR_CMD_GET_DEVICE_INFO    0x50
+#define RPLIDAR_CMD_GET_DEVICE_HEALTH  0x52
+
+#if AP_PROXIMITY_RPLIDAR_EXPRESSSCAN_ENABLED
+// Commands with payload and have response
+#define RPLIDAR_CMD_EXPRESS_SCAN       0x82
+#endif
+
 class AP_Proximity_RPLidarA2 : public AP_Proximity_Backend_Serial
 {
 
@@ -210,6 +231,23 @@ private:
     } model = Model::UNKNOWN;
 
     bool make_first_byte_in_payload(uint8_t desired_byte);
+
+    // identify the payload data after the descriptor
+    inline static constexpr _descriptor SCAN_DATA_DESCRIPTOR[7] {
+        { RPLIDAR_PREAMBLE, 0x5A, 0x05, 0x00, 0x00, 0x40, 0x81 }
+    };
+    inline static constexpr _descriptor HEALTH_DESCRIPTOR[7] {
+        { RPLIDAR_PREAMBLE, 0x5A, 0x03, 0x00, 0x00, 0x00, 0x06 }
+    };
+    inline static constexpr _descriptor DEVICE_INFO_DESCRIPTOR[7] {
+        { RPLIDAR_PREAMBLE, 0x5A, 0x14, 0x00, 0x00, 0x00, 0x04 }
+    };
+#if AP_PROXIMITY_RPLIDAR_EXPRESSSCAN_ENABLED
+    inline static constexpr _descriptor EXPRESS_DATA_DESCRIPTOR[7] {
+        { RPLIDAR_PREAMBLE, 0x5A, 0x54, 0x00, 0x00, 0x40, 0x85 }
+    };
+#endif
+
 };
 
 #endif // AP_PROXIMITY_RPLIDARA2_ENABLED


### PR DESCRIPTION
### Summary

This PR refactors the AP_Proximity_RPLidarA2 driver by moving protocol definitions and descriptor arrays to the header file, improving code readability and memory efficiency.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

**Testing description:**
Successfully compiled using Waf (e.g., `fmuv3` target). Verified that declaring the arrays as `inline static constexpr` properly resolves ODR-use (undefined reference) linking errors without requiring out-of-line definitions in the CPP file.

### Description

This PR refactors the `AP_Proximity_RPLidarA2` driver to centralize the protocol specifications and optimize memory layout. 

**Key Changes:**
* **Centralized Protocol Definitions:** Moved protocol command definitions (e.g., `#define RPLIDAR_CMD_SCAN`) and payload descriptor arrays (`SCAN_DATA_DESCRIPTOR`, etc.) from the `.cpp` file to the `.h` header file. This makes the overall protocol structure immediately visible and much easier to maintain.
* **Memory Optimization:** Declared the descriptor arrays as `inline static constexpr`. This ensures identical fixed data does not consume RAM for each sensor instance, placing them safely in ROM instead. Using `inline` gracefully avoids ODR-use linkage errors without cluttering the `.cpp` file with redundant declarations.