### PR TITLE
GPS: dual antenna yaw support for new uBlox chips  ZED-X20D, ZED-F9H

### DIFF
--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -422,7 +422,7 @@ AP_GPS_UBLOX::_request_next_config(void)
                 // must be pre-configured externally. Clear config bit here.
                 _unconfigured_messages &= ~CONFIG_RATE_DAHEADING;
             } else
-#endif
+#endif  // AP_GPS_UBLOX_CFGV2_ENABLED
             if (!_request_message_rate(CLASS_NAV, MSG_DAHEADING)) {
                 _next_message--;
             }

--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -413,6 +413,26 @@ AP_GPS_UBLOX::_request_next_config(void)
         break;
     }
 
+    case STEP_DAHEADING:
+#if GPS_MOVING_BASELINE
+        if (_has_dual_antenna_heading) {
+#if AP_GPS_UBLOX_CFGV2_ENABLED
+            if (!_legacy_cfg_supported) {
+                // X20D (PROTVER>=40): legacy CFG-MSG not supported; DAHEADING output
+                // must be pre-configured externally. Clear config bit here.
+                _unconfigured_messages &= ~CONFIG_RATE_DAHEADING;
+            } else
+#endif
+            if (!_request_message_rate(CLASS_NAV, MSG_DAHEADING)) {
+                _next_message--;
+            }
+        } else
+#endif
+        {
+            _unconfigured_messages &= ~CONFIG_RATE_DAHEADING;
+        }
+        break;
+
     default:
         // this case should never be reached, do a full reset if it is hit
         _next_message = STEP_PVT;
@@ -454,6 +474,10 @@ AP_GPS_UBLOX::_verify_rate(uint8_t msg_class, uint8_t msg_id, uint8_t rate) {
         case MSG_DOP:
             desired_rate = RATE_DOP;
             config_msg_id = CONFIG_RATE_DOP;
+            break;
+        case MSG_DAHEADING:
+            desired_rate = _has_dual_antenna_heading ? 1 : 0;
+            config_msg_id = CONFIG_RATE_DAHEADING;
             break;
         default:
             return;
@@ -1450,6 +1474,12 @@ AP_GPS_UBLOX::_parse_gps(void)
                         _hardware_variant = UBLOX_F9_ZED;
                     } else if (strncmp(_module, "NEO-F9P", UBLOX_MODULE_LEN) == 0) {
                         _hardware_variant = UBLOX_F9_NEO;
+                    } else if (strncmp(_module, "ZED-F9H", UBLOX_MODULE_LEN) == 0) {
+#if GPS_MOVING_BASELINE
+                        _has_dual_antenna_heading = true;
+                        state.gps_yaw_configured = true;
+                        _unconfigured_messages |= CONFIG_RATE_DAHEADING;
+#endif
                     }
                 }
                 if (strncmp(_version.swVersion, "EXT CORE 4", 10) == 0) {
@@ -1469,6 +1499,21 @@ AP_GPS_UBLOX::_parse_gps(void)
                 // M10 does not support multi-valued VALGET
                 use_single_valget = true;
             }
+#if AP_GPS_UBLOX_CFGV2_ENABLED
+            // check for X20 series (ZED-X20D etc.) - hwVersion 000B0000
+            if (strncmp(_version.hwVersion, "000B0000", 8) == 0) {
+                _hardware_generation = UBLOX_X20;
+                // X20 uses VALSET-based config; legacy GNSS/SBAS config not supported
+                _unconfigured_messages &= ~CONFIG_GNSS;
+                if (strncmp(_module, "ZED-X20D", UBLOX_MODULE_LEN) == 0) {
+#if GPS_MOVING_BASELINE
+                    _has_dual_antenna_heading = true;
+                    state.gps_yaw_configured = true;
+                    _unconfigured_messages |= CONFIG_RATE_DAHEADING;
+#endif
+                }
+            }
+#endif  // AP_GPS_UBLOX_CFGV2_ENABLED
             if (check_L1L5) {
                 // check if L1L5 in extension
                 if (memmem(_buffer.mon_ver.extension, sizeof(_buffer.mon_ver.extension), "L1L5", 4) != nullptr) {
@@ -1668,6 +1713,39 @@ AP_GPS_UBLOX::_parse_gps(void)
             }
         }
         break;
+
+    case MSG_DAHEADING:
+        if (_has_dual_antenna_heading && _buffer.daheading.version == 1) {
+            // DATA1 format (64 bytes): same layout as RELPOSNED; relPosLength in cm
+            _check_new_itow(_buffer.daheading.iTOW);
+            // receiving the message is sufficient confirmation the rate is configured
+            _unconfigured_messages &= ~CONFIG_RATE_DAHEADING;
+            const uint32_t dah_valid = static_cast<uint32_t>(DAHEADING::relPosHeadingValid) |
+                                       static_cast<uint32_t>(DAHEADING::relPosValid) |
+                                       static_cast<uint32_t>(DAHEADING::gnssFixOK) |
+                                       static_cast<uint32_t>(DAHEADING::carrSolnFixed);
+            const uint32_t dah_invalid = static_cast<uint32_t>(DAHEADING::carrSolnFloat);
+            if (((_buffer.daheading.flags & dah_valid) == dah_valid) &&
+                ((_buffer.daheading.flags & dah_invalid) == 0)) {
+                // relPosLength is in cm; multiply by 0.01 for metres
+                if (calculate_moving_base_yaw(_buffer.daheading.relPosHeading * 1e-5f,
+                                              _buffer.daheading.relPosLength * 0.01f,
+                                              _buffer.daheading.relPosD * 0.01f)) {
+                    state.have_gps_yaw_accuracy = true;
+                    state.gps_yaw_accuracy = _buffer.daheading.accHeading * 1e-5f;
+                    _last_daheading_ms = AP_HAL::millis();
+                    _last_daheading_itow = _buffer.daheading.iTOW;
+                }
+                state.relPosHeading = _buffer.daheading.relPosHeading * 1e-5f;
+                state.relPosLength  = _buffer.daheading.relPosLength * 0.01f;
+                state.relPosD       = _buffer.daheading.relPosD * 0.01f;
+                state.accHeading    = _buffer.daheading.accHeading * 1e-5f;
+                state.relposheading_ts = AP_HAL::millis();
+            } else {
+                state.have_gps_yaw_accuracy = false;
+            }
+        }
+        break;
 #endif // GPS_MOVING_BASELINE
 
     case MSG_PVT:
@@ -1848,15 +1926,21 @@ AP_GPS_UBLOX::_parse_gps(void)
     }
 
     if (state.have_gps_yaw) {
-        // when we are a rover we want to ensure we have both the new
-        // PVT and the new RELPOSNED message so that we give a
-        // consistent view
-        if (AP_HAL::millis() - _last_relposned_ms > 400) {
-            // we have stopped receiving valid RELPOSNED messages, disable yaw reporting
-            state.have_gps_yaw = false;
-        } else if (_last_relposned_itow != _last_pvt_itow) {
-            // wait until ITOW matches
-            return false;
+        // Ensure position and heading messages are from the same epoch and
+        // haven't gone stale. DAHEADING (single-module) and RELPOSNED
+        // (moving-baseline) are handled separately.
+        if (_has_dual_antenna_heading) {
+            if (AP_HAL::millis() - _last_daheading_ms > 400) {
+                state.have_gps_yaw = false;
+            } else if (_last_daheading_itow != _last_pvt_itow) {
+                return false;
+            }
+        } else {
+            if (AP_HAL::millis() - _last_relposned_ms > 400) {
+                state.have_gps_yaw = false;
+            } else if (_last_relposned_itow != _last_pvt_itow) {
+                return false;
+            }
         }
     }
 

--- a/libraries/AP_GPS/AP_GPS_UBLOX.cpp
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.cpp
@@ -2299,7 +2299,8 @@ static const char *reasons[] = {"navigation rate",
                                 "TIM TM2",
                                 "F9",
                                 "M10",
-                                "L5 Enable Disable"};
+                                "L5 Enable Disable",
+                                "dual antenna heading rate"};
 
 static_assert((1 << ARRAY_SIZE(reasons)) == CONFIG_LAST, "UBLOX: Missing configuration description");
 

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -107,6 +107,7 @@
 #define CONFIG_F9            (1<<19)
 #define CONFIG_M10           (1<<20)
 #define CONFIG_L5            (1<<21)
+#define CONFIG_RATE_DAHEADING (1<<22)
 #define CONFIG_LAST          (1<<22) // this must always be the last bit
 
 #define CONFIG_REQUIRED_INITIAL (CONFIG_RATE_NAV | CONFIG_RATE_POSLLH | CONFIG_RATE_STATUS | CONFIG_RATE_VELNED)
@@ -414,6 +415,34 @@ private:
         uint32_t flags;
     };
 
+    // UBX-NAV-DAHEADING (0x01 0x45) DATA1 (version=1) - single-module dual-antenna heading
+    // ZED-X20D PROTVER>=57. 64-byte payload, structurally identical to ubx_nav_relposned.
+    // relPosLength is in cm; multiply by 0.01 to get metres.
+    // Flags use the same bit layout as RELPOSNED (carrSoln encoded in bits 3-4).
+    struct PACKED ubx_nav_daheading {
+        uint8_t  version;       // 0x01 for DATA1
+        uint8_t  reserved0;
+        uint16_t refStationId;
+        uint32_t iTOW;          // ms, GPS time of week
+        int32_t  relPosN;       // cm, North
+        int32_t  relPosE;       // cm, East
+        int32_t  relPosD;       // cm, Down
+        uint32_t relPosLength;  // cm, baseline length
+        uint32_t relPosHeading; // deg * 1e-5
+        uint8_t  reserved1[4];
+        int8_t   relPosHPN;     // mm * 0.1
+        int8_t   relPosHPE;
+        int8_t   relPosHPD;
+        int8_t   relPosHPLength;
+        uint32_t accN;          // mm * 0.1
+        uint32_t accE;
+        uint32_t accD;
+        uint32_t accLength;     // mm * 0.1
+        uint32_t accHeading;    // deg * 1e-5
+        uint8_t  reserved2[4];
+        uint32_t flags;         // same bit layout as RELPOSNED
+    };
+
     struct PACKED ubx_nav_velned {
         uint32_t itow;                                  // GPS msToW
         int32_t ned_north;
@@ -654,6 +683,7 @@ private:
         ubx_cfg_valget valget;
         ubx_nav_svinfo_header svinfo_header;
         ubx_nav_relposned relposned;
+        ubx_nav_daheading daheading;
 #if UBLOX_RXM_RAW_LOGGING
         ubx_rxm_raw rxm_raw;
         ubx_rxm_rawx rxm_rawx;
@@ -665,6 +695,16 @@ private:
         ubx_mon_comms_header mon_comms;
 #endif
     } _buffer;
+
+    // Flags for UBX-NAV-DAHEADING — same bit positions as RELPOSNED for the
+    // common subset; isMoving/refPosMiss/refObsMiss are not required for F9H.
+    enum class DAHEADING {
+        gnssFixOK          = 1U << 0,
+        relPosValid        = 1U << 2,
+        carrSolnFloat      = 1U << 3,
+        carrSolnFixed      = 1U << 4,
+        relPosHeadingValid = 1U << 8,
+    };
 
     enum class RELPOSNED {
         gnssFixOK          = 1U << 0,
@@ -698,6 +738,7 @@ private:
         MSG_SOL = 0x6,
         MSG_PVT = 0x7,
         MSG_TIMEGPS = 0x20,
+        MSG_DAHEADING = 0x45,   // single-module dual-antenna heading (ZED-X20D DATA1, version=1)
         MSG_RELPOSNED = 0x3c,
         MSG_VELNED = 0x12,
         MSG_CFG_CFG = 0x09,
@@ -823,6 +864,7 @@ private:
         STEP_F9_VALIDATE,
         STEP_M10,
         STEP_L5,
+        STEP_DAHEADING,     // enable UBX-NAV-DAHEADING on single-module dual-antenna receivers
         STEP_LAST
     };
 
@@ -860,6 +902,9 @@ private:
     uint32_t        _last_pvt_itow;
     uint32_t        _last_relposned_itow;
     uint32_t        _last_relposned_ms;
+    uint32_t        _last_daheading_itow;
+    uint32_t        _last_daheading_ms;
+    bool            _has_dual_antenna_heading;
 
     // the role set from GPS_TYPE
     AP_GPS::GPS_Role role;

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -108,7 +108,7 @@
 #define CONFIG_M10           (1<<20)
 #define CONFIG_L5            (1<<21)
 #define CONFIG_RATE_DAHEADING (1<<22)
-#define CONFIG_LAST          (1<<22) // this must always be the last bit
+#define CONFIG_LAST          (1<<23) // this must always be the last bit
 
 #define CONFIG_REQUIRED_INITIAL (CONFIG_RATE_NAV | CONFIG_RATE_POSLLH | CONFIG_RATE_STATUS | CONFIG_RATE_VELNED)
 

--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -107,6 +107,7 @@
 #define CONFIG_F9            (1<<19)
 #define CONFIG_M10           (1<<20)
 #define CONFIG_L5            (1<<21)
+#define CONFIG_RATE_DAHEADING (1<<22)
 #define CONFIG_LAST          (1<<22) // this must always be the last bit
 
 #define CONFIG_REQUIRED_INITIAL (CONFIG_RATE_NAV | CONFIG_RATE_POSLLH | CONFIG_RATE_STATUS | CONFIG_RATE_VELNED)
@@ -414,6 +415,34 @@ private:
         uint32_t flags;
     };
 
+    // UBX-NAV-DAHEADING (0x01 0x45) DATA1 (version=1) - single-module dual-antenna heading
+    // ZED-X20D PROTVER>=57. 64-byte payload, structurally identical to ubx_nav_relposned.
+    // relPosLength is in cm; multiply by 0.01 to get metres.
+    // Flags use the same bit layout as RELPOSNED (carrSoln encoded in bits 3-4).
+    struct PACKED ubx_nav_daheading {
+        uint8_t  version;       // 0x01 for DATA1
+        uint8_t  reserved0;
+        uint16_t refStationId;
+        uint32_t iTOW;          // ms, GPS time of week
+        int32_t  relPosN;       // cm, North
+        int32_t  relPosE;       // cm, East
+        int32_t  relPosD;       // cm, Down
+        uint32_t relPosLength;  // cm, baseline length
+        uint32_t relPosHeading; // deg * 1e-5
+        uint8_t  reserved1[4];
+        int8_t   relPosHPN;     // mm * 0.1
+        int8_t   relPosHPE;
+        int8_t   relPosHPD;
+        int8_t   relPosHPLength;
+        uint32_t accN;          // mm * 0.1
+        uint32_t accE;
+        uint32_t accD;
+        uint32_t accLength;     // mm * 0.1
+        uint32_t accHeading;    // deg * 1e-5
+        uint8_t  reserved2[4];
+        uint32_t flags;         // same bit layout as RELPOSNED
+    };
+
     struct PACKED ubx_nav_velned {
         uint32_t itow;                                  // GPS msToW
         int32_t ned_north;
@@ -654,6 +683,7 @@ private:
         ubx_cfg_valget valget;
         ubx_nav_svinfo_header svinfo_header;
         ubx_nav_relposned relposned;
+        ubx_nav_daheading daheading;
 #if UBLOX_RXM_RAW_LOGGING
         ubx_rxm_raw rxm_raw;
         ubx_rxm_rawx rxm_rawx;
@@ -665,6 +695,16 @@ private:
         ubx_mon_comms_header mon_comms;
 #endif
     } _buffer;
+
+    // Flags for UBX-NAV-DAHEADING — same bit positions as RELPOSNED for the
+    // common subset; isMoving/refPosMiss/refObsMiss are not required for F9H.
+    enum class DAHEADING {
+        gnssFixOK          = 1U << 0,
+        relPosValid        = 1U << 2,
+        carrSolnFloat      = 1U << 3,
+        carrSolnFixed      = 1U << 4,
+        relPosHeadingValid = 1U << 8,
+    };
 
     enum class RELPOSNED {
         gnssFixOK          = 1U << 0,
@@ -698,6 +738,7 @@ private:
         MSG_SOL = 0x6,
         MSG_PVT = 0x7,
         MSG_TIMEGPS = 0x20,
+        MSG_DAHEADING = 0x45,   // single-module dual-antenna heading (ZED-X20D DATA1, version=1)
         MSG_RELPOSNED = 0x3c,
         MSG_VELNED = 0x12,
         MSG_CFG_CFG = 0x09,
@@ -824,6 +865,7 @@ private:
         STEP_F9_VALIDATE,
         STEP_M10,
         STEP_L5,
+        STEP_DAHEADING,     // enable UBX-NAV-DAHEADING on single-module dual-antenna receivers
         STEP_LAST
     };
 
@@ -861,6 +903,9 @@ private:
     uint32_t        _last_pvt_itow;
     uint32_t        _last_relposned_itow;
     uint32_t        _last_relposned_ms;
+    uint32_t        _last_daheading_itow;
+    uint32_t        _last_daheading_ms;
+    bool            _has_dual_antenna_heading;
 
     // the role set from GPS_TYPE
     AP_GPS::GPS_Role role;


### PR DESCRIPTION
### Summary

Adds support for new YAW-providing dual-antenna uBlox chipsets

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Tested with ZED-X20D  - which, just like ZED-F9H is delivering the heading in the new UBX-NAV-DAHEADING message.
Tested on cube black too:

<img width="1920" height="1080" alt="YAW-works" src="https://github.com/user-attachments/assets/e78316e4-95c9-4ff0-804e-1442ac832c60" />


### Description

Adding support for  ZED-X20D  and ZED-F9H - that provides dual antenna yaw.

