### PR TITLE
AP_AHRS: create and use a backends_and_estimates structure

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -419,22 +419,10 @@ void AP_AHRS::reset_gyro_drift(void)
 {
     // support locked access functions to AHRS data
     WITH_SEMAPHORE(_rsem);
-    
-    // update DCM
-#if AP_AHRS_DCM_ENABLED
-    dcm.reset_gyro_drift();
-#endif
-#if AP_AHRS_EXTERNAL_ENABLED
-    external.reset_gyro_drift();
-#endif
 
-    // reset the EKF gyro bias states
-#if HAL_NAVEKF2_AVAILABLE
-    ekf2.reset_gyro_drift();
-#endif
-#if HAL_NAVEKF3_AVAILABLE
-    ekf3.reset_gyro_drift();
-#endif
+    for (auto &backend_and_estimates : backends_and_estimates) {
+        backend_and_estimates.backend.reset_gyro_drift();
+    }
 }
 
 /*
@@ -780,23 +768,9 @@ void AP_AHRS::reset()
     // support locked access functions to AHRS data
     WITH_SEMAPHORE(_rsem);
 
-#if AP_AHRS_DCM_ENABLED
-    dcm.reset();
-#endif
-#if AP_AHRS_SIM_ENABLED
-    sim.reset();
-#endif
-
-#if AP_AHRS_EXTERNAL_ENABLED
-    external.reset();
-#endif
-
-#if HAL_NAVEKF2_AVAILABLE
-    ekf2.reset();
-#endif
-#if HAL_NAVEKF3_AVAILABLE
-    ekf3.reset();
-#endif
+    for (auto &backend_and_estimates : backends_and_estimates) {
+        backend_and_estimates.backend.reset();
+    }
 }
 
 // dead-reckoning support
@@ -2408,15 +2382,9 @@ void AP_AHRS::resetHeightDatum(void)
     // support locked access functions to AHRS data
     WITH_SEMAPHORE(_rsem);
 
-#if HAL_NAVEKF3_AVAILABLE
-    ekf3.resetHeightDatum();
-#endif
-#if HAL_NAVEKF2_AVAILABLE
-    ekf2.resetHeightDatum();
-#endif
-#if AP_AHRS_SIM_ENABLED
-    sim.resetHeightDatum();
-#endif
+    for (auto &backend_and_estimates : backends_and_estimates) {
+        backend_and_estimates.backend.resetHeightDatum();
+    }
 }
 
 // send a EKF_STATUS_REPORT for configured EKF

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -1060,6 +1060,36 @@ private:
     struct AP_AHRS_Backend::Estimates external_estimates;
 #endif
 
+// FIXME: C++-17 will let us do away with this construct:
+#define AP_AHRS_BACKEND_COUNT                   \
+    (!!(AP_AHRS_DCM_ENABLED) +                  \
+     !!(AP_AHRS_NAVEKF2_ENABLED) +              \
+     !!(AP_AHRS_NAVEKF3_ENABLED) +              \
+     !!(AP_AHRS_SIM_ENABLED) +                  \
+     !!(AP_AHRS_EXTERNAL_ENABLED))
+
+    struct {
+        AP_AHRS_Backend &backend;
+        AP_AHRS_Backend::Estimates &estimates;
+    } backends_and_estimates[AP_AHRS_BACKEND_COUNT] {
+#if AP_AHRS_DCM_ENABLED
+        { dcm, dcm_estimates },
+#endif  // AP_AHRS_DCM_ENABLED
+#if AP_AHRS_NAVEKF2_ENABLED
+        { ekf2, ekf2_estimates },
+#endif  // AP_AHRS_NAVEKF2_ENABLED
+#if AP_AHRS_NAVEKF3_ENABLED
+        { ekf3, ekf3_estimates },
+#endif  // AP_AHRS_NAVEKF3_ENABLED
+#if AP_AHRS_SIM_ENABLED
+        { sim, sim_estimates },
+#endif  // AP_AHRS_SIM_ENABLED
+#if AP_AHRS_EXTERNAL_ENABLED
+        { external, external_estimates },
+#endif  // AP_AHRS_EXTERNAL_ENABLED
+    };
+
+
     enum class Options : uint16_t {
         DISABLE_DCM_FALLBACK_FW=(1U<<0),
         DISABLE_DCM_FALLBACK_VTOL=(1U<<1),


### PR DESCRIPTION
### Summary

Creates a structure with backends and their results which can be iterated over.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request


### Description

Creates a structure to hold the backends and their estimates, iterates it.

We will be using the same structure in the update loop soon-ish, which is why I want the estimates in the structure, not just a list of backends.
