### PR TITLE
AP_Baro: SPL06: read calibration coefficients into a fixed-size buffer

### DIFF
--- a/libraries/AP_Baro/AP_Baro_SPL06.cpp
+++ b/libraries/AP_Baro/AP_Baro_SPL06.cpp
@@ -46,6 +46,13 @@ extern const AP_HAL::HAL &hal;
 #define SPL06_REG_CALIB_COEFFS_END             0x21
 #define SPA06_REG_CALIB_COEFFS_END             0x24
 
+// number of calibration coefficient bytes for each device
+#define SPL06_NUM_CALIB_COEFFS                 (SPL06_REG_CALIB_COEFFS_END - SPL06_REG_CALIB_COEFFS_START + 1)
+#define SPA06_NUM_CALIB_COEFFS                 (SPA06_REG_CALIB_COEFFS_END - SPL06_REG_CALIB_COEFFS_START + 1)
+
+// MAX_NUM_CALIB_COEFFS is the largest of the per-device counts:
+#define MAX_NUM_CALIB_COEFFS SPA06_NUM_CALIB_COEFFS
+
 // PRESSURE_CFG_REG
 #define SPL06_PRES_RATE_32HZ				   (0x05 << 4)
 
@@ -138,14 +145,14 @@ bool AP_Baro_SPL06::_init()
         return false;
     }
 
-    // read the calibration data
-    uint8_t SPL06_CALIB_COEFFS_LEN = 18;
+    // number of calibration coefficient bytes to read for this device
+    uint8_t calib_coeffs_len = SPL06_NUM_CALIB_COEFFS;
 	switch(type) {
 	case Type::SPL06:
-		SPL06_CALIB_COEFFS_LEN = SPL06_REG_CALIB_COEFFS_END - SPL06_REG_CALIB_COEFFS_START + 1;
+		calib_coeffs_len = SPL06_NUM_CALIB_COEFFS;
 		break;
 	case Type::SPA06:
-		SPL06_CALIB_COEFFS_LEN = SPA06_REG_CALIB_COEFFS_END - SPL06_REG_CALIB_COEFFS_START + 1;
+		calib_coeffs_len = SPA06_NUM_CALIB_COEFFS;
 		break;
 	default:
 		break;
@@ -167,12 +174,21 @@ bool AP_Baro_SPL06::_init()
         return false;
     }
 
-    uint8_t buf[SPL06_CALIB_COEFFS_LEN];
+    // fixed-size buffer holding the largest device's coefficients; a
+    // compile-time constant rather than a VLA sized by calib_coeffs_len
+    uint8_t buf[MAX_NUM_CALIB_COEFFS];
+
+    // fail safe if a device's length exceeds the buffer, e.g. a new device
+    // type was added without growing MAX_NUM_CALIB_COEFFS above
+    if (calib_coeffs_len > sizeof(buf)) {
+        return false;
+    }
 
 #define READ_LENGTH 9
 
-    for (uint8_t i = 0; i < ARRAY_SIZE(buf); ) {
-        ssize_t chunk = MIN(READ_LENGTH, SPL06_CALIB_COEFFS_LEN - i);
+    // only read this device's coefficients (calib_coeffs_len <= buffer size)
+    for (uint8_t i = 0; i < calib_coeffs_len; ) {
+        ssize_t chunk = MIN(READ_LENGTH, calib_coeffs_len - i);
         if (!_dev->read_registers(SPL06_REG_CALIB_COEFFS_START + i, buf + i, chunk)) {
             return false;
         }


### PR DESCRIPTION
### Summary

Uses a constant-sized buffer in place of a VLA to hold device calibration co-efficients.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  0                                 *                                                   
Durandal                            0               8      *           8       0                 8      0      8
Hitec-Airspeed           *                                 *                                                   
KakuteH7-bdshot                     8               8      *           0       8                 0      0      8
MatekF405                           *               *      *           *       *                 *      *      *
MatekH7A3                           0               0      *           0       8                 8      0      8
Pixhawk1-1M-bdshot                  *               *                  *       *                 *      *      *
SITL_x86_64_linux_gnu               *               *                  *       *                 *      *      *
YJUAV_A6SE                          0               8      *           8       0                 0      8      0
f103-QiotekPeriph        *                                 *                                                   
f303-MatekGPS            8                                 *                                                   
f303-Universal           8                                 *                                                   
iomcu                                                                                *                         
mindpx-v2                           8               0      *           0       8                 0      0      8
revo-mini                           *               *      *           *       *                 *      *      *
skyviper-v2450                                                         *                                       
speedybeef4                         *               *      *           *       *                 *      *      *
```

### Description

The calibration read used a stack VLA sized by a runtime length, and the loop bounded itself with ARRAY_SIZE(buf).  clang-scan-build reported a garbage read of buf[0]: it models sizeof() of a VLA as a separate symbolic (possibly-zero) value, so ARRAY_SIZE(buf) did not carry the known length and it concluded the loop might not run.

Size the buffer at compile time to the largest device's coefficient count (MAX_NUM_CALIB_COEFFS, built up per-device with #if blocks so adding a device is a local change), rename the runtime length to a lower-case calib_coeffs_len, and loop over that.  This removes the VLA (saving the runtime sizing code) and clears the finding.  A guard rejects any device whose length exceeds the buffer, failing safe if a future device type is added without growing the maximum.


An alternative fix here would be to use a pair of structures modelling the calibration coefficient registers and a union of them to read into.  This would be quite clean, I think, but would mean rewriting all of the extract-coefficients code, which would be bad.  Unless that extract-coefficients code could actually be done with a bit-packed structure in which case it could end up as Awesome.

Another alternative fix is to tell the damned analyzer to shut up about this already.... this does seem overkill for something which is almost certainly a can't-happen with the current code structure.

