### PR TITLE
AP_FETtecOneWire: avoid variable-length array in update()

### DIFF
--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
@@ -821,8 +821,7 @@ void AP_FETtecOneWire::update()
     }
 #endif
 
-    // get ESC set points
-    uint16_t motor_pwm[_esc_count];
+    uint16_t motor_pwm[MAX_ESC_COUNT];
     for (uint8_t i = 0; i < _esc_count; i++) {
         const ESC &esc = _escs[i];
         const SRV_Channel* c = SRV_Channels::srv_channel(esc.servo_ofs);

--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.h
@@ -112,6 +112,7 @@ private:
 
     static constexpr uint8_t FRAME_OVERHEAD = 6;          ///< OneWire message frame overhead (header+tail bytes)
     static constexpr uint8_t MAX_RECEIVE_LENGTH = 12;     ///< OneWire max receive message payload length in bytes
+    static constexpr uint8_t MAX_ESC_COUNT = 24;          ///< Max ESCs supported (will be fewer with telemetry)
 #if HAL_AP_FETTEC_ONEWIRE_GET_STATIC_INFO
     static constexpr uint8_t SERIAL_NUMBER_LENGTH = 12;   ///< ESC serial number length in bytes
 #endif


### PR DESCRIPTION
### Summary

Avoid the use of a VLA which makes static analysis problematic.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                 *                                                   
Durandal                            8               0      *           0       8                 8      8      0
Hitec-Airspeed           *                                 *                                                   
KakuteH7-bdshot                     0               0      *           8       0                 0      8      0
MatekF405                           *               *      *           *       *                 *      *      *
MatekH7A3                           8               8      *           8       0                 8      8      0
Pixhawk1-1M-bdshot                  *               *                  *       *                 *      *      *
SITL_x86_64_linux_gnu               0               0                  0       0                 0      0      0
YJUAV_A6SE                          8               0      *           0       8                 0      0      8
f103-QiotekPeriph        *                                 *                                                   
f303-MatekGPS            *                                 *                                                   
f303-Universal           *                                 *                                                   
iomcu                                                                                *                         
mindpx-v2                           -8              0      *           0       -8                0      0      -8
revo-mini                           *               *      *           *       *                 *      *      *
skyviper-v2450                                                         *                                       
speedybeef4                         *               *      *           *       *                 *      *      *
```
(updated for force-pushed simpler patch)

### Description

update() declared a stack buffer sized by the runtime _esc_count. clang-scan-build's core.VLASize flagged it as a possible zero-size VLA because it cannot see that init() bounds _esc_count to [1, MAX_ESC_COUNT].

Introduce a named MAX_ESC_COUNT (the OneWire protocol maximum, replacing the bare 24 in the init bounds check) and size the buffer to it.  We do not size from NUM_SERVO_CHANNELS: it is board-dependent and can be zero (e.g. AP_Periph), which would give a zero-length array.  Add an explicit [1, MAX_ESC_COUNT] guard so the buffer is provably large enough and fully populated by the loop, and as defence-in-depth.

Clears one clang-scan-build finding.

We could also just suppress the thing.
