### PR TITLE
add a new board id for SIYI-UniFC-6-PICO

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -333,6 +333,7 @@ AP_HW_CORVON_V5                      1211
 AP_HW_CSKY_PMU                       1212
 AP_HW_PilotGaeaSH7V1                 1213
 AP_HW_JPilot-C                       1214
+AP_HW_SIYI-UniFC-6-PICO              1215
 
 AP_HW_MUPilot                        1222
 AP_HW_HWH7                           1223


### PR DESCRIPTION
### Summary


Apply for a board ID for SIYI-UniFC-6-PICO.