### PR TITLE
AP_HAL_SITL: avoid buffer overread in SPIDevice

### DIFF
--- a/libraries/AP_HAL_SITL/SPIDevice.cpp
+++ b/libraries/AP_HAL_SITL/SPIDevice.cpp
@@ -115,6 +115,7 @@ static const struct SPIDriverInfo {
     // uint8_t dma_channel_tx;
 } spi_devices[] = {
     { 0, },
+    { 1, },
 };
 
 // name, bus, cs_pin
@@ -178,6 +179,9 @@ SPIDevice::SPIDevice(SPIBus &_bus, SPIDesc &_device_desc)
     : bus(_bus)
     , device_desc(_device_desc)
 {
+    if (_bus.bus >= ARRAY_SIZE(spi_devices)) {
+        AP_HAL::panic("SPIDevice: bus %u out of range", (unsigned)_bus.bus);
+    }
     set_device_bus(spi_devices[_bus.bus].busid);
     set_device_address(_device_desc.cs_pin);
 }


### PR DESCRIPTION


### Summary

<!-- Put a one or two line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [ ] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

recent fix to deconflict caused an issue

```
=================================================================
==94982==ERROR: AddressSanitizer: global-buffer-overflow on address 0x5c94214bb3c1 at pc 0x5c94210103f1 bp 0x7fff55a04910 sp 0x7fff55a04908
READ of size 1 at 0x5c94214bb3c1 thread T0
    #0 0x5c94210103f0 in HALSITL::SPIDevice::SPIDevice(SPIBus&, HALSITL::SPIDesc&) /home/pbarker/rc/ardupilot-claude/build/sitl/../../libraries/AP_HAL_SITL/SPIDevice.cpp:181:42
    #1 0x5c942101021e in HALSITL::SPIDeviceManager::get_device_ptr(char const*) /home/pbarker/rc/ardupilot-claude/build/sitl/../../libraries/AP_HAL_SITL/SPIDevice.cpp:163:24
    #2 0x5c9420a20ca2 in AP_HAL::SPIDeviceManager::get_device(char const*) /home/pbarker/rc/ardupilot-claude/build/sitl/../../libraries/AP_HAL/SPIDevice.h:81:50
    #3 0x5c942132e090 in AP_Logger_Flash_JEDEC::Init() /home/pbarker/rc/ardupilot-claude/build/sitl/../../libraries/AP_Logger/AP_Logger_Flash_JEDEC.cpp:68:20
    #4 0x5c9420cd1579 in AP_Logger::init(AP_ParamT<int, (ap_var_type)3> const&, LogStructure const*, unsigned char) /home/pbarker/rc/ardupilot-claude/build/sitl/../../libraries/AP_Logger/AP_Logger.cpp:286:22
    #5 0x5c9420cc524e in AP_Vehicle::setup() /home/pbarker/rc/ardupilot-claude/build/sitl/../../libraries/AP_Vehicle/AP_Vehicle.cpp:423:12
    #6 0x5c9420ffdc8c in HAL_SITL::run(int, char* const*, AP_HAL::HAL::Callbacks*) const /home/pbarker/rc/ardupilot-claude/build/sitl/../../libraries/AP_HAL_SITL/HAL_SITL_Class.cpp:259:16
    #7 0x5c942099182d in main /home/pbarker/rc/ardupilot-claude/build/sitl/../../Rover/Rover.cpp:563:1
    #8 0x77b941c2a1c9 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #9 0x77b941c2a28a in __libc_start_main csu/../csu/libc-start.c:360:3
    #10 0x5c94208a6284 in _start (/home/pbarker/rc/ardupilot-claude/build/sitl/bin/ardurover+0x1ec284) (BuildId: ece89d5aa70f0ea49e0c6fcc8eb5330b7f9f29ec)

0x5c94214bb3c1 is located 31 bytes before global variable '.str.4' defined in '/home/pbarker/rc/ardupilot-claude/build/sitl/../../libraries/AP_HAL_SITL/SPIDevice.cpp:249' (0x5c94214bb3e0) of size 36
  '.str.4' is ascii string 'SPIDevice: error transferring data
'
0x5c94214bb3c1 is located 0 bytes after global variable 'spi_devices' defined in '/home/pbarker/rc/ardupilot-claude/build/sitl/../../libraries/AP_HAL_SITL/SPIDevice.cpp:116' (0x5c94214bb3c0) of size 1
  'spi_devices' is ascii string ''
SUMMARY: AddressSanitizer: global-buffer-overflow /home/pbarker/rc/ardupilot-claude/build/sitl/../../libraries/AP_HAL_SITL/SPIDevice.cpp:181:42 in HALSITL::SPIDevice::SPIDevice(SPIBus&, HALSITL::SPIDesc&)
Shadow bytes around the buggy address:
  0x5c94214bb100: 05 f9 f9 f9 05 f9 f9 f9 04 f9 f9 f9 04 f9 f9 f9
  0x5c94214bb180: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x5c94214bb200: 00 00 00 00 00 00 00 00 00 00 00 03 f9 f9 f9 f9
  0x5c94214bb280: 00 00 00 00 00 00 00 00 05 f9 f9 f9 00 01 f9 f9
  0x5c94214bb300: 00 05 f9 f9 00 00 00 00 00 00 00 00 00 00 00 00
=>0x5c94214bb380: 00 f9 f9 f9 00 02 f9 f9[01]f9 f9 f9 00 00 00 00
  0x5c94214bb400: 04 f9 f9 f9 f9 f9 f9 f9 00 00 00 05 f9 f9 f9 f9
  0x5c94214bb480: 00 00 00 00 00 00 05 f9 f9 f9 f9 f9 00 00 00 00
  0x5c94214bb500: 00 00 00 00 00 00 00 00 00 00 00 02 f9 f9 f9 f9
  0x5c94214bb580: 00 00 05 f9 f9 f9 f9 f9 00 00 00 04 f9 f9 f9 f9
  0x5c94214bb600: 00 00 05 f9 f9 f9 f9 f9 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==94982==ABORTING
```
