### PR TITLE
AntennaTracker:add dronecan actuator output support

### DIFF
--- a/AntennaTracker/mode_auto.cpp
+++ b/AntennaTracker/mode_auto.cpp
@@ -8,5 +8,8 @@ void ModeAuto::update()
         update_auto();
     } else if (tracker.target_set || (tracker.g.auto_opts.get() & (1 << 0)) != 0) {
         update_scan();
+    } else {
+        SRV_Channels::set_output_scaled(SRV_Channel::k_tracker_yaw, 0);
+        SRV_Channels::set_output_scaled(SRV_Channel::k_tracker_pitch, 0);
     }
 }

--- a/AntennaTracker/mode_servotest.cpp
+++ b/AntennaTracker/mode_servotest.cpp
@@ -18,7 +18,7 @@ bool ModeServoTest::set_servo(uint8_t servo_num, uint16_t pwm)
         return false;
     }
 
-    hal.rcout->cork();
+    AP::srv().cork();
 
     // set yaw servo pwm and send output to servo
     if (servo_num == CH_YAW) {
@@ -35,7 +35,7 @@ bool ModeServoTest::set_servo(uint8_t servo_num, uint16_t pwm)
     SRV_Channels::calc_pwm();
     SRV_Channels::output_ch_all();
 
-    hal.rcout->push();
+    AP::srv().push();
 
     // return success
     return true;

--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -162,10 +162,12 @@ void Tracker::disarm_servos()
 void Tracker::prepare_servos()
 {
     start_time_ms = AP_HAL::millis();
-    SRV_Channels::set_output_limit(SRV_Channel::k_tracker_yaw, SRV_Channel::Limit::TRIM);
-    SRV_Channels::set_output_limit(SRV_Channel::k_tracker_pitch, SRV_Channel::Limit::TRIM);
+    servo_channels.cork();
+    SRV_Channels::set_output_scaled(SRV_Channel::k_tracker_yaw, 0);
+    SRV_Channels::set_output_scaled(SRV_Channel::k_tracker_pitch, 0);
     SRV_Channels::calc_pwm();
     SRV_Channels::output_ch_all();
+    servo_channels.push();
 }
 
 void Tracker::set_mode(Mode &newmode, const ModeReason reason)

--- a/AntennaTracker/tracking.cpp
+++ b/AntennaTracker/tracking.cpp
@@ -104,7 +104,7 @@ void Tracker::update_tracking(void)
         return;
     }
 
-    hal.rcout->cork();
+    servo_channels.cork();
 
     // do not move if we are not armed:
     if (!hal.util->get_soft_armed()) {
@@ -127,7 +127,7 @@ void Tracker::update_tracking(void)
     SRV_Channels::calc_pwm();
     SRV_Channels::output_ch_all();
 
-    hal.rcout->push();
+    servo_channels.push();
 
     return;
 }


### PR DESCRIPTION
### Summary

<!-- Put a one or two line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->
add dronecan actuator output support for AntennaTracker
param setup to test
```
SERVO1_FUNCTION  71.0        # TrackerYaw
SERVO2_FUNCTION  72.0        # TrackerPitch
CAN_D1_UC_SRV_BM 3.0         # Servo 1|Servo 2
```
<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
