### PR TITLE
autotest: default to a speedup of 100 in the base test suite

### DIFF
--- a/Tools/autotest/antennatracker.py
+++ b/Tools/autotest/antennatracker.py
@@ -26,10 +26,6 @@ class AutoTestTracker(vehicle_test_suite.TestSuite):
     def log_name(self):
         return "AntennaTracker"
 
-    def default_speedup(self):
-        '''Tracker seems to be race-free'''
-        return 100
-
     def test_filepath(self):
         return os.path.realpath(__file__)
 

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -83,9 +83,6 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
     def test_filepath(self):
         return os.path.realpath(__file__)
 
-    def default_speedup(self):
-        return 100
-
     def set_current_test_name(self, name):
         self.current_test_name_directory = "ArduCopter_Tests/" + name + "/"
 

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -57,9 +57,6 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
     def log_name(self):
         return "ArduPlane"
 
-    def default_speedup(self):
-        return 100
-
     def test_filepath(self):
         return os.path.realpath(__file__)
 

--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -74,10 +74,6 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
     def log_name(self):
         return "ArduSub"
 
-    def default_speedup(self):
-        '''Sub seems to be race-free'''
-        return 100
-
     def test_filepath(self):
         return os.path.realpath(__file__)
 

--- a/Tools/autotest/blimp.py
+++ b/Tools/autotest/blimp.py
@@ -55,9 +55,6 @@ class AutoTestBlimp(TestSuite):
     def test_filepath(self):
         return os.path.realpath(__file__)
 
-    def default_speedup(self):
-        return 100
-
     def set_current_test_name(self, name):
         self.current_test_name_directory = "Blimp_Tests/" + name + "/"
 

--- a/Tools/autotest/helicopter.py
+++ b/Tools/autotest/helicopter.py
@@ -33,10 +33,6 @@ class AutoTestHelicopter(AutoTestCopter):
     def sitl_start_location(self):
         return self.sitl_start_loc
 
-    def default_speedup(self):
-        '''Heli seems to be race-free'''
-        return 100
-
     def is_heli(self):
         return True
 

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -64,10 +64,6 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
     def sitl_start_location(self):
         return SITL_START_LOCATION
 
-    def default_speedup(self):
-        '''QuadPlane seems to be race-free'''
-        return 100
-
     def log_name(self):
         return "QuadPlane"
 

--- a/Tools/autotest/test_param_upgrade.py
+++ b/Tools/autotest/test_param_upgrade.py
@@ -40,6 +40,11 @@ class TestParamUpgradeTestSuite(vehicle_test_suite.TestSuite):
     def __init__(self, binary):
         super(TestParamUpgradeTestSuite, self).__init__(binary)
 
+    def default_speedup(self):
+        # the base-class default was 8 when this suite was written;
+        # preserve that now the base default has been raised to 100:
+        return 8
+
     def sysid_thismav(self):
         if "antennatracker" in self.binary:
             return 2

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -2086,7 +2086,7 @@ class TestSuite(abc.ABC):
             self.rc_thread = None
 
     def default_speedup(self):
-        return 8
+        return 100
 
     def progress(self, text, send_statustext=True):
         """Display autotest progress text."""


### PR DESCRIPTION
### Summary

Makes 100 the default s it is clearly available in most places now

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request


### Description

Most vehicle test suites overrode default_speedup() to return 100; raise the base-class default to 100 and remove those now-redundant overrides.

Behaviour is preserved for every existing suite:
 - Rover keeps its explicit override of 30
 - TestParamUpgradeTestSuite relied on the old base default of 8 (it does not pass a speedup to the base __init__), so it gets an explicit override returning 8
 - RunMission already defaults its own speedup to 100 and never consults default_speedup(), so it is unaffected

