### PR TITLE
AP_AHRS: add and use configured_backend pointer and estimates

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -250,6 +250,7 @@ AP_AHRS::AP_AHRS(uint8_t flags) :
 
     // we assume active_backend is not nullptr in many places, so make
     // sure it is set early:
+    update_configured_ekf_type();
     update_active_EKF_type();
 
 #if APM_BUILD_COPTER_OR_HELI || APM_BUILD_TYPE(APM_BUILD_ArduSub)
@@ -290,6 +291,21 @@ AP_AHRS_Backend *AP_AHRS::backend_for_type(EKFType type)
 #endif
     }
     return nullptr;
+}
+
+// updates the cached value for the currently configured EKF type
+// (i.e. the one that the user has specified with parameters).  Also
+// sets the pointer to the allocated backend for that type.
+void AP_AHRS::update_configured_ekf_type()
+{
+    const auto new_type = _configured_ekf_type();
+    auto *new_backend = backend_for_type(new_type);
+    if (new_backend != nullptr) {
+        state.configured_ekf_type = new_type;
+        configured_backend = new_backend;
+        return;
+    }
+    INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
 }
 
 void AP_AHRS::update_active_EKF_type()
@@ -337,6 +353,7 @@ void AP_AHRS::init()
     last_active_ekf_type = (EKFType)_ekf_type.get();
 
     // we may have updated ekf_type()'s results, so set the backend again:
+    update_configured_ekf_type();
     update_active_EKF_type();
 
     // init backends
@@ -569,6 +586,7 @@ void AP_AHRS::update(bool skip_ins_update)
 #endif
     }
 
+    update_configured_ekf_type();
     update_active_EKF_type();
 
 #if HAL_GCS_ENABLED
@@ -1619,7 +1637,7 @@ void AP_AHRS::get_relative_position_D_home(float &posD) const
   canonicalise _ekf_type, forcing it to be 0, 2 or 3
   type 1 has been deprecated
  */
-AP_AHRS::EKFType AP_AHRS::configured_ekf_type(void) const
+AP_AHRS::EKFType AP_AHRS::_configured_ekf_type(void) const
 {
     EKFType type = (EKFType)_ekf_type.get();
     switch (type) {
@@ -2005,36 +2023,7 @@ bool AP_AHRS::pre_arm_check(bool requires_position, char *failure_msg, uint8_t f
         return false;
     }
 
-    switch (configured_ekf_type()) {
-#if AP_AHRS_SIM_ENABLED
-    case EKFType::SIM:
-        return ret;
-#endif
-
-#if AP_AHRS_DCM_ENABLED
-    case EKFType::DCM:
-        return dcm.pre_arm_check(requires_position, failure_msg, failure_msg_len) && ret;
-#endif
-
-#if AP_AHRS_EXTERNAL_ENABLED
-    case EKFType::EXTERNAL:
-        return external.pre_arm_check(requires_position, failure_msg, failure_msg_len);
-#endif
-
-#if HAL_NAVEKF2_AVAILABLE
-    case EKFType::TWO:
-        return ekf2.pre_arm_check(requires_position, failure_msg, failure_msg_len) && ret;
-#endif
-
-#if HAL_NAVEKF3_AVAILABLE
-    case EKFType::THREE:
-        return ekf3.pre_arm_check(requires_position, failure_msg, failure_msg_len) && ret;
-#endif
-    }
-
-    // if we get here then ekf type is invalid
-    hal.util->snprintf(failure_msg, failure_msg_len, "invalid EKF type");
-    return false;
+    return (configured_backend->pre_arm_check(requires_position, failure_msg, failure_msg_len) && ret);
 }
 
 // true if the AHRS has completed initialisation
@@ -2069,40 +2058,6 @@ bool AP_AHRS::initialised(void) const
     }
     return false;
 };
-
-// get_filter_status : returns filter status as a series of flags
-bool AP_AHRS::get_filter_status(nav_filter_status &status) const
-{
-    switch (configured_ekf_type()) {
-#if AP_AHRS_DCM_ENABLED
-    case EKFType::DCM:
-        return dcm.get_filter_status(status);
-#endif
-
-#if HAL_NAVEKF2_AVAILABLE
-    case EKFType::TWO:
-        ekf2.get_filter_status(status);
-        return true;
-#endif
-
-#if HAL_NAVEKF3_AVAILABLE
-    case EKFType::THREE:
-        ekf3.get_filter_status(status);
-        return true;
-#endif
-
-#if AP_AHRS_SIM_ENABLED
-    case EKFType::SIM:
-        return sim.get_filter_status(status);
-#endif
-#if AP_AHRS_EXTERNAL_ENABLED
-    case EKFType::EXTERNAL:
-        return external.get_filter_status(status);
-#endif
-    }
-
-    return false;
-}
 
 // write optical flow data to EKF
 void  AP_AHRS::writeOptFlowMeas(const uint8_t rawFlowQuality, const Vector2f &rawFlowRates, const Vector2f &rawGyroRates, const uint32_t msecFlowMeas, const Vector3f &posOffset, float heightOverride)
@@ -2360,37 +2315,7 @@ void AP_AHRS::resetHeightDatum(void)
 // send a EKF_STATUS_REPORT for configured EKF
 void AP_AHRS::send_ekf_status_report(GCS_MAVLINK &link) const
 {
-    switch (configured_ekf_type()) {
-#if AP_AHRS_DCM_ENABLED
-    case EKFType::DCM:
-        // send zero status report
-        dcm.send_ekf_status_report(link);
-        break;
-#endif
-#if AP_AHRS_SIM_ENABLED
-    case EKFType::SIM:
-        sim.send_ekf_status_report(link);
-        break;
-#endif
-
-#if AP_AHRS_EXTERNAL_ENABLED
-    case EKFType::EXTERNAL: {
-        external.send_ekf_status_report(link);
-        break;
-    }
-#endif
-
-#if HAL_NAVEKF2_AVAILABLE
-    case EKFType::TWO:
-        return ekf2.send_ekf_status_report(link);
-#endif
-
-#if HAL_NAVEKF3_AVAILABLE
-    case EKFType::THREE:
-        return ekf3.send_ekf_status_report(link);
-#endif
-
-    }
+    configured_backend->send_ekf_status_report(link);
 }
 
 // return origin for a specified EKF type
@@ -2555,43 +2480,6 @@ void AP_AHRS::set_terrain_hgt_stable(bool stable)
 #endif
 }
 
-// return the innovations for the primarily EKF
-// boolean false is returned if innovations are not available
-bool AP_AHRS::get_innovations(Vector3f &velInnov, Vector3f &posInnov, Vector3f &magInnov, float &tasInnov, float &yawInnov) const
-{
-    switch (configured_ekf_type()) {
-#if AP_AHRS_DCM_ENABLED
-    case EKFType::DCM:
-        // We are not using an EKF so no data
-        return false;
-#endif
-
-#if HAL_NAVEKF2_AVAILABLE
-    case EKFType::TWO:
-        // use EKF to get innovations
-        return ekf2.get_innovations(velInnov, posInnov, magInnov, tasInnov, yawInnov);
-#endif
-
-#if HAL_NAVEKF3_AVAILABLE
-    case EKFType::THREE:
-        // use EKF to get innovations
-        return ekf3.get_innovations(velInnov, posInnov, magInnov, tasInnov, yawInnov);
-#endif
-
-#if AP_AHRS_SIM_ENABLED
-    case EKFType::SIM:
-        return sim.get_innovations(velInnov, posInnov, magInnov, tasInnov, yawInnov);
-#endif
-
-#if AP_AHRS_EXTERNAL_ENABLED
-    case EKFType::EXTERNAL:
-        return false;
-#endif
-    }
-
-    return false;
-}
-
 // returns true when the state estimates are significantly degraded by vibration
 bool AP_AHRS::is_vibration_affected() const
 {
@@ -2614,47 +2502,6 @@ bool AP_AHRS::is_vibration_affected() const
 #endif
         return false;
     }
-    return false;
-}
-
-// get_variances - provides the innovations normalised using the innovation variance where a value of 0
-// indicates prefect consistency between the measurement and the EKF solution and a value of 1 is the maximum
-// inconsistency that will be accepted by the filter
-// boolean false is returned if variances are not available
-bool AP_AHRS::get_variances(float &velVar, float &posVar, float &hgtVar, Vector3f &magVar, float &tasVar) const
-{
-    switch (configured_ekf_type()) {
-#if AP_AHRS_DCM_ENABLED
-    case EKFType::DCM:
-        // We are not using an EKF so no data
-        return false;
-#endif
-
-#if HAL_NAVEKF2_AVAILABLE
-    case EKFType::TWO: {
-        // use EKF to get variance
-        return ekf2.get_variances(velVar, posVar, hgtVar, magVar, tasVar);
-    }
-#endif
-
-#if HAL_NAVEKF3_AVAILABLE
-    case EKFType::THREE: {
-        // use EKF to get variance
-        return ekf3.get_variances(velVar, posVar, hgtVar, magVar, tasVar);
-    }
-#endif
-
-#if AP_AHRS_SIM_ENABLED
-    case EKFType::SIM:
-        return sim.get_variances(velVar, posVar, hgtVar, magVar, tasVar);
-#endif
-
-#if AP_AHRS_EXTERNAL_ENABLED
-    case EKFType::EXTERNAL:
-        return external.get_variances(velVar, posVar, hgtVar, magVar, tasVar);
-#endif
-    }
-
     return false;
 }
 

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -366,7 +366,9 @@ public:
 #endif
 
     // get_filter_status - returns filter status as a series of flags
-    bool get_filter_status(nav_filter_status &status) const;
+    bool get_filter_status(nav_filter_status &status) const {
+        return configured_backend->get_filter_status(status);
+    }
 
     // get compass offset estimates
     // true if offsets are valid
@@ -415,7 +417,9 @@ public:
 
     // return the innovations for the specified instance
     // An out of range instance (eg -1) returns data for the primary instance
-    bool get_innovations(Vector3f &velInnov, Vector3f &posInnov, Vector3f &magInnov, float &tasInnov, float &yawInnov) const;
+    bool get_innovations(Vector3f &velInnov, Vector3f &posInnov, Vector3f &magInnov, float &tasInnov, float &yawInnov) const {
+        return configured_backend->get_innovations(velInnov, posInnov, magInnov, tasInnov, yawInnov);
+    }
 
     // returns true when the state estimates are significantly degraded by vibration
     bool is_vibration_affected() const;
@@ -424,7 +428,9 @@ public:
     // indicates perfect consistency between the measurement and the EKF solution and a value of 1 is the maximum
     // inconsistency that will be accepted by the filter
     // boolean false is returned if variances are not available
-    bool get_variances(float &velVar, float &posVar, float &hgtVar, Vector3f &magVar, float &tasVar) const;
+    bool get_variances(float &velVar, float &posVar, float &hgtVar, Vector3f &magVar, float &tasVar) const {
+        return configured_backend->get_variances(velVar, posVar, hgtVar, magVar, tasVar);
+    }
 
     // get 1-sigma position and velocity uncertainty derived from the EKF state error covariance matrix P
     // pos_horiz_m: 2D RMS horizontal position uncertainty (m)
@@ -513,7 +519,9 @@ public:
 
     // returns a canonicalised and valid EKFType, as opposed to the raw
     // parameter value which may be any value the user has set
-    EKFType configured_ekf_type(void) const;
+    EKFType configured_ekf_type(void) const {
+        return state.configured_ekf_type;
+    }
 
     // set the selected ekf type, for RC aux control
     void set_ekf_type(EKFType ahrs_type) {
@@ -939,11 +947,17 @@ private:
     // return secondary attitude solution if available, as quaternion
     bool _get_secondary_quaternion(Quaternion &quat) const;
 
+    // set state.configured_ekf_type and the pointer to the configured backend
+    void update_configured_ekf_type();
+
     // set state.active_EKF_type and the pointer to the active backend
     void update_active_EKF_type();
 
     // get active EKF type
     EKFType _active_EKF_type(void) const;
+
+    // get configured EKF type:
+    EKFType _configured_ekf_type(void) const;
 
     // return a true airspeed estimate (navigation airspeed) if
     // available. return true if we have an estimate
@@ -998,7 +1012,8 @@ private:
       state updated at the end of each update() call
      */
     struct {
-        EKFType active_EKF_type;
+        EKFType active_EKF_type;  // EKFType of backend these results are for
+        EKFType configured_ekf_type;  // vetted parameter-configured EKFType
         uint8_t primary_gyro;
         uint8_t primary_accel;
         uint8_t primary_core;
@@ -1121,6 +1136,13 @@ private:
         return const_cast<AP_AHRS*>(this)->estimates_for_type(type);
     }
 
+    // configured_backend is the backend the user wants to use as
+    // indicated by parameter values
+    AP_AHRS_Backend *configured_backend;
+
+    // active_backend is the backend which is currently providing
+    // results (e.g. this may be a fallback estimator if the
+    // configured_backend is unhealthy)
     AP_AHRS_Backend *active_backend;
     AP_AHRS_Backend::Estimates *active_estimates;
 


### PR DESCRIPTION
### Summary

Creates a `configured_backend` pointer similar to the `active_backend` pointer, uses it in place of switch statements.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                 *                                                   
Durandal                            -32             -120   *           -80     -144              72     -40    32
Hitec-Airspeed           *                                 *                                                   
KakuteH7-bdshot                     -48             -128   *           -112    312               -96    -72    -40
MatekF405                           -40             -128   *           -96     -136              -120   -88    -80
MatekH7A3                           -40             -96    *           16      -200              -72    -64    -160
Pixhawk1-1M-bdshot                  -48             -104               -96     -88               88     -48    -112
SITL_x86_64_linux_gnu               -208            -296               -208    -216              -80    -80    -136
YJUAV_A6SE                          -152            -232   *           -240    -256              -200   -184   -216
f103-QiotekPeriph        *                                 *                                                   
f303-MatekGPS            *                                 *                                                   
f303-Universal           *                                 *                                                   
iomcu                                                                                *                         
mindpx-v2                           -40             -104   *           296     -168              -24    -48    -80
revo-mini                           -48             -104   *           -144    -136              -88    -80    -96
skyviper-v2450                                                         -104                                    
speedybeef4                         -40             -112   *           -64     -64               -152   -64    -80
```

### Description

Like the active pointer, this is guaranteed not-nullptr.

I'm pretty sure we should be using active pointer for some of these, but I'm being careful to preserve current behaviour.
