### PR TITLE
AP_Param: avoid variable-length arrays in parameter conversion

### DIFF
--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -694,7 +694,9 @@ const struct AP_Param::Info *AP_Param::find_var_info_token(const ParamToken &tok
     return nullptr;
 }
 
-// return the storage size for a AP_PARAM_* type
+// return the storage size for a AP_PARAM_* type.
+// NOTE: if you add a type here, also add it to AP_Param_value_storage
+// (below) so the value buffers used during conversion stay big enough.
 uint8_t AP_Param::type_size(enum ap_var_type type)
 {
     switch (type) {
@@ -715,6 +717,23 @@ uint8_t AP_Param::type_size(enum ap_var_type type)
     Debug("unknown type %d\n", type);
     return 0;
 }
+
+// a union of every storable parameter type; an object of this type is
+// large enough and suitably aligned to hold the value of any single
+// parameter without assuming which type is largest.  Used as a value
+// buffer during parameter conversion.  Keep the members in sync with
+// type_size().
+union AP_Param_value_storage {
+    // Vector3f has a non-trivial constructor, so the union's default
+    // constructor would otherwise be deleted; the value is always filled
+    // in (read from EEPROM) before use.
+    AP_Param_value_storage() {}
+    int8_t i8;
+    int16_t i16;
+    int32_t i32;
+    float f;
+    Vector3f v3f;
+};
 
 /*
   extract 9 bit key from Param_header
@@ -1985,8 +2004,10 @@ bool AP_Param::find_old_parameter(const struct ConversionInfo *info, AP_Param *v
 // convert one old vehicle parameter to new object parameter
 void AP_Param::convert_old_parameter(const struct ConversionInfo *info, float scaler, uint8_t flags)
 {
-    uint8_t old_value[type_size(info->type)];
-    AP_Param *ap = (AP_Param *)&old_value[0];
+    // a buffer large enough (and aligned) for any parameter value, which
+    // also avoids a VLA here
+    AP_Param_value_storage old_value;
+    AP_Param *ap = (AP_Param *)&old_value;
 
     if (!find_old_parameter(info, ap)) {
         // the old parameter isn't saved in the EEPROM. It was
@@ -2013,9 +2034,12 @@ void AP_Param::convert_old_parameter(const struct ConversionInfo *info, float sc
     // see if they are the same type and no scaling applied
     if (ptype == info->type && is_equal(scaler, 1.0f) && flags == 0) {
         // copy the value over only if the new parameter does not already
-        // have the old value (via a default).
-        if (memcmp(ap2, ap, sizeof(old_value)) != 0) {
-            memcpy(ap2, ap, sizeof(old_value));
+        // have the old value (via a default).  Size the copy by the
+        // parameter type; old_value is large enough for any type, so
+        // sizeof() it would overrun the destination parameter.
+        const uint8_t value_size = type_size(info->type);
+        if (memcmp(ap2, ap, value_size) != 0) {
+            memcpy(ap2, ap, value_size);
             // and save
             ap2->save();
         }
@@ -2087,9 +2111,11 @@ void AP_Param::convert_class(uint16_t param_key, void *object_pointer,
 
         info.old_group_element = (idx << group_shift) + old_index;
 
-        uint8_t old_value[type_size(info.type)];
-        AP_Param *ap = (AP_Param *)&old_value[0];
-        
+        // a buffer large enough (and aligned) for any parameter value,
+        // which also avoids a VLA here
+        AP_Param_value_storage old_value;
+        AP_Param *ap = (AP_Param *)&old_value;
+
         if (!AP_Param::find_old_parameter(&info, ap)) {
             // the parameter wasn't set in the old eeprom
             continue;
@@ -2100,7 +2126,9 @@ void AP_Param::convert_class(uint16_t param_key, void *object_pointer,
             // user has already set a value, or previous conversion was done
             continue;
         }
-        memcpy(ap2, ap, sizeof(old_value));
+        // size the copy by the parameter type; old_value is large enough
+        // for any type, so sizeof() it would overrun the destination
+        memcpy(ap2, ap, type_size(info.type));
         // and save
         ap2->save();
     }
@@ -2175,11 +2203,12 @@ bool AP_Param::_convert_parameter_width(ap_var_type old_ptype, float scale_facto
         return false;
     }
 
-    // load the old value from EEPROM
-    uint8_t old_value[type_size(old_ptype)];
-    _storage.read_block(old_value, pofs+sizeof(phdr), sizeof(old_value));
-    
-    AP_Param *old_ap = (AP_Param *)&old_value[0];
+    // load the old value from EEPROM.  a buffer large enough (and aligned)
+    // for any parameter value also avoids a VLA here
+    AP_Param_value_storage old_value;
+    _storage.read_block(&old_value, pofs+sizeof(phdr), type_size(old_ptype));
+
+    AP_Param *old_ap = (AP_Param *)&old_value;
 
     if (!bitmask) {
         // Numeric conversion

--- a/libraries/AP_Param/tests/test_param_conversion.cpp
+++ b/libraries/AP_Param/tests/test_param_conversion.cpp
@@ -13,6 +13,22 @@ const AP_HAL::HAL& hal = AP_HAL::get_HAL();
 // write into these.
 #define CONVERSION_GUARD_LEN 16
 
+// an object used as both the source and destination of a
+// convert_class() conversion.  guard follows the parameter for the same
+// reason as in Parameters, below.
+class ConvObj {
+public:
+    AP_Int8 v;
+    uint8_t guard[CONVERSION_GUARD_LEN];
+
+    static const struct AP_Param::GroupInfo var_info[];
+};
+
+const AP_Param::GroupInfo ConvObj::var_info[] = {
+    AP_GROUPINFO("V", 0, ConvObj, v, 0),
+    AP_GROUPEND
+};
+
 class Parameters {
 public:
     enum {
@@ -20,6 +36,9 @@ public:
         k_param_new_i8,
         k_param_old_v3f,
         k_param_new_v3f,
+        k_param_new_i16,
+        k_param_oldobj,
+        k_param_newobj,
     };
 
     AP_Int8 old_i8;
@@ -31,6 +50,9 @@ public:
 
     AP_Vector3f old_v3f;
     AP_Vector3f new_v3f;
+
+    // destination for the parameter-width conversion tests
+    AP_Int16 new_i16;
 };
 
 class TestVehicle : public AP_Vehicle {
@@ -71,6 +93,11 @@ public:
     static const AP_Param::Info var_info[];
 
     Parameters g;
+
+    // source and destination of the convert_class() conversion
+    ConvObj oldobj;
+    ConvObj newobj;
+
     // setup the var_info table
     AP_Param param_loader{var_info};
 };
@@ -81,6 +108,9 @@ const AP_Param::Info TestVehicle::var_info[] {
     GSCALAR(new_i8,   "NEWI8",  0),
     GSCALAR(old_v3f,  "OLDV3F", 0),
     GSCALAR(new_v3f,  "NEWV3F", 0),
+    GSCALAR(new_i16,  "NEWI16", 0),
+    GOBJECT(oldobj,   "OLD_",   ConvObj),
+    GOBJECT(newobj,   "NEW_",   ConvObj),
     AP_VAREND
 };
 
@@ -153,6 +183,57 @@ TEST(ParamConversion, VectorConversionCopiesWholeValue)
     AP_Param::convert_old_parameter(&info, 1.0f);
 
     EXPECT_TRUE(testvehicle.g.new_v3f.get() == value);
+}
+
+// convert_class() copies each scalar in a class across with the same
+// same-type copy that convert_old_parameter() uses, and so must size
+// that copy the same way
+TEST(ParamConversion, ClassConversionDoesNotOverrunDestination)
+{
+    reset_storage();
+
+    // store a value for the old object's parameter
+    testvehicle.oldobj.v.set((int8_t)0x3C);
+    save_now(testvehicle.oldobj.v);
+
+    // lay down a known pattern after the destination parameter
+    memset(testvehicle.newobj.guard, 0xA5, sizeof(testvehicle.newobj.guard));
+
+    AP_Param::convert_class(Parameters::k_param_oldobj, &testvehicle.newobj,
+                            ConvObj::var_info, 0, true);
+
+    // the value was converted...
+    EXPECT_EQ(testvehicle.newobj.v.get(), (int8_t)0x3C);
+
+    // ... and nothing beyond the one-byte destination was written
+    for (uint8_t i=0; i<sizeof(testvehicle.newobj.guard); i++) {
+        EXPECT_EQ(testvehicle.newobj.guard[i], 0xA5)
+            << "guard byte " << (int)i << " was overwritten by the conversion";
+    }
+}
+
+// convert_parameter_width() finds the old value by scanning for a
+// storage entry carrying the old type, so a successful widening can only
+// be produced by storage written by an earlier firmware.  The paths
+// reachable from here are the two which decline to convert.
+TEST(ParamConversion, WidthConversionDeclinesWhenNothingStored)
+{
+    reset_storage();
+
+    EXPECT_FALSE(testvehicle.g.new_i16.convert_parameter_width(AP_PARAM_INT8));
+}
+
+TEST(ParamConversion, WidthConversionDeclinesWhenAlreadyConfigured)
+{
+    reset_storage();
+
+    // a value the user has already set must not be overwritten by a
+    // conversion
+    testvehicle.g.new_i16.set((int16_t)0x1234);
+    save_now(testvehicle.g.new_i16);
+
+    EXPECT_FALSE(testvehicle.g.new_i16.convert_parameter_width(AP_PARAM_INT8));
+    EXPECT_EQ(testvehicle.g.new_i16.get(), (int16_t)0x1234);
 }
 
 AP_GTEST_MAIN()

--- a/libraries/AP_Param/tests/test_param_conversion.cpp
+++ b/libraries/AP_Param/tests/test_param_conversion.cpp
@@ -1,0 +1,158 @@
+#define AP_PARAM_VEHICLE_NAME testvehicle
+
+#include <AP_gtest.h>
+#include <AP_Math/AP_Math.h>
+#include <AP_Param/AP_Param.h>
+#include <AP_Vehicle/AP_Vehicle.h>
+
+const AP_HAL::HAL& hal = AP_HAL::get_HAL();
+
+// number of guard bytes placed immediately after the scalar conversion
+// destination.  A copy sized by the largest storable parameter type
+// (Vector3f, 12 bytes) rather than by the parameter's own type would
+// write into these.
+#define CONVERSION_GUARD_LEN 16
+
+class Parameters {
+public:
+    enum {
+        k_param_old_i8,
+        k_param_new_i8,
+        k_param_old_v3f,
+        k_param_new_v3f,
+    };
+
+    AP_Int8 old_i8;
+
+    // new_i8 is the destination of the scalar conversion; guard follows
+    // it in memory so that an over-long copy is detected
+    AP_Int8 new_i8;
+    uint8_t guard[CONVERSION_GUARD_LEN];
+
+    AP_Vector3f old_v3f;
+    AP_Vector3f new_v3f;
+};
+
+class TestVehicle : public AP_Vehicle {
+public:
+    TestVehicle() { unused_log_bitmask.set(-1); }
+
+    // HAL::Callbacks implementation.
+    void load_parameters(void) override {};
+    void get_scheduler_tasks(const AP_Scheduler::Task *&tasks,
+                             uint8_t &task_count,
+                             uint32_t &log_bit) override {
+        tasks = nullptr;
+        task_count = 0;
+        log_bit = 0;
+    };
+
+    bool set_mode(const uint8_t new_mode, const ModeReason reason) override { return true; }
+    uint8_t get_mode() const override { return 0; }
+
+    AP_Int32 unused_log_bitmask; // logging is magic for Test; this is unused
+    struct LogStructure log_structure[256] = {
+    };
+
+protected:
+
+    const AP_Int32 &get_log_bitmask() override { return unused_log_bitmask; }
+    const struct LogStructure *get_log_structures() const override {
+        return log_structure;
+    }
+    uint8_t get_num_log_structures() const override {
+        return uint8_t(ARRAY_SIZE(log_structure));
+    }
+
+    void init_ardupilot() override {};
+
+public:
+
+    static const AP_Param::Info var_info[];
+
+    Parameters g;
+    // setup the var_info table
+    AP_Param param_loader{var_info};
+};
+static TestVehicle testvehicle;
+
+const AP_Param::Info TestVehicle::var_info[] {
+    GSCALAR(old_i8,   "OLDI8",  0),
+    GSCALAR(new_i8,   "NEWI8",  0),
+    GSCALAR(old_v3f,  "OLDV3F", 0),
+    GSCALAR(new_v3f,  "NEWV3F", 0),
+    AP_VAREND
+};
+
+// start each test from an empty EEPROM so that the conversion
+// destination is not already set in storage
+static void reset_storage()
+{
+    AP_Param::erase_all();
+    AP_Param::load_all();
+}
+
+// there is no IO thread here to drain the deferred save queue, so write
+// the value out synchronously
+static void save_now(AP_Param &p)
+{
+    p.save_sync(true, false);
+}
+
+// convert_old_parameter() copies the value across when the old and new
+// parameters are the same type.  The copy must be the length of that
+// type, not the length of the buffer the old value was read into: the
+// destination parameter is only as big as its own type, so a longer copy
+// walks off the end of it.
+TEST(ParamConversion, ScalarConversionDoesNotOverrunDestination)
+{
+    reset_storage();
+
+    // store a value for the old parameter
+    testvehicle.g.old_i8.set((int8_t)0x5A);
+    save_now(testvehicle.g.old_i8);
+
+    // lay down a known pattern after the destination parameter
+    memset(testvehicle.g.guard, 0xA5, sizeof(testvehicle.g.guard));
+
+    const AP_Param::ConversionInfo info {
+        Parameters::k_param_old_i8,
+        0,
+        AP_PARAM_INT8,
+        "NEWI8"
+    };
+    AP_Param::convert_old_parameter(&info, 1.0f);
+
+    // the value was converted...
+    EXPECT_EQ(testvehicle.g.new_i8.get(), (int8_t)0x5A);
+
+    // ... and nothing beyond the one-byte destination was written
+    for (uint8_t i=0; i<sizeof(testvehicle.g.guard); i++) {
+        EXPECT_EQ(testvehicle.g.guard[i], 0xA5)
+            << "guard byte " << (int)i << " was overwritten by the conversion";
+    }
+}
+
+// the counterpart to the above: the largest storable type must still be
+// copied in full, so that sizing the copy by type does not truncate it
+TEST(ParamConversion, VectorConversionCopiesWholeValue)
+{
+    reset_storage();
+
+    const Vector3f value{1.5f, -2.25f, 3.75f};
+    testvehicle.g.old_v3f.set(value);
+    save_now(testvehicle.g.old_v3f);
+    testvehicle.g.new_v3f.set(Vector3f{});
+
+    const AP_Param::ConversionInfo info {
+        Parameters::k_param_old_v3f,
+        0,
+        AP_PARAM_VECTOR3F,
+        "NEWV3F"
+    };
+    AP_Param::convert_old_parameter(&info, 1.0f);
+
+    EXPECT_TRUE(testvehicle.g.new_v3f.get() == value);
+}
+
+AP_GTEST_MAIN()


### PR DESCRIPTION
### Summary

Removes a clang-scan-build warning of a zero-length VLA.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  -40                               *
Durandal                            -64             -64    *           -72     -72               -64    -72    -72
Hitec-Airspeed           -48                               *
KakuteH7-bdshot                     -72             -72    *           -64     -72               -64    -64    -72
MatekF405                           -64             -64    *           -72     -72               -72    -64    -72
Pixhawk1-1M-bdshot                  -72             -72                -72     -64               -72    -64    -72
SITL_x86_64_linux_gnu               0               0                  0       0                 0      0      0
YJUAV_A6SE                          -72             -72    *           -64     -64               -72    -72    -72
f103-QiotekPeriph        -32                               *
f303-MatekGPS            -48                               *
f303-Universal           -64                               *
iomcu                                                                                *
revo-mini                           -72             -72    *           -72     -64               -64    -64    -72
skyviper-v2450                                                         -64
speedybeef4                         -72             -64    *           -64     -64               -72    -64    -72
```
(freshened 2027-731)

### Description

Code flow actually means a zero-length VLA can't happen at the moment.

convert_old_parameter(), convert_class() and _convert_parameter_width() each declared a stack buffer sized by type_size() of a runtime parameter type.  type_size() can return zero (AP_PARAM_NONE/GROUP, or an unknown type), which makes the array a zero-length VLA - undefined behaviour - and VLAs are non-standard C++ in any case.

Replace the VLAs with a fixed buffer sized via a union of every storable parameter type, so it is always large enough without assuming which type is largest.  In _convert_parameter_width() the buffer size had been used as the EEPROM read length, so read type_size(old_ptype) bytes explicitly now that the buffer is no longer exactly that size.

This clears two clang-scan-build core.VLASize findings



There is an alternative fix which is for callers to these methods to pass in the length of the type e.g.
```
    g.terrain_follow.convert_parameter_width(AP_PARAM_INT8);
```
becomes
```
    g.terrain_follow.convert_parameter_width(AP_PARAM_INT8, 1);
```

There is another alternative fix which is to suppress the clang-scan-build warning entirely and trust that we will never return 0 from the get-size-of-this-ap_var_type method.  If we ever did then bad things will happen.

FWIW the `union` here was my idea, don't blame claude for that bit :-)
