### PR TITLE
autotest: run external AHRS tests at reduced speedup

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -3109,6 +3109,13 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
     def fly_external_AHRS(self, sim, eahrs_type,
                           dist_to_final_wp_threshold_m: float | None = None):
         """Fly with external AHRS"""
+        # The external AHRS drivers parse their serial stream on a
+        # real-time thread.  At the default plane speedup (100x) that
+        # thread cannot keep the simulated GPS within its health window
+        # on a loaded CI runner, producing intermittent "GPS 1: not
+        # healthy" arm failures.  Run these tests at a reduced speedup so
+        # the thread keeps up.
+        self.context_set_speedup(20)
         self.customise_SITL_commandline(["--serial4=sim:%s" % sim])
 
         self.set_parameters({


### PR DESCRIPTION
### Summary

Vastly reduce the chance of flakiness on these EAHRS tests by reducing the speedup

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

### Description

The external AHRS drivers parse their serial stream on a real-time thread.  At ArduPlane's default autotest speedup (100x) that thread cannot keep the simulated GPS within its health window on a loaded CI runner: a given wall-clock scheduling stall maps to 100x as much sim-time, pushing the GPS frame delta past the is_healthy() thresholds. This produced intermittent "GPS 1: not healthy" arm failures in InertialLabsEAHRS (and is a latent risk for the other EAHRS tests that share fly_external_AHRS).

Lower the speedup to 20x for the duration of fly_external_AHRS so the parse thread keeps the GPS healthy, restoring it afterwards.

.... I think I need to do that context_set_speedup stuff...
