### PR TITLE
AP_HAL_ChibiOS: fix CAN bit timing and SYSCLK on L4 LSE/MSI-PLL boards

### DIFF
--- a/libraries/AP_HAL_ChibiOS/CanIface.cpp
+++ b/libraries/AP_HAL_ChibiOS/CanIface.cpp
@@ -189,7 +189,17 @@ bool CANIface::computeTimings(uint32_t target_bitrate, Timings& out_timings)
      * ==>
      *   PRESCALER_BS = PCLK / BITRATE
      */
+#if HAL_CAN_ALLOW_INEXACT_CLOCK
+    /*
+     *
+     * Rounded to nearest so a PCLK that is not an exact multiple of the bitrate
+     * (e.g. MSI-PLL derived clocks like 79.96MHz) still resolves to a divisor.
+     * This is a no-op when PCLK is an exact multiple.
+     */
+    const uint32_t prescaler_bs = (pclk + target_bitrate / 2) / target_bitrate;
+#else
     const uint32_t prescaler_bs = pclk / target_bitrate;
+#endif
 
     /*
      * Searching for such prescaler value so that the number of quanta per bit is highest.
@@ -266,9 +276,20 @@ bool CANIface::computeTimings(uint32_t target_bitrate, Timings& out_timings)
      *     return (1+ts1+1)/(1+ts1+1+ts2+1)
      *
      */
+#if HAL_CAN_ALLOW_INEXACT_CLOCK
+    // accept the closest achievable bitrate within CAN oscillator tolerance;
+    // an exact match is not possible when PCLK is not an integer multiple.
+    const uint32_t achieved_bitrate = pclk / (prescaler * (1 + solution.bs1 + solution.bs2));
+    const uint32_t bitrate_error = achieved_bitrate > target_bitrate ?
+                                   achieved_bitrate - target_bitrate : target_bitrate - achieved_bitrate;
+    if ((bitrate_error > target_bitrate / 100U) || !solution.isValid()) {
+        return false;
+    }
+#else
     if ((target_bitrate != (pclk / (prescaler * (1 + solution.bs1 + solution.bs2)))) || !solution.isValid()) {
         return false;
     }
+#endif
 
     out_timings.prescaler = uint16_t(prescaler - 1U);
     out_timings.sjw = 0;                                        // Which means one

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/halconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/halconf.h
@@ -584,6 +584,12 @@
 #define WSPI_USE_MUTUAL_EXCLUSION           TRUE
 #endif
 
+/**
+ * @brief   Enables inexact clock matching.
+ */
+#if !defined(HAL_CAN_ALLOW_INEXACT_CLOCK) || defined(__DOXYGEN__)
+#define HAL_CAN_ALLOW_INEXACT_CLOCK         FALSE
+#endif
 
 
 /** @} */

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stm32l4_mcuconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stm32l4_mcuconf.h
@@ -43,6 +43,11 @@
 #define STM32_PLLSAI1N_VALUE                24
 #define STM32_PLLSRC                        STM32_PLLSRC_MSI
 #define STM32_MSIPLL_ENABLED                TRUE
+// MSIPLL locks MSI to the 32.768kHz LSE, so the 4MHz range runs at the real
+// 3.998MHz rather than a nominal 4MHz, giving 3998000*40/2 SYSCLK
+#undef HAL_EXPECTED_SYSCLOCK
+#define HAL_EXPECTED_SYSCLOCK               79960000
+#define HAL_CAN_ALLOW_INEXACT_CLOCK         1
 
 #elif STM32_HSECLK == 8000000U
 #define STM32_HSE_ENABLED                   TRUE


### PR DESCRIPTION
### Summary

Fix DroneCAN nodes failing to come up on STM32L4 boards clocked from a 32.768kHz LSE via MSI-PLL (e.g. TBS-L431, 3DR-L431).

### Classification & Testing

- [x] Checked by a human programmer
- [x] Tested on hardware

### Description

On L4 boards using `OSCILLATOR_HZ 32768` the system clock is derived from MSI locked to the LSE. Newer ChibiOS reports that MSI range at its real 3.998MHz rather than a nominal 4MHz, so SYSCLK/PCLK1 is 79,960,000 rather than 80,000,000.

`CANIface::computeTimings()` required PCLK to be an exact integer multiple of the bitrate. At 1Mbit it computed `79,960,000 / 1,000,000 = 79` (truncated, prime), found no prescaler/quanta factorisation, and returned false. `AP_Periph` ignores the init failure, so the node ran but never initialised CAN and never appeared on the bus.

The fix rounds the prescaler search to nearest and accepts the closest achievable bitrate within 1% instead of demanding an exact match. Where PCLK is an exact multiple this is a no-op, so other boards are unaffected (verified: identical register values at 80MHz). The same change is applied to the FDCAN path.

The hwdef change updates `HAL_EXPECTED_SYSCLOCK` for the LSE branch so the `system.cpp` clock static_assert matches the now-accurate 79.96MHz on these boards.

Verified on hardware: a TBS-L431-Airspeed that previously never enumerated now comes up correctly on a flight controller's CAN bus.

The bootloader carries the same timing routine (libcanard's `canardSTM32ComputeCANTimings`); that is fixed separately upstream and will follow as a submodule update once merged.

https://github.com/dronecan/libcanard/pull/92

This also fixes the current build failures on boards with this configuration
