### PR TITLE
Bootloaders: Add IDs for two upcoming boards

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -334,6 +334,8 @@ AP_HW_CSKY_PMU                       1212
 AP_HW_PilotGaeaSH7V1                 1213
 AP_HW_JPilot-C                       1214
 AP_HW_SIYI-UniFC-6-PICO              1215
+AP_HW_CSKY_AVEGA6X                   1216
+AP_HW_CSKY_AVEGALITER03              1217
 
 AP_HW_MUPilot                        1222
 AP_HW_HWH7                           1223


### PR DESCRIPTION
Added board ID for CSKY_AVEGA6X and CSKY_AVEGALITER03 upcoming boards.