### PR TITLE
Restrict CI job on github action yml change

### DIFF
--- a/.github/workflows/colcon.yml
+++ b/.github/workflows/colcon.yml
@@ -63,7 +63,8 @@ on:
       - '.vscode/**'
       - '.github/ISSUE_TEMPLATE/**'
       # Remove change on other workflows
-      - '.github/workflows/test_environment.yml'
+      - '.github/**'
+      - '!.github/workflows/colcon.yml'  # except this one
 
   pull_request:
     paths-ignore:
@@ -128,7 +129,8 @@ on:
       - '.vscode/**'
       - '.github/ISSUE_TEMPLATE/**'
       # Remove change on other workflows
-      - '.github/workflows/test_environment.yml'
+      - '.github/**'
+      - '!.github/workflows/colcon.yml'  # except this one
 
   workflow_dispatch:
 

--- a/.github/workflows/cygwin_build.yml
+++ b/.github/workflows/cygwin_build.yml
@@ -65,7 +65,8 @@ on:
       - '.vscode/**'
       - '.github/ISSUE_TEMPLATE/**'
       # Remove change on other workflows
-      - '.github/workflows/test_environment.yml'
+      - '.github/**'
+      - '!.github/workflows/cygwin_build.yml'  # except this one
 
   pull_request:
     paths-ignore:
@@ -132,7 +133,8 @@ on:
       - '.vscode/**'
       - '.github/ISSUE_TEMPLATE/**'
       # Remove change on other workflows
-      - '.github/workflows/test_environment.yml'
+      - '.github/**'
+      - '!.github/workflows/cygwin_build.yml'  # except this one
 
   workflow_dispatch:
 

--- a/.github/workflows/esp32_build.yml
+++ b/.github/workflows/esp32_build.yml
@@ -66,7 +66,8 @@ on:
       - '.vscode/**'
       - '.github/ISSUE_TEMPLATE/**'
       # Remove change on other workflows
-      - '.github/workflows/test_environment.yml'
+      - '.github/**'
+      - '!.github/workflows/esp32_build.yml'  # except this one
 
   pull_request:
     paths-ignore:
@@ -134,7 +135,8 @@ on:
       - '.vscode/**'
       - '.github/ISSUE_TEMPLATE/**'
       # Remove change on other workflows
-      - '.github/workflows/test_environment.yml'
+      - '.github/**'
+      - '!.github/workflows/esp32_build.yml'  # except this one
 
   workflow_dispatch:
 

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -62,7 +62,9 @@ on:
       - '.vscode/**'
       - '.github/ISSUE_TEMPLATE/**'
       # Remove change on other workflows
-      - '.github/workflows/test_environment.yml'
+      - '.github/**'
+      - '!.github/workflows/macos_build.yml'  # except this one
+
 
   pull_request:
     paths-ignore:
@@ -126,7 +128,8 @@ on:
       - '.vscode/**'
       - '.github/ISSUE_TEMPLATE/**'
       # Remove change on other workflows
-      - '.github/workflows/test_environment.yml'
+      - '.github/**'
+      - '!.github/workflows/macos_build.yml'  # except this one
 
   workflow_dispatch:
 

--- a/.github/workflows/qurt_build.yml
+++ b/.github/workflows/qurt_build.yml
@@ -65,7 +65,8 @@ on:
       - '.vscode/**'
       - '.github/ISSUE_TEMPLATE/**'
       # Remove change on other workflows
-      - '.github/workflows/test_environment.yml'
+      - '.github/**'
+      - '!.github/workflows/qurt_build.yml'  # except this one
 
   pull_request:
     paths-ignore:
@@ -132,7 +133,8 @@ on:
       - '.vscode/**'
       - '.github/ISSUE_TEMPLATE/**'
       # Remove change on other workflows
-      - '.github/workflows/test_environment.yml'
+      - '.github/**'
+      - '!.github/workflows/qurt_build.yml'  # except this one
 
   workflow_dispatch:
 

--- a/.github/workflows/test_ccache.yml
+++ b/.github/workflows/test_ccache.yml
@@ -56,7 +56,8 @@ on:
       - '.vscode/**'
       - '.github/ISSUE_TEMPLATE/**'
       # Remove change on other workflows
-      - '.github/workflows/test_environment.yml'
+      - '.github/**'
+      - '!.github/workflows/test_ccache.yml'  # except this one
 
   pull_request:
     paths-ignore:
@@ -114,7 +115,8 @@ on:
       - '.vscode/**'
       - '.github/ISSUE_TEMPLATE/**'
       # Remove change on other workflows
-      - '.github/workflows/test_environment.yml'
+      - '.github/**'
+      - '!.github/workflows/test_ccache.yml'  # except this one
 
   workflow_dispatch:
 

--- a/.github/workflows/test_chibios.yml
+++ b/.github/workflows/test_chibios.yml
@@ -58,7 +58,8 @@ on:
       - '.vscode/**'
       - '.github/ISSUE_TEMPLATE/**'
       # Remove change on other workflows
-      - '.github/workflows/test_environment.yml'
+      - '.github/**'
+      - '!.github/workflows/test_chibios.yml'  # except this one
 
   pull_request:
     paths-ignore:
@@ -122,7 +123,8 @@ on:
       - '.vscode/**'
       - '.github/ISSUE_TEMPLATE/**'
       # Remove change on other workflows
-      - '.github/workflows/test_environment.yml'
+      - '.github/**'
+      - '!.github/workflows/test_chibios.yml'  # except this one
 
   workflow_dispatch:
 

--- a/.github/workflows/test_dds.yml
+++ b/.github/workflows/test_dds.yml
@@ -63,7 +63,8 @@ on:
       - '.vscode/**'
       - '.github/ISSUE_TEMPLATE/**'
       # Remove change on other workflows
-      - '.github/workflows/test_environment.yml'
+      - '.github/**'
+      - '!.github/workflows/test_dds.yml'  # except this one
 
   pull_request:
     paths-ignore:
@@ -128,7 +129,8 @@ on:
       - '.vscode/**'
       - '.github/ISSUE_TEMPLATE/**'
       # Remove change on other workflows
-      - '.github/workflows/test_environment.yml'
+      - '.github/**'
+      - '!.github/workflows/test_dds.yml'  # except this one
 
   workflow_dispatch:
 

--- a/.github/workflows/test_linux_sbc.yml
+++ b/.github/workflows/test_linux_sbc.yml
@@ -60,7 +60,8 @@ on:
       - '.vscode/**'
       - '.github/ISSUE_TEMPLATE/**'
       # Remove change on other workflows
-      - '.github/workflows/test_environment.yml'
+      - '.github/**'
+      - '!.github/workflows/test_linux_sbc.yml'  # except this one
 
   pull_request:
     paths-ignore:
@@ -123,7 +124,8 @@ on:
       - '.vscode/**'
       - '.github/ISSUE_TEMPLATE/**'
       # Remove change on other workflows
-      - '.github/workflows/test_environment.yml'
+      - '.github/**'
+      - '!.github/workflows/test_linux_sbc.yml'  # except this one
 
   workflow_dispatch:
 

--- a/.github/workflows/test_replay.yml
+++ b/.github/workflows/test_replay.yml
@@ -68,7 +68,8 @@ on:
       - '.vscode/**'
       - '.github/ISSUE_TEMPLATE/**'
       # Remove change on other workflows
-      - '.github/workflows/test_environment.yml'
+      - '.github/**'
+      - '!.github/workflows/test_replay.yml'  # except this one
 
   pull_request:
     paths-ignore:
@@ -138,7 +139,8 @@ on:
       - '.vscode/**'
       - '.github/ISSUE_TEMPLATE/**'
       # Remove change on other workflows
-      - '.github/workflows/test_environment.yml'
+      - '.github/**'
+      - '!.github/workflows/test_replay.yml'  # except this one
 
   workflow_dispatch:
 

--- a/.github/workflows/test_sitl_blimp.yml
+++ b/.github/workflows/test_sitl_blimp.yml
@@ -76,6 +76,9 @@ on:
       # Remove some directories check
       - '.vscode/**'
       - '.github/ISSUE_TEMPLATE/**'
+      # Remove change on other workflows
+      - '.github/**'
+      - '!.github/workflows/test_sitl_blimp.yml'  # except this one
 
 
   pull_request:
@@ -154,6 +157,9 @@ on:
       # Remove some directories check
       - '.vscode/**'
       - '.github/ISSUE_TEMPLATE/**'
+      # Remove change on other workflows
+      - '.github/**'
+      - '!.github/workflows/test_sitl_blimp.yml'  # except this one
 
   workflow_dispatch:
 

--- a/.github/workflows/test_sitl_copter.yml
+++ b/.github/workflows/test_sitl_copter.yml
@@ -74,7 +74,8 @@ on:
       - '.vscode/**'
       - '.github/ISSUE_TEMPLATE/**'
       # Remove change on other workflows
-      - '.github/workflows/test_environment.yml'
+      - '.github/**'
+      - '!.github/workflows/test_sitl_copter.yml'  # except this one
 
 
   pull_request:
@@ -151,7 +152,8 @@ on:
       - '.vscode/**'
       - '.github/ISSUE_TEMPLATE/**'
       # Remove change on other workflows
-      - '.github/workflows/test_environment.yml'
+      - '.github/**'
+      - '!.github/workflows/test_sitl_copter.yml'  # except this one
 
   workflow_dispatch:
 

--- a/.github/workflows/test_sitl_periph.yml
+++ b/.github/workflows/test_sitl_periph.yml
@@ -74,7 +74,8 @@ on:
       - '.vscode/**'
       - '.github/ISSUE_TEMPLATE/**'
       # Remove change on other workflows
-      - '.github/workflows/test_environment.yml'
+      - '.github/**'
+      - '!.github/workflows/test_sitl_periph.yml'  # except this one
 
   pull_request:
     paths-ignore:
@@ -150,7 +151,8 @@ on:
       - '.vscode/**'
       - '.github/ISSUE_TEMPLATE/**'
       # Remove change on other workflows
-      - '.github/workflows/test_environment.yml'
+      - '.github/**'
+      - '!.github/workflows/test_sitl_periph.yml'  # except this one
 
   workflow_dispatch:
 

--- a/.github/workflows/test_sitl_plane.yml
+++ b/.github/workflows/test_sitl_plane.yml
@@ -75,7 +75,8 @@ on:
       - '.vscode/**'
       - '.github/ISSUE_TEMPLATE/**'
       # Remove change on other workflows
-      - '.github/workflows/test_environment.yml'
+      - '.github/**'
+      - '!.github/workflows/test_sitl_plane.yml'  # except this one
 
   pull_request:
     paths-ignore:
@@ -152,7 +153,8 @@ on:
       - '.vscode/**'
       - '.github/ISSUE_TEMPLATE/**'
       # Remove change on other workflows
-      - '.github/workflows/test_environment.yml'
+      - '.github/**'
+      - '!.github/workflows/test_sitl_plane.yml'  # except this one
 
   workflow_dispatch:
 

--- a/.github/workflows/test_sitl_rover.yml
+++ b/.github/workflows/test_sitl_rover.yml
@@ -74,8 +74,8 @@ on:
       - '.vscode/**'
       - '.github/ISSUE_TEMPLATE/**'
       # Remove change on other workflows
-      - '.github/workflows/test_environment.yml'
-
+      - '.github/**'
+      - '!.github/workflows/test_sitl_rover.yml'  # except this one
 
   pull_request:
     paths-ignore:
@@ -151,7 +151,8 @@ on:
       - '.vscode/**'
       - '.github/ISSUE_TEMPLATE/**'
       # Remove change on other workflows
-      - '.github/workflows/test_environment.yml'
+      - '.github/**'
+      - '!.github/workflows/test_sitl_rover.yml'  # except this one
 
   workflow_dispatch:
 

--- a/.github/workflows/test_sitl_sub.yml
+++ b/.github/workflows/test_sitl_sub.yml
@@ -76,7 +76,8 @@ on:
       - '.vscode/**'
       - '.github/ISSUE_TEMPLATE/**'
       # Remove change on other workflows
-      - '.github/workflows/test_environment.yml'
+      - '.github/**'
+      - '!.github/workflows/test_sitl_sub.yml'  # except this one
 
   pull_request:
     paths-ignore:
@@ -154,7 +155,8 @@ on:
       - '.vscode/**'
       - '.github/ISSUE_TEMPLATE/**'
       # Remove change on other workflows
-      - '.github/workflows/test_environment.yml'
+      - '.github/**'
+      - '!.github/workflows/test_sitl_sub.yml'  # except this one
 
   workflow_dispatch:
 

--- a/.github/workflows/test_sitl_tracker.yml
+++ b/.github/workflows/test_sitl_tracker.yml
@@ -76,7 +76,8 @@ on:
       - '.vscode/**'
       - '.github/ISSUE_TEMPLATE/**'
       # Remove change on other workflows
-      - '.github/workflows/test_environment.yml'
+      - '.github/**'
+      - '!.github/workflows/test_sitl_tracker.yml'  # except this one
 
   pull_request:
     paths-ignore:
@@ -154,7 +155,8 @@ on:
       - '.vscode/**'
       - '.github/ISSUE_TEMPLATE/**'
       # Remove change on other workflows
-      - '.github/workflows/test_environment.yml'
+      - '.github/**'
+      - '!.github/workflows/test_sitl_tracker.yml'  # except this one
 
   workflow_dispatch:
 

--- a/.github/workflows/test_size.yml
+++ b/.github/workflows/test_size.yml
@@ -49,7 +49,9 @@ on:
       - 'libraries/AP_HAL_ESP32/**'
       - 'libraries/AP_HAL_Linux/**'
       # Remove change on other workflows
-      - '.github/workflows/test_environment.yml'
+      - '.github/**'
+      - '!.github/workflows/test_size.yml'  # except this one
+
   workflow_dispatch:
 
 

--- a/.github/workflows/test_unit_tests.yml
+++ b/.github/workflows/test_unit_tests.yml
@@ -45,7 +45,8 @@ on:
       - 'libraries/AP_HAL_ESP32/**'
       - 'libraries/AP_HAL_QURT/**'
       # Remove change on other workflows
-      - '.github/workflows/test_environment.yml'
+      - '.github/**'
+      - '!.github/workflows/test_unit_tests.yml'  # except this one
   pull_request:
     paths-ignore:
       # Remove markdown files as irrelevant
@@ -91,7 +92,9 @@ on:
       - 'libraries/AP_HAL_ESP32/**'
       - 'libraries/AP_HAL_QURT/**'
       # Remove change on other workflows
-      - '.github/workflows/test_environment.yml'
+      - '.github/**'
+      - '!.github/workflows/test_unit_tests.yml'  # except this one
+
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
### Summary

Don't run CI when we push changes in .github beside the .yml changed
Fix exclusion syntax that is recommanded to not use ./.xxxx but directly .xxxx

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request


Working here, only plane workflow was changed and only it was running (+ test scripts that got no restrictions) : 
https://github.com/khancyr/ardupilot/pull/34
