### PR TITLE
AC_Loiter: remove drag from feed-forward accel to fix loiter overshoot

### DIFF
--- a/libraries/AC_WPNav/AC_Loiter.cpp
+++ b/libraries/AC_WPNav/AC_Loiter.cpp
@@ -343,7 +343,7 @@ void AC_Loiter::calc_desired_velocity(bool avoidance_on)
     // update the desired velocity using our predicted acceleration
     desired_vel_ne_ms += _predicted_accel_ne_mss * dt_s;
 
-    Vector2f loiter_accel_brake_mss;
+    Vector2f loiter_accel_decel_mss;
     float desired_speed_ms = desired_vel_ne_ms.length();
     if (!is_zero(desired_speed_ms)) {
         Vector2f desired_vel_norm = desired_vel_ne_ms / desired_speed_ms;
@@ -360,15 +360,19 @@ void AC_Loiter::calc_desired_velocity(bool avoidance_on)
 
         // Integrate jerk-limited brake acceleration
         _brake_accel_mss += constrain_float(loiter_brake_accel_mss - _brake_accel_mss, -_brake_jerk_max_msss * dt_s, _brake_jerk_max_msss * dt_s);
-        loiter_accel_brake_mss = desired_vel_norm * _brake_accel_mss;
+        // drag and braking both decelerate the desired velocity below, so both
+        // must be removed from the feed-forward acceleration to keep it equal to
+        // d(desired_vel)/dt; leaving drag in over-drives the vehicle past the
+        // speed-limited desired velocity and builds a position error
+        loiter_accel_decel_mss = desired_vel_norm * (_brake_accel_mss + drag_decel_mss);
 
         // Update desired speed based on braking and drag
         desired_speed_ms = MAX(desired_speed_ms - (drag_decel_mss + _brake_accel_mss) * dt_s, 0.0f);
         desired_vel_ne_ms = desired_vel_norm * desired_speed_ms;
     }
 
-    // Apply braking acceleration to overall feed-forward acceleration
-    _desired_accel_ne_mss -= loiter_accel_brake_mss;
+    // Apply braking and drag deceleration to the feed-forward acceleration
+    _desired_accel_ne_mss -= loiter_accel_decel_mss;
 
     // Apply final velocity magnitude constraint
     float desired_vel_ms = desired_vel_ne_ms.length();

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
@@ -374,10 +374,19 @@ void NavEKF3_core::getEkfControlLimits(float &ekfGndSpdLimit, float &ekfNavVelGa
     // If relying on optical flow, limit speed to prevent sensor limit being exceeded and adjust
     // nav gains to prevent body rate feedback into flow rates destabilising the control loop
     if (PV_AidingMode == AID_RELATIVE && relyingOnFlowData) {
+        // height above ground that scales both limits; prefer the IMU-aided AGL KF
+        // when enabled and valid so the cap matches the height used for flow velocity
+        // scaling (see EstimateOptFlowDataFrame) instead of the drift-prone terrainState
+        ftype heightAboveGndEst = MAX((terrainState - stateStruct.position[2]), rngOnGnd);
+#if EK3_FEATURE_OPTFLOW_AGL_KF
+        if (frontend->option_is_enabled(NavEKF3::Option::AglKfForOptflow) && aglKfValid) {
+            heightAboveGndEst = MAX(aglKfH, rngOnGnd);
+        }
+#endif
         // allow 1.0 rad/sec margin for angular motion
-        ekfGndSpdLimit = MAX((frontend->_maxFlowRate - 1.0f), 0.0f) * MAX((terrainState - stateStruct.position[2]), rngOnGnd);
+        ekfGndSpdLimit = MAX((frontend->_maxFlowRate - 1.0f), 0.0f) * heightAboveGndEst;
         // use standard gains up to 5.0 metres height and reduce above that
-        ekfNavVelGainScaler = 4.0f / MAX((terrainState - stateStruct.position[2]),4.0f);
+        ekfNavVelGainScaler = 4.0f / MAX(heightAboveGndEst, 4.0f);
     } else {
         ekfGndSpdLimit = 400.0f; //return 80% of max filter speed
         ekfNavVelGainScaler = 1.0f;


### PR DESCRIPTION
### Summary

In Loiter, `AC_Loiter::calc_desired_velocity` applies a "drag" deceleration to shape the desired velocity smoothly toward the speed limit. That drag is removed from the desired velocity, but only the braking term was removed from the acceleration feed-forward handed to the position controller - the drag was left in. The (velocity, acceleration) pair is then not kinematically consistent (`accel != d(vel)/dt`), so the feed-forward over-drives the vehicle past its speed-limited desired velocity. Actual position runs ahead of the target and the position loop corrects abruptly: a forward stick produces a backward lurch on release.

The error scales with the drag term, `pilot_accel_max * speed / gnd_speed_limit`. It is pronounced on optical-flow Loiter at low height (small EKF flow speed limit -> large drag) and negligible with GPS (high speed limit -> tiny drag).

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Automated test(s) verify changes (autotest `LoiterFlowBrakeOvershoot`)
- [x] Tested manually, description below (SITL)
- [x] Tested on hardware
- [x] Logs available on request

### Description

The fix subtracts the drag from the feed-forward acceleration as well, so it equals `d(desired_vel)/dt`. The braking term was already removed from both the desired velocity and the feed-forward; the drag was only removed from the desired velocity. This makes the two paths consistent.

A small residual over-drive (~6%, not 0%) remains because `desired_vel` integrates the shaped `_predicted_accel` while the feed-forward uses the raw `_desired_accel`. The dominant, height-scaling error is the drag, which this fixes; reconciling predicted-vs-desired accel is a larger change and not required for the symptom.

#### SITL evidence

`autotest.py test.Copter.LoiterFlowBrakeOvershoot` - optical-flow Loiter, no GPS, ~2 m height, `LOIT_ANG_MAX=30`, deterministic forward jab + release. Matched builds (identical source apart from the one-line change):

| metric | before | after |
|---|---|---|
| peak actual/desired velocity (over-drive) | 1.51x | 1.06x |
| peak position overshoot \|PN-TPN\| | 0.229 m | 0.078 m |
| peak backward reversal velocity | 0.286 m/s | 0.047 m/s |
| peak braking pitch | 20.7 deg | 18.5 deg |

GPS Loiter (`test.Copter.ModeLoiter`) passes unchanged - the drag term is negligible with a high speed limit.

#### Hardware evidence

Indoor optical-flow Loiter, slow forward stick + release, same airframe before and after the fix:

| metric | before | after |
|---|---|---|
| peak position overshoot \|PN-TPN\| | 0.55 m | 0.04 m |
| peak feed-forward velocity vs commanded | 0.57 vs 0.15 m/s | 0.55 vs 0.50 m/s |
| peak backward reversal velocity | -0.91 m/s | -0.10 m/s |
| peak braking pitch | 12 deg | 9 deg |

Before, a gentle forward push over-drove the feed-forward ~4x past the speed-limited target, ran 0.55 m past its own position target, and flew back at nearly 1 m/s on release. After, the feed-forward tracks the desired velocity, position holds within 4 cm of target, and the vehicle stops where it got to with no backward lurch.

On a real vehicle, before:

<img width="1170" height="1105" alt="loiter_overshoot_before" src="https://github.com/user-attachments/assets/68c688ee-09bc-4c82-88cc-ede78bff73e2" />

after: 

<img width="1170" height="1105" alt="loiter_overshoot_after" src="https://github.com/user-attachments/assets/34f5828d-bc16-4cc9-ae8c-5e6c3dcc167b" />
