### PR TITLE
AP_Logger: add LOG_ANON parameter for onboard log anonymization

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -12874,6 +12874,86 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.progress("Sprayer OK")
 
+    def LogAnon(self):
+        '''test log anonymization with LOG_ANON parameter'''
+
+        home = self.sitl_start_location()
+        home_lat = home.lat
+        home_lng = home.lng
+
+        # Test 1: LOG_ANON=1 - coordinates should be offset
+        self.context_push()
+        self.set_parameters({
+            "LOG_ANON": 1,
+            "LOG_DISARMED": 1,
+        })
+        self.reboot_sitl()
+        self.wait_ready_to_arm()
+        self.change_mode("ALT_HOLD")
+        self.arm_vehicle()
+        self.set_rc(3, 1700)
+        self.wait_altitude(8, 12, relative=True, timeout=30)
+        self.delay_sim_time(5)
+        self.set_rc(3, 1000)
+        self.wait_disarmed(timeout=60)
+
+        dfreader = self.dfreader_for_current_onboard_log()
+        for mtype in ['POS', 'AHR2', 'ORGN']:
+            dfreader.rewind()
+            # skip messages with zero lat/lng (before EKF convergence)
+            while True:
+                m = dfreader.recv_match(type=mtype)
+                if m is None:
+                    raise NotAchievedException("No non-zero %s message in log" % mtype)
+                if m.Lat != 0 and m.Lng != 0:
+                    break
+            lat = m.Lat
+            lng = m.Lng
+            if abs(lat - home_lat) < 0.1 and abs(lng - home_lng) < 0.1:
+                raise NotAchievedException(
+                    "%s not anonymized: lat=%f lng=%f (home: %f,%f)" %
+                    (mtype, lat, lng, home_lat, home_lng))
+            self.progress(
+                "%s anonymized OK: lat=%f lng=%f (offset: %+.2f, %+.2f)" %
+                (mtype, lat, lng, lat - home_lat, lng - home_lng))
+        self.context_pop()
+
+        # Test 2: LOG_ANON=0 - coordinates should match home
+        self.context_push()
+        self.set_parameters({
+            "LOG_ANON": 0,
+            "LOG_DISARMED": 1,
+        })
+        self.reboot_sitl()
+        self.wait_ready_to_arm()
+        self.change_mode("ALT_HOLD")
+        self.arm_vehicle()
+        self.set_rc(3, 1700)
+        self.wait_altitude(8, 12, relative=True, timeout=30)
+        self.delay_sim_time(5)
+        self.set_rc(3, 1000)
+        self.wait_disarmed(timeout=60)
+
+        dfreader = self.dfreader_for_current_onboard_log()
+        for mtype in ['POS', 'AHR2', 'ORGN']:
+            dfreader.rewind()
+            while True:
+                m = dfreader.recv_match(type=mtype)
+                if m is None:
+                    raise NotAchievedException("No non-zero %s message in log" % mtype)
+                if m.Lat != 0 and m.Lng != 0:
+                    break
+            lat = m.Lat
+            lng = m.Lng
+            if abs(lat - home_lat) > 0.1 or abs(lng - home_lng) > 0.1:
+                raise NotAchievedException(
+                    "%s unexpectedly offset: lat=%f lng=%f (home: %f,%f)" %
+                    (mtype, lat, lng, home_lat, home_lng))
+            self.progress(
+                "%s not anonymized OK: lat=%f lng=%f" %
+                (mtype, lat, lng))
+        self.context_pop()
+
     def tests1a(self):
         '''return list of all tests'''
         ret = super(AutoTestCopter, self).tests()  # about 5 mins and ~20 initial tests from autotest/vehicle_test_suite.py
@@ -15890,6 +15970,7 @@ return update, 1000
             self.GripperInitialPosition,
             self.REQUIRE_LOCATION_FOR_ARMING,
             self.LoggingFormat,
+            self.LogAnon,
             self.MissionRTLYawBehaviour,
             self.BatteryInternalUseOnly,
             self.MAV_CMD_MISSION_START_p1_p2,

--- a/libraries/AP_Logger/AP_Logger.cpp
+++ b/libraries/AP_Logger/AP_Logger.cpp
@@ -10,6 +10,7 @@
 #include "AP_Logger_MAVLink.h"
 
 #include <AP_InternalError/AP_InternalError.h>
+#include <AP_Math/AP_Math.h>
 #include <GCS_MAVLink/GCS.h>
 #include <AP_BoardConfig/AP_BoardConfig.h>
 #include <AP_Rally/AP_Rally.h>
@@ -203,6 +204,14 @@ const AP_Param::GroupInfo AP_Logger::var_info[] = {
     // @RebootRequired: True
     AP_GROUPINFO("_MAX_FILES", 12, AP_Logger, _params.max_log_files, MAX_LOG_FILES),
 
+    // @Param: _ANON
+    // @DisplayName: Log anonymization
+    // @Description: If enabled, all latitude and longitude values in onboard logs are shifted by a random offset generated at boot. The flight path shape is preserved but the absolute location is hidden. Useful for sharing logs without revealing flight location. Does not affect telemetry to the GCS. Note: LOG_REPLAY should be disabled when using this feature as EKF replay messages contain un-anonymized coordinates.
+    // @Values: 0:Disabled,1:Enabled
+    // @RebootRequired: True
+    // @User: Standard
+    AP_GROUPINFO("_ANON", 13, AP_Logger, _params.anon, 0),
+
     AP_GROUPEND
 };
 
@@ -289,6 +298,95 @@ void AP_Logger::init(const AP_Int32 &log_bitmask, const struct LogStructure *str
     start_io_thread();
 
     EnableWrites(true);
+
+    // generate anonymization offsets if enabled
+    _anon_lat_offset = 0;
+    _anon_lng_offset = 0;
+    if (_params.anon.get() != 0) {
+        uint32_t raw_lat, raw_lng;
+        if (!hal.util->get_random_vals(reinterpret_cast<uint8_t*>(&raw_lat), sizeof(raw_lat)) ||
+            !hal.util->get_random_vals(reinterpret_cast<uint8_t*>(&raw_lng), sizeof(raw_lng))) {
+            raw_lat = (static_cast<uint32_t>(get_random16()) << 16) | get_random16();
+            raw_lng = (static_cast<uint32_t>(get_random16()) << 16) | get_random16();
+        }
+        _anon_lat_offset = static_cast<int32_t>(raw_lat % 200000001) - 100000000;
+        _anon_lng_offset = static_cast<int32_t>(raw_lng % 200000001) - 100000000;
+    }
+}
+
+/*
+  anonymize lat/lng fields in a log block buffer. Scans the format
+  string for 'L' (lat/lng) fields and adds the random offset.
+ */
+void AP_Logger::anonymize_log_block(const void *pBuffer, uint16_t size) const
+{
+    if (_anon_lat_offset == 0 && _anon_lng_offset == 0) {
+        return;
+    }
+    if (size < LOG_PACKET_HEADER_LEN) {
+        return;
+    }
+    auto *buf = const_cast<uint8_t *>(static_cast<const uint8_t *>(pBuffer));
+    const uint8_t msg_type = buf[2];
+
+    // find the format string for this message type
+    const char *fmt = nullptr;
+    const struct LogStructure *s = structure_for_msg_type(msg_type);
+    if (s != nullptr) {
+        fmt = s->format;
+    } else {
+        const struct log_write_fmt *f = log_write_fmt_for_msg_type(msg_type);
+        if (f != nullptr) {
+            fmt = f->fmt;
+        }
+    }
+    if (fmt == nullptr) {
+        return;
+    }
+
+    // walk the format string, tracking byte offset into the buffer
+    // the first field starts after the 3-byte header (HEAD1, HEAD2, msg_type)
+    uint16_t offset = LOG_PACKET_HEADER_LEN;
+    bool is_lat = true;  // alternate lat/lng for consecutive L fields
+    for (uint8_t i = 0; fmt[i] != '\0' && offset < size; i++) {
+        uint8_t field_size;
+        switch (fmt[i]) {
+        case 'a': field_size = sizeof(int16_t[32]); break;
+        case 'b': field_size = sizeof(int8_t); break;
+        case 'c': field_size = sizeof(int16_t); break;
+        case 'd': field_size = sizeof(double); break;
+        case 'e': field_size = sizeof(int32_t); break;
+        case 'f': field_size = sizeof(float); break;
+        case 'g': field_size = 2; break; // float16
+        case 'h': field_size = sizeof(int16_t); break;
+        case 'i': field_size = sizeof(int32_t); break;
+        case 'n': field_size = 4; break;
+        case 'B': field_size = sizeof(uint8_t); break;
+        case 'C': field_size = sizeof(uint16_t); break;
+        case 'E': field_size = sizeof(uint32_t); break;
+        case 'H': field_size = sizeof(uint16_t); break;
+        case 'I': field_size = sizeof(uint32_t); break;
+        case 'L': field_size = sizeof(int32_t); break;
+        case 'M': field_size = sizeof(uint8_t); break;
+        case 'N': field_size = 16; break;
+        case 'Z': field_size = 64; break;
+        case 'q': field_size = sizeof(int64_t); break;
+        case 'Q': field_size = sizeof(uint64_t); break;
+        default:
+            return;  // unknown format, bail
+        }
+        if (fmt[i] == 'L' && offset + sizeof(int32_t) <= size) {
+            auto *field = buf + offset;
+            int32_t val;
+            memcpy(&val, field, sizeof(val));
+            if (val != 0) {
+                val += is_lat ? _anon_lat_offset : _anon_lng_offset;
+                memcpy(field, &val, sizeof(val));
+            }
+            is_lat = !is_lat;
+        }
+        offset += field_size;
+    }
 }
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
@@ -754,16 +852,18 @@ void AP_Logger::WriteBlock(const void *pBuffer, uint16_t size) {
 #if APM_BUILD_TYPE(APM_BUILD_Replay)
     save_format_Replay(pBuffer);
 #endif
+    anonymize_log_block(pBuffer, size);
     FOR_EACH_BACKEND(WriteBlock(pBuffer, size));
 }
 
 // only the first backend write need succeed for us to be successful
-bool AP_Logger::WriteBlock_first_succeed(const void *pBuffer, uint16_t size) 
+bool AP_Logger::WriteBlock_first_succeed(const void *pBuffer, uint16_t size)
 {
     if (_next_backend == 0) {
         return false;
     }
-    
+    anonymize_log_block(pBuffer, size);
+
     for (uint8_t i=1; i<_next_backend; i++) {
         backends[i]->WriteBlock(pBuffer, size);
     }
@@ -799,6 +899,7 @@ bool AP_Logger::WriteReplayBlock(uint8_t msg_id, const void *pBuffer, uint16_t s
 }
 
 void AP_Logger::WriteCriticalBlock(const void *pBuffer, uint16_t size) {
+    anonymize_log_block(pBuffer, size);
     FOR_EACH_BACKEND(WriteCriticalBlock(pBuffer, size));
 }
 

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -364,6 +364,7 @@ public:
         AP_Float blk_ratemax;
         AP_Float disarm_ratemax;
         AP_Int16 max_log_files;
+        AP_Int8 anon;
     } _params;
 
     const struct LogStructure *structure(uint16_t num) const;
@@ -450,6 +451,12 @@ private:
     uint8_t _next_backend;
     AP_Logger_Backend *backends[LOGGER_MAX_BACKENDS];
     const AP_Int32 *_log_bitmask;
+
+    // log anonymization: offset 'L' (lat/lng) fields in a log block
+    // buffer in-place before it is passed to backends
+    void anonymize_log_block(const void *pBuffer, uint16_t size) const;
+    int32_t _anon_lat_offset;
+    int32_t _anon_lng_offset;
 
     enum class Backend_Type : uint8_t {
         NONE       = 0,

--- a/libraries/AP_Logger/AP_Logger_Backend.cpp
+++ b/libraries/AP_Logger/AP_Logger_Backend.cpp
@@ -324,6 +324,7 @@ bool AP_Logger_Backend::Write(const uint8_t msg_type, va_list arg_list, bool is_
         }
     }
 
+    _front.anonymize_log_block(buffer, msg_len);
     return WritePrioritisedBlock(buffer, msg_len, is_critical, is_streaming);
 }
 

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -1268,7 +1268,7 @@ LOG_STRUCTURE_FROM_VISUALODOM \
     { LOG_WHEELENCODER_MSG, sizeof(log_WheelEncoder), \
       "WENC",  "Qfbfb", "TimeUS,Dist0,Qual0,Dist1,Qual1", "sm-m-", "F0-0-" , true }, \
     { LOG_ADSB_MSG, sizeof(log_ADSB), \
-      "ADSB",  "QIiiiHHhH", "TimeUS,ICAO_address,Lat,Lng,Alt,Heading,Hor_vel,Ver_vel,Squark", "s-DUmhnn-", "F-GGCBCC-" }, \
+      "ADSB",  "QILLiHHhH", "TimeUS,ICAO_address,Lat,Lng,Alt,Heading,Hor_vel,Ver_vel,Squark", "s-DUmhnn-", "F-GGCBCC-" }, \
     { LOG_EVENT_MSG, sizeof(log_Event), \
       "EV",   "QB",           "TimeUS,Id", "s-", "F-" }, \
     { LOG_ARM_DISARM_MSG, sizeof(log_Arm_Disarm), \


### PR DESCRIPTION
## Summary

Add a `LOG_ANON` parameter that shifts all lat/lng fields in onboard DataFlash logs by a random per-boot offset, preserving flight-path shape while hiding absolute location.

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [x] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [x] Autotest included

## Description

When `LOG_ANON=1`, all latitude/longitude fields (format type `L`) in onboard logs are offset by a random value generated at boot. The shape of the flight path is preserved but the absolute location is hidden.

The anonymization is applied centrally in `WriteBlock`, `WriteCriticalBlock`, `WriteBlock_first_succeed`, and the `Backend::Write` (variadic) path by scanning the format string for `L` fields and offsetting them in-place. This covers all log messages automatically, including any future messages that use the `L` format character.

This also fixes the ADSB and MAVC log format strings to use `L` instead of `i` for their lat/lng fields, which correctly marks them as coordinates.

Notes on scope:

- DAL replay messages (`WriteReplayBlock`) are not affected, as they bypass the anonymization path so replay remains correct.
- Does not affect MAVLink telemetry to the GCS.

An autotest (`LogAnon`) is included to verify the anonymization behavior in SITL.