### PR TITLE
AP_Bootloader: reserve ID range for NWBlue

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -542,6 +542,7 @@ AP_HW_IOMCU_F103                     5711
 AP_HW_IOMCU_F103_8MHZ                5712  # some boards are clocked differently
 AP_HW_IOMCU_F100                     5713
 
+# IDs 5730-5739 reserved for NWBlue
 
 #IDs 5800-5809 reserved for Droneer
 AP_HW_DroneerF405                    5800


### PR DESCRIPTION
### Summary

ID Range for NWBlue - https://nwblue.com/

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [X] Non-functional change
- [X] No-binary change
