### PR TITLE
Fix race conditions in DDS/colcon tests

### DIFF
--- a/Tools/ros2/ardupilot_sitl/src/ardupilot_sitl/launch.py
+++ b/Tools/ros2/ardupilot_sitl/src/ardupilot_sitl/launch.py
@@ -408,7 +408,11 @@ class SITLLaunch:
 
         # Required arguments.
         cmd_args = [
-            f"{command} ",
+            # Use 'exec' so the /bin/sh -c wrapper is replaced by the
+            # arducopter process: the launch service then delivers its
+            # shutdown signals (SIGINT/SIGTERM) to arducopter directly
+            # rather than to the shell.
+            f"exec {command} ",
             f"--model {model} ",
             f"--speedup {speedup} ",
             f"--slave {slave} ",

--- a/libraries/AP_DDS/AP_DDS_Client.cpp
+++ b/libraries/AP_DDS/AP_DDS_Client.cpp
@@ -1300,8 +1300,13 @@ void AP_DDS_Client::main_loop(void)
 
         // create session
         if (!init_session() || !create()) {
-            GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "%s Creation Requests failed", msg_prefix);
-            return;
+            // A transient timeout creating the participant/topics (the requests
+            // have a hard per-request timeout) must not permanently kill DDS.
+            // Drop any half-open session and retry the whole connect sequence.
+            GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "%s Creation Requests failed, retrying", msg_prefix);
+            uxr_delete_session(&session);
+            hal.scheduler->delay(1000);
+            continue;
         }
         connected = true;
         GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s Initialization passed", msg_prefix);
@@ -1400,9 +1405,15 @@ bool AP_DDS_Client::init_session()
         hal.scheduler->delay(1000);
     }
 
-    // setup reliable stream buffers
-    input_reliable_stream = NEW_NOTHROW uint8_t[DDS_BUFFER_SIZE];
-    output_reliable_stream = NEW_NOTHROW uint8_t[DDS_BUFFER_SIZE];
+    // setup reliable stream buffers.  init_session() can be re-entered when a
+    // connection attempt fails and the main loop retries, so only allocate the
+    // buffers once and reuse them across retries to avoid leaking.
+    if (input_reliable_stream == nullptr) {
+        input_reliable_stream = NEW_NOTHROW uint8_t[DDS_BUFFER_SIZE];
+    }
+    if (output_reliable_stream == nullptr) {
+        output_reliable_stream = NEW_NOTHROW uint8_t[DDS_BUFFER_SIZE];
+    }
     if (input_reliable_stream == nullptr || output_reliable_stream == nullptr) {
         GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "%s Allocation failed", msg_prefix);
         return false;

--- a/libraries/AP_DDS/AP_DDS_Client.cpp
+++ b/libraries/AP_DDS/AP_DDS_Client.cpp
@@ -1300,6 +1300,7 @@ void AP_DDS_Client::main_loop(void)
 
         // create session
         if (!init_session() || !create()) {
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
             // A transient timeout creating the participant/topics (the requests
             // have a hard per-request timeout) must not permanently kill DDS.
             // Drop any half-open session and retry the whole connect sequence.
@@ -1307,6 +1308,15 @@ void AP_DDS_Client::main_loop(void)
             uxr_delete_session(&session);
             hal.scheduler->delay(1000);
             continue;
+#else
+            // FIXME: determine whether we can use the retry code
+            // above on real vehicles.  We have two different paths
+            // here because the DDS CI tests were flapping for years
+            // and this was the most viable way of getting a fix
+            // merged.
+            GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "%s Creation Requests failed", msg_prefix);
+            return;
+#endif  // CONFIG_HAL_BOARD == HAL_BOARD_SITL
         }
         connected = true;
         GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s Initialization passed", msg_prefix);


### PR DESCRIPTION
### Summary

Several fixes to the DDS test suite to avoid the flapping we've had for years

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

 - be more careful about when we treat connections as open
 - retry opening connections on startup (rather than just at runtime)
 - adjust the sitl binary process to exit immediately when ros2 wants it to to prevent socket binding port reuse  race condition
