### PR TITLE
Pr/clang werror=absolute value

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -339,6 +339,7 @@ class Board:
                 '-cl-single-precision-constant',
                 '-Wno-vla-extension',
                 '-ftrapping-math',  # prevent re-ordering of sanity checks
+                '-Werror=absolute-value',
             ]
         else:
             env.CFLAGS += [
@@ -463,6 +464,7 @@ class Board:
                 '-Werror=implicit-fallthrough',
                 '-cl-single-precision-constant',
                 '-ftrapping-math',  # prevent re-ordering of sanity checks
+                '-Werror=absolute-value',
             ]
             if self.cc_version_gte(cfg, 10, 0):
                 use_prefix_map = True

--- a/libraries/AC_PrecLand/AC_PrecLand_StateMachine.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand_StateMachine.cpp
@@ -216,7 +216,7 @@ AC_PrecLand_StateMachine::Status AC_PrecLand_StateMachine::retry_landing(Vector3
         // z_target is in "D" frame
         const float z_target = go_to_pos.z + RETRY_OFFSET_ALT_M;
         retry_pos_m = Vector3p{pos.x, pos.y, z_target};
-        if (fabsf(pos.z - retry_pos_m.z) < MAX_POS_ERROR_M) {
+        if (fabsP(pos.z - retry_pos_m.z) < MAX_POS_ERROR_M) {
             // we have descended to the original height where we started the climb from
             _retry_state = RetryLanding::COMPLETE;
             GCS_SEND_TEXT(MAV_SEVERITY_INFO, "PrecLand: Retry Completed");

--- a/libraries/AP_HAL/AP_HAL_Macros.h
+++ b/libraries/AP_HAL/AP_HAL_Macros.h
@@ -47,6 +47,9 @@
 #if !HAL_NUM_CAN_IFACES
 // we should do log() and fabs() as well, but can't because of a conflict in uavcan
 #define log(x) DO_NOT_USE_DOUBLE_MATHS()
+#endif
+#if !HAL_NUM_CAN_IFACES && !HAL_WITH_POSTYPE_DOUBLE
+// as above the CAN, but postype_double uses fabsf
 #define fabs(x) DO_NOT_USE_DOUBLE_MATHS()
 #endif
 #endif

--- a/libraries/AP_Math/control.h
+++ b/libraries/AP_Math/control.h
@@ -9,11 +9,13 @@ typedef double postype_t;
 typedef Vector2d Vector2p;
 typedef Vector3d Vector3p;
 #define topostype todouble
+#define fabsP fabs
 #else
 typedef float postype_t;
 typedef Vector2f Vector2p;
 typedef Vector3f Vector3p;
 #define topostype tofloat
+#define fabsP fabsf
 #endif
 
 /*


### PR DESCRIPTION
### Summary

Adds a compiler flag so we don't regress again on using fabsf instead of fabsF for locations

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Everything still seems to compile that did compile.

### Description

We had a regression creep in which clang was warning about.

Make clang more emphatic about things so we don't regress again.
