### PR TITLE
AC_Avoidance: explicitly nominate constants as floats

### DIFF
--- a/libraries/AC_Avoidance/AC_Avoid.h
+++ b/libraries/AC_Avoidance/AC_Avoid.h
@@ -58,7 +58,11 @@ public:
     }
     void adjust_velocity_NED_m(Vector3f &desired_vel_ned_ms, float kP, float accel_mss, float kP_z, float accel_z_mss, float dt) {
         bool backing_up = false;
-        Vector3f desired_vel_neu_cms{desired_vel_ned_ms.x * 100.0, desired_vel_ned_ms.y * 100.0, -desired_vel_ned_ms.z * 100.0};
+        Vector3f desired_vel_neu_cms{
+            desired_vel_ned_ms.x * 100.0f,
+            desired_vel_ned_ms.y * 100.0f,
+            -desired_vel_ned_ms.z * 100.0f
+        };
         adjust_velocity(desired_vel_neu_cms, backing_up, kP, accel_mss * 100.0, kP_z, accel_z_mss * 100.0, dt);
         desired_vel_ned_ms = Vector3f{desired_vel_neu_cms.x, desired_vel_neu_cms.y, -desired_vel_neu_cms.z} * 0.01;
     }


### PR DESCRIPTION
### Summary

Adds `f` qualifiers to some constants in a header file as clang doesn't grok constants-are-floats directive

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

this is purely cosmetic in gcc as we use a compiler option to narrow the type.

it causes untold number of warnings when compiling with clang:

```
2026-05-30T13:15:14.4949610Z ../../libraries/AC_Avoidance/AC_Avoid.h:61:68: error: non-constant-expression cannot be narrowed from type 'double' to 'float' in initializer list [-Wc++11-narrowing]
2026-05-30T13:15:14.4951383Z         Vector3f desired_vel_neu_cms{desired_vel_ned_ms.x * 100.0, desired_vel_ned_ms.y * 100.0, -desired_vel_ned_ms.z * 100.0};
2026-05-30T13:15:14.4952289Z                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
2026-05-30T13:15:14.4953058Z ../../libraries/AC_Avoidance/AC_Avoid.h:61:68: note: insert an explicit cast to silence this issue
2026-05-30T13:15:14.4954146Z         Vector3f desired_vel_neu_cms{desired_vel_ned_ms.x * 100.0, desired_vel_ned_ms.y * 100.0, -desired_vel_ned_ms.z * 100.0};
2026-05-30T13:15:14.4955068Z                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
2026-05-30T13:15:14.4955704Z                                                                    static_cast<float>(         )
2026-05-30T13:15:14.4956886Z ../../libraries/AC_Avoidance/AC_Avoid.h:61:98: error: non-constant-expression cannot be narrowed from type 'double' to 'float' in initializer list [-Wc++11-narrowing]
2026-05-30T13:15:14.4958370Z         Vector3f desired_vel_neu_cms{desired_vel_ned_ms.x * 100.0, desired_vel_ned_ms.y * 100.0, -desired_vel_ned_ms.z * 100.0};
2026-05-30T13:15:14.4959324Z                                                                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2026-05-30T13:15:14.4962091Z ../../libraries/AC_Avoidance/AC_Avoid.h:61:98: note: insert an explicit cast to silence this issue
2026-05-30T13:15:14.4963217Z         Vector3f desired_vel_neu_cms{desired_vel_ned_ms.x * 100.0, desired_vel_ned_ms.y * 100.0, -desired_vel_ned_ms.z * 100.0};
2026-05-30T13:15:14.4964188Z                                                                                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2026-05-30T13:15:14.4964943Z                                                                                                  static_cast<float>(          )
2026-05-30T13:15:14.4965518Z 3 errors generated.
```
