### PR TITLE
AntennaTracker:add dronecan actuator output support

### DIFF
--- a/AntennaTracker/Tracker.h
+++ b/AntennaTracker/Tracker.h
@@ -66,6 +66,8 @@ public:
 
     void arm_servos();
     void disarm_servos();
+    void cork_servos();
+    void push_servos();
 
 private:
     Parameters g;

--- a/AntennaTracker/mode_servotest.cpp
+++ b/AntennaTracker/mode_servotest.cpp
@@ -18,7 +18,7 @@ bool ModeServoTest::set_servo(uint8_t servo_num, uint16_t pwm)
         return false;
     }
 
-    hal.rcout->cork();
+    tracker.cork_servos();
 
     // set yaw servo pwm and send output to servo
     if (servo_num == CH_YAW) {
@@ -35,7 +35,7 @@ bool ModeServoTest::set_servo(uint8_t servo_num, uint16_t pwm)
     SRV_Channels::calc_pwm();
     SRV_Channels::output_ch_all();
 
-    hal.rcout->push();
+    tracker.push_servos();
 
     // return success
     return true;

--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -143,6 +143,8 @@ bool Tracker::set_home(const Location &temp, bool lock)
 void Tracker::arm_servos()
 {
     hal.util->set_soft_armed(true);
+    SRV_Channels::set_output_limit(SRV_Channel::k_tracker_yaw, SRV_Channel::Limit::TRIM);
+    SRV_Channels::set_output_limit(SRV_Channel::k_tracker_pitch, SRV_Channel::Limit::TRIM);
 #if HAL_LOGGING_ENABLED
     logger.set_vehicle_armed(true);
 #endif
@@ -156,16 +158,28 @@ void Tracker::disarm_servos()
 #endif
 }
 
+void Tracker::cork_servos()
+{
+    servo_channels.cork();
+}
+
+void Tracker::push_servos()
+{
+    servo_channels.push();
+}
+
 /*
   setup servos to trim value after initialising
  */
 void Tracker::prepare_servos()
 {
     start_time_ms = AP_HAL::millis();
+    servo_channels.cork();
     SRV_Channels::set_output_limit(SRV_Channel::k_tracker_yaw, SRV_Channel::Limit::TRIM);
     SRV_Channels::set_output_limit(SRV_Channel::k_tracker_pitch, SRV_Channel::Limit::TRIM);
     SRV_Channels::calc_pwm();
     SRV_Channels::output_ch_all();
+    servo_channels.push();
 }
 
 void Tracker::set_mode(Mode &newmode, const ModeReason reason)

--- a/AntennaTracker/tracking.cpp
+++ b/AntennaTracker/tracking.cpp
@@ -104,7 +104,7 @@ void Tracker::update_tracking(void)
         return;
     }
 
-    hal.rcout->cork();
+    cork_servos();
 
     // do not move if we are not armed:
     if (!hal.util->get_soft_armed()) {
@@ -127,7 +127,7 @@ void Tracker::update_tracking(void)
     SRV_Channels::calc_pwm();
     SRV_Channels::output_ch_all();
 
-    hal.rcout->push();
+    push_servos();
 
     return;
 }


### PR DESCRIPTION
### Summary

<!-- Put a one or two line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->
add dronecan actuator output support for AntennaTracker
param setup to test
```
SERVO1_FUNCTION  71.0        # TrackerYaw
SERVO2_FUNCTION  72.0        # TrackerPitch
CAN_D1_UC_SRV_BM 3.0         # Servo 1|Servo 2
```
<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
