### PR TITLE
AP_Scripting: add is_crashed() binding and crash-actions.lua applet

### DIFF
--- a/Rover/Parameters.cpp
+++ b/Rover/Parameters.cpp
@@ -634,6 +634,42 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Path: mode_circle.cpp
     AP_SUBGROUPINFO(mode_circle, "CIRC", 57, ParametersG2, ModeCircle),
 
+    // @Param: CRASH_THR_MIN
+    // @DisplayName: Crash throttle minimum
+    // @Description: Throttle above this threshold accompanied by a low speed condition triggers crash detection. Zero disables velocity and turn rate checks.
+    // @Units: %
+    // @Range: 0 100
+    // @Increment: 1
+    // @User: Advanced
+    AP_GROUPINFO("CRASH_THR_MIN", 58, ParametersG2, crash_thr_min, 5),
+
+    // @Param: CRASH_VEL_MIN
+    // @DisplayName: Crash velocity minimum
+    // @Description: Velocity below this threshold with accompanying throttle demand triggers crash detection. Zero disables velocity check.
+    // @Units: m/s
+    // @Range: 0 60
+    // @Increment: 0.1
+    // @User: Advanced
+    AP_GROUPINFO("CRASH_VEL_MIN", 59, ParametersG2, crash_vel_min, 0.08),
+
+    // @Param: CRASH_TRAT_MIN
+    // @DisplayName: Crash turn rate minimum
+    // @Description: Turn rate below this threshold with accompanying throttle demand triggers crash detection. Zero disables turn rate check.
+    // @Units: deg/s
+    // @Range: 0 360
+    // @Increment: 1
+    // @User: Advanced
+    AP_GROUPINFO("CRASH_TRAT_MIN", 60, ParametersG2, crash_turn_rate_min, 10.0),
+
+    // @Param: CRASH_TIMEOUT
+    // @DisplayName: Crash timeout
+    // @Description: Crash conditions persisting for this duration trigger crash detection.
+    // @Units: s
+    // @Range: 0 60
+    // @Increment: 0.5
+    // @User: Advanced
+    AP_GROUPINFO("CRASH_TIMEOUT", 61, ParametersG2, crash_timeout, 2.0),
+
     AP_GROUPEND
 };
 

--- a/Rover/Parameters.h
+++ b/Rover/Parameters.h
@@ -343,6 +343,18 @@ public:
     // pitch/roll angle for crash check
     AP_Int8 crash_angle;
 
+    // min throttle for crash check
+    AP_Float crash_thr_min;
+
+    // velocity threshold for crash check
+    AP_Float crash_vel_min;
+
+    // turn rate threshold for crash check
+    AP_Float crash_turn_rate_min;
+
+    // crash trigger time in seconds
+    AP_Float crash_timeout;
+
 #if AP_FOLLOW_ENABLED
     // follow mode library
     AP_Follow follow;

--- a/Rover/Rover.h
+++ b/Rover/Rover.h
@@ -293,6 +293,7 @@ private:
 
     // crash_check.cpp
     void crash_check();
+    bool is_crashed() const override;
 
     // cruise_learn.cpp
     void cruise_learn_start();

--- a/Rover/crash_check.cpp
+++ b/Rover/crash_check.cpp
@@ -1,12 +1,10 @@
 #include "Rover.h"
 
 // Code to detect a crash or block
-static const uint16_t CRASH_CHECK_TRIGGER_SEC = 2;   // 2 seconds blocked indicates a crash
-static const float CRASH_CHECK_THROTTLE_MIN = 5.0f;  // vehicle must have a throttle greater that 5% to be considered crashed
-static const float CRASH_CHECK_VEL_MIN = 0.08f;      // vehicle must have a velocity under 0.08 m/s or rad/s to be considered crashed
 
-// crash_check - disarms motors if a crash or block has been detected
-// crashes are detected by the vehicle being static (no speed) for more than CRASH_CHECK_TRIGGER_SEC and motor are running
+// crash_check - sets hold mode and optionally disarms motors if a crash or block has been detected
+// crashes are detected by speed below crash_vel_min or turn rate below crash_turn_rate_min
+//     with throttle demand above crash_thr_min for longer than crash_timeout
 // called at 10Hz
 void Rover::crash_check()
 {
@@ -25,12 +23,13 @@ void Rover::crash_check()
     }
 
     // TODO : Check if min vel can be calculated
-    // min_vel = ( CRASH_CHECK_THROTTLE_MIN * g.speed_cruise) / g.throttle_cruise;
+    // min_vel = ( g2.crash_thr_min * g.speed_cruise) / g.throttle_cruise;
 
-    if (!is_balancebot()) {
-        if (!crashed && ((ahrs.groundspeed() >= CRASH_CHECK_VEL_MIN) ||        // Check velocity
-            (fabsf(ahrs.get_gyro().z) >= CRASH_CHECK_VEL_MIN) ||  // Check turn speed
-            (fabsf(g2.motors.get_throttle()) < CRASH_CHECK_THROTTLE_MIN))) {
+    if (!is_balancebot() && g2.crash_thr_min > 0.0f && g2.crash_timeout > 0.0f) {
+        if (!crashed && 
+            ((g2.crash_vel_min > 0.0f && ahrs.groundspeed() >= g2.crash_vel_min) ||                      // Check velocity
+            (g2.crash_turn_rate_min > 0.0f && fabsf(ahrs.get_gyro().z) >= radians(g2.crash_turn_rate_min)) ||  // Check turn rate
+            (fabsf(g2.motors.get_throttle()) < g2.crash_thr_min))) {
             crash_counter = 0;
             return;
         }
@@ -38,8 +37,8 @@ void Rover::crash_check()
         // we may be crashing
         crash_counter++;
 
-        // check if crashing for 2 seconds
-        if (crash_counter >= (CRASH_CHECK_TRIGGER_SEC * 10)) {
+        // check if crashing for crash_timeout seconds
+        if (crash_counter >= (g2.crash_timeout * 10)) {
             crashed = true;
         }
     }
@@ -62,4 +61,13 @@ void Rover::crash_check()
             }
         }
     }
+}
+
+// override AP_Vehicle::is_crashed() to also check control mode reason
+// returns true if control_mode_reason is CRASH_FAILSAFE or
+// parent method returns true
+bool Rover::is_crashed() const
+{
+    return (control_mode_reason == ModeReason::CRASH_FAILSAFE) ||
+        AP_Vehicle::is_crashed();
 }

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -201,6 +201,40 @@ class AutoTestRover(vehicle_test_suite.TestSuite):
         self.disarm_vehicle()
         self.progress("Loiter or Hold as throttle failsafe OK")
 
+    def CrashCheck(self):
+        """Test crash detection with FS_CRASH_CHECK 1 (hold) and 2 (hold+disarm)"""
+        self.set_parameters({
+            "CRASH_VEL_MIN": 60.0,    # unreachably high so any speed triggers
+            "CRASH_TRAT_MIN": 360.0,  # same for turn rate
+            "CRASH_TIMEOUT": 2.0,
+            "CRASH_THR_MIN": 5.0,
+        })
+        self.upload_simple_relhome_mission([
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 300, 0, 0),
+        ])
+
+        self.progress("Testing FS_CRASH_CHECK,1 (hold only)")
+        self.set_parameter("FS_CRASH_CHECK", 1)
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+        self.change_mode('AUTO')
+        self.wait_statustext("Crash: Going to HOLD")
+        self.wait_mode("HOLD")
+        self.progress("Confirming still armed after hold-only crash")
+        self.assert_armed()
+        self.disarm_vehicle(force=True)
+        self.progress("FS_CRASH_CHECK,1 (hold only) OK")
+
+        self.progress("Testing FS_CRASH_CHECK,2 (hold + disarm)")
+        self.set_parameter("FS_CRASH_CHECK", 2)
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+        self.change_mode('AUTO')
+        self.wait_statustext("Crash: Going to HOLD")
+        self.wait_mode("HOLD")
+        self.wait_disarmed()
+        self.progress("FS_CRASH_CHECK,2 (hold + disarm) OK")
+
     def PARAM_ERROR(self):
         '''test PARAM_ERROR mavlink message'''
         self.start_subtest("Non-existent parameter (get)")
@@ -7365,6 +7399,7 @@ return update()
             self.GetMessageInterval,
             self.SafetySwitch,
             self.ThrottleFailsafe,
+            self.CrashCheck,
             self.DriveEachFrame,
             self.AP_ROVER_AUTO_ARM_ONCE_ENABLED,
             self.GPSAntennaPositionOffset,

--- a/libraries/AP_Scripting/applets/crash-actions.lua
+++ b/libraries/AP_Scripting/applets/crash-actions.lua
@@ -1,0 +1,198 @@
+--[[
+    crash-actions.lua augments FS_CRASH_CHECK (Copter/Rover) and CRASH_DETECT (Plane).
+
+    If crash detection is enabled, this script enables additional, configurable
+        post-crash actions. See crash-actions.md for configuration details.
+
+    -- Yuri Rage, May 2026
+]]
+
+local SCRIPT_NAME          = "Crash Actions"
+local UPDATE_MS            = 500
+local MAV_SEVERITY         = { EMERGENCY = 0, ALERT = 1, CRITICAL = 2, ERROR = 3, WARNING = 4, NOTICE = 5, INFO = 6, DEBUG = 7 }
+local MAV_CMD_DO_SET_SERVO = 183
+local ACTION               = {
+    DISARM         = 1,
+    SET_RELAY_OFF  = 2,
+    SET_RELAY_ON   = 3,
+    SET_SERVO_MIN  = 4,
+    SET_SERVO_TRIM = 5,
+    SET_SERVO_MAX  = 6,
+}
+local SERVO_PARAM          = {
+    [ACTION.SET_SERVO_MIN]  = "MIN",
+    [ACTION.SET_SERVO_TRIM] = "TRIM",
+    [ACTION.SET_SERVO_MAX]  = "MAX",
+}
+local MAX_INSTANCES        = 32 -- max number of relay/servo instances
+
+-- parameter table variables
+local NUM_CRASH_ACTIONS    = 4
+local PARAM_TABLE_PREFIX   = "CRASH_"
+local PARAM_TABLE_SIZE     = NUM_CRASH_ACTIONS * 3
+local PARAM_TABLE_KEY      = 188
+
+-- parameter variables bound at runtime
+local CRASH_ACTIONS        = {}
+
+-- forward declarations for state machine functions
+local standby              = nil
+local do_crash_actions     = nil
+local protected_wrapper    = nil
+
+local valid_relays         = {}
+local valid_servos         = {}
+
+local crash_time_ms        = uint32_t(0)
+
+-- determine valid (configured) servo/relay instances
+for i = 1, MAX_INSTANCES do
+    local val = param:get(string.format("RELAY%d_FUNCTION", i)) or 0
+    if val > 0 then
+        valid_relays[i] = true
+    end
+
+    val = param:get(string.format("SERVO%d_FUNCTION", i)) or 0
+    if val > 0 then
+        valid_servos[i] = true
+    end
+end
+
+-- add a parameter and bind it to a variable
+local function bind_add_param(name, idx, default_value)
+    assert(param:add_param(PARAM_TABLE_KEY, idx, name, default_value),
+        string.format("%s: could not add param %s", SCRIPT_NAME, name))
+    return Parameter(PARAM_TABLE_PREFIX .. name)
+end
+
+-- add CRASH_ param table
+assert(param:add_table(PARAM_TABLE_KEY, PARAM_TABLE_PREFIX, PARAM_TABLE_SIZE),
+    string.format("%s: could not add param table", SCRIPT_NAME))
+
+-- bind CRASH_ params
+for i = 1, PARAM_TABLE_SIZE - 1, 3 do
+    local idx = (i + 2) // 3
+    CRASH_ACTIONS[idx] = {
+        action = bind_add_param(string.format("ACT%d", idx), i, 0),
+        instance = bind_add_param(string.format("ACT%d_INST", idx), i + 1, 0),
+        timeout = bind_add_param(string.format("ACT%d_TIME", idx), i + 2, 0),
+        complete = false,
+    }
+end
+
+-- handle a crash action
+-- sends GCS message on failure
+local function handle_crash_action(action_type, instance)
+    if action_type == ACTION.DISARM then
+        gcs:send_text(MAV_SEVERITY.NOTICE, string.format("%s: Disarming", SCRIPT_NAME))
+        arming:disarm()
+        return
+    end
+
+    if action_type == ACTION.SET_RELAY_OFF or action_type == ACTION.SET_RELAY_ON then
+        if not valid_relays[instance] then
+            gcs:send_text(MAV_SEVERITY.ERROR, string.format("%s: RELAY%d not configured", SCRIPT_NAME, instance))
+            return
+        end
+        local state = (action_type == ACTION.SET_RELAY_OFF) and "OFF" or "ON"
+        gcs:send_text(MAV_SEVERITY.NOTICE, string.format("%s: Setting RELAY%d %s", SCRIPT_NAME, instance, state))
+        if action_type == ACTION.SET_RELAY_OFF then
+            relay:off(instance - 1)
+        else
+            relay:on(instance - 1)
+        end
+        return
+    end
+
+    if action_type == ACTION.SET_SERVO_MIN or action_type == ACTION.SET_SERVO_TRIM or action_type == ACTION.SET_SERVO_MAX then
+        if not valid_servos[instance] then
+            gcs:send_text(MAV_SEVERITY.ERROR, string.format("%s: SERVO%d not configured", SCRIPT_NAME, instance))
+            return
+        end
+
+        local suffix = SERVO_PARAM[action_type]
+        local val = param:get(string.format("SERVO%d_%s", instance, suffix))
+        if not val then
+            gcs:send_text(MAV_SEVERITY.ERROR,
+                string.format("%s: Failed to get SERVO%d_%s", SCRIPT_NAME, instance, suffix))
+            return
+        end
+        gcs:send_text(MAV_SEVERITY.NOTICE, string.format("%s: Setting SERVO%d %s", SCRIPT_NAME, instance, suffix))
+        -- uses MAV_CMD_DO_SET_SERVO rather than SRV_Channels:set_() bindings
+        -- gets ignore_small_rcin_changes() behavior used by AP_ServoRelayEvents
+        gcs:run_command_int(MAV_CMD_DO_SET_SERVO, { p1 = instance, p2 = val })
+        return
+    end
+
+    gcs:send_text(MAV_SEVERITY.ERROR, string.format("%s: Unknown action %d", SCRIPT_NAME, action_type))
+end
+
+-- state machine function to iterate over crash actions
+-- returns next state function
+do_crash_actions = function()
+    if not vehicle:is_crashed() then
+        gcs:send_text(MAV_SEVERITY.NOTICE, string.format("%s: Recovered", SCRIPT_NAME))
+        return standby
+    end
+
+    for _, crash_action in ipairs(CRASH_ACTIONS) do
+        local action = crash_action.action:get()
+
+        if not crash_action.complete and
+            action > 0 and
+            millis() - crash_time_ms > (crash_action.timeout:get() * 1000) then
+            handle_crash_action(action, crash_action.instance:get())
+            crash_action.complete = true
+        end
+    end
+
+    return do_crash_actions
+end
+
+-- state machine function active until crash detection
+-- returns next state function
+standby = function()
+    if vehicle:is_crashed() then
+        crash_time_ms = millis()
+        for _, crash_action in ipairs(CRASH_ACTIONS) do
+            crash_action.complete = (crash_action.action:get() == 0)
+        end
+        gcs:send_text(MAV_SEVERITY.EMERGENCY, string.format("%s: Executing...", SCRIPT_NAME))
+        return do_crash_actions
+    end
+    return standby
+end
+
+-- wrapper around the state machine to handle errors
+-- if a state machine function fails, an error message is sent and the function is retried after 1s
+local result = standby
+protected_wrapper = function()
+    local last_fn = result
+    local success
+    success, result = pcall(result)
+    if not success then
+        gcs:send_text(MAV_SEVERITY.ERROR, "Internal Error: " .. result)
+        result = standby -- reset the state machine
+        return protected_wrapper, 1000
+    end
+
+    if last_fn == standby and result == do_crash_actions then
+        -- execute crash actions ASAP if changing state from standby
+        return protected_wrapper, 0
+    end
+    return protected_wrapper, UPDATE_MS
+end
+
+-- Copter/Rover firmware crash detection check/warning
+if param:get("FS_CRASH_CHECK") == 0 then
+    gcs:send_text(MAV_SEVERITY.WARNING, string.format("%s: FS_CRASH_CHECK is disabled", SCRIPT_NAME))
+end
+
+-- Plane firmware crash detection check/warning
+if param:get("CRASH_DETECT") == 0 then
+    gcs:send_text(MAV_SEVERITY.WARNING, string.format("%s: CRASH_DETECT is disabled", SCRIPT_NAME))
+end
+
+gcs:send_text(MAV_SEVERITY.INFO, string.format("%s: Script loaded", SCRIPT_NAME))
+
+return protected_wrapper()

--- a/libraries/AP_Scripting/applets/crash-actions.md
+++ b/libraries/AP_Scripting/applets/crash-actions.md
@@ -1,0 +1,36 @@
+# Crash Actions
+
+Crash Actions (`crash-actions.lua`) augments `FS_CRASH_CHECK` (Copter/Rover) and `CRASH_DETECT` (Plane) in firmware v4.8 and later. If crash detection is enabled, this script enables additional, configurable post-crash actions via the following parameters:
+
+- `CRASH_ACT1`: Action type; see definitions below.
+- `CRASH_ACT1_INST`: Instance number of relay/servo, as required.
+- `CRASH_ACT1_TIME`: Time in seconds after crash detection to trigger the action.
+- `CRASH_ACT2`
+- `CRASH_ACT2_INST`
+- `CRASH_ACT2_TIME`
+- ...and so on, through `CRASH_ACT4`.
+
+## Configuration
+
+- Enable `FS_CRASH_CHECK` (or `CRASH_DETECT` for Plane).
+- Set `CRASH_ACTx` (where `x` is 1-4) to one of the following action types:
+  - `0`: Disable (default)
+  - `1`: Disarm
+  - `2`: Relay off
+  - `3`: Relay on
+  - `4`: Servo min
+  - `5`: Servo trim
+  - `6`: Servo max
+
+- Set `CRASH_ACTx_INST` to the desired relay number or servo channel (unused for disarm).
+- Set `CRASH_ACTx_TIME` to the desired time in seconds after crash detection to trigger the action.
+
+## Use Cases
+
+This script was developed for use with large Rovers, where fire risk or other damage could result from an unmitigated mechanical failure or stuck condition. Once a crash is detected, the script can automatically disengage autopilot controlled PTO drives, command a combustion engine to idle, kill ignition, etc.
+
+These features may be less useful on airborne platforms, but the script is vehicle agnostic, should a use case arise.
+
+## Advanced Configuration
+
+If more than 4 post-crash actions are desired, edit the script's `NUM_CRASH_ACTIONS` variable to the desired number of actions. This will increase the number of available `CRASH_ACTx` parameters accordingly.

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -2916,6 +2916,10 @@ function vehicle:reboot(hold_in_bootloader) end
 ---@return boolean
 function vehicle:is_taking_off() end
 
+-- Returns true if the vehicle's crash detection has triggered
+---@return boolean
+function vehicle:is_crashed() end
+
 -- desc
 ---@return boolean
 function vehicle:is_landing() end

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -387,6 +387,7 @@ singleton AP_Vehicle method has_ekf_failsafed boolean
 singleton AP_Vehicle method reboot void boolean
 singleton AP_Vehicle method is_landing boolean
 singleton AP_Vehicle method is_taking_off boolean
+singleton AP_Vehicle method is_crashed boolean
 singleton AP_Vehicle method set_crosstrack_start boolean Location
 singleton AP_Vehicle method register_custom_mode AP_Vehicle::custom_mode_state uint8_t'skip_check string string
 


### PR DESCRIPTION
### Summary

Adds a `vehicle:is_crashed()` Lua binding and `crash-actions.lua` applet that uses the binding to extend failsafe actions.

### Classification & Testing

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

Tested in SITL and on a Pixhawk6X Rover.

### Description

Fixes a long-standing hidden bug by overriding Rover's inherited `is_crashed()` method that would previously always return false if `FS_CRASH_CHECK` was set to 1 (`HOLD` only). Also fixes an oddity where velocity and turn rate used the same 0.08 magic number threshold, mixing units.

Adds Rover params to give finer control over crash detection thresholds (particularly useful for very slow rovers or other unique cases - defaults remain essentially unchanged from previous magic numbers):

- `CRASH_THR_MIN`: Throttle above this threshold accompanied by a low speed condition triggers crash detection. Zero disables check.
- `CRASH_VEL_MIN`: Velocity below this threshold with accompanying throttle demand triggers crash detection.
- `CRASH_TRAT_MIN`: Turn rate below this threshold with accompanying throttle demand triggers crash detection.
- `CRASH_TIMEOUT`: Crash conditions persisting for this duration trigger crash detection.

Adds `Rover.CrashCheck autotest` covering both `FS_CRASH_CHECK` enabled values.

Adds `crash-actions.lua`, see `crash-actions.md`.

Applet and binding are vehicle agnostic, though generally targeted toward Rover use cases.