### PR TITLE
hwdef: SPL06 baro on SkystarsH7HDv3

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/SkystarsH7HDv2/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SkystarsH7HDv2/README.md
@@ -6,7 +6,7 @@ The Skystars H7HDv2 is a flight controller produced by [Skystars](http://www.sky
 
 - STM32H743 microcontroller
 - ICM42688 IMU x2
-- BMP280 barometer
+- BMP280 barometer (v3 has SPL06)
 - AT7456E OSD
 - 8 UARTs
 - 9 PWM outputs

--- a/libraries/AP_HAL_ChibiOS/hwdef/SkystarsH7HDv2/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SkystarsH7HDv2/hwdef.dat
@@ -32,3 +32,6 @@ define DEFAULT_SERIAL6_PROTOCOL SerialProtocol_MSP_DisplayPort
 
 # other pin defaults come from hwdefs this one includes
 define RELAY4_PIN_DEFAULT 83
+
+define AP_BARO_SPL06_ENABLED 1
+BARO SPL06 I2C:0:0x76


### PR DESCRIPTION
### Summary

SPL06 baro on SkystarsH7HDv3 rather than the BMP280 which was on the v2

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [X] Tested on hardware
