### PR TITLE
AP_Landing: remove dead initialisation of target_airspeed_cm

### DIFF
--- a/libraries/AP_Landing/AP_Landing_Slope.cpp
+++ b/libraries/AP_Landing/AP_Landing_Slope.cpp
@@ -349,13 +349,16 @@ int32_t AP_Landing::type_slope_get_target_airspeed_cm(void)
     // we're landing, check for custom approach and
     // pre-flare airspeeds. Also increase for head-winds
 
+    // default landing target airspeed is the average of cruise and
+    // minimum airspeed:
+    int32_t target_airspeed_cm = 100 * 0.5 * (aparm.airspeed_cruise + aparm.airspeed_min);
+
+    // land airspeed can be explicitly specified:
     const float land_airspeed = tecs_Controller->get_land_airspeed();
-    int32_t target_airspeed_cm = aparm.airspeed_cruise*100;
     if (land_airspeed >= 0) {
         target_airspeed_cm = land_airspeed * 100;
-    } else {
-        target_airspeed_cm = 100 * 0.5 * (aparm.airspeed_cruise + aparm.airspeed_min);
     }
+
     switch (type_slope_stage) {
     case SlopeStage::NORMAL:
         target_airspeed_cm = aparm.airspeed_cruise*100;


### PR DESCRIPTION
### Summary

Avoids a dead assignment and associated calculation

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                 *                                                   
Durandal                            *               *      *           *       *                 16     *      *
Hitec-Airspeed           *                                 *                                                   
KakuteH7-bdshot                     *               *      *           *       *                 8      *      *
MatekF405                           *               *      *           *       *                 8      *      *
MatekH7A3                           *               *      *           *       *                 16     *      *
Pixhawk1-1M-bdshot                  *               *                  *       *                 8      *      *
SITL_x86_64_linux_gnu               *               *                  *       *                 0      *      *
YJUAV_A6SE                          *               *      *           *       *                 8      *      *
f103-QiotekPeriph        *                                 *                                                   
f303-MatekGPS            *                                 *                                                   
f303-Universal           *                                 *                                                   
iomcu                                                                                *                         
mindpx-v2                           *               *      *           *       *                 8      *      *
revo-mini                           *               *      *           *       *                 8      *      *
skyviper-v2450                                                         *                                       
speedybeef4                         *               *      *           *       *                 8      *      *
```

### Description

type_slope_get_target_airspeed_cm() initialised target_airspeed_cm and then unconditionally reassigned it in the immediately following if/else, so the initial value was never used.  Declare it without the redundant initialiser.

Clears one clang-scan-build "Dead initialization" finding

Rearranged the code slightly to separate off the various adjustments we make to this airspeed from the initial defaulting.
