### PR TITLE
hwdef: ARK_FPV: expose 12V POWER AUX output as a relay

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/ARK_FPV/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ARK_FPV/README.md
@@ -20,7 +20,7 @@
 ### Power
 
 - 5.5V - 54V (2S - 12S) input
-- 12V, 2A output
+- 12V, 2A output (POWER AUX; on by default, optionally switchable via RELAY1)
 - 5V, 2A output. 300ma for main system, 200ma for heater
 
 ### Interfaces
@@ -245,6 +245,17 @@ All outputs are capable of PWM and DShot. Motors 1-4 are capable of Bidirectiona
 - Motors 1-4  Group1 (TIM5)
 - Motors 5-8  Group2 (TIM8)
 - Motor 9     Group3 (TIM4)
+
+## 12V Peripheral Output (POWER AUX)
+
+The 12V pin on the **POWER AUX** connector is gated by a BEC enable (`PG4`) that is **on by default** - it is driven high once the main firmware boots, so no setup is needed to use it.
+
+To make it controllable from the transmitter, expose it as **RELAY1** (the pin is pre-mapped to GPIO 81):
+
+- Set `RELAY1_FUNCTION` = 1 (Relay) and `RELAY1_DEFAULT` = 1 (so it still powers on at boot; the relay's own default state is off).
+- Assign `RCx_OPTION` = 28 (Relay1 On/Off) to the channel you want to use as the switch.
+
+The 12V output is off at power-on and in the bootloader, coming on once the firmware initializes the pin. The VBAT pin on the same connector is a direct battery pass-through and is not controlled by firmware.
 
 ## Loading Firmware
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/ARK_FPV/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ARK_FPV/hwdef.dat
@@ -145,15 +145,16 @@ PE6 nARMED OUTPUT HIGH
 PC13 VDD_3V3_SD_CARD_EN OUTPUT HIGH
 PI11 VDD_3V3_SENSORS1_EN OUTPUT HIGH
 
-# 12V enable, start with it ON
-PG4 VDD_5V_PERIPH_EN OUTPUT HIGH
+# 12V peripheral output (POWER AUX). Default enabled at boot.
+PG4 VDD_12V_PERIPH_EN OUTPUT HIGH GPIO(81)
+define RELAY1_PIN_DEFAULT 81
 
-# Power sensing
-# 12V PGOOD
+# Power sensing. External pull-ups idle these high.
+# 12V rail PGOOD
 PE15 VDD_5V_PERIPH_nOC INPUT FLOATING
-# 5V PGOOD
+# 5V rail
 PF13 VDD_5V_HIPOWER_nOC INPUT FLOATING
-# 5V_ON_BATn
+# 5V source select: low = 5V from battery, high = 5V from USB
 PG1 VDD_BRICK_nVALID INPUT FLOATING
 
 # LEDs


### PR DESCRIPTION
## Summary

The 12V output on the POWER AUX connector is gated by a BEC enable on PG4. It was driven on at boot with no way to control it, and the enable was mislabeled `VDD_5V_PERIPH_EN` even though it drives the 12V rail, not 5V.

This renames it to `VDD_12V_PERIPH_EN`, gives it a GPIO, and pre-maps it to RELAY1 via `RELAY1_PIN_DEFAULT` so it can be switched from an RC channel (`RELAY1_FUNCTION` + `RCx_OPTION`). Default behavior is unchanged — the rail is still on at boot via the pin's `OUTPUT HIGH` state.
