### PR TITLE
Tools: ros2: drop scipy dependency from DDS tests

### DIFF
--- a/Tools/ros2/ardupilot_dds_tests/package.xml
+++ b/Tools/ros2/ardupilot_dds_tests/package.xml
@@ -37,7 +37,6 @@
   <test_depend>python3-pytest</test_depend>
   <test_depend>rclpy</test_depend>
   <test_depend>sensor_msgs</test_depend>
-  <test_depend>python3-scipy</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_geopose_msg_received.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_geopose_msg_received.py
@@ -27,7 +27,6 @@ import math
 import pytest
 import rclpy
 import rclpy.node
-from scipy.spatial.transform import Rotation as R
 import threading
 
 from launch_pytest.tools import process as process_tools
@@ -53,10 +52,12 @@ CMAC_HEADING = 353
 
 
 def ros_quat_to_heading_deg(quat):
-    # By default, scipy follows scalar-last order – (x, y, z, w)
-    rot = R.from_quat([quat.x, quat.y, quat.z, quat.w])
-    r, p, y = rot.as_euler(seq="xyz", degrees=True)
-    return y
+    # Yaw (rotation about Z) extracted from the quaternion using the
+    # aerospace ZYX (== extrinsic xyz) convention, equivalent to
+    # scipy's Rotation.from_quat([x, y, z, w]).as_euler("xyz", degrees=True)[2].
+    x, y, z, w = quat.x, quat.y, quat.z, quat.w
+    yaw_rad = math.atan2(2.0 * (w * z + x * y), 1.0 - 2.0 * (y * y + z * z))
+    return math.degrees(yaw_rad)
 
 
 def validate_position_cmac(position):

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_joy_msg_received.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_joy_msg_received.py
@@ -35,7 +35,6 @@ from geopy import point
 from ardupilot_msgs.srv import ArmMotors
 from ardupilot_msgs.srv import ModeSwitch
 from sensor_msgs.msg import Joy
-from scipy.spatial.transform import Rotation as R
 import pytest
 from launch_pytest.tools import process as process_tools
 import threading


### PR DESCRIPTION
fixes #33310 

The ardupilot_dds_tests package pulled in scipy solely to convert a quaternion to a heading in test_geopose_msg_received.py. On systems where numpy 2.x is installed alongside a scipy built against numpy 1.x, importing scipy fails at collection time with:

    ValueError: numpy.dtype size changed, may indicate binary incompatibility

which aborts the entire test session before any test runs.

Replace the single scipy use with an equivalent math.atan2 yaw extraction (aerospace ZYX / extrinsic-xyz convention, identical to Rotation.from_quat([x,y,z,w]).as_euler("xyz", degrees=True)[2]; verified to 0.0 deg over 1e5 random quaternions). Also remove the unused scipy import in test_joy_msg_received.py and the python3-scipy test_depend in package.xml.

This removes the numpy/scipy ABI coupling from the test suite entirely.

### Summary

<!-- Put a one or two line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
