### PR TITLE
AP_Baro: soft reset BMP581 on init for reliable warm boot

### DIFF
--- a/libraries/AP_Baro/AP_Baro_BMP581.cpp
+++ b/libraries/AP_Baro/AP_Baro_BMP581.cpp
@@ -54,6 +54,18 @@ extern const AP_HAL::HAL &hal;
 #define BMP581_REG_OSR_EFF            0x38
 #define BMP581_REG_CMD                0x7E
 
+#define BMP581_CMD_SOFT_RESET         0xB6
+
+// STATUS register (0x28) bits
+#define BMP581_STATUS_NVM_RDY         (1U << 1)
+#define BMP581_STATUS_NVM_ERR         (1U << 2)
+
+// INT_STATUS register (0x27): set on power-on or soft reset, cleared on read
+#define BMP581_INT_STATUS_POR         (1U << 4)
+
+// datasheet soft-reset duration is 2ms; use a margin
+#define BMP581_RESET_DELAY_MS         5
+
 AP_Baro_BMP581::AP_Baro_BMP581(AP_Baro &baro, AP_HAL::Device &dev)
     : AP_Baro_Backend(baro)
     , _dev(&dev)
@@ -103,12 +115,35 @@ bool AP_Baro_BMP581::init()
         return false;
     }
 
+    // On a warm reboot the MCU restarts but the BMP581 can stay powered, and
+    // init() then rejects a working sensor: STATUS reads 0x01 (core_rdy=1,
+    // nvm_rdy=0, nvm_err=0) and the INT_STATUS POR bit is 0, though pressure
+    // output is still valid. nvm_rdy and POR only reflect the chip's own
+    // power-on, so soft reset here to re-run that sequence and keep the
+    // STATUS/INT_STATUS checks below valid. The I2C reset write may not be
+    // ACKed, so its result is intentionally ignored; the reads below confirm
+    // the state.
+    _dev->write_register(BMP581_REG_CMD, BMP581_CMD_SOFT_RESET);
+    hal.scheduler->delay(BMP581_RESET_DELAY_MS);
+
+    // A soft reset drops SPI back to the chip's default interface. The first
+    // SPI read afterwards is a dummy whose value is discarded to re-lock SPI;
+    // then confirm the ID still reads back before continuing.
+    if (_dev->bus_type() == AP_HAL::Device::BUS_TYPE_SPI) {
+        uint8_t dummy;
+        _dev->read_registers(BMP581_REG_CHIP_ID, &dummy, 1);
+
+        if (!_dev->read_registers(BMP581_REG_CHIP_ID, &whoami, 1) || whoami != BMP581_ID) {
+            return false;
+        }
+    }
+
     uint8_t status;
     if (!_dev->read_registers(BMP581_REG_STATUS, &status, 1)) {
         return false;
     }
 
-    if ((status & 0b10) == 0 || (status & 0b100)) {
+    if ((status & BMP581_STATUS_NVM_RDY) == 0 || (status & BMP581_STATUS_NVM_ERR)) {
         return false;
     }
 
@@ -117,7 +152,7 @@ bool AP_Baro_BMP581::init()
         return false;
     }
 
-    if ((int_status & 0x10) == 0) {
+    if ((int_status & BMP581_INT_STATUS_POR) == 0) {
         return false;
     }
 


### PR DESCRIPTION
### Problem
On a warm reboot (MCU reset, watchdog, firmware update) the BMP581 fails to initialise and the driver reports "Baro: unable to initialise driver". A full power cycle clears it; any reboot that keeps the sensor powered reproduces the failure.

### Cause
init() gates on the INT_STATUS POR bit (bit 4, register 0x27), which the chip sets on a power-on or soft reset and clears on read (BMP581 datasheet BST-BMP581-DS004). The chip sets it once per power-on unless a soft reset is issued. On a warm reboot the MCU restarts but the BMP581 keeps its supply, so the bit was already consumed by the previous boot's read and the check rejects a healthy sensor. A board whose only barometer is a BMP581 is left in a Config Error loop. Boards that pair it with a second baro (Pixhawk6X, CUAV-V6X-v2, CUAV-7-Nano, CUAV-X25-EVO, SULILGH7-P1-P2) keep running on the other baro and just drop the BMP581 from the count, so this can be masked on those boards.

### Fix
Soft reset the chip (command 0xB6) after the ID check so it re-runs its power-on sequence and the POR bit is set when the status check reads it. This is the same reset the PX4 and Bosch reference drivers issue. The I2C reset write may not be ACKed, so its result is ignored and the state is verified by the following STATUS/INT_STATUS reads; on SPI a dummy read re-locks the interface and the chip ID is re-checked.

### Testing
Reproduced and fixed on a CORVON 743v2 (STM32H743, BMP581 as the sole baro on I2C):

| Firmware | Boot | Result |
|----------|------|--------|
| without fix | cold (power cycle) | baro OK |
| without fix | warm (reboot) | Config Error: Baro: unable to initialise driver |
| with fix | warm (reboot) | baro OK, valid pressure |

Same binary, cold vs warm, isolates the cause to the warm-boot path; verified over repeated warm reboots on I2C. The SPI path is build-tested only - I have no SPI BMP581 board to run, so the SPI re-lock + ID re-check follows the PX4/Bosch sequence as a conservative guard. Build-checked on Pixhawk6X (I2C) and CUAV-7-Nano (SPI).
