### PR TITLE
ArduCopter: AUTO_OPTIONS bit to wait for yaw at waypoint

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -813,8 +813,8 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
 #if MODE_AUTO_ENABLED
     // @Param: AUTO_OPTIONS
     // @DisplayName: Auto mode options
-    // @Description: A range of options that can be applied to change auto mode behaviour. Allow Arming allows the copter to be armed in Auto. Allow Takeoff Without Raising Throttle allows takeoff without the pilot having to raise the throttle. Ignore pilot yaw overrides the pilot's yaw stick being used while in auto.
-    // @Bitmask: 0:Allow Arming,1:Allow Takeoff Without Raising Throttle,2:Ignore pilot yaw,7:Allow weathervaning
+    // @Description: A range of options that can be applied to change auto mode behaviour. Allow Arming allows the copter to be armed in Auto. Allow Takeoff Without Raising Throttle allows takeoff without the pilot having to raise the throttle. Ignore pilot yaw overrides the pilot's yaw stick being used while in auto. Wait for yaw at waypoint holds at each waypoint until the heading commanded by a CONDITION_YAW command has been reached before continuing.
+    // @Bitmask: 0:Allow Arming,1:Allow Takeoff Without Raising Throttle,2:Ignore pilot yaw,3:Wait for yaw at waypoint,7:Allow weathervaning
     // @User: Advanced
     AP_GROUPINFO("AUTO_OPTIONS", 40, ParametersG2, auto_options, 0),
 #endif

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -655,6 +655,7 @@ private:
         AllowArming                        = (1 << 0U),
         AllowTakeOffWithoutRaisingThrottle = (1 << 1U),
         IgnorePilotYaw                     = (1 << 2U),
+        WaitForYaw                         = (1 << 3U),
         AllowWeatherVaning                 = (1 << 7U),
     };
     bool option_is_enabled(Option option) const;

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -2203,6 +2203,12 @@ bool ModeAuto::verify_loiter_time(const AP_Mission::Mission_Command& cmd)
         return false;
     }
 
+    // optionally hold until the yaw target set by a CONDITION_YAW command
+    // has been reached (see verify_nav_wp)
+    if (option_is_enabled(Option::WaitForYaw) && !auto_yaw.reached_fixed_yaw_target()) {
+        return false;
+    }
+
     // start our loiter timer
     if ( loiter_time == 0 ) {
         loiter_time = millis();
@@ -2275,6 +2281,14 @@ bool ModeAuto::verify_nav_wp(const AP_Mission::Mission_Command& cmd)
 {
     // check if we have reached the waypoint
     if ( !copter.wp_nav->reached_wp_destination() ) {
+        return false;
+    }
+
+    // optionally hold at the waypoint until the yaw target set by a
+    // CONDITION_YAW command has been reached.  reached_fixed_yaw_target()
+    // returns true when not in a fixed yaw mode, so this is a no-op unless
+    // a yaw has actually been commanded for this leg.
+    if (option_is_enabled(Option::WaitForYaw) && !auto_yaw.reached_fixed_yaw_target()) {
         return false;
     }
 


### PR DESCRIPTION
## Summary

Draft for #33238 — gives auto mode an option to hold at a waypoint until a commanded heading is reached, without touching the mission storage format.

A new `AUTO_OPTIONS` bit (3, "Wait for yaw at waypoint") makes `verify_nav_wp` and `verify_loiter_time` hold the command as incomplete until `auto_yaw.reached_fixed_yaw_target()` is true. The yaw target comes from an ordinary `CONDITION_YAW` command, so a mission looks like:

```
NAV_WAYPOINT   (the point)
CONDITION_YAW  (heading to face)
```

`CONDITION_YAW` already sets the fixed yaw target during the leg; with the bit set the waypoint just won't report "done" until that heading is hit, so the vehicle parks at the point, finishes rotating, then continues.

Per @rmackay9's guidance in the issue this stays out of the mission commands entirely (no NAV_WAYPOINT param4, so the 15-byte limit is a non-issue) and leaves `CONDITION_YAW` as a normal fire-and-forget DO command — nothing in the do/nav independence changes. `reached_fixed_yaw_target()` returns true when not in a fixed yaw mode, so the gate is a no-op unless a yaw was actually commanded for that leg, and existing missions are unaffected.

Opening as a draft to confirm the approach before polishing.

## Classification & Testing

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Built ArduCopter SITL on macOS (arm64) — compiles cleanly. Functional SITL mission testing of the hold-until-yaw behaviour still to do; flagging the approach for review first.
