### PR TITLE
waf: compile DroneCAN generated sources once into a shared target

### DIFF
--- a/Tools/ardupilotwaf/ap_library.py
+++ b/Tools/ardupilotwaf/ap_library.py
@@ -161,7 +161,7 @@ def process_ap_libraries(self):
             self.use.append(_vehicle_tgen_name(l, vehicle))
 
 @before_method('process_source')
-@feature('cxxstlib')
+@feature('cxxstlib', 'ap_dynamic_source')
 def dynamic_post(self):
     if not getattr(self, 'dynamic_source', None):
         return

--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -438,8 +438,12 @@ def ap_stlib(bld, **kw):
     for l in kw['ap_libraries']:
         bld.ap_library(l, kw['ap_vehicle'])
 
-    if 'dynamic_source' not in kw:
-        kw['dynamic_source'] = 'modules/DroneCAN/libcanard/dsdlc_generated/src/**.c'
+    # Pull the shared 'dronecan_libs' objects target (see
+    # _build_common_taskgens()) in via 'use'
+    if 'dynamic_source' not in kw and \
+            (bld.get_board().with_can or bld.env.HAL_NUM_CAN_IFACES) and \
+            not bld.env.AP_PERIPH:
+        kw['use'] = unique_list(Utils.to_list(kw.get('use', [])) + ['dronecan_libs'])
 
     kw['features'] = kw.get('features', []) + ['cxx', 'cxxstlib']
     kw['target'] = kw['name']

--- a/libraries/AP_DroneCAN/examples/DroneCAN_sniffer/wscript
+++ b/libraries/AP_DroneCAN/examples/DroneCAN_sniffer/wscript
@@ -9,7 +9,6 @@ def build(bld):
     bld.ap_stlib(
         name=vehicle + '_libs',
         ap_vehicle='UNKNOWN',
-        dynamic_source='modules/DroneCAN/libcanard/dsdlc_generated/src/**.c',
         ap_libraries=bld.ap_common_vehicle_libraries() + [
             'AP_OSD',
             'AP_Avoidance',

--- a/wscript
+++ b/wscript
@@ -820,6 +820,17 @@ def _build_dynamic_sources(bld):
     ])
 
 def _build_common_taskgens(bld):
+    # Compile the DroneCAN/libcanard generated sources once into a shared
+    # objects target that every stlib links via 'use' (see ap_stlib)
+    if (bld.get_board().with_can or bld.env.HAL_NUM_CAN_IFACES) and not bld.env.AP_PERIPH:
+        bld.objects(
+            name='dronecan_libs',
+            source=[],
+            features=['c', 'ap_dynamic_source'],
+            dynamic_source='modules/DroneCAN/libcanard/dsdlc_generated/src/**.c',
+            use=['dronecan', 'mavlink'],
+        )
+
     # NOTE: Static library with vehicle set to UNKNOWN, shared by all
     # the tools and examples. This is the first step until the
     # dependency on the vehicles is reduced. Later we may consider


### PR DESCRIPTION
### Summary

Fixes `2026-06-06T12:17:45.1115962Z /usr/bin/ar: lib/libAP_FW_Controller_test_libs.a: error reading modules/DroneCAN/libcanard/dsdlc_generated/src/uavcan.equipment.ahrs.MagneticFieldStrength2.c.1.o: file truncated`

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Sayeth the robot:
```
Each ap_stlib() defaulted to dynamic_source globbing the libcanard dsdlc_generated/src/**.c files into itself, so every vehicle, tool, test and example static library compiled the same generated sources.

waf names an object as "<source-name>.<idx>.o" placed next to the source node, where idx is unique only per wscript folder. The generated sources live in a single shared directory, and most of these wscripts create their stlib as the first task generator in their folder (idx==1), so they all emit e.g. MagneticFieldStrength2.c.1.o into the same path. A task's uid is computed from its class and input/output paths only (no compiler flags), so waf treats the colliding compile tasks as identical and runs them anyway. With many static libraries built in parallel, one library's archive (ar) step can read one of these object files while another library's compile task is still writing it, giving intermittent "ar: ... file truncated" failures. This showed up with clang in CI, where compile timing widens the race window.

Compile the generated sources exactly once into a shared 'dronecan_libs' objects target and pull it into each stlib via 'use'. This gives each generated object a single owning task and a single output path, removing the collision entirely (verified: full SITL build graph drops from 528+ colliding object outputs to zero). It also avoids recompiling the generated sources for every library.

AP_Periph and the bootloader pass an explicit dynamic_source and are single-firmware builds with no such collision, so they are unchanged.

This change was made with AI assistance (Claude).
```
