### PR TITLE
Renames and typehints for autotest RC values

### DIFF
--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -2048,8 +2048,8 @@ class TestSuite(abc.ABC):
         self.tlog = None
         self.enable_fgview = enable_fgview
 
-        self.rc_thread = None
-        self.rc_thread_should_quit = False
+        self.rc_thread: threading.Thread | None = None
+        self.rc_thread_should_quit: bool = False
         self.rc_queue = queue.Queue()
 
         self.expect_list = []
@@ -5881,40 +5881,28 @@ class TestSuite(abc.ABC):
                 raise ValueError("RC thread is dead")  # FIXME: type
 
     def rc_thread_main(self):
-        chan16 = [1000] * 16
-
+        """When this function completes, the thread terminates."""
         sitl_output = mavutil.mavudp("127.0.0.1:%u" % self.sitl_rcin_port(), input=False)
-        buf = None
+        num_rc_channels = 16
 
-        while True:
-            if self.rc_thread_should_quit:
-                break
+        # Pay attention, there are race conditions /
+        # wallclock-vs-simtime issues to worry about here.
+        max_wait_before_sending_values = 0.2 / self.speedup
 
-            # the 0.05 here means we're updating the RC values into
-            # the autopilot at 20Hz - that's our 50Hz wallclock, , not
-            # the autopilot's simulated 20Hz, so if speedup is 10 the
-            # autopilot will see ~2Hz.
-            timeout = 0.02
-            # ... and 2Hz is too slow when we now run at 100x speedup:
-            timeout /= (self.speedup / 10.0)
-
+        format_str = "<" + "H" * num_rc_channels
+        rc_values = [1000] * num_rc_channels
+        while not self.rc_thread_should_quit:
             try:
-                map_copy = self.rc_queue.get(timeout=timeout)
-
-                # 16 packed entries:
-                for i in range(1, 17):
-                    if i in map_copy:
-                        chan16[i-1] = map_copy[i]
-
+                rc_value_updates = self.rc_queue.get(timeout=max_wait_before_sending_values)
+                for chan, val in rc_value_updates.items():
+                    if not isinstance(chan, int):
+                        raise ValueError(f"{chan} is not a valid RC channel, must be an int.")
+                    if not (1 <= chan <= num_rc_channels):
+                        raise ValueError(f"{chan} is not a valid RC channel, must be in range [1, {num_rc_channels}].")
+                    rc_values[chan-1] = val
             except queue.Empty:
                 pass
-
-            buf = struct.pack('<HHHHHHHHHHHHHHHH', *chan16)
-
-            if buf is None:
-                continue
-
-            sitl_output.write(buf)
+            sitl_output.write(struct.pack(format_str, *rc_values))
 
     def set_rc_default(self):
         """Setup all simulated RC control to 1500."""

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -198,6 +198,9 @@ class ArmedAtEndOfTestException(ErrorException):
     pass
 
 
+NUM_RC_CHANNELS = 16
+
+
 class Context(object):
     def __init__(self):
         self.parameters = []
@@ -5819,24 +5822,7 @@ class TestSuite(abc.ABC):
         return path
 
     def rc_defaults(self):
-        return {
-            1: 1500,
-            2: 1500,
-            3: 1500,
-            4: 1500,
-            5: 1500,
-            6: 1500,
-            7: 1500,
-            8: 1500,
-            9: 1500,
-            10: 1500,
-            11: 1500,
-            12: 1500,
-            13: 1500,
-            14: 1500,
-            15: 1500,
-            16: 1500,
-        }
+        return {channel: 1500 for channel in range(1, NUM_RC_CHANNELS+1)}
 
     def set_rc_from_map(self, _map, *, timeout: float | int | None = 20.0, quiet=False):
         """Sets provided RC channel/value pairs.
@@ -5883,40 +5869,37 @@ class TestSuite(abc.ABC):
     def rc_thread_main(self):
         """When this function completes, the thread terminates."""
         sitl_output = mavutil.mavudp("127.0.0.1:%u" % self.sitl_rcin_port(), input=False)
-        num_rc_channels = 16
 
         # Pay attention, there are race conditions /
         # wallclock-vs-simtime issues to worry about here.
         max_wait_before_sending_values = 0.2 / self.speedup
 
-        format_str = "<" + "H" * num_rc_channels
-        rc_values = [1000] * num_rc_channels
+        format_str = "<" + "H" * NUM_RC_CHANNELS
+        rc_values = [1000] * NUM_RC_CHANNELS
         while not self.rc_thread_should_quit:
             try:
                 rc_value_updates = self.rc_queue.get(timeout=max_wait_before_sending_values)
                 for chan, val in rc_value_updates.items():
                     if not isinstance(chan, int):
                         raise ValueError(f"{chan} is not a valid RC channel, must be an int.")
-                    if not (1 <= chan <= num_rc_channels):
-                        raise ValueError(f"{chan} is not a valid RC channel, must be in range [1, {num_rc_channels}].")
+                    if not (1 <= chan <= NUM_RC_CHANNELS):
+                        raise ValueError(f"{chan} is not a valid RC channel, must be in range [1, {NUM_RC_CHANNELS}].")
                     rc_values[chan-1] = val
             except queue.Empty:
                 pass
             sitl_output.write(struct.pack(format_str, *rc_values))
 
     def set_rc_default(self):
-        """Setup all simulated RC control to 1500."""
+        """Set all channels of simulated RC control to the default value (typically 1500)."""
         _defaults = self.rc_defaults()
         self.set_rc_from_map(_defaults)
 
     def check_rc_defaults(self):
         """Ensure all rc outputs are at defaults"""
         self.do_timesync_roundtrip()
-        _defaults = self.rc_defaults()
         m = self.assert_receive_message('RC_CHANNELS', timeout=5)
         need_set = {}
-        for chan in _defaults:
-            default_value = _defaults[chan]
+        for chan, default_value in self.rc_defaults().items():
             current_value = getattr(m, "chan" + str(chan) + "_raw")
             if default_value != current_value:
                 self.progress("chan=%u needs resetting is=%u want=%u" %

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -2053,7 +2053,7 @@ class TestSuite(abc.ABC):
 
         self.rc_thread: threading.Thread | None = None
         self.rc_thread_should_quit: bool = False
-        self.rc_queue = queue.Queue()
+        self.rc_queue: queue.Queue[dict[int, int]] = queue.Queue()
 
         self.expect_list = []
 
@@ -5824,16 +5824,15 @@ class TestSuite(abc.ABC):
     def rc_defaults(self):
         return {channel: 1500 for channel in range(1, NUM_RC_CHANNELS+1)}
 
-    def set_rc_from_map(self, _map, *, timeout: float | int | None = 20.0, quiet=False):
+    def set_rc_from_map(self, rc_values: dict[int, int], *, timeout: float | int | None = 20.0, quiet=False):
         """Sets provided RC channel/value pairs.
 
         Passing the special value 'None' for timeout means 'do not wait for confirmation'.
         """
-        map_copy = _map.copy()
-        for v in map_copy.values():
+        for v in rc_values.values():
             if not isinstance(v, int):
                 raise NotAchievedException("RC values must be integers")
-        self.rc_queue.put(map_copy)
+        self.rc_queue.put(rc_values.copy())
 
         if self.rc_thread is None:
             self.rc_thread = threading.Thread(target=self.rc_thread_main, name='RC')
@@ -5852,10 +5851,10 @@ class TestSuite(abc.ABC):
             if m is None:
                 continue
             bad_channels = ""
-            for chan in map_copy:
+            for chan in rc_values:
                 chan_pwm = getattr(m, "chan" + str(chan) + "_raw")
-                if chan_pwm != map_copy[chan]:
-                    bad_channels += " (ch=%u want=%u got=%u)" % (chan, map_copy[chan], chan_pwm)
+                if chan_pwm != rc_values[chan]:
+                    bad_channels += " (ch=%u want=%u got=%u)" % (chan, rc_values[chan], chan_pwm)
                     break
             if len(bad_channels) == 0:
                 if not quiet:
@@ -5907,7 +5906,7 @@ class TestSuite(abc.ABC):
                 need_set[chan] = default_value
         self.set_rc_from_map(need_set)
 
-    def set_rc(self, chan, pwm, *, timeout: float | int | None = 20.0):
+    def set_rc(self, chan: int, pwm: int, *, timeout: float | int | None = 20.0):
         """Setup a simulated RC control to a PWM value.
 
         Passing the special value 'None' for timeout means 'do not wait for confirmation'.


### PR DESCRIPTION
### Summary

This minor contribution was spun out of #33061 per reviewer request. It is chained behind that and #33283 .
(I'll keep it in DRAFT until that one lands.)

It renames & adds typehints to specify what `_map` is in the context of rc-value setting.
It adds typehints to clarify the intended usage of `set_rc( )`.
It adds a typehint to clarify what belongs in the `rc_queue`.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

For data objects with known structure, such as the RC values focused here, creating a structured object is even better. I have proposed that in https://github.com/ArduPilot/ardupilot/pull/33072 but it may be rejected.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
