### PR TITLE
autotest: update TerrainAvoidApplet test and tilecache for new terrain

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -3085,7 +3085,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
         self.progress(self.dump_message_verbose(report))
 
-        expected_terrain_height = 583.5
+        expected_terrain_height = 586.0
         if abs(report.terrain_height - expected_terrain_height) > 0.5:
             raise NotAchievedException("Expected terrain height=%f got=%f" %
                                        (expected_terrain_height, report.terrain_height))

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -2902,6 +2902,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             "TERRAIN_SPACING": 30,
             "TERRAIN_FOLLOW": 1,
             "TERRAIN_OFS_MAX": 0,
+            "TERRAIN_CACHE_SZ": 60,
         })
 
         self.install_terrain_handlers_context()
@@ -2975,7 +2976,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.wait_ready_to_arm()
 
         # TopOfTheWord "ground" is at over 1km altitude
-        expected_terrain_height = 1101
+        expected_terrain_height = 1102
         if abs(report.terrain_height - expected_terrain_height) > 1.0:
             raise NotAchievedException("Expected terrain height=%f got=%f" %
                                        (expected_terrain_height, report.terrain_height))
@@ -2996,73 +2997,57 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.arm_vehicle()
         self.wait_text("TerrAvoid: close to home", check_context=True)
         self.wait_waypoint(2, 4, max_dist_to_final_wp_m=100)
-        self.wait_text("TerrAvoid: away from home", check_context=True, regex=True)
-        self.wait_text("TerrAvoid: CMTC loiter left", check_context=True, regex=True)
+        self.wait_text("TerrAvoid: away from home", check_context=True)
+        self.wait_text("TerrAvoid: CMTC loiter left|TerrAvoid: CMTC loiter right", check_context=True, regex=True)
         self.progress("CMTC alt #1 is %f" % self.get_altitude(relative=False, timeout=2))
         # wait for CMTC to gain altitude 1170m +-20
         self.wait_altitude(1150, 1190, timeout=60, relative=False, minimum_duration=5)
 
-        self.wait_text("TerrAvoid: CMTC Done|TerrAvoid: Quading overrides CMTC", check_context=True, regex=True, timeout=60)
+        self.wait_text("TerrAvoid: CMTC Done|TerrAvoid: Quading overrides CMTC|TerrAvoid: Quading done",
+                       check_context=True, regex=True, timeout=60)
         self.wait_text("TerrAvoid: CMTC loiter left", check_context=True, regex=True, timeout=60)
         self.progress("CMTC alt #2 is %f" % self.get_altitude(relative=False, timeout=2))
         # wait for CMTC to gain altitude to 1125m +- 55
-        self.wait_altitude(1070, 1180, timeout=60, relative=False, minimum_duration=5)
-        self.wait_text("TerrAvoid: CMTC Done|TerrAvoid: Quading overrides CMTC", check_context=True, regex=True)
+        self.wait_altitude(1070, 1180, timeout=120, relative=False, minimum_duration=5)
 
-        self.wait_text("TerrAvoid: high terrain detected", check_context=True, regex=True, timeout=60)
+        self.context_clear_collection("STATUSTEXT")
+
+        self.wait_text("TerrAvoid: high terrain detected", check_context=True, timeout=120)
         self.wait_text("TerrAvoid: CMTC loiter left", check_context=True, regex=True)
         self.progress("CMTC alt #3 is %f" % self.get_altitude(relative=False, timeout=2))
         # 1020 +- 20
-        self.wait_altitude(1000, 1040, timeout=120, relative=False, minimum_duration=5)
-        self.wait_text("TerrAvoid: CMTC STOP", check_context=True, regex=True)
-        self.wait_text("TerrAvoid: CMTC Done", check_context=True, regex=True)
-
-        self.wait_text("TerrAvoid: CMTC loiter left", check_context=True, regex=True)
-        self.wait_text("TerrAvoid: CMTC STOP", check_context=True, regex=True)
-        self.wait_text("TerrAvoid: CMTC Done", check_context=True, regex=True)
-        self.wait_text("TerrAvoid: CMTC loiter left", check_context=True, regex=True)
-        self.wait_text("TerrAvoid: CMTC STOP", check_context=True, regex=True)
-        self.wait_text("TerrAvoid: CMTC Done", check_context=True, regex=True)
-
-        self.wait_text("TerrAvoid: high terrain detected", check_context=True, regex=True, timeout=60)
-
-        self.wait_text("TerrAvoid: CMTC loiter left", check_context=True, regex=True)
-        self.progress("CMTC alt #4 is %f" % self.get_altitude(relative=False, timeout=2))
-        self.wait_text("TerrAvoid: high terrain detected", check_context=True, regex=True, timeout=60)
-        self.wait_text("TerrAvoid: CMTC loiter left", check_context=True, regex=True)
-        self.progress("CMTC alt #6 is %f" % self.get_altitude(relative=False, timeout=2))
-        self.wait_text("TerrAvoid: CMTC STOP", check_context=True, regex=True)
-        self.wait_text("TerrAvoid: CMTC Done", check_context=True, regex=True)
-
-        self.progress("alt is %f" % self.get_altitude(relative=False, timeout=2))
-
-        self.wait_text("TerrAvoid: CMTC STOP", check_context=True, regex=True)
-        self.wait_text("TerrAvoid: CMTC Done", check_context=True, regex=True)
 
         self.progress("#Pitching alt is %f" % self.get_altitude(relative=False, timeout=2))
         self.wait_text("TerrAvoid: Pitching Started", check_context=True, regex=True, timeout=600)
-        self.wait_text("TerrAvoid: Terrain Ok", check_context=True, regex=True, timeout=60)
-        self.wait_text("TerrAvoid: CMTC loiter left", check_context=True, regex=True)
-        self.progress("CMTC alt #7 is %f" % self.get_altitude(relative=False, timeout=2))
         self.wait_text("TerrAvoid: Pitching DONE", check_context=True, regex=True)
         self.progress("#Pitching DONE alt is %f" % self.get_altitude(relative=False, timeout=2))
 
-        # After Pitching CMTC to 1170m +- 30
-        self.wait_altitude(1140, 1200, timeout=120, relative=False, minimum_duration=5)
+        self.wait_altitude(1160, 1200, timeout=120, relative=False, minimum_duration=5)
 
         self.wait_text("TerrAvoid: CMTC STOP", check_context=True, regex=True)
         self.wait_text("TerrAvoid: CMTC Done", check_context=True, regex=True)
-        # wait for 1 more CMTC's
+
+        self.context_clear_collection("STATUSTEXT")
+        self.wait_text("Mission: 14 WP", check_context=True, regex=True, timeout=60)
+
+        self.wait_text("TerrAvoid: CMTC loiter right", check_context=True, regex=True)
+        self.wait_text("TerrAvoid: CMTC STOP", check_context=True, regex=True)
         self.wait_text("TerrAvoid: CMTC Done", check_context=True, regex=True)
 
-        # now we get a guaranteed quadding
-        self.wait_text("TerrAvoid: Pitching started", check_context=True, regex=True, timeout=120)
-        self.progress("Pitching alt #1 is %f" % self.get_altitude(relative=False, timeout=2))
-        self.wait_text("TerrAvoid: Pitching DONE", check_context=True, regex=True)
-        self.progress("Pitching alt #2 is %f" % self.get_altitude(relative=False, timeout=2))
+        self.context_clear_collection("STATUSTEXT")
 
-        # wait for 1 more CMTC
+        self.wait_text("TerrAvoid: Quading started", timeout=120, check_context=True, regex=True)
+        self.wait_text("TerrAvoid: Quading DONE", timeout=120, check_context=True, regex=True)
+        self.wait_text("Transition done", timeout=120, check_context=True, regex=True)
+
+        self.context_clear_collection("STATUSTEXT")
+
+        self.wait_text("TerrAvoid: CMTC loiter left", check_context=True, regex=True)
+        self.progress("CMTC alt #4 is %f" % self.get_altitude(relative=False, timeout=2))
+        self.wait_text("TerrAvoid: CMTC STOP", timeout=120, check_context=True, regex=True)
         self.wait_text("TerrAvoid: CMTC Done", check_context=True, regex=True)
+
+        self.context_clear_collection("STATUSTEXT")
 
         self.wait_statustext('Land complete', timeout=600)
         self.wait_disarmed(timeout=120) # give quadplane a long time to land


### PR DESCRIPTION
### Summary

Update the QuadPlane TerrainAvoidApplet autotest and cached terrain files used by the test with "post 2026 terrain update"  versions

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [X] Non-functional change
- [X] No-binary change
- [X] Infrastructure change (e.g. unit tests, helper scripts)
- [X] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request


### Description

This autotest uses non-CMAC locations (Alaska) for terrain testing. The terrain tiles for this tests are stored in Tools/autotest/tilecache/srtm. After the terrain data was updated in early 2026, the terrain file was were not updated, so the test should have failed.

Based on helping @IamPete1 trying to get his input shaping change working with the quadplane_terrain_avoid applet, I discovered that the terrain was so different with the new tiles that the test needed to be reworked. Pete also helped me to clean up some questionable use of the statustext context in the test.

The TerrainAvoidApplet test needed to change because the expected terrain height in the new data files for the location used in the test is different from the previous version.
