### PR TITLE
AP_PrecLand: remove YAW_ALIGN from plane and copter

### DIFF
--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -44,14 +44,14 @@ const AP_Param::GroupInfo AC_PrecLand::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("TYPE",    1, AC_PrecLand, _type, 0),
 
-    // @Param: YAW_ALIGN
+    // @Param{Rover}: YAW_ALIGN
     // @DisplayName: Sensor yaw alignment
     // @Description: Yaw angle from body x-axis to sensor x-axis.
     // @Range: 0 36000
     // @Increment: 10
     // @User: Advanced
     // @Units: cdeg
-    AP_GROUPINFO("YAW_ALIGN",    2, AC_PrecLand, _yaw_align_cd, 0),
+    AP_GROUPINFO_FRAME("YAW_ALIGN",    2, AC_PrecLand, _yaw_align_cd, 0, AP_PARAM_FRAME_ROVER),
 
     // @Param: LAND_OFS_X
     // @DisplayName: Land offset forward


### PR DESCRIPTION
### Summary

Remove unused param PLND_YAW_ALIGN from Copter and Plane since only downward facing RFs are used

- [x ] Checked by a human programmer
- [ ] Non-functional change (does remove an unused param, but no behvior change)
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
