### PR TITLE
Avoid use of uninitialised data when parsing SmartAudio data

### DIFF
--- a/libraries/AP_VideoTX/AP_SmartAudio.cpp
+++ b/libraries/AP_VideoTX/AP_SmartAudio.cpp
@@ -479,8 +479,14 @@ void AP_SmartAudio::unpack_settings(Settings *settings, const SettingsExtendedRe
 {
     unpack_settings(settings, &frame->settings);
     settings->power_in_dbm = frame->power_dbm;
-    settings->num_power_levels = frame->num_power_levels + 1;
-    memcpy(settings->power_levels, frame->power_levels, frame->num_power_levels + 1);
+    // the level count comes from the wire; clamp it to the size of the
+    // destination (and source) arrays to avoid overrunning them
+    uint8_t num_power_levels = frame->num_power_levels + 1;
+    if (num_power_levels > sizeof(settings->power_levels)) {
+        num_power_levels = sizeof(settings->power_levels);
+    }
+    settings->num_power_levels = num_power_levels;
+    memcpy(settings->power_levels, frame->power_levels, num_power_levels);
 }
 
 #ifdef SA_DEBUG

--- a/libraries/AP_VideoTX/AP_SmartAudio.cpp
+++ b/libraries/AP_VideoTX/AP_SmartAudio.cpp
@@ -353,7 +353,7 @@ bool AP_SmartAudio::read_response(uint8_t *response_buffer)
 #endif
     _is_waiting_response = false;
 
-    bool correct_parse = parse_response_buffer(response_buffer);
+    bool correct_parse = parse_response_buffer(response_buffer, _inline_buffer_length);
     response_buffer = nullptr;
     _inline_buffer_length=0;
     _packet_size = 0;
@@ -543,7 +543,7 @@ void AP_SmartAudio::update_vtx_settings(const Settings& settings)
     _vtx_power_change_pending = _vtx_freq_change_pending = _vtx_options_change_pending = false;
 }
 
-bool  AP_SmartAudio::parse_response_buffer(const uint8_t *buffer)
+bool  AP_SmartAudio::parse_response_buffer(const uint8_t *buffer, uint8_t buffer_length)
 {
     const FrameHeader *header = (const FrameHeader *)buffer;
     const uint8_t fullFrameLength = sizeof(FrameHeader) + header->length;
@@ -557,12 +557,18 @@ bool  AP_SmartAudio::parse_response_buffer(const uint8_t *buffer)
         debug("parse_response_buffer() failed - invalid CRC or header");
         return false;
     }
-    // SEND TO GCS A MESSAGE TO UNDERSTAND WHATS HAPPENING
     AP_VideoTX& vtx = AP::vtx();
     Settings settings {};
 
+    // the length field is taken from the wire, so before interpreting the
+    // buffer as a particular frame each case checks that we actually
+    // received enough bytes for it.  A short or corrupt frame would
+    // otherwise be parsed from stale buffer contents.
     switch (header->command) {
     case SMARTAUDIO_RSP_GET_SETTINGS_V1:
+        if (buffer_length < sizeof(SettingsResponseFrame)) {
+            return false;
+        }
         _protocol_version = SMARTAUDIO_SPEC_PROTOCOL_v1;
         unpack_settings(&settings, (const SettingsResponseFrame *)buffer);
         settings.version = SMARTAUDIO_SPEC_PROTOCOL_v1;
@@ -571,6 +577,9 @@ bool  AP_SmartAudio::parse_response_buffer(const uint8_t *buffer)
         break;
 
     case SMARTAUDIO_RSP_GET_SETTINGS_V2:
+        if (buffer_length < sizeof(SettingsResponseFrame)) {
+            return false;
+        }
         _protocol_version = SMARTAUDIO_SPEC_PROTOCOL_v2;
         unpack_settings(&settings, (const SettingsResponseFrame *)buffer);
         settings.version = SMARTAUDIO_SPEC_PROTOCOL_v2;
@@ -579,6 +588,9 @@ bool  AP_SmartAudio::parse_response_buffer(const uint8_t *buffer)
         break;
 
     case SMARTAUDIO_RSP_GET_SETTINGS_V21:
+        if (buffer_length < sizeof(SettingsExtendedResponseFrame)) {
+            return false;
+        }
         _protocol_version = SMARTAUDIO_SPEC_PROTOCOL_v21;
         unpack_settings(&settings, (const SettingsExtendedResponseFrame *)buffer);
         settings.version = SMARTAUDIO_SPEC_PROTOCOL_v21;
@@ -587,6 +599,9 @@ bool  AP_SmartAudio::parse_response_buffer(const uint8_t *buffer)
         break;
 
     case SMARTAUDIO_RSP_SET_FREQUENCY: {
+        if (buffer_length < sizeof(U16ResponseFrame)) {
+            return false;
+        }
         const U16ResponseFrame *resp = (const U16ResponseFrame *)buffer;
         unpack_frequency(&settings, resp->payload);
         vtx.set_frequency_mhz(settings.frequency);
@@ -597,6 +612,9 @@ bool  AP_SmartAudio::parse_response_buffer(const uint8_t *buffer)
         break;
 
     case SMARTAUDIO_RSP_SET_CHANNEL: {
+        if (buffer_length < sizeof(U8ResponseFrame)) {
+            return false;
+        }
         const U8ResponseFrame *resp = (const U8ResponseFrame *)buffer;
         vtx.set_band(resp->payload / VTX_MAX_CHANNELS);
         vtx.set_channel(resp->payload % VTX_MAX_CHANNELS);
@@ -608,6 +626,9 @@ bool  AP_SmartAudio::parse_response_buffer(const uint8_t *buffer)
         break;
 
     case SMARTAUDIO_RSP_SET_POWER: {
+        if (buffer_length < sizeof(U16ResponseFrame)) {
+            return false;
+        }
         const U16ResponseFrame *resp = (const U16ResponseFrame *)buffer;
         const uint8_t power = resp->payload & 0xFF;
         switch (_protocol_version) {
@@ -638,6 +659,9 @@ bool  AP_SmartAudio::parse_response_buffer(const uint8_t *buffer)
         break;
 
     case SMARTAUDIO_RSP_SET_MODE: {
+        if (buffer_length < sizeof(FrameHeader) + 1) {
+            return false;
+        }
         vtx.set_options(vtx.get_configured_options()); // easiest to just make them match
         debug("Mode was set to 0x%x", buffer[4]);
     }

--- a/libraries/AP_VideoTX/AP_SmartAudio.h
+++ b/libraries/AP_VideoTX/AP_SmartAudio.h
@@ -224,7 +224,7 @@ private:
     bool read_response(uint8_t *response_buffer);
     // parses the response and updates the vtx settings
     bool parse_frame_response(const uint8_t *buffer);
-    bool parse_response_buffer(const uint8_t *buffer);
+    bool parse_response_buffer(const uint8_t *buffer, uint8_t buffer_length);
     // get last reading from the fifo queue
     bool get_readings(AP_VideoTX *vtx_dest);
 


### PR DESCRIPTION
### Summary

Avoids use of uninitialised data:
 - trusting length from the wire when we shouldn't
 - indexing an array with a value received off the wire without clamping it

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                 *                                                   
Durandal                            32              40     *           40      32                40     32     40
Hitec-Airspeed           *                                 *                                                   
KakuteH7-bdshot                     40              40     *           32      40                32     32     40
MatekF405                           32              40     *           32      32                32     32     40
MatekH7A3                           32              32     *           32      40                40     32     40
Pixhawk1-1M-bdshot                  *               *                  *       *                 *      *      *
SITL_x86_64_linux_gnu               0               0                  0       8                 0      0      0
YJUAV_A6SE                          32              40     *           40      32                32     40     32
f103-QiotekPeriph        *                                 *                                                   
f303-MatekGPS            *                                 *                                                   
f303-Universal           *                                 *                                                   
iomcu                                                                                *                         
mindpx-v2                           40              32     *           32      40                32     32     40
revo-mini                           40              40     *           32      32                32     32     32
skyviper-v2450                                                         *                                       
speedybeef4                         40              32     *           40      40                32     32     40
```

### Description

tlwr; clamp before indexing.  Check size of struct before casting a buffer to a pointer to that struct.

```
parse_response_buffer() cast the received buffer to the response frame
struct selected by the command byte without checking that enough bytes
were actually received.  A short or corrupt frame (for example a
GET_SETTINGS response with a length field of zero) could pass the CRC
check yet cause the parser to read channel/power/frequency fields from
buffer positions that were never written this cycle, pushing stale
values into the VTX settings.

Pass the received byte count into parse_response_buffer() and, in each
command case, reject frames that are too short for the struct being
interpreted.
```

```
unpack_settings() for the v2.1 extended response frame copied
num_power_levels+1 bytes into the fixed power_levels[8] array, where
num_power_levels comes straight from the wire and is unbounded.  A
malformed frame could request a copy of up to 256 bytes, overrunning
both the source and destination arrays.

Clamp the count to the size of the arrays before copying.
```