### PR TITLE
AP_L1_Control: use M_PI_2 constant instead of hardcoded float

### DIFF
--- a/libraries/AP_L1_Control/AP_L1_Control.cpp
+++ b/libraries/AP_L1_Control/AP_L1_Control.cpp
@@ -334,7 +334,7 @@ void AP_L1_Control::update_waypoint(const Location &prev_WP, const Location &nex
     _last_Nu = Nu;
 
     // Limit Nu to +-(pi/2)
-    Nu = constrain_float(Nu, -1.5708f, +1.5708f);
+    Nu = constrain_float(Nu, -M_PI_2, M_PI_2);
     _latAccDem = K_L1 * groundSpeed * groundSpeed / _L1_dist * sinf(Nu);
 
     // Waypoint capture status is always false during waypoint following


### PR DESCRIPTION
### Summary

Replace the hardcoded float literal `1.5708f` with the standard mathematical constant `M_PI_2` in `AP_L1_Control.cpp` to improve code readability and numerical precision.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

The change has been successfully verified to compile on the `fmuv3` target (`./waf copter` builds successfully).

### Description

This PR refactors `libraries/AP_L1_Control/AP_L1_Control.cpp` by replacing the hardcoded float literal `1.5708f` with `M_PI_2` when limiting the angle `Nu`:

1. **Clarity**: Using `M_PI_2` makes the mathematical intent of limiting `Nu` to $\pm\frac{\pi}{2}$ radians explicit and immediately obvious to developers reading the code.
2. **Precision**: The standard constant `M_PI_2` provides higher numerical precision compared to the 4-decimal approximation `1.5708f`.
3. **Style**: It aligns with modern coding standards by removing an unnecessary magic number literal.