### PR TITLE
AP_NavEKF3: use the AGL KF for the optical-flow rangefinder height switch and observation

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -1269,9 +1269,17 @@ void NavEKF3_core::selectHeightForFusion()
         // and rangefinder only — so it gives a reliable height-above-
         // ground for the switching decision.
         ftype heightAboveGnd;
+        // Freshness gate for the switch-on decision below. It normally tracks the
+        // legacy terrain-offset estimator, but that estimator predicts range from the
+        // baro-contaminated main-filter altitude and stalls near the ground, leaving
+        // gndHgtValidTime_ms stale. When the AGL KF is the height authority it owns the
+        // rangefinder, so gate on its own last-fusion time instead - otherwise the stale
+        // legacy timestamp vetoes the switch and altitude stays on baro below the switch height.
+        uint32_t hgtValidTime_ms = gndHgtValidTime_ms;
 #if EK3_FEATURE_OPTFLOW_AGL_KF
         if (frontend->option_is_enabled(NavEKF3::Option::AglKfForOptflow) && aglKfValid) {
             heightAboveGnd = aglKfH;
+            hgtValidTime_ms = lastAglRngFuseTime_ms;
         } else
 #endif
         {
@@ -1279,7 +1287,7 @@ void NavEKF3_core::selectHeightForFusion()
         }
 
         bool aboveUpperSwHgt = heightAboveGnd > rangeMaxUse;
-        bool belowLowerSwHgt = (heightAboveGnd < 0.7f * rangeMaxUse) && (imuSampleTime_ms - gndHgtValidTime_ms < 1000);
+        bool belowLowerSwHgt = (heightAboveGnd < 0.7f * rangeMaxUse) && (imuSampleTime_ms - hgtValidTime_ms < 1000);
 
         // The vehicle only marks terrain stable during takeoff and landing, leaving
         // altitude on baro through cruise/hover. When the IMU-aided AGL KF is enabled

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -1261,8 +1261,25 @@ void NavEKF3_core::selectHeightForFusion()
     } else if ((frontend->_useRngSwHgt > 0) && ((frontend->sources.getPosZSource(core_index) == AP_NavEKF_Source::SourceZ::BARO) || (frontend->sources.getPosZSource(core_index) == AP_NavEKF_Source::SourceZ::GPS)) && _rng && rangeFinderDataIsFresh) {
         // determine if we are above or below the height switch region
         const ftype rangeMaxUse = 1e-2 * (ftype)_rng->max_distance_orient(ROTATION_PITCH_270) * (ftype)frontend->_useRngSwHgt;
-        bool aboveUpperSwHgt = (terrainState - stateStruct.position.z) > rangeMaxUse;
-        bool belowLowerSwHgt = ((terrainState - stateStruct.position.z) < 0.7f * rangeMaxUse) && (imuSampleTime_ms - gndHgtValidTime_ms < 1000);
+
+        // Use the AGL KF height estimate when available.  The default
+        // (terrainState - position.z) depends on the main filter's
+        // vertical position which can be corrupted by baro ground
+        // effect.  The AGL KF is independent of baro — it fuses IMU
+        // and rangefinder only — so it gives a reliable height-above-
+        // ground for the switching decision.
+        ftype heightAboveGnd;
+#if EK3_FEATURE_OPTFLOW_AGL_KF
+        if (frontend->option_is_enabled(NavEKF3::Option::AglKfForOptflow) && aglKfValid) {
+            heightAboveGnd = aglKfH;
+        } else
+#endif
+        {
+            heightAboveGnd = terrainState - stateStruct.position.z;
+        }
+
+        bool aboveUpperSwHgt = heightAboveGnd > rangeMaxUse;
+        bool belowLowerSwHgt = (heightAboveGnd < 0.7f * rangeMaxUse) && (imuSampleTime_ms - gndHgtValidTime_ms < 1000);
 
         // If the terrain height is consistent and we are moving slowly, then it can be
         // used as a height reference in combination with a range finder

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -1407,8 +1407,22 @@ void NavEKF3_core::selectHeightForFusion()
         // using range finder data
         // correct for tilt using a flat earth model
         if (prevTnb.c.z >= 0.7) {
-            // calculate height above ground
-            hgtMea  = MAX(rangeDataDelayed.rng * prevTnb.c.z, rngOnGnd);
+            // calculate height above ground and its observation noise
+#if EK3_FEATURE_OPTFLOW_AGL_KF
+            if (frontend->option_is_enabled(NavEKF3::Option::AglKfForOptflow) && aglKfValid) {
+                // Fuse the IMU-aided AGL KF height in place of the raw rangefinder: it is the
+                // same tilt-compensated range, de-glitched, and its covariance already folds
+                // in terrain-gradient uncertainty, so it does not need the extra term below.
+                hgtMea = MAX(aglKfH, rngOnGnd);
+                posDownObsNoise = MAX(aglKfP[0][0], sq(constrain_ftype(frontend->_rngNoise, 0.1f, 10.0f)));
+            } else
+#endif
+            {
+                hgtMea = MAX(rangeDataDelayed.rng * prevTnb.c.z, rngOnGnd);
+                posDownObsNoise = sq(constrain_ftype(frontend->_rngNoise, 0.1f, 10.0f));
+                // add uncertainty created by terrain gradient and vehicle tilt
+                posDownObsNoise += sq(rangeDataDelayed.rng * frontend->_terrGradMax) * MAX(0.0f , (1.0f - sq(prevTnb.c.z)));
+            }
             // correct for terrain position relative to datum
             hgtMea -= terrainState;
             // correct sensor so that local position height adjusts to match GPS
@@ -1419,10 +1433,6 @@ void NavEKF3_core::selectHeightForFusion()
             velPosObs[5] = -hgtMea;
             // enable fusion
             fuseHgtData = true;
-            // set the observation noise
-            posDownObsNoise = sq(constrain_ftype(frontend->_rngNoise, 0.1f, 10.0f));
-            // add uncertainty created by terrain gradient and vehicle tilt
-            posDownObsNoise += sq(rangeDataDelayed.rng * frontend->_terrGradMax) * MAX(0.0f , (1.0f - sq(prevTnb.c.z)));
         } else {
             // disable fusion if tilted too far
             fuseHgtData = false;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -1281,6 +1281,17 @@ void NavEKF3_core::selectHeightForFusion()
         bool aboveUpperSwHgt = heightAboveGnd > rangeMaxUse;
         bool belowLowerSwHgt = (heightAboveGnd < 0.7f * rangeMaxUse) && (imuSampleTime_ms - gndHgtValidTime_ms < 1000);
 
+        // The vehicle only marks terrain stable during takeoff and landing, leaving
+        // altitude on baro through cruise/hover. When the IMU-aided AGL KF is enabled
+        // and valid it provides a reliable, de-glitched height above ground that is
+        // independent of baro, so let it act as a stable terrain reference here too.
+        bool terrainStable = terrainHgtStable;
+#if EK3_FEATURE_OPTFLOW_AGL_KF
+        if (frontend->option_is_enabled(NavEKF3::Option::AglKfForOptflow) && aglKfValid) {
+            terrainStable = true;
+        }
+#endif
+
         // If the terrain height is consistent and we are moving slowly, then it can be
         // used as a height reference in combination with a range finder
         // apply a hysteresis to the speed check to prevent rapid switching
@@ -1288,13 +1299,13 @@ void NavEKF3_core::selectHeightForFusion()
         if (filterStatus.flags.horiz_vel) {
             // We can use the velocity estimate
             ftype horizSpeed = stateStruct.velocity.xy().length();
-            dontTrustTerrain = (horizSpeed > frontend->_useRngSwSpd) || !terrainHgtStable;
+            dontTrustTerrain = (horizSpeed > frontend->_useRngSwSpd) || !terrainStable;
             ftype trust_spd_trigger = MAX((frontend->_useRngSwSpd - 1.0f),(frontend->_useRngSwSpd * 0.5f));
-            trustTerrain = (horizSpeed < trust_spd_trigger) && terrainHgtStable;
+            trustTerrain = (horizSpeed < trust_spd_trigger) && terrainStable;
         } else {
             // We can't use the velocity estimate
-            dontTrustTerrain = !terrainHgtStable;
-            trustTerrain = terrainHgtStable;
+            dontTrustTerrain = !terrainStable;
+            trustTerrain = terrainStable;
         }
 
         /*

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -1403,8 +1403,22 @@ void NavEKF3_core::selectHeightForFusion()
         // using range finder data
         // correct for tilt using a flat earth model
         if (prevTnb.c.z >= 0.7) {
-            // calculate height above ground
-            hgtMea  = MAX(rangeDataDelayed.rng * prevTnb.c.z, rngOnGnd);
+            // calculate height above ground and its observation noise
+#if EK3_FEATURE_OPTFLOW_AGL_KF
+            if (frontend->option_is_enabled(NavEKF3::Option::AglKfForOptflow) && aglKfValid) {
+                // Fuse the IMU-aided AGL KF height in place of the raw rangefinder: it is the
+                // same tilt-compensated range, de-glitched, and its covariance already folds
+                // in terrain-gradient uncertainty, so it does not need the extra term below.
+                hgtMea = MAX(aglKfH, rngOnGnd);
+                posDownObsNoise = MAX(aglKfP[0][0], sq(constrain_ftype(frontend->_rngNoise, 0.1f, 10.0f)));
+            } else
+#endif
+            {
+                hgtMea = MAX(rangeDataDelayed.rng * prevTnb.c.z, rngOnGnd);
+                posDownObsNoise = sq(constrain_ftype(frontend->_rngNoise, 0.1f, 10.0f));
+                // add uncertainty created by terrain gradient and vehicle tilt
+                posDownObsNoise += sq(rangeDataDelayed.rng * frontend->_terrGradMax) * MAX(0.0f , (1.0f - sq(prevTnb.c.z)));
+            }
             // correct for terrain position relative to datum
             hgtMea -= terrainState;
             // correct sensor so that local position height adjusts to match GPS
@@ -1415,10 +1429,6 @@ void NavEKF3_core::selectHeightForFusion()
             velPosObs[5] = -hgtMea;
             // enable fusion
             fuseHgtData = true;
-            // set the observation noise
-            posDownObsNoise = sq(constrain_ftype(frontend->_rngNoise, 0.1f, 10.0f));
-            // add uncertainty created by terrain gradient and vehicle tilt
-            posDownObsNoise += sq(rangeDataDelayed.rng * frontend->_terrGradMax) * MAX(0.0f , (1.0f - sq(prevTnb.c.z)));
         } else {
             // disable fusion if tilted too far
             fuseHgtData = false;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -1268,9 +1268,14 @@ void NavEKF3_core::selectHeightForFusion()
         // and rangefinder, so it does not carry that error directly - baro
         // reaches it only through the accel bias the main filter learns.
         ftype heightAboveGnd;
+        // The legacy terrain-offset estimator stalls near the ground, so its
+        // timestamp goes stale and vetoes the switch. Gate on the AGL KF's own
+        // last-fusion time when it is the height authority.
+        uint32_t hgtValidTime_ms = gndHgtValidTime_ms;
 #if EK3_FEATURE_OPTFLOW_AGL_KF
         if (frontend->option_is_enabled(NavEKF3::Option::AglKfForOptflow) && aglKfValid) {
             heightAboveGnd = aglKfH;
+            hgtValidTime_ms = lastAglRngFuseTime_ms;
         } else
 #endif
         {
@@ -1278,7 +1283,7 @@ void NavEKF3_core::selectHeightForFusion()
         }
 
         bool aboveUpperSwHgt = heightAboveGnd > rangeMaxUse;
-        bool belowLowerSwHgt = (heightAboveGnd < 0.7f * rangeMaxUse) && (imuSampleTime_ms - gndHgtValidTime_ms < 1000);
+        bool belowLowerSwHgt = (heightAboveGnd < 0.7f * rangeMaxUse) && (imuSampleTime_ms - hgtValidTime_ms < 1000);
 
         // The vehicle only marks terrain stable during takeoff and landing, leaving
         // altitude on baro through cruise/hover. When the IMU-aided AGL KF is enabled

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -1280,6 +1280,17 @@ void NavEKF3_core::selectHeightForFusion()
         bool aboveUpperSwHgt = heightAboveGnd > rangeMaxUse;
         bool belowLowerSwHgt = (heightAboveGnd < 0.7f * rangeMaxUse) && (imuSampleTime_ms - gndHgtValidTime_ms < 1000);
 
+        // The vehicle only marks terrain stable during takeoff and landing, leaving
+        // altitude on baro through cruise/hover. When the IMU-aided AGL KF is enabled
+        // and valid it provides a de-glitched height above ground that does not carry
+        // baro error directly, so let it act as a stable terrain reference here too.
+        bool terrainStable = terrainHgtStable;
+#if EK3_FEATURE_OPTFLOW_AGL_KF
+        if (frontend->option_is_enabled(NavEKF3::Option::AglKfForOptflow) && aglKfValid) {
+            terrainStable = true;
+        }
+#endif
+
         // If the terrain height is consistent and we are moving slowly, then it can be
         // used as a height reference in combination with a range finder
         // apply a hysteresis to the speed check to prevent rapid switching
@@ -1287,13 +1298,13 @@ void NavEKF3_core::selectHeightForFusion()
         if (filterStatus.flags.horiz_vel) {
             // We can use the velocity estimate
             ftype horizSpeed = stateStruct.velocity.xy().length();
-            dontTrustTerrain = (horizSpeed > frontend->_useRngSwSpd) || !terrainHgtStable;
+            dontTrustTerrain = (horizSpeed > frontend->_useRngSwSpd) || !terrainStable;
             ftype trust_spd_trigger = MAX((frontend->_useRngSwSpd - 1.0f),(frontend->_useRngSwSpd * 0.5f));
-            trustTerrain = (horizSpeed < trust_spd_trigger) && terrainHgtStable;
+            trustTerrain = (horizSpeed < trust_spd_trigger) && terrainStable;
         } else {
             // We can't use the velocity estimate
-            dontTrustTerrain = !terrainHgtStable;
-            trustTerrain = terrainHgtStable;
+            dontTrustTerrain = !terrainStable;
+            trustTerrain = terrainStable;
         }
 
         /*

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -1261,8 +1261,24 @@ void NavEKF3_core::selectHeightForFusion()
     } else if ((frontend->_useRngSwHgt > 0) && ((frontend->sources.getPosZSource(core_index) == AP_NavEKF_Source::SourceZ::BARO) || (frontend->sources.getPosZSource(core_index) == AP_NavEKF_Source::SourceZ::GPS)) && _rng && rangeFinderDataIsFresh) {
         // determine if we are above or below the height switch region
         const ftype rangeMaxUse = 1e-2 * (ftype)_rng->max_distance_orient(ROTATION_PITCH_270) * (ftype)frontend->_useRngSwHgt;
-        bool aboveUpperSwHgt = (terrainState - stateStruct.position.z) > rangeMaxUse;
-        bool belowLowerSwHgt = ((terrainState - stateStruct.position.z) < 0.7f * rangeMaxUse) && (imuSampleTime_ms - gndHgtValidTime_ms < 1000);
+
+        // Use the AGL KF height estimate when available. The default
+        // (terrainState - position.z) rides on the main filter's vertical
+        // position, which baro ground effect corrupts. The AGL KF fuses IMU
+        // and rangefinder, so it does not carry that error directly - baro
+        // reaches it only through the accel bias the main filter learns.
+        ftype heightAboveGnd;
+#if EK3_FEATURE_OPTFLOW_AGL_KF
+        if (frontend->option_is_enabled(NavEKF3::Option::AglKfForOptflow) && aglKfValid) {
+            heightAboveGnd = aglKfH;
+        } else
+#endif
+        {
+            heightAboveGnd = terrainState - stateStruct.position.z;
+        }
+
+        bool aboveUpperSwHgt = heightAboveGnd > rangeMaxUse;
+        bool belowLowerSwHgt = (heightAboveGnd < 0.7f * rangeMaxUse) && (imuSampleTime_ms - gndHgtValidTime_ms < 1000);
 
         // If the terrain height is consistent and we are moving slowly, then it can be
         // used as a height reference in combination with a range finder


### PR DESCRIPTION
### Summary

When flying optical flow with the IMU-aided AGL KF enabled, the EKF's rangefinder height-source switch keys off the main filter's baro-corrupted altitude and only engages during takeoff and landing, so altitude rides baro through cruise and hover. Indoors, where baro is wrecked by propwash, that lets the height estimate diverge by metres while a clean rangefinder reading sits unused. This routes the switch through the AGL KF, and fuses the AGL KF height as the rangefinder observation.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Tested manually, description below (SITL Replay against real indoor logs)
- [x] Tested on hardware
- [x] Logs available on request

Replayed two real indoor optical-flow flights (`--force-ekf3`, EKF3 replay data captured in-flight) comparing the as-flown core against a replayed core with the switch changes. Altitude error vs the rangefinder ground truth:

| | as flown (baro in hover) | with this PR |
|---|---|---|
| flight A: std / max | 1.14 m / 5.40 m | 0.20 m / 0.66 m |
| flight B: std / max | 1.38 m / 2.96 m | 0.30 m / 0.95 m |

In flight A the as-flown estimate ballooned to +5.7 m on a vehicle physically holding under 1.2 m (rangefinder, which never read out-of-range-high); with the PR it tracks the rangefinder.

### Description

Builds on the AGL KF (`EK3_OPTIONS` AglKfForOptflow), which already provides a reliable, baro-independent height above ground for optical-flow velocity scaling. Three related changes to `selectHeightForFusion`:

- Use the AGL KF height for the switch decision (the up/down threshold) instead of `terrainState - position.z`, which depends on the main filter's vertical state and is corrupted by baro ground effect. This removes a feedback loop where bad baro raised the estimated height, tripped the upper threshold, and locked the rangefinder out, leaving baro uncorrected.
- Allow the rangefinder to engage outside takeoff/landing. The switch needs the vehicle's `terrain_hgt_stable` flag, which Copter only sets while taking off or landing, so a steady hover never engages it. When the AGL KF is enabled and valid, treat terrain as stable for this decision. The existing `EK3_RNG_USE_SPD` speed gate still confines rangefinder height to slow flight, so altitude over varying terrain in cruise is unaffected.
- Fuse the AGL KF height as the rangefinder observation. When the rangefinder is the active height source, fuse the de-glitched `aglKfH` (with the AGL KF covariance as the observation noise, which already folds in terrain-gradient uncertainty) in place of the raw tilt-corrected reading, so a single spurious range sample no longer feeds straight into the main filter's altitude. This is a refinement of the same path added after the replay study above, not separately quantified in the table.

All three are gated on the AglKfForOptflow option, so with the option off (the default) behaviour is unchanged. Reviewer note on the obvious alternative: setting the rangefinder as the primary `POSZ` source also fixes the symptom in replay, but it bypasses this switch entirely, has no baro fallback, and assumes flat terrain. This keeps baro primary and only leans on the rangefinder where the AGL KF vouches for it.
