### PR TITLE
GCS_MAVLink: add support for ListDirectoryWithTime

### DIFF
--- a/libraries/GCS_MAVLink/GCS_FTP.cpp
+++ b/libraries/GCS_MAVLink/GCS_FTP.cpp
@@ -155,7 +155,8 @@ void GCS_FTP::Session::push_reply(Transaction &reply)
 }
 
 // calculates how much string length is needed to fit this in a list response
-int GCS_FTP::Session::gen_dir_entry(char *dest, size_t space, const char *path, const struct dirent * entry)
+// when with_time is set, file entries also carry their last-modification time
+int GCS_FTP::Session::gen_dir_entry(char *dest, size_t space, const char *path, const struct dirent * entry, bool with_time)
 {
 #if AP_FILESYSTEM_HAVE_DIRENT_DTYPE
     const bool is_file = entry->d_type == DT_REG || entry->d_type == DT_LNK;
@@ -194,6 +195,10 @@ int GCS_FTP::Session::gen_dir_entry(char *dest, size_t space, const char *path, 
             return hal.util->snprintf(dest, space, "D%s%c", entry->d_name, (char)0);
         }
 #endif
+        if (with_time) {
+            // F<name>\t<size>\t<mtime>\0 - mtime in seconds since the UNIX epoch (UTC), 0 if unknown
+            return hal.util->snprintf(dest, space, "F%s\t%u\t%u%c", entry->d_name, (unsigned)st.st_size, (unsigned)st.st_mtime, (char)0);
+        }
         return hal.util->snprintf(dest, space, "F%s\t%u%c", entry->d_name, (unsigned)st.st_size, (char)0);
     } else {
         return hal.util->snprintf(dest, space, "D%s%c", entry->d_name, (char)0);
@@ -201,7 +206,7 @@ int GCS_FTP::Session::gen_dir_entry(char *dest, size_t space, const char *path, 
 }
 
 // list the contents of a directory, skip the offset number of entries before providing data
-void GCS_FTP::Session::list_dir(Transaction &request, Transaction &response)
+void GCS_FTP::Session::list_dir(Transaction &request, Transaction &response, bool with_time)
 {
     response.offset = request.offset; // this should be set for any failure condition for debugging
 
@@ -236,7 +241,7 @@ void GCS_FTP::Session::list_dir(Transaction &request, Transaction &response)
         }
 
         // check how much space would be needed to emit the listing
-        const int needed_space = gen_dir_entry((char *)response.data, sizeof(request.data), (char *)request.data, entry);
+        const int needed_space = gen_dir_entry((char *)response.data, sizeof(request.data), (char *)request.data, entry, with_time);
 
         if (needed_space < 0 || needed_space > (int)sizeof(request.data)) {
             continue;
@@ -250,7 +255,7 @@ void GCS_FTP::Session::list_dir(Transaction &request, Transaction &response)
     struct dirent *entry;
     while ((entry = AP::FS().readdir(dir))) {
         // figure out if we can fit the file
-        const int required_space = gen_dir_entry((char *)(response.data + index), sizeof(response.data) - index, (char *)request.data, entry);
+        const int required_space = gen_dir_entry((char *)(response.data + index), sizeof(response.data) - index, (char *)request.data, entry, with_time);
 
         // couldn't ever send this so drop it
         if (required_space < 0) {
@@ -334,7 +339,10 @@ bool GCS_FTP::Session::handle_request(Transaction &request, Transaction &reply)
         }
         break;
     case FTP_OP::ListDirectory:
-        list_dir(request, reply);
+        list_dir(request, reply, false);
+        break;
+    case FTP_OP::ListDirectoryWithTime:
+        list_dir(request, reply, true);
         break;
     case FTP_OP::OpenFileRO:
     {

--- a/libraries/GCS_MAVLink/GCS_FTP.cpp
+++ b/libraries/GCS_MAVLink/GCS_FTP.cpp
@@ -267,8 +267,11 @@ void GCS_FTP::Session::list_dir(Transaction &request, Transaction &response, boo
             break;
         }
 
-        // step the index forward and keep going
-        index += required_space + 1;
+        // step the index forward and keep going. required_space already
+        // includes the entry's null terminator (the trailing "%c" with a 0),
+        // so we must not add another - a stray second null would appear as an
+        // empty entry to clients, inflating their offset across paged listings.
+        index += required_space;
     }
 
     if (index == 0) {

--- a/libraries/GCS_MAVLink/GCS_FTP.h
+++ b/libraries/GCS_MAVLink/GCS_FTP.h
@@ -37,6 +37,11 @@ private:
         Rename = MAV_FTP_OPCODE_RENAME,
         CalcFileCRC32 = MAV_FTP_OPCODE_CALCFILECRC,
         BurstReadFile = MAV_FTP_OPCODE_BURSTREADFILE,
+        // ListDirectoryWithTime: like ListDirectory, but each entry also
+        // carries its last-modification time. Not yet in the bundled mavlink
+        // definitions, so the opcode value (16) is hardcoded for now; switch
+        // to MAV_FTP_OPCODE_LISTDIRECTORYWITHTIME once it lands upstream.
+        ListDirectoryWithTime = 16,
         Ack = MAV_FTP_OPCODE_ACK,
         Nack = MAV_FTP_OPCODE_NAK,
     };
@@ -90,8 +95,8 @@ private:
         uint8_t compid;
 
         bool check_name_len(const Transaction &request);
-        int gen_dir_entry(char *dest, size_t space, const char * path, const struct dirent * entry); // FTP helper for emitting a dir response
-        void list_dir(Transaction &request, Transaction &response);
+        int gen_dir_entry(char *dest, size_t space, const char * path, const struct dirent * entry, bool with_time); // FTP helper for emitting a dir response
+        void list_dir(Transaction &request, Transaction &response, bool with_time);
         void push_reply(Transaction &reply);
         bool handle_request(Transaction &request, Transaction &reply);
 


### PR DESCRIPTION
### Summary

This extends MAVLink FTP to support the new opcode that allows to list files with modification time in UTC.

This is according to the new spec in:
https://github.com/mavlink/mavlink-devguide/pull/701

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Tested using SITL, MAVSDK (https://github.com/mavlink/MAVSDK/pull/2891), and QGC (https://github.com/mavlink/qgroundcontrol/pull/14495)