### PR TITLE
AP_FETtecOneWire: tidy calculation of max. ESCs

### DIFF
--- a/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
+++ b/libraries/AP_FETtecOneWire/AP_FETtecOneWire.cpp
@@ -124,11 +124,12 @@ void AP_FETtecOneWire::init()
     // OneWire supports telemetry in at most 15 ESCs, because of the 4 bit limitation
     // on the fast-throttle command.  But we are still limited to the
     // number of ESCs the telem library will collect data for.
-    if (_esc_count == 0 || _motor_mask >= (1U << MIN(15, ESC_TELEM_MAX_ESCS))) {
+    const auto esc_count_limit = MIN(15, ESC_TELEM_MAX_ESCS);
 #else
     // OneWire supports at most 24 ESCs without telemetry
-    if (_esc_count == 0 || _motor_mask >= (1U << MIN(24, NUM_SERVO_CHANNELS))) {
+    const auto esc_count_limit = MIN(24, NUM_SERVO_CHANNELS);
 #endif
+    if (_esc_count == 0 || _motor_mask >= (1U << esc_count_limit)) {
         _invalid_mask = true;
         return;
     }


### PR DESCRIPTION
### Summary

Simplify the code around calculating and validating the ESC count

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board,plane
CubeOrangePlus,*
```

The code does not currently compile with:
```
define HAL_WITH_ESC_TELEM 0
define AP_EXTENDED_ESC_TELEM_ENABLED 0
```

and `./Tools/scripts/size_compare_branches.py --board=CubeOrangePlus --extra-hwdef=/tmp/x`:
```
../../libraries/AP_DroneCAN/AP_DroneCAN.cpp: In member function 'void AP_DroneCAN::handle_hobbywing_StatusMsg1(const CanardRxTransfer&, const com_hobbywing_esc_StatusMsg1&)':
../../libraries/AP_DroneCAN/AP_DroneCAN.cpp:629:9: error: 'update_rpm' was not declared in this scope
  629 |         update_rpm(esc_index, msg.rpm);
      |         ^~~~~~~~~~
```

(that is obviously pre-existing)

### Description

Makes the minimum amount of code dependent on the defines
