### PR TITLE
AP_HAL_Linux: retrieve multiple packets per poll

### DIFF
--- a/libraries/AP_HAL_Linux/CANSocketIface.cpp
+++ b/libraries/AP_HAL_Linux/CANSocketIface.cpp
@@ -260,7 +260,7 @@ void CANIface::_pollWrite()
 
 bool CANIface::_pollRead()
 {
-    uint8_t iterations_count = 0;
+    uint8_t iterations_count = 0, packets_read = 0;
     while (iterations_count < CAN_MAX_POLL_ITERATIONS_COUNT)
     {
         iterations_count++;
@@ -280,7 +280,7 @@ bool CANIface::_pollRead()
                 WITH_SEMAPHORE(sem);
                 _rx_queue.push(rx);
                 stats.rx_received++;
-                return true;
+                packets_read++;
             }
         } else if (res == 0) {
             break;
@@ -289,7 +289,7 @@ bool CANIface::_pollRead()
             break;
         }
     }
-    return false;
+    return packets_read > 0;
 }
 
 int CANIface::_write(const AP_HAL::CANFrame& frame) const


### PR DESCRIPTION
### Summary

Ensures Linux HAL CAN processing retrieves all of the packets from the socket queue.

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [X] Tested manually, description below (e.g. SITL)
- [X] Tested on hardware
- [ ] Logs attached
- [X] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

I've encountered an issue with CAN on a non-RT kernel system whereas my CAN thread was consistenly being delayed a little bit. This caused AP not to read the entire queue of packets at times and thus a lot of traffic is randomly lost. The change ensures we pick up multiple packets in one polling operation until we encounter an error or the queue is actually empty. This shouldn't affect the existing Linux setups negatively as the reading is still bound by the retries counter that was initially there, e.g. it shouldn't be taking longer than it was earlier, but if requested I can add a define like "max `read` operations per poll" with default being 1 which would ensure the behavior wouldn't change at all.

Tested with 1 Mbit/s CAN (non-FD) that has an AP_Periph serving a barometer, an airspeed sensor, a magnetometer and a GPS. The average  queue depth was about 7-10 reads per poll, far below the 100 attempts that the ealier code was designed for.  