### PR TITLE
Remove use of `std` library from SIM::Battery unit tests

### DIFF
--- a/libraries/SITL/SIM_Battery.cpp
+++ b/libraries/SITL/SIM_Battery.cpp
@@ -69,6 +69,8 @@ static const struct {
     { 0.01,  0.01},
     { 0.001, 0.001 }};
 
+constexpr float maximum_permissible_dt = 0.1f; // seconds
+
 /*
   use table to get resting voltage from remaining capacity
  */
@@ -152,11 +154,10 @@ void Battery::consume_energy(float current_amp, uint64_t now_us)
 {
     constexpr float microsec_to_sec = 1.0e-6f;
     float dt = static_cast<float>(now_us - last_us) * microsec_to_sec;
-    if (dt > 0.1) {
-        // we stopped updating
-        dt = 0;
-    }
     last_us = now_us;
+    if (dt > maximum_permissible_dt) {
+        return;
+    }
     const float delta_Ah = current_amp * dt / 3600;
     remaining_Ah -= delta_Ah;
     remaining_Ah = MAX(0, remaining_Ah);

--- a/libraries/SITL/tests/test_battery.cpp
+++ b/libraries/SITL/tests/test_battery.cpp
@@ -38,7 +38,7 @@ protected:
     }
 
     struct BattAndObservations {
-        SITL::Battery* batt;
+        SITL::Battery& batt;
         float min_observed_voltage;
         float final_observed_voltage;
     };
@@ -58,11 +58,11 @@ protected:
     };
 
     BattAndObservations batteries_and_data[5] = {
-        { &small_battery, -1.0f, -2.0f },
-        { &large_battery, -1.0f, -2.0f },
-        { &infinite_battery, -1.0f, -2.0f },
-        { &small_high_resistance_battery, -1.0f, -2.0f },
-        { &infinite_high_resistance_battery, -1.0f, -2.0f },
+        { small_battery, -1.0f, -2.0f },
+        { large_battery, -1.0f, -2.0f },
+        { infinite_battery, -1.0f, -2.0f },
+        { small_high_resistance_battery, -1.0f, -2.0f },
+        { infinite_high_resistance_battery, -1.0f, -2.0f },
     };
 
     // These are just syntactic sugar.
@@ -81,7 +81,7 @@ TEST_F(BatteryTest, EnergyConsumption)
     constexpr float dt_sec = 0.01f;
 
     for (auto& b_and_d : batteries_and_data) {
-        SITL::Battery& battery = std::ref(*b_and_d.batt);
+        SITL::Battery& battery = b_and_d.batt;
         float& min_observed_voltage = b_and_d.min_observed_voltage;
 
         const float initial_voltage = battery.get_voltage();
@@ -192,7 +192,7 @@ TEST_F(BatteryTest, MaximumDeltaTime)
     constexpr float current_amp = 25.0f; // This value is arbitrary
 
     for (auto& b_and_d : batteries_and_data) {
-        SITL::Battery& battery = std::ref(*b_and_d.batt);
+        SITL::Battery& battery = b_and_d.batt;
         const float initial_voltage = battery.get_voltage();
         const float initial_temperature_degC = battery.get_temperature_degC();
 
@@ -224,7 +224,7 @@ void use_some_energy(SITL::Battery& battery) {
 TEST_F(BatteryTest, Resetting)
 {
     for (auto& b_and_d : batteries_and_data) {
-        SITL::Battery& battery = std::ref(*b_and_d.batt);
+        SITL::Battery& battery = b_and_d.batt;
 
         // Show that resetting to some new voltage works.
         const float partial_voltage = 0.8f * max_voltage;

--- a/libraries/SITL/tests/test_battery.cpp
+++ b/libraries/SITL/tests/test_battery.cpp
@@ -184,6 +184,31 @@ TEST_F(BatteryTest, EnergyConsumption)
                     batteries_and_data[infinite].final_observed_voltage);
 }
 
+TEST_F(BatteryTest, MaximumDeltaTime)
+{
+    // For this test, value must be larger than SIM::Battery's maximum permissible dt.
+    constexpr float dt_sec = 0.11f;
+
+    constexpr float current_amp = 25.0f; // This value is arbitrary
+
+    for (auto& b_and_d : batteries_and_data) {
+        SITL::Battery& battery = std::ref(*b_and_d.batt);
+        const float initial_voltage = battery.get_voltage();
+        const float initial_temperature_degC = battery.get_temperature_degC();
+
+        for (float t = 0.0f; t <= dt_sec * 10; t+=dt_sec) {
+            const uint64_t now_us = initial_us + static_cast<uint64_t>(t * 1e6);
+
+            // Attempt to consume battery energy (but does not work because dt is too large)
+            battery.consume_energy(current_amp, now_us);
+
+            // Confirm no voltage or temperature change (because energy-consumption did not work)
+            EXPECT_FLOAT_EQ(battery.get_voltage(), initial_voltage);
+            EXPECT_FLOAT_EQ(battery.get_temperature_degC(), initial_temperature_degC);
+        }
+    }
+}
+
 namespace {
 void use_some_energy(SITL::Battery& battery) {
     constexpr float current_amp = 25.0f;
@@ -218,7 +243,7 @@ TEST_F(BatteryTest, Resetting)
 
         // Show that attempting a reset without changing any batt params is a no-op.
         use_some_energy(battery);
-        if (is_positive(battery.get_capacity())) {
+        if (!battery.capacity_is_unlimited()) {
             // Show that some voltage has been lost
             float observed = battery.get_voltage();
             EXPECT_LT(observed, max_voltage);


### PR DESCRIPTION
### Summary

This PR removes use of `std::ref` from SIM::Battery unit tests.
This satisfies a reviewer request made [here](https://github.com/ArduPilot/ardupilot/pull/33045#discussion_r3307333672).

(I've used DRAFT because this PR is currently chained behind #33044 . But that will land soon and this will be rebased to stand-alone.)

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
