### PR TITLE
autotest: wait for RTL to complete rather than a flat timeout

### DIFF
--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -4460,13 +4460,19 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             target_system=target_system,
             target_component=target_component)
 
-        self.delay_sim_time(5, reason="RTL to complete")
+        self.wait_rtl_complete()
+
         self.progress("Drive outside bottom polygon")
         fence_middle = self.offset_location_ne(here, 150, 0)
         self.drive_somewhere_breach_boundary_and_rtl(
             fence_middle,
             target_system=target_system,
             target_component=target_component)
+
+    def wait_rtl_complete(self):
+        """Wait for RTL to reach home and disarm"""
+        self.progress("Waiting RTL to reach Home")
+        self.wait_distance_to_home(0, 7, timeout=30)
 
     def test_poly_fence_exclusion(self, here, target_system=1, target_component=1):
 


### PR DESCRIPTION
### Summary

Replaces a flat 5 second sleep with a check that we actually get home

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

5 seconds is just a guess - wait properly!

Potentially a fix for recently-started-to-flap PolyFence test.

```
2026-06-01T00:03:50.2746493Z AT-0295.6: Fence: FENCE_STATUS {breach_status : 0, breach_count : 9, breach_type : 0, breach_time : 327462, breach_mitigation : 1}
2026-06-01T00:03:50.2748381Z AT-0295.6: Position: (GLOBAL_POSITION_INT {time_boot_ms : 410742, lat : 400713712, lon : -1052297902, alt : 1583090, relative_alt : 92, vx : 2, vy : -1, vz : 0, hdg : 238})
2026-06-01T00:03:50.2750126Z AT-0295.6: Fence: FENCE_STATUS {breach_status : 0, breach_count : 9, breach_type : 0, breach_time : 327462, breach_mitigation : 1}
2026-06-01T00:03:50.2751482Z AT-0295.6: Position: (GLOBAL_POSITION_INT {time_boot_ms : 410842, lat : 400713712, lon : -1052297902, alt : 1583090, relative_alt : 93, vx : 2, vy : -1, vz : 0, hdg : 238})
2026-06-01T00:03:50.2752341Z AT-0295.6: Exception caught: Did not breach boundary + RTL
2026-06-01T00:03:50.2752768Z Traceback (most recent call last):
2026-06-01T00:03:50.2760923Z   File "/__w/ardupilot/ardupilot/Tools/autotest/vehicle_test_suite.py", line 9252, in run_one_test_attempt
2026-06-01T00:03:50.2761616Z     test_function(**test_kwargs)
2026-06-01T00:03:50.2762277Z   File "/__w/ardupilot/ardupilot/Tools/autotest/rover.py", line 4361, in PolyFence
2026-06-01T00:03:50.2763179Z     self.test_poly_fence_inclusion(here, target_system=target_system, target_component=target_component)
2026-06-01T00:03:50.2764422Z   File "/__w/ardupilot/ardupilot/Tools/autotest/rover.py", line 4466, in test_poly_fence_inclusion
2026-06-01T00:03:50.2765090Z     self.drive_somewhere_breach_boundary_and_rtl(
2026-06-01T00:03:50.2765939Z   File "/__w/ardupilot/ardupilot/Tools/autotest/rover.py", line 3808, in drive_somewhere_breach_boundary_and_rtl
2026-06-01T00:03:50.2767362Z     raise NotAchievedException("Did not breach boundary + RTL")
2026-06-01T00:03:50.2791066Z ##[error]vehicle_test_suite.NotAchievedException: Did not breach boundary + RTL
2026-06-01T00:03:50.2798428Z 
2026-06-01T00:03:50.2807351Z AT-0295.6: log list: ['logs/00000001.BIN', 'logs/00000002.BIN', 'logs/00000003.BIN', 
```