### PR TITLE
SITL: add SIM_MOVE_X/Y/Z/TIME params for ground relocation

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -6722,6 +6722,34 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.wait_disarmed()
 
+    def SIMGroundRelocation(self):
+        '''test SIM_MOVE_X/Y/TIME ground relocation'''
+        self.wait_ready_to_arm()
+        for terrain in [0, 1]:
+            self.set_parameter("SIM_TERRAIN", terrain)
+            start = self.sim_location()
+            move_north_m = 10
+            move_east_m = 5
+            self.set_parameters({
+                "SIM_MOVE_X": move_north_m,
+                "SIM_MOVE_Y": move_east_m,
+            })
+            self.set_parameter("SIM_MOVE_TIME", 3000)
+            # wait for the move to complete (params auto-reset to 0)
+            self.wait_parameter_value("SIM_MOVE_TIME", 0, timeout=10)
+            # confirm params were cleared
+            self.assert_parameter_value("SIM_MOVE_X", 0)
+            self.assert_parameter_value("SIM_MOVE_Y", 0)
+            # confirm vehicle moved the expected distance
+            end = self.sim_location()
+            moved = self.get_distance(start, end)
+            expected = math.sqrt(move_north_m**2 + move_east_m**2)
+            if abs(moved - expected) > 1.0:
+                raise NotAchievedException(
+                    "SIMGroundRelocation: moved %.2fm, expected %.2fm (terrain=%d)" %
+                    (moved, expected, terrain))
+            self.progress("SIMGroundRelocation: moved %.2fm as expected (terrain=%d)" % (moved, terrain))
+
     def Weathervane(self):
         '''Test copter weathervaning'''
         # We test nose into wind code paths and yaw direction here and test side into wind
@@ -14524,6 +14552,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
              self.FenceRelativeToAMSLCliff,
              self.FenceRelativeToTerrainMaxAlt,
              self.FenceRelativeToTerrainMinAlt,
+             self.SIMGroundRelocation,
         ])
         return ret
 

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -7315,6 +7315,45 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.wait_disarmed()
 
+    def SIMGroundRelocation(self):
+        '''test SIM_MOVE_X/Y/TIME ground relocation'''
+        self.wait_ready_to_arm()
+        move_north_m = 10
+        move_east_m = 5
+        total_north = 0
+        total_east = 0
+        for terrain in [0, 1]:
+            self.set_parameter("SIM_TERRAIN", terrain)
+            start = self.get_location('SIMSTATE')
+            self.set_parameters({
+                "SIM_MOVE_X": move_north_m,
+                "SIM_MOVE_Y": move_east_m,
+            })
+            self.set_parameter("SIM_MOVE_TIME", 3000)
+            # wait for the move to complete (params auto-reset to 0)
+            self.wait_parameter_value("SIM_MOVE_TIME", 0, timeout=10)
+            # confirm params were cleared
+            self.assert_parameter_value("SIM_MOVE_X", 0)
+            self.assert_parameter_value("SIM_MOVE_Y", 0)
+            # confirm vehicle moved the expected distance
+            end = self.get_location('SIMSTATE')
+            moved = self.get_distance(start, end)
+            expected = math.sqrt(move_north_m**2 + move_east_m**2)
+            if abs(moved - expected) > 1.0:
+                raise NotAchievedException(
+                    "SIMGroundRelocation: moved %.2fm, expected %.2fm (terrain=%d)" %
+                    (moved, expected, terrain))
+            self.progress("SIMGroundRelocation: moved %.2fm as expected (terrain=%d)" % (moved, terrain))
+            total_north += move_north_m
+            total_east += move_east_m
+        # return vehicle to startup location so post-test position check passes
+        self.set_parameters({
+            "SIM_MOVE_X": -total_north,
+            "SIM_MOVE_Y": -total_east,
+        })
+        self.set_parameter("SIM_MOVE_TIME", 3000)
+        self.wait_parameter_value("SIM_MOVE_TIME", 0, timeout=10)
+
     def Weathervane(self):
         '''Test copter weathervaning'''
         # We test nose into wind code paths and yaw direction here and test side into wind
@@ -16367,6 +16406,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
              self.FenceRelativeToAMSLCliff,
              self.FenceRelativeToTerrainMaxAlt,
              self.FenceRelativeToTerrainMinAlt,
+             self.SIMGroundRelocation,
         ])
         return ret
 

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -2126,6 +2126,34 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         '''Test deadreckoning support with no airspeed sensor'''
         self.deadreckoning_main(disable_airspeed_sensor=True)
 
+    def SIMGroundRelocation(self):
+        '''test SIM_MOVE_X/Y/TIME ground relocation'''
+        self.wait_ready_to_arm()
+        for terrain in [0, 1]:
+            self.set_parameter("SIM_TERRAIN", terrain)
+            start = self.sim_location()
+            move_north_m = 10
+            move_east_m = 5
+            self.set_parameters({
+                "SIM_MOVE_X": move_north_m,
+                "SIM_MOVE_Y": move_east_m,
+            })
+            self.set_parameter("SIM_MOVE_TIME", 3000)
+            # wait for the move to complete (params auto-reset to 0)
+            self.wait_parameter_value("SIM_MOVE_TIME", 0, timeout=10)
+            # confirm params were cleared
+            self.assert_parameter_value("SIM_MOVE_X", 0)
+            self.assert_parameter_value("SIM_MOVE_Y", 0)
+            # confirm vehicle moved the expected distance
+            end = self.sim_location()
+            moved = self.get_distance(start, end)
+            expected = math.sqrt(move_north_m**2 + move_east_m**2)
+            if abs(moved - expected) > 1.0:
+                raise NotAchievedException(
+                    "SIMGroundRelocation: moved %.2fm, expected %.2fm (terrain=%d)" %
+                    (moved, expected, terrain))
+            self.progress("SIMGroundRelocation: moved %.2fm as expected (terrain=%d)" % (moved, terrain))
+
     def ClimbBeforeTurn(self):
         '''Test climb-before-turn'''
         self.wait_ready_to_arm()
@@ -8738,6 +8766,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         '''kind of reserved for flapping tests which we still have hopes for'''
         return [
             self.DeadreckoningNoAirSpeed,
+            self.SIMGroundRelocation,
         ]
 
     def disabled_tests(self):

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -2251,6 +2251,45 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         '''Test deadreckoning support with no airspeed sensor'''
         self.deadreckoning_main(disable_airspeed_sensor=True)
 
+    def SIMGroundRelocation(self):
+        '''test SIM_MOVE_X/Y/TIME ground relocation'''
+        self.wait_ready_to_arm()
+        move_north_m = 10
+        move_east_m = 5
+        total_north = 0
+        total_east = 0
+        for terrain in [0, 1]:
+            self.set_parameter("SIM_TERRAIN", terrain)
+            start = self.get_location('SIMSTATE')
+            self.set_parameters({
+                "SIM_MOVE_X": move_north_m,
+                "SIM_MOVE_Y": move_east_m,
+            })
+            self.set_parameter("SIM_MOVE_TIME", 3000)
+            # wait for the move to complete (params auto-reset to 0)
+            self.wait_parameter_value("SIM_MOVE_TIME", 0, timeout=10)
+            # confirm params were cleared
+            self.assert_parameter_value("SIM_MOVE_X", 0)
+            self.assert_parameter_value("SIM_MOVE_Y", 0)
+            # confirm vehicle moved the expected distance
+            end = self.get_location('SIMSTATE')
+            moved = self.get_distance(start, end)
+            expected = math.sqrt(move_north_m**2 + move_east_m**2)
+            if abs(moved - expected) > 1.0:
+                raise NotAchievedException(
+                    "SIMGroundRelocation: moved %.2fm, expected %.2fm (terrain=%d)" %
+                    (moved, expected, terrain))
+            self.progress("SIMGroundRelocation: moved %.2fm as expected (terrain=%d)" % (moved, terrain))
+            total_north += move_north_m
+            total_east += move_east_m
+        # return vehicle to startup location
+        self.set_parameters({
+            "SIM_MOVE_X": -total_north,
+            "SIM_MOVE_Y": -total_east,
+        })
+        self.set_parameter("SIM_MOVE_TIME", 3000)
+        self.wait_parameter_value("SIM_MOVE_TIME", 0, timeout=10)
+
     def ClimbBeforeTurn(self):
         '''Test climb-before-turn'''
         self.wait_ready_to_arm()
@@ -9378,6 +9417,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         '''kind of reserved for flapping tests which we still have hopes for'''
         return [
             self.DeadreckoningNoAirSpeed,
+            self.SIMGroundRelocation,
         ]
 
     def disabled_tests(self):

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -1283,7 +1283,7 @@ void Aircraft::apply_move(void)
         return;
     }
     auto &m = sitl->move;
-    if (m.t == 0) {
+    if (m.t <= 0) {
         return;
     }
     const uint32_t now = AP_HAL::millis();

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -721,6 +721,7 @@ void Aircraft::update_model(const struct sitl_input &input)
     } else {
         time_advance();
     }
+    apply_move();
 }
 
 /*

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -1273,6 +1273,72 @@ void Aircraft::add_shove_forces(Vector3f &rot_accel, Vector3f &body_accel)
     }
 }
 
+/*
+  smoothly move the vehicle on the ground by interpolating position over SIM_MOVE_TIME ms.
+  Called each simulation step; does nothing unless SIM_MOVE_TIME is non-zero.
+*/
+void Aircraft::apply_move(void)
+{
+    if (sitl == nullptr) {
+        return;
+    }
+    auto &m = sitl->move;
+    if (m.t == 0) {
+        return;
+    }
+    const uint32_t now = AP_HAL::millis();
+    if (m.start_ms == 0) {
+        m.start_ms = now;
+        m.moved_x = 0.0f;
+        m.moved_y = 0.0f;
+        m.moved_z = 0.0f;
+    }
+    // abort if the vehicle has taken off (significant upward velocity, not just a ground shift)
+    if (velocity_ef.z < -1.0f) {
+        m.start_ms = 0;
+        m.x.set_and_save(0);
+        m.y.set_and_save(0);
+        m.z.set_and_save(0);
+        m.t.set_and_save(0);
+        return;
+    }
+
+    const uint32_t elapsed = now - m.start_ms;
+
+    if (elapsed >= uint32_t(m.t)) {
+        // final step: snap to exact destination and clear
+        position.x += float(m.x) - m.moved_x;
+        position.y += float(m.y) - m.moved_y;
+        ground_level -= float(m.z) - m.moved_z;
+        m.start_ms = 0;
+        m.x.set_and_save(0);
+        m.y.set_and_save(0);
+        m.z.set_and_save(0);
+        m.t.set_and_save(0);
+    } else {
+        // fractional step this frame
+        const float dt = frame_time_us * 1.0e-6f;
+        const float total_t = float(m.t) * 1.0e-3f;
+        const float dn = float(m.x) * (dt / total_t);
+        const float de = float(m.y) * (dt / total_t);
+        const float dd = float(m.z) * (dt / total_t);
+        position.x += dn;
+        position.y += de;
+        ground_level -= dd;
+        m.moved_x += dn;
+        m.moved_y += de;
+        m.moved_z += dd;
+    }
+    // Shifting ground_level makes hagl() > 0 so the clamp in update_position()
+    // won't fire. Explicitly keep position.z on the new ground level each frame.
+    position.z = -(ground_level + frame_height - home.alt * 0.01f + ground_height_difference());
+
+    // zero velocity so physics doesn't fight the move
+    velocity_ef.x = 0.0f;
+    velocity_ef.y = 0.0f;
+    velocity_ef.z = 0.0f;
+}
+
 float Aircraft::get_local_updraft(const Vector3d &currentPos)
 {
     int scenario = sitl->thermal_scenario;

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -715,6 +715,7 @@ void Aircraft::update_model(const struct sitl_input &input)
     } else {
         time_advance();
     }
+    apply_move();
 }
 
 /*

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -1286,7 +1286,7 @@ void Aircraft::apply_move(void)
         return;
     }
     auto &m = sitl->move;
-    if (m.t == 0) {
+    if (m.t <= 0) {
         return;
     }
     const uint32_t now = AP_HAL::millis();

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -1276,6 +1276,72 @@ void Aircraft::add_shove_forces(Vector3f &rot_accel, Vector3f &body_accel)
     }
 }
 
+/*
+  smoothly move the vehicle on the ground by interpolating position over SIM_MOVE_TIME ms.
+  Called each simulation step; does nothing unless SIM_MOVE_TIME is non-zero.
+*/
+void Aircraft::apply_move(void)
+{
+    if (sitl == nullptr) {
+        return;
+    }
+    auto &m = sitl->move;
+    if (m.t == 0) {
+        return;
+    }
+    const uint32_t now = AP_HAL::millis();
+    if (m.start_ms == 0) {
+        m.start_ms = now;
+        m.moved_x = 0.0f;
+        m.moved_y = 0.0f;
+        m.moved_z = 0.0f;
+    }
+    // abort if the vehicle has taken off (significant upward velocity, not just a ground shift)
+    if (velocity_ef.z < -1.0f) {
+        m.start_ms = 0;
+        m.x.set_and_save(0);
+        m.y.set_and_save(0);
+        m.z.set_and_save(0);
+        m.t.set_and_save(0);
+        return;
+    }
+
+    const uint32_t elapsed = now - m.start_ms;
+
+    if (elapsed >= uint32_t(m.t)) {
+        // final step: snap to exact destination and clear
+        position.x += float(m.x) - m.moved_x;
+        position.y += float(m.y) - m.moved_y;
+        ground_level -= float(m.z) - m.moved_z;
+        m.start_ms = 0;
+        m.x.set_and_save(0);
+        m.y.set_and_save(0);
+        m.z.set_and_save(0);
+        m.t.set_and_save(0);
+    } else {
+        // fractional step this frame
+        const float dt = frame_time_us * 1.0e-6f;
+        const float total_t = float(m.t) * 1.0e-3f;
+        const float dn = float(m.x) * (dt / total_t);
+        const float de = float(m.y) * (dt / total_t);
+        const float dd = float(m.z) * (dt / total_t);
+        position.x += dn;
+        position.y += de;
+        ground_level -= dd;
+        m.moved_x += dn;
+        m.moved_y += de;
+        m.moved_z += dd;
+    }
+    // Shifting ground_level makes hagl() > 0 so the clamp in update_position()
+    // won't fire. Explicitly keep position.z on the new ground level each frame.
+    position.z = -(ground_level + frame_height - home.alt * 0.01f + ground_height_difference());
+
+    // zero velocity so physics doesn't fight the move
+    velocity_ef.x = 0.0f;
+    velocity_ef.y = 0.0f;
+    velocity_ef.z = 0.0f;
+}
+
 float Aircraft::get_local_updraft(const Vector3d &currentPos)
 {
     int scenario = sitl->thermal_scenario;

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -329,6 +329,9 @@ protected:
     /* update location from position */
     void update_position(void);
 
+    /* smoothly move vehicle on the ground if a move is pending */
+    void apply_move(void);
+
     /* update body frame magnetic field */
     void update_mag_field_bf(void);
 

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -320,6 +320,9 @@ protected:
     /* update location from position */
     void update_position(void);
 
+    /* smoothly move vehicle on the ground if a move is pending */
+    void apply_move(void);
+
     /* update body frame magnetic field */
     void update_mag_field_bf(void);
 

--- a/libraries/SITL/SIM_Multicopter.cpp
+++ b/libraries/SITL/SIM_Multicopter.cpp
@@ -76,9 +76,6 @@ void MultiCopter::update(const struct sitl_input &input)
 
     update_battery();
 
-    apply_move();
-
-
     update_dynamics(rot_accel);
     update_external_payload(input);
 

--- a/libraries/SITL/SIM_Multicopter.cpp
+++ b/libraries/SITL/SIM_Multicopter.cpp
@@ -75,6 +75,10 @@ void MultiCopter::update(const struct sitl_input &input)
     }
 
     update_battery();
+
+    apply_move();
+
+
     update_dynamics(rot_accel);
     update_external_payload(input);
 

--- a/libraries/SITL/SIM_Multicopter.cpp
+++ b/libraries/SITL/SIM_Multicopter.cpp
@@ -78,6 +78,10 @@ void MultiCopter::update(const struct sitl_input &input)
     }
 
     update_battery();
+
+    apply_move();
+
+
     update_dynamics(rot_accel);
     update_external_payload(input);
 

--- a/libraries/SITL/SIM_Multicopter.cpp
+++ b/libraries/SITL/SIM_Multicopter.cpp
@@ -79,9 +79,6 @@ void MultiCopter::update(const struct sitl_input &input)
 
     update_battery();
 
-    apply_move();
-
-
     update_dynamics(rot_accel);
     update_external_payload(input);
 

--- a/libraries/SITL/SIM_Plane.cpp
+++ b/libraries/SITL/SIM_Plane.cpp
@@ -522,6 +522,8 @@ void Plane::update(const struct sitl_input &input)
     battery_current = (battery_voltage/sitl->batt_voltage)*50.0f*sq(throttle);
     battery_temperature_degC = 0.0f;
 
+    apply_move();
+
     update_dynamics(rot_accel);
 
     /*

--- a/libraries/SITL/SIM_Plane.cpp
+++ b/libraries/SITL/SIM_Plane.cpp
@@ -522,8 +522,6 @@ void Plane::update(const struct sitl_input &input)
     battery_current = (battery_voltage/sitl->batt_voltage)*50.0f*sq(throttle);
     battery_temperature_degC = 0.0f;
 
-    apply_move();
-
     update_dynamics(rot_accel);
 
     /*

--- a/libraries/SITL/SIM_Plane.cpp
+++ b/libraries/SITL/SIM_Plane.cpp
@@ -526,6 +526,9 @@ void Plane::update(const struct sitl_input &input)
     
     calculate_forces(input, rot_accel);
     update_battery(input);
+
+    apply_move();
+
     update_dynamics(rot_accel);
 
     /*

--- a/libraries/SITL/SIM_Plane.cpp
+++ b/libraries/SITL/SIM_Plane.cpp
@@ -527,8 +527,6 @@ void Plane::update(const struct sitl_input &input)
     calculate_forces(input, rot_accel);
     update_battery(input);
 
-    apply_move();
-
     update_dynamics(rot_accel);
 
     /*

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -506,6 +506,27 @@ const AP_Param::GroupInfo SIM::var_info3[] = {
     // @Values: 0:Disable, 1:Enable
     AP_GROUPINFO("ODOM_ENABLE",   1, SIM,  odom_enable, 0),
 
+    // @Param: MOVE_X
+    // @DisplayName: Move vehicle north
+    // @Description: Smoothly move vehicle on ground, offset in north direction
+    // @Units: m
+    AP_GROUPINFO("MOVE_X",  24, SIM,  move.x, 0),
+    // @Param: MOVE_Y
+    // @DisplayName: Move vehicle east
+    // @Description: Smoothly move vehicle on ground, offset in east direction
+    // @Units: m
+    AP_GROUPINFO("MOVE_Y",  25, SIM,  move.y, 0),
+    // @Param: MOVE_Z
+    // @DisplayName: Move vehicle down
+    // @Description: Smoothly move vehicle on ground, offset in down direction
+    // @Units: m
+    AP_GROUPINFO("MOVE_Z",  26, SIM,  move.z, 0),
+    // @Param: MOVE_TIME
+    // @DisplayName: Move duration
+    // @Description: Time over which to interpolate the ground relocation move
+    // @Units: ms
+    AP_GROUPINFO("MOVE_TIME",  27, SIM,  move.t, 0),
+
     // @Param: LED_LAYOUT
     // @DisplayName: LED layout
     // @Description: LED layout config value

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -532,6 +532,27 @@ const AP_Param::GroupInfo SIM::var_info3[] = {
     // @Values: 0:Disable, 1:Enable
     AP_GROUPINFO("ODOM_ENABLE",   1, SIM,  odom_enable, 0),
 
+    // @Param: MOVE_X
+    // @DisplayName: Move vehicle north
+    // @Description: Smoothly move vehicle on ground, offset in north direction
+    // @Units: m
+    AP_GROUPINFO("MOVE_X",  24, SIM,  move.x, 0),
+    // @Param: MOVE_Y
+    // @DisplayName: Move vehicle east
+    // @Description: Smoothly move vehicle on ground, offset in east direction
+    // @Units: m
+    AP_GROUPINFO("MOVE_Y",  25, SIM,  move.y, 0),
+    // @Param: MOVE_Z
+    // @DisplayName: Move vehicle down
+    // @Description: Smoothly move vehicle on ground, offset in down direction
+    // @Units: m
+    AP_GROUPINFO("MOVE_Z",  26, SIM,  move.z, 0),
+    // @Param: MOVE_TIME
+    // @DisplayName: Move duration
+    // @Description: Time over which to interpolate the ground relocation move
+    // @Units: ms
+    AP_GROUPINFO("MOVE_TIME",  27, SIM,  move.t, 0),
+
     // @Param: LED_LAYOUT
     // @DisplayName: LED layout
     // @Description: LED layout config value

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -499,6 +499,18 @@ public:
         uint32_t start_ms;
     } twist;
 
+    // ground relocation: smoothly move the vehicle on the ground (NED metres, duration ms)
+    struct {
+        AP_Float x;
+        AP_Float y;
+        AP_Float z;
+        AP_Int32 t;
+        uint32_t start_ms;
+        float moved_x;
+        float moved_y;
+        float moved_z;
+    } move;
+
     AP_Int8 gnd_behav;
 
     AP_Enum<Rotation> imu_orientation;

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -503,6 +503,18 @@ public:
         uint32_t start_ms;
     } twist;
 
+    // ground relocation: smoothly move the vehicle on the ground (NED metres, duration ms)
+    struct {
+        AP_Float x;
+        AP_Float y;
+        AP_Float z;
+        AP_Int32 t;
+        uint32_t start_ms;
+        float moved_x;
+        float moved_y;
+        float moved_z;
+    } move;
+
     AP_Int8 gnd_behav;
 
     AP_Enum<Rotation> imu_orientation;


### PR DESCRIPTION
### Summary
Added a way to simulate moving the aircraft on the ground without flying by sending SITL params via mav proxy. This has been very useful for testing our integration with ArduCopter and handling takeoff location changes.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

### Description

Adds four SITL parameters to simulate walking a multicopter sim vehicle to a new ground position. 

- `SIM_MOVE_X` — north offset in meters
- `SIM_MOVE_Y` — east offset in meters  
- `SIM_MOVE_Z` — down offset in meters
- `SIM_MOVE_TIME` — interpolation duration in milliseconds

## Usage (MAVProxy)

```
param set SIM_MOVE_X 10
param set SIM_MOVE_Y 5
param set SIM_MOVE_Z 0
--then--
param set SIM_MOVE_TIME 5000   # trigger: interpolate over 5 seconds
```
As soon as SIM_MOVE_TIME is sent, the drone moves towards the new offset by linearly interpolating each sim step. Velocity is zeroed during the move so physics doesn't fight the translation. When the move completes (or is aborted because the vehicle has taken off), all four params are written back to zero via `set_and_save` so a reboot does not redo the last move.

Adds `apply_move()` to `Aircraft` (base class implementation, wired into `MultiCopter::update()`). Params registered in `var_info3`.


This has been tested and validated using ArduCopter SITL
<!--
Do not overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->