### PR TITLE
DeadReckoningNoAirspeed Fix: AP_NavEKF3: zero wind cross-covariances when treating wind as truth

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -1114,7 +1114,7 @@ void NavEKF3_core::CovariancePrediction(Vector3F *rotVarVecPtr)
         const bool newTreatWindStatesAsTruth = isDragFusionDeadReckoning || !windStateIsObservable;
         if (newTreatWindStatesAsTruth) {
             treatWindStatesAsTruth = true;
-            P[23][23] = P[22][22] = 0.0f;
+            zeroStatesVarCov(22, 23);
         } else {
             if (treatWindStatesAsTruth) {
                 treatWindStatesAsTruth = false;
@@ -1982,7 +1982,7 @@ void NavEKF3_core::ConstrainVariances()
 
     if (!inhibitWindStates) {
         if (treatWindStatesAsTruth) {
-            P[23][23] = P[22][22] = 0.0f;
+            zeroStatesVarCov(22, 23);
         } else {
             for (uint8_t i=22; i<=23; i++) P[i][i] = constrain_ftype(P[i][i],0.0f,WIND_VEL_VARIANCE_MAX);
         }


### PR DESCRIPTION
### Summary

fixes tests1c, DeadReckoningNoAirspeed

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

The statistical test is telling: Statistical: 6/6 prior rounds reproduced the failure → now 200/200

Before/after logs from CI (and some pretty pictures) here: https://drive.google.com/drive/folders/1njw27KbC95Rqeubqb-_hqr5BWz50tV7V?usp=sharing

Testing branch which can be used to reproduce the results is https://github.com/peterbarker/ardupilot/tree/pr-claude/deadreckoning-noairspeed-debug-branch

### Description

This resolves a test which has been flapping for years now.  Probably a real problem with our dead-reckoning.

I'm not sure this is actually all of what we should be doing.  When the problem is detected we say we're no longer fusing airspeed and make the entire filter unhealthy for *exactly* one cycle, then we start to fuse again.  The flappiness in autotest is just whether we see the fallack DCM position for the one cycle it is in charge!  I wonder if we should delay declaring everything-has-gone-to-hell until we at least *try* to do that fusion again.  I put that question to claude, its response it below.

Note: this is all claude speaking here:

When the EKF starts treating the wind states as truth (during drag-fusion dead reckoning, or when wind is unobservable) it set the wind state variances to zero but left their cross-covariances with the velocity states in place:

    P[23][23] = P[22][22] = 0.0f;

A state with zero variance must be uncorrelated with all other states, so leaving the velocity/wind cross-covariances non-zero makes the covariance matrix non-positive-definite: var(vel - wind) computed from P can go negative. The next true-airspeed fusion then sees an innovation variance smaller than the measurement variance, declares the calculation badly conditioned, resets the covariance and sets faultStatus.bad_airspeed. That single-cycle fault makes the core report unhealthy, which (in no-airspeed dead reckoning) can briefly hand navigation to DCM and surface a bad position. This is the intermittent DeadreckoningNoAirSpeed failure.

Zero the wind variances and their cross-covariances together with zeroStatesVarCov(), matching the adjacent inhibitWindStates branch.

AI assistance (Claude Code) was used to identify and prepare this change.




Additional:

```
  The intermittent DeadreckoningNoAirSpeed failure is resolved.

  Statistical: 6/6 prior rounds reproduced the failure → now 200/200
  samples pass (20 jobs × 10 repeats), run 26998964474.

  Mechanistic (from a passing log's XKWB trace): in 769 wind-as-truth
  cycles the velocity↔wind cross-covariances now stay exactly 0, so
  var(vel−wind) never goes negative, and bad_airspeed never fires — the
  entire failure chain is cut at its source.

  The fix

  AP_NavEKF3: zero wind cross-covariances when treating wind as truth
  (4c1d2d6) — at core.cpp:1117 and :1985, replaced P[23][23] = P[22][22] =
  0.0f; with zeroStatesVarCov(22, 23) so a zero-variance ("truth") wind
  state is also uncorrelated, keeping the covariance positive-definite. 6
  lines.

  The full causal chain (for the PR writeup)

  GPS jamming forces drag dead-reckoning  →  treatWindStatesAsTruth
  The fix

  AP_NavEKF3: zero wind cross-covariances when treating wind as truth (4c1d2d6) — at core.cpp:1117 and :1985, replaced P[23][23] = P[22][22] =
  0.0f; with zeroStatesVarCov(22, 23) so a zero-variance ("truth") wind state is also uncorrelated, keeping the covariance positive-definite.6
  lines.

  The full causal chain (for the PR writeup)
  var(vel−wind) never goes negative, and bad_airspeed never fires — the entire failure chain is cut at its source.

  The fix

  AP_NavEKF3: zero wind cross-covariances when treating wind as truth (4c1d2d6) — at core.cpp:1117 and :1985, replaced P[23][23] = P[22][22] =
  0.0f; with zeroStatesVarCov(22, 23) so a zero-variance ("truth") wind state is also uncorrelated, keeping the covariance positive-definite.
  6 lines.

  The full causal chain (for the PR writeup)

  GPS jamming forces drag dead-reckoning  →  treatWindStatesAsTruth
    →  wind variances zeroed but cross-covariances left intact  →  P non-positive-definite
    →  var(vel−wind) < 0  →  FuseAirspeed temp<tasVariance  →  bad_airspeed + CovarianceInit
    →  EKF3 healthy()=false for 1 cycle  →  filter status all-zero
    →  AP_AHRS can_use_ekf=false  →  momentary DCM fallback
    →  DCM reports the jammed GPS position  →  GLOBAL_POSITION_INT jumps  →  test trips
  Your original instinct (EKF numeric instability) was right — it just surfaced through the AHRS→DCM health path rather than as direct
  position drift.
```


On the "stop pannicking?" question:
```
    Why the instinct is sound — and arguably the stronger framing: the EKF's navigation solution was never actually unhealthy. Throughout the
    event the EKF position stayed accurate (~3–5 m); the only thing that went wrong was one airspeed-fusion update being numerically
    ill-conditioned. Yet bad_airspeed feeds getFilterFaults() → healthy() == false, which condemns the whole filter and hands navigation to
    DCM. Escalating "one fusion step was skipped" to "entire filter is unhealthy, fall back to dead-reckoning on DCM" is disproportionate.
    That's precisely what the reviewer is putting their finger on.

    It's complementary to the covariance fix, not a substitute. Two things worth saying back:
    - The zeroStatesVarCov fix is still correct and worth keeping on its own merits: a covariance with a zero variance but non-zero
    cross-covariance is mathematically invalid and can hurt more than just airspeed fusion. The reviewer isn't saying the fix is wrong —
    they're saying it may not be all of it, which is right.
    - Even with that fix, any other source of ill-conditioning along the airspeed direction would trip the same heavy response. So hardening
    the response is defense-in-depth, independent of this particular root cause. There are two natural levers: the EKF side (don't flip
    healthy() on a single transient bad_airspeed — retry, or require persistence before declaring it, à la the existing
    lastTasFailTime_ms-style timing) and/or the AHRS side (debounce the EKF→DCM switch so a one-cycle !can_use_ekf doesn't surface DCM). The
    reviewer is favouring the EKF side, which is reasonable.

    One caveat to raise in reply: whatever the "try again before declaring disaster" change is, it needs a bound so that genuinely persistent
    ill-conditioning still eventually marks the filter unhealthy — you don't want to suppress a real failure indefinitely. And because
    changing EKF health reporting affects every vehicle, it's a broader behavioural change than the minimal covariance fix. A defensible split
    is: land the root-cause fix now (small, low-risk), and treat the fault-response hardening as a focused follow-up — but that's a
    maintainer call.

    So: agree with the comment, keep the fix, and the "don't declare everything-broken on the first cycle" idea is a legitimate and probably
    worthwhile second change rather than a reason to rework the first.
```