### PR TITLE
SITL: Use correct bitmasks for rangefinders

### DIFF
--- a/libraries/SITL/SIM_JSON.cpp
+++ b/libraries/SITL/SIM_JSON.cpp
@@ -462,11 +462,11 @@ void JSON::recv_fdm(const struct sitl_input &input)
     update_position();
 
     // update range finder distances
-    for (uint8_t i=7; i<13; i++) {
-        if ((received_bitmask &  1ULL << i) == 0) {
+    for (uint8_t i=0; i<6; i++) {
+        if ((received_bitmask & (RNG_1 << i)) == 0) {
             continue;
         }
-        rangefinder_m[i-7] = state.rng[i-7];
+        rangefinder_m[i] = state.rng[i];
     }
 
     // update wind vane


### PR DESCRIPTION
### Summary

Fix off-by-3 error so that all simulated rangefinders are accessible from all FDMs.

Fixes #33341

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

I tested this on SITL + ardupilot_gazebo + Gazebo + this model: https://github.com/clydemcqueen/bluerov2_gz/tree/main/models/bluerov2_ping