### PR TITLE
Convert AP_Landing target speed interface to metres/second

### DIFF
--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -228,7 +228,7 @@ void Plane::calc_airspeed_errors()
 
     } else if (flight_stage == AP_FixedWing::FlightStage::LAND) {
         // Landing airspeed target
-        target_airspeed_cm = landing.get_target_airspeed_cm();
+        target_airspeed_cm = landing.get_target_airspeed_ms() * 100.0f;  // m/s -> cm/s
     } else if (control_mode == &mode_guided && new_airspeed_cm > 0) { //DO_CHANGE_SPEED overrides onboard guided speed commands, user would have re-enter guided mode to revert
                        target_airspeed_cm = new_airspeed_cm;
     } else if (control_mode == &mode_auto) {

--- a/libraries/AP_Landing/AP_Landing.cpp
+++ b/libraries/AP_Landing/AP_Landing.cpp
@@ -606,27 +606,27 @@ bool AP_Landing::get_target_altitude_location(Location &location)
 }
 
 /*
- * returns target airspeed in cm/s depending on flight stage
+ * returns target airspeed in m/s depending on flight stage
  */
-int32_t AP_Landing::get_target_airspeed_cm(void)
+float AP_Landing::get_target_airspeed_ms(void)
 {
     if (!flags.in_progress) {
         // not landing, use regular cruise airspeed
-        return aparm.airspeed_cruise*100;
+        return aparm.airspeed_cruise;
     }
 
     switch (type) {
     case TYPE_STANDARD_GLIDE_SLOPE:
-        return type_slope_get_target_airspeed_ms() * 100.0;
+        return type_slope_get_target_airspeed_ms();
 #if HAL_LANDING_DEEPSTALL_ENABLED
     case TYPE_DEEPSTALL:
-        return deepstall.get_target_airspeed_ms() * 100.0;
+        return deepstall.get_target_airspeed_ms();
 #endif
     default:
         // don't return the landing airspeed, because if type is invalid we have
         // no postive indication that the land airspeed has been configured or
         // how it was meant to be utilized
-        return tecs_Controller->get_target_airspeed();
+        return tecs_Controller->get_target_airspeed() * 0.01f;  // cm/s -> m/s
     }
 }
 

--- a/libraries/AP_Landing/AP_Landing.cpp
+++ b/libraries/AP_Landing/AP_Landing.cpp
@@ -626,7 +626,7 @@ float AP_Landing::get_target_airspeed_ms(void)
         // don't return the landing airspeed, because if type is invalid we have
         // no postive indication that the land airspeed has been configured or
         // how it was meant to be utilized
-        return tecs_Controller->get_target_airspeed() * 0.01f;  // cm/s -> m/s
+        return tecs_Controller->get_target_airspeed();
     }
 }
 

--- a/libraries/AP_Landing/AP_Landing.cpp
+++ b/libraries/AP_Landing/AP_Landing.cpp
@@ -617,10 +617,10 @@ int32_t AP_Landing::get_target_airspeed_cm(void)
 
     switch (type) {
     case TYPE_STANDARD_GLIDE_SLOPE:
-        return type_slope_get_target_airspeed_cm();
+        return type_slope_get_target_airspeed_ms() * 100.0;
 #if HAL_LANDING_DEEPSTALL_ENABLED
     case TYPE_DEEPSTALL:
-        return deepstall.get_target_airspeed_cm();
+        return deepstall.get_target_airspeed_ms() * 100.0;
 #endif
     default:
         // don't return the landing airspeed, because if type is invalid we have

--- a/libraries/AP_Landing/AP_Landing.h
+++ b/libraries/AP_Landing/AP_Landing.h
@@ -200,7 +200,7 @@ private:
     void type_slope_adjust_landing_slope_for_rangefinder_bump(AP_FixedWing::Rangefinder_State &rangefinder_state, Location &prev_WP_loc, Location &next_WP_loc, const Location &current_loc, const float wp_distance, int32_t &target_altitude_offset_cm);
 
     void type_slope_setup_landing_glide_slope(const Location &prev_WP_loc, const Location &next_WP_loc, const Location &current_loc, int32_t &target_altitude_offset_cm);
-    int32_t type_slope_get_target_airspeed_cm(void);
+    float type_slope_get_target_airspeed_ms(void);
     void type_slope_check_if_need_to_abort(const AP_FixedWing::Rangefinder_State &rangefinder_state);
     int32_t type_slope_constrain_roll(const int32_t desired_roll_cd, const int32_t level_roll_limit_cd);
     bool type_slope_request_go_around(void);

--- a/libraries/AP_Landing/AP_Landing.h
+++ b/libraries/AP_Landing/AP_Landing.h
@@ -96,7 +96,7 @@ public:
 
     // helper functions
     bool restart_landing_sequence(void);
-    int32_t get_target_airspeed_cm(void);
+    float get_target_airspeed_ms(void);
 
     // accessor functions for the params and states
     static const struct AP_Param::GroupInfo var_info[];

--- a/libraries/AP_Landing/AP_Landing_Deepstall.cpp
+++ b/libraries/AP_Landing/AP_Landing_Deepstall.cpp
@@ -423,14 +423,14 @@ bool AP_Landing_Deepstall::get_target_altitude_location(Location &location)
     return true;
 }
 
-int32_t AP_Landing_Deepstall::get_target_airspeed_cm(void) const
+float AP_Landing_Deepstall::get_target_airspeed_ms(void) const
 {
     if (stage == DEEPSTALL_STAGE_APPROACH ||
         stage == DEEPSTALL_STAGE_LAND) {
-        return landing.pre_flare_airspeed * 100;
-    } else {
-        return landing.aparm.airspeed_cruise*100;
+        return landing.pre_flare_airspeed;
     }
+
+    return landing.aparm.airspeed_cruise;
 }
 
 bool AP_Landing_Deepstall::send_deepstall_message(mavlink_channel_t chan) const

--- a/libraries/AP_Landing/AP_Landing_Deepstall.h
+++ b/libraries/AP_Landing/AP_Landing_Deepstall.h
@@ -91,7 +91,7 @@ private:
     bool override_servos(void);
     bool request_go_around(void);
     bool get_target_altitude_location(Location &location);
-    int32_t get_target_airspeed_cm(void) const;
+    float get_target_airspeed_ms(void) const;
     bool is_throttle_suppressed(void) const;
     bool is_flying_forward(void) const;
     bool is_on_approach(void) const;

--- a/libraries/AP_Landing/AP_Landing_Slope.cpp
+++ b/libraries/AP_Landing/AP_Landing_Slope.cpp
@@ -344,24 +344,24 @@ void AP_Landing::type_slope_setup_landing_glide_slope(const Location &prev_WP_lo
     constrain_target_altitude_location_fn(loc, prev_WP_loc);
 }
 
-int32_t AP_Landing::type_slope_get_target_airspeed_cm(void)
+float AP_Landing::type_slope_get_target_airspeed_ms(void)
 {
     // we're landing, check for custom approach and
     // pre-flare airspeeds. Also increase for head-winds
 
     // default landing target airspeed is the average of cruise and
     // minimum airspeed:
-    int32_t target_airspeed_cm = 100 * 0.5 * (aparm.airspeed_cruise + aparm.airspeed_min);
+    float target_airspeed_ms = 0.5f * (aparm.airspeed_cruise + aparm.airspeed_min);
 
     // land airspeed can be explicitly specified:
     const float land_airspeed = tecs_Controller->get_land_airspeed();
     if (land_airspeed >= 0) {
-        target_airspeed_cm = land_airspeed * 100;
+        target_airspeed_ms = land_airspeed;
     }
 
     switch (type_slope_stage) {
     case SlopeStage::NORMAL:
-        target_airspeed_cm = aparm.airspeed_cruise*100;
+        target_airspeed_ms = aparm.airspeed_cruise;
         break;
     case SlopeStage::APPROACH:
         break;
@@ -369,19 +369,19 @@ int32_t AP_Landing::type_slope_get_target_airspeed_cm(void)
     case SlopeStage::FINAL:
         if (pre_flare_airspeed > 0) {
             // if we just preflared then continue using the pre-flare airspeed during final flare
-            target_airspeed_cm = pre_flare_airspeed * 100;
+            target_airspeed_ms = pre_flare_airspeed;
         }
         break;
     }
 
-    // when landing, add half of head-wind.
+    // when landing, add scaled amount of head-wind based on a
+    // percentage-parameter
     const float head_wind_comp = constrain_float(wind_comp, 0.0f, 100.0f)*0.01;
-    const int32_t head_wind_compensation_cm = ahrs.head_wind() * head_wind_comp * 100;
+    const float head_wind_compensation_ms = ahrs.head_wind() * head_wind_comp;
 
-    const uint32_t max_airspeed_cm = AP_Landing::allow_max_airspeed_on_land() ? aparm.airspeed_max*100 : aparm.airspeed_cruise*100;
-    
-    return constrain_int32(target_airspeed_cm + head_wind_compensation_cm, target_airspeed_cm, max_airspeed_cm);
-    
+    const float max_airspeed_ms = AP_Landing::allow_max_airspeed_on_land() ? aparm.airspeed_max : aparm.airspeed_cruise;
+
+    return constrain_float(target_airspeed_ms + head_wind_compensation_ms, target_airspeed_ms, max_airspeed_ms);
 }
 
 int32_t AP_Landing::type_slope_constrain_roll(const int32_t desired_roll_cd, const int32_t level_roll_limit_cd)


### PR DESCRIPTION
### Summary

Moves the interface in the library to be in metres/second, our preferred units

Edit: now contains a bugfix for a returned airspeed in a badly-configured-vehicle case.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Doing the minimal fix on https://github.com/ArduPilot/ardupilot/pull/33247 was difficult for me.  Just so many *100 and *0.01 going on!

Rewrite the interface to me in metres/second.
