### PR TITLE
AP_AHRS: gate absolute position logging behind MASK_LOG_GPS

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -207,7 +207,7 @@ const AP_Param::Info Copter::var_info[] = {
     // @Param: LOG_BITMASK
     // @DisplayName: Log bitmask
     // @Description: Bitmap of what on-board log types to enable. This value is made up of the sum of each of the log types you want to be saved. It is usually best just to enable all basiclog types by setting this to 65535. Note that if you want to reduce log sizes you should consider using LOG_FILE_RATEMAX instead of disabling logging items with this parameter.
-    // @Bitmask: 0:Fast Attitude,1:Medium Attitude,2:GPS,3:System Performance,4:Control Tuning,5:Navigation Tuning,6:RC input,7:IMU,8:Mission Commands,9:Battery Monitor,10:RC output,11:Optical Flow,12:PID,13:Compass,15:Camera,17:Motors,18:Fast IMU,19:Raw IMU,20:Video Stabilization,21:Fast harmonic notch logging
+    // @Bitmask: 0:Fast Attitude,1:Medium Attitude,2:GPS/Position,3:System Performance,4:Control Tuning,5:Navigation Tuning,6:RC input,7:IMU,8:Mission Commands,9:Battery Monitor,10:RC output,11:Optical Flow,12:PID,13:Compass,15:Camera,17:Motors,18:Fast IMU,19:Raw IMU,20:Video Stabilization,21:Fast harmonic notch logging
     // @User: Standard
     GSCALAR(log_bitmask,    "LOG_BITMASK",          DEFAULT_LOG_BITMASK),
 

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -90,6 +90,8 @@ void Copter::init_ardupilot()
     gps.set_log_gps_bit(MASK_LOG_GPS);
     gps.init();
 
+    ahrs.set_log_pos_bit(MASK_LOG_GPS);
+
     AP::compass().set_log_bit(MASK_LOG_COMPASS);
     AP::compass().init();
 

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -628,7 +628,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @Param: LOG_BITMASK
     // @DisplayName: Log bitmask
     // @Description: Bitmap of what on-board log types to enable. This value is made up of the sum of each of the log types you want to be saved. It is usually best just to enable all basic log types by setting this to 65535.
-    // @Bitmask: 0:Fast Attitude,1:Medium Attitude,2:GPS,3:Performance,4:Control Tuning,5:Navigation Tuning,7:IMU,8:Mission Commands,9:Battery Monitor,10:Compass,11:TECS,12:Camera,13:RC Input-Output,14:Rangefinder,19:Raw IMU,20:Fullrate Attitude,21:Video Stabilization,22:Fullrate Notch
+    // @Bitmask: 0:Fast Attitude,1:Medium Attitude,2:GPS/Position,3:Performance,4:Control Tuning,5:Navigation Tuning,7:IMU,8:Mission Commands,9:Battery Monitor,10:Compass,11:TECS,12:Camera,13:RC Input-Output,14:Rangefinder,19:Raw IMU,20:Fullrate Attitude,21:Video Stabilization,22:Fullrate Notch
     // @User: Advanced
     GSCALAR(log_bitmask,            "LOG_BITMASK",    DEFAULT_LOG_BITMASK),
 

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -70,6 +70,8 @@ void Plane::init_ardupilot()
     gps.set_log_gps_bit(MASK_LOG_GPS);
     gps.init();
 
+    ahrs.set_log_pos_bit(MASK_LOG_GPS);
+
     init_rc_in();               // sets up rc channels from radio
 
 #if HAL_MOUNT_ENABLED

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -270,7 +270,7 @@ const AP_Param::Info Sub::var_info[] = {
     // @Param: LOG_BITMASK
     // @DisplayName: Log bitmask
     // @Description: 4 byte bitmap of log types to enable
-    // @Bitmask: 0:ATTITUDE_FAST,1:ATTITUDE_MED,2:GPS,3:PM,4:CTUN,5:NTUN,6:RCIN,7:IMU,8:CMD,9:CURRENT,10:RCOUT,11:OPTFLOW,12:PID,13:COMPASS,14:INAV,15:CAMERA,17:MOTBATT,18:IMU_FAST,19:IMU_RAW
+    // @Bitmask: 0:ATTITUDE_FAST,1:ATTITUDE_MED,2:GPS/Position,3:PM,4:CTUN,5:NTUN,6:RCIN,7:IMU,8:CMD,9:CURRENT,10:RCOUT,11:OPTFLOW,12:PID,13:COMPASS,14:INAV,15:CAMERA,17:MOTBATT,18:IMU_FAST,19:IMU_RAW
     // @User: Standard
     GSCALAR(log_bitmask,    "LOG_BITMASK",          DEFAULT_LOG_BITMASK),
 

--- a/ArduSub/system.cpp
+++ b/ArduSub/system.cpp
@@ -74,6 +74,8 @@ void Sub::init_ardupilot()
     gps.set_log_gps_bit(MASK_LOG_GPS);
     gps.init();
 
+    ahrs.set_log_pos_bit(MASK_LOG_GPS);
+
     AP::compass().set_log_bit(MASK_LOG_COMPASS);
     AP::compass().init();
 

--- a/Blimp/Parameters.cpp
+++ b/Blimp/Parameters.cpp
@@ -151,7 +151,7 @@ const AP_Param::Info Blimp::var_info[] = {
     // @Param: LOG_BITMASK
     // @DisplayName: Log bitmask
     // @Description: Bitmap of what log types to enable in on-board logger. This value is made up of the sum of each of the log types you want to be saved. On boards supporting microSD cards or other large block-storage devices it is usually best just to enable all basic log types by setting this to 65535.
-    // @Bitmask: 0:Fast Attitude,1:Medium Attitude,2:GPS,3:System Performance,4:Control Tuning,6:RC Input,7:IMU,9:Battery Monitor,10:RC Output,12:PID,13:Compass
+    // @Bitmask: 0:Fast Attitude,1:Medium Attitude,2:GPS/Position,3:System Performance,4:Control Tuning,6:RC Input,7:IMU,9:Battery Monitor,10:RC Output,12:PID,13:Compass
     // @User: Standard
     GSCALAR(log_bitmask,    "LOG_BITMASK",          DEFAULT_LOG_BITMASK),
 

--- a/Blimp/system.cpp
+++ b/Blimp/system.cpp
@@ -62,6 +62,8 @@ void Blimp::init_ardupilot()
     gps.set_log_gps_bit(MASK_LOG_GPS);
     gps.init();
 
+    ahrs.set_log_pos_bit(MASK_LOG_GPS);
+
     AP::compass().set_log_bit(MASK_LOG_COMPASS);
     AP::compass().init();
 

--- a/Rover/Parameters.cpp
+++ b/Rover/Parameters.cpp
@@ -16,7 +16,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @Param: LOG_BITMASK
     // @DisplayName: Log bitmask
     // @Description: Bitmap of what log types to enable in on-board logger. This value is made up of the sum of each of the log types you want to be saved. On boards supporting microSD cards or other large block-storage devices it is usually best just to enable all basic log types by setting this to 65535.
-    // @Bitmask: 0:Fast Attitude,1:Medium Attitude,2:GPS,3:System Performance,4:Throttle,5:Navigation Tuning,7:IMU,8:Mission Commands,9:Battery Monitor,10:Rangefinder,11:Compass,12:Camera,13:Steering,14:RC Input-Output,19:Raw IMU,20:Video Stabilization,21:Optical Flow
+    // @Bitmask: 0:Fast Attitude,1:Medium Attitude,2:GPS/Position,3:System Performance,4:Throttle,5:Navigation Tuning,7:IMU,8:Mission Commands,9:Battery Monitor,10:Rangefinder,11:Compass,12:Camera,13:Steering,14:RC Input-Output,19:Raw IMU,20:Video Stabilization,21:Optical Flow
     // @User: Advanced
     GSCALAR(log_bitmask,            "LOG_BITMASK",      DEFAULT_LOG_BITMASK),
 

--- a/Rover/system.cpp
+++ b/Rover/system.cpp
@@ -61,6 +61,8 @@ void Rover::init_ardupilot()
     gps.set_log_gps_bit(MASK_LOG_GPS);
     gps.init();
 
+    ahrs.set_log_pos_bit(MASK_LOG_GPS);
+
     ins.set_log_raw_bit(MASK_LOG_IMU_RAW);
 
     init_rc_in();            // sets up rc channels deadzone

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -12539,6 +12539,42 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             "IMU": 25,
         })
 
+    def LogBitmaskGPSPosition(self):
+        '''ensure MASK_LOG_GPS gates absolute position messages'''
+
+        # Test 1: default bitmask — position messages should be present
+        path = self.generate_rate_sample_log()
+        dfreader = self.dfreader_for_path(path)
+        for msg_type in ['GPS', 'POS', 'ORGN', 'AHR2']:
+            dfreader.rewind()
+            m = dfreader.recv_match(type=msg_type)
+            if m is None:
+                raise NotAchievedException(
+                    "Expected %s in log with default bitmask" % msg_type)
+
+        # Test 2: GPS bit disabled — position messages should be absent
+        log_bitmask = int(self.get_parameter('LOG_BITMASK'))
+        log_bitmask_no_gps = log_bitmask & ~(1 << 2)  # clear bit 2
+
+        path = self.generate_rate_sample_log(log_bitmask=log_bitmask_no_gps)
+        dfreader = self.dfreader_for_path(path)
+
+        # These should be absent
+        for msg_type in ['GPS', 'POS', 'ORGN', 'AHR2']:
+            dfreader.rewind()
+            m = dfreader.recv_match(type=msg_type)
+            if m is not None:
+                raise NotAchievedException(
+                    "%s found in log with GPS bit disabled" % msg_type)
+
+        # These should still be present
+        for msg_type in ['XKF1', 'ATT', 'IMU']:
+            dfreader.rewind()
+            m = dfreader.recv_match(type=msg_type)
+            if m is None:
+                raise NotAchievedException(
+                    "Expected %s in log even with GPS bit disabled" % msg_type)
+
     def FETtecESC_flight(self):
         '''fly with servo outputs from FETtec ESC'''
         self.start_subtest("FETtec ESC flight")
@@ -12980,6 +13016,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
              self.VisionPosition,
              self.ATTITUDE_FAST,
              self.BaseLoggingRates,
+             self.LogBitmaskGPSPosition,
              self.BodyFrameOdom,
              self.GPSViconSwitching,
         ])

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -528,6 +528,10 @@ public:
     void Log_Write_Home_And_Origin();
     void Write_Attitude(const Vector3f &targets) const;
 
+    // indicate which bit in LOG_BITMASK indicates position logging enabled
+    void set_log_pos_bit(uint32_t log_bit) { _log_pos_bit = log_bit; }
+    uint32_t get_log_pos_bit() const { return _log_pos_bit; }
+
     enum class LogOriginType {
         ekf_origin = 0,
         ahrs_home = 1
@@ -724,6 +728,9 @@ public:
     const EKFGSF_yaw *get_yaw_estimator(void) const;
 
 private:
+
+    // bitmask bit for position logging (set by vehicle code)
+    uint32_t _log_pos_bit;
 
     // roll/pitch/yaw euler angles, all in radians
     float roll;

--- a/libraries/AP_AHRS/AP_AHRS_Logging.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_Logging.cpp
@@ -12,6 +12,9 @@
 // Write an AHRS2 packet
 void AP_AHRS::Write_AHRS2() const
 {
+    if (_log_pos_bit && !AP::logger().should_log(_log_pos_bit)) {
+        return;
+    }
     Vector3f euler;
     Location loc;
     Quaternion quat;
@@ -71,6 +74,9 @@ void AP_AHRS::Write_Attitude(const Vector3f &targets) const
 
 void AP_AHRS::Write_Origin(LogOriginType origin_type, const Location &loc) const
 {
+    if (_log_pos_bit && !AP::logger().should_log(_log_pos_bit)) {
+        return;
+    }
     int32_t alt_cm;
     if (!loc.initialised() || !loc.get_alt_cm(Location::AltFrame::ABSOLUTE, alt_cm)) {
         alt_cm = 0;
@@ -89,6 +95,9 @@ void AP_AHRS::Write_Origin(LogOriginType origin_type, const Location &loc) const
 // Write a POS packet
 void AP_AHRS::Write_POS() const
 {
+    if (_log_pos_bit && !AP::logger().should_log(_log_pos_bit)) {
+        return;
+    }
     Location loc;
     if (!get_location(loc)) {
         return;

--- a/libraries/AP_Landing/AP_Landing_Deepstall.cpp
+++ b/libraries/AP_Landing/AP_Landing_Deepstall.cpp
@@ -458,6 +458,10 @@ const AP_PIDInfo& AP_Landing_Deepstall::get_pid_info(void) const
 
 #if HAL_LOGGING_ENABLED
 void AP_Landing_Deepstall::Log(void) const {
+    const uint32_t pos_bit = AP::ahrs().get_log_pos_bit();
+    if (pos_bit && !AP::logger().should_log(pos_bit)) {
+        return;
+    }
     const AP_PIDInfo& pid_info = ds_PID.get_pid_info();
     struct log_DSTL pkt = {
         LOG_PACKET_HEADER_INIT(LOG_DSTL_MSG),

--- a/libraries/AP_Logger/LoggerMessageWriter.cpp
+++ b/libraries/AP_Logger/LoggerMessageWriter.cpp
@@ -448,6 +448,13 @@ void LoggerMessageWriter_WriteEntireMission::process() {
         return;
     }
 
+    // suppress mission commands when position logging is disabled
+    const uint32_t pos_bit = AP::ahrs().get_log_pos_bit();
+    if (pos_bit && !AP::logger().should_log(pos_bit)) {
+        _finished = true;
+        return;
+    }
+
     switch(stage) {
 
     case Stage::WRITE_NEW_MISSION_MESSAGE:

--- a/libraries/AP_Logger/LoggerMessageWriter.cpp
+++ b/libraries/AP_Logger/LoggerMessageWriter.cpp
@@ -8,6 +8,7 @@
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 #include "AP_Logger.h"
 #include <AP_RCProtocol/AP_RCProtocol.h>
+#include <AP_AHRS/AP_AHRS.h>
 
 #if HAL_LOGGER_FENCE_ENABLED
     #include <AC_Fence/AC_Fence.h>
@@ -390,6 +391,13 @@ void LoggerMessageWriter_WriteAllRallyPoints::process()
         return;
     }
 
+    // suppress rally points when position logging is disabled
+    const uint32_t pos_bit = AP::ahrs().get_log_pos_bit();
+    if (pos_bit && !AP::logger().should_log(pos_bit)) {
+        _finished = true;
+        return;
+    }
+
     switch(stage) {
 
     case Stage::WRITE_NEW_RALLY_MESSAGE:
@@ -492,6 +500,13 @@ void LoggerMessageWriter_Write_Polyfence::process() {
 
     AC_Fence *fence = AP::fence();
     if (fence == nullptr) {
+        _finished = true;
+        return;
+    }
+
+    // suppress fence points when position logging is disabled
+    const uint32_t pos_bit = AP::ahrs().get_log_pos_bit();
+    if (pos_bit && !AP::logger().should_log(pos_bit)) {
         _finished = true;
         return;
     }


### PR DESCRIPTION
## Summary

Extend the `MASK_LOG_GPS` bit (bit 2) in `LOG_BITMASK` so that clearing it also suppresses absolute-position log messages that were previously always logged, preventing location leakage when GPS logging is disabled.

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [x] Tested in SITL
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
- [x] Autotest included

## Description

Previously, several absolute lat/lng-bearing messages were always written to the log regardless of `LOG_BITMASK`, leaking location even when the GPS/Position bit was cleared. This PR gates them behind the existing `MASK_LOG_GPS` (bit 2):

- `AP_AHRS`: gates ORGN, POS, AHR2, rally points, fence vertices, and deepstall landing points. EKF relative NED data (XKF1, etc.) is preserved, since it cannot be geo-referenced without the origin. Uses the existing `set_log_bit()` pattern to pass the bitmask value from vehicle init code to the AP_AHRS library.
- `AP_Logger`: the `WriteEntireMission` startup writer dumped every mission waypoint's lat/lng into the log regardless of `LOG_BITMASK`. It is now gated on the position bit, matching the rally-point and polyfence writers, so clearing the GPS/Position bit no longer leaks the mission location.

An autotest (`LogBitmaskGPSPosition`) is included verifying that disabling `MASK_LOG_GPS` suppresses absolute-position messages (GPS, POS, ORGN, AHR2) while preserving non-position messages (XKF1, ATT, IMU).