### PR TITLE
GCS_MAVLink: do not accept RADIO packets

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4487,7 +4487,6 @@ void GCS_MAVLINK::handle_message(const mavlink_message_t &msg)
         handle_param_value(msg);
         break;
 
-    case MAVLINK_MSG_ID_RADIO:
     case MAVLINK_MSG_ID_RADIO_STATUS:
         handle_radio_status(msg);
         break;
@@ -7380,8 +7379,7 @@ bool GCS_MAVLINK::accept_packet(const mavlink_status_t &status,
         return true;
     }
 
-    if (msg.msgid == MAVLINK_MSG_ID_RADIO ||
-        msg.msgid == MAVLINK_MSG_ID_RADIO_STATUS) {
+    if (msg.msgid == MAVLINK_MSG_ID_RADIO_STATUS) {
         return true;
     }
 

--- a/libraries/GCS_MAVLink/GCS_Signing.cpp
+++ b/libraries/GCS_MAVLink/GCS_Signing.cpp
@@ -110,7 +110,6 @@ extern "C" {
 
 static const uint32_t accept_list[] = {
     MAVLINK_MSG_ID_RADIO_STATUS,
-    MAVLINK_MSG_ID_RADIO
 };
     
 static bool accept_unsigned_callback(const mavlink_status_t *status, uint32_t msgId)


### PR DESCRIPTION
### Summary

Removes ArduPilot's acceptance of a packet which we misunderstood field values for.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

RADIO and RADIO_STATUS were assumed to be identical.

They actually have the opposite meaning for their txbuf.

@nickwithers [pointed this out](https://github.com/ArduPilot/mavlink/issues/213) 5 years ago.

RFD900+ sends RADIO_STATUS, and PX4 Autopilot uses RADIO_STATUS exclusively.
