### PR TITLE
Separate setting SIM::Battery state-of-charge from computing it

### DIFF
--- a/libraries/SITL/SIM_Battery.cpp
+++ b/libraries/SITL/SIM_Battery.cpp
@@ -17,6 +17,7 @@
 */
 
 #include "SIM_Battery.h"
+#include <float.h>
 #include <AP_Math/AP_Math.h>
 
 using namespace SITL;
@@ -96,10 +97,14 @@ float Battery::get_resting_voltage(void) const
 }
 
 /*
-  use table to set initial state of charge from voltage
+  return remaining Amp-hours (aka "charge", "state of charge") corresponding to a voltage
  */
-void Battery::set_initial_SoC(float voltage)
+float Battery::compute_remaining_Ah(float voltage) const
 {
+    if (capacity_is_unlimited()) {
+        return FLT_MAX;
+    }
+
     const float max_cell_voltage = soc_table[0].volt_per_cell;
     const float cell_volt = (voltage / max_voltage) * max_cell_voltage;
 
@@ -111,13 +116,11 @@ void Battery::set_initial_SoC(float voltage)
             const float soc1 = soc_table[i].soc_pct;
             const float soc2 = soc_table[i-1].soc_pct;
             const float soc = soc1 + (dv1 / dv2) * (soc2 - soc1);
-            remaining_Ah = capacity_Ah * soc * 0.01;
-            return;
+            return capacity_Ah * (soc * 0.01);
         }
     }
-
     // off the bottom of the table
-    remaining_Ah = 0;
+    return 0.0f;
 }
 
 // Reminder: capacity <= 0 means **unlimited**
@@ -130,7 +133,7 @@ void Battery::setup(float _capacity_Ah, float _resistance_ohm, float _max_voltag
 
     voltage_set = max_voltage;
     voltage_filter.reset(voltage_set);
-    set_initial_SoC(voltage_set);
+    remaining_Ah = compute_remaining_Ah(voltage_set);
 }
 
 void Battery::maybe_reset(float desired_voltage, float desired_capacity_Ah)
@@ -145,7 +148,7 @@ void Battery::maybe_reset(float desired_voltage, float desired_capacity_Ah)
     // a negative desired voltage is unexpected, but not problematic
     voltage_set = MIN(desired_voltage, max_voltage);
     voltage_filter.reset(voltage_set);
-    set_initial_SoC(voltage_set);
+    remaining_Ah = compute_remaining_Ah(voltage_set);
 }
 
 void Battery::consume_energy(float current_amp, uint64_t now_us)

--- a/libraries/SITL/SIM_Battery.h
+++ b/libraries/SITL/SIM_Battery.h
@@ -44,7 +44,7 @@ private:
     float max_voltage;
     float ambient_temperature_degC;
     float voltage_set;
-    float remaining_Ah;
+    float remaining_Ah; // if capacity is unlimited, this is FLT_MAX
     uint64_t last_us;
 
     float temperature_degC = 0.0f;
@@ -54,6 +54,6 @@ private:
     LowPassFilterFloat voltage_filter{10};
 
     float get_resting_voltage(void) const;
-    void set_initial_SoC(float voltage);
+    float compute_remaining_Ah(float voltage) const;
 };
 }


### PR DESCRIPTION
### Summary

A core SIM::Battery implementation detail is how the state of charge is computed. This PR puts that into a single-purpose const function for improved code clarity.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Does not affect autopilot functionality
- [x] Does not affect autopilot binary
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

This PR also implements a more natural value for `remaining_Ah` of an unlimited-capacity battery, to avoid future confusion. (It's a private member, so merely an implementation-clarity thing.)

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
