### PR TITLE
AP_NavEKF3: remove redundant loop in wind variance setup

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -97,9 +97,7 @@ void NavEKF3_core::setWindMagStateLearningMode()
         } else {
             // set the variances using a typical max wind speed for small UAV operation
             zeroStatesVarCov(22, 23);
-            for (uint8_t index=22; index<=23; index++) {
-                P[index][index] = sq(WIND_VEL_VARIANCE_MAX);
-            }
+            P[22][22] = (P[23][23] = sq(WIND_VEL_VARIANCE_MAX));
         }
     }
 


### PR DESCRIPTION
### Summary
AP_NavEKF3: remove redundant loop in wind variance setup

### Classification & Testing (check all that apply and add your own)
- [x] Checked by a human programmer
- [x] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description
This PR replaces a short `for` loop (iterating from index 22 to 23) used for initializing the wind velocity variance in `AP_NavEKF3_Control.cpp` with a direct inline assignment. 

By changing the loop to a direct assignment (`P[22][22] = P[23][23] = sq(WIND_VEL_VARIANCE_MAX)`), the code becomes more readable, concise, and consistent with similar variance initializations found elsewhere in the EKF core. This is a non-functional refactoring change and does not alter the mathematical behavior or logic of the EKF wind state initialization.