### PR TITLE
AP_Bootloader: reserve board ID for AMOV Flycore

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -336,6 +336,7 @@ AP_HW_JPilot-C                       1214
 AP_HW_SIYI-UniFC-6-PICO              1215
 AP_HW_CSKY_AVEGA6X                   1216
 AP_HW_CSKY_AVEGALITER03              1217
+AP_HW_AMOV_FLYCORE                   1218
 
 AP_HW_MUPilot                        1222
 AP_HW_HWH7                           1223


### PR DESCRIPTION
### Summary

Reserve ArduPilot bootloader board ID 1218 for the AMOV Flycore flight
controller, which is based on the STM32H743VI.

### Classification & Testing (check all that apply and add your own)

- [ ] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Validation performed:

- `./Tools/autotest/validate_board_list.py`
- `git diff --check`

### Description

Add `AP_HW_AMOV_FLYCORE` with board ID `1218` to
`Tools/AP_Bootloader/board_types.txt`.

Flycore is an STM32H743VI-based flight controller. The same numeric board ID
is intended to be used by both ArduPilot and PX4 for this physical board so
their bootloader and firmware metadata identify it consistently and avoid
board ID or firmware package conflicts.

This PR only reserves the board ID. ArduPilot Flycore board support will be
submitted separately after the ID is accepted, without modifying
`board_types.txt` again.

This contribution was prepared with AI assistance for repository
synchronization, Board ID collision checks, the one-line edit, validation,
and pull request preparation. The human submitter remains responsible for
the contribution.
