### PR TITLE
AP_HAL_ChibiOS: log idle-hook based true CPU load

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -332,6 +332,14 @@ private:
     // takeoff check
     uint32_t takeoff_check_warning_ms;  // system time user was last warned of takeoff check failure
 
+#if HAL_WITH_ESC_TELEM && FRAME_CONFIG != HELI_FRAME && AP_CPU_IDLE_STATS_ENABLED
+    // cached previous window of the takeoff CPU load check
+    uint32_t takeoff_load_window_ms;    // system time the CPU load window was last consumed
+    float takeoff_load_avg;             // average CPU load in percent over the previous window
+    float takeoff_load_peak;            // peak CPU load in percent over the previous window
+    bool takeoff_load_valid;            // true if the previous window contained data
+#endif
+
     // GCS selection
     GCS_Copter _gcs; // avoid using this; use gcs()
     GCS_Copter &gcs() { return _gcs; }

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1068,6 +1068,24 @@ const AP_Param::GroupInfo ParametersG2::var_info2[] = {
     // @Range: 0 10000
     // @User: Standard
     AP_GROUPINFO("TKOFF_RPM_MAX", 7, ParametersG2, takeoff_rpm_max, 0),
+
+#if AP_CPU_IDLE_STATS_ENABLED
+    // @Param: TKOFF_CPU_AVG
+    // @DisplayName: Takeoff Check average CPU load maximum
+    // @Description: Takeoff is not permitted while the average true CPU load, captured using the idle threads over the previous 2 seconds, exceeds this value. REQUIRES BRD_IDLE_STATS: the load is measured by the idle threads, so this check does nothing, whatever this value, while BRD_IDLE_STATS is zero. Set to zero to disable check
+    // @Units: %
+    // @Range: 0 99.9
+    // @User: Advanced
+    AP_GROUPINFO("TKOFF_CPU_AVG", 60, ParametersG2, takeoff_cpu_avg_max, 95.0),
+
+    // @Param: TKOFF_CPU_PEAK
+    // @DisplayName: Takeoff Check peak CPU load maximum
+    // @Description: Takeoff is not permitted while the peak true CPU load, captured using the idle threads over the previous 2 seconds, exceeds this value. REQUIRES BRD_IDLE_STATS: the load is measured by the idle threads, so this check does nothing, whatever this value, while BRD_IDLE_STATS is zero. Set to zero to disable check
+    // @Units: %
+    // @Range: 0 99.9
+    // @User: Advanced
+    AP_GROUPINFO("TKOFF_CPU_PEAK", 61, ParametersG2, takeoff_cpu_peak_max, 99.5),
+#endif
 #endif
 
     // @Param: FS_EKF_FILT

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -699,6 +699,10 @@ public:
 #if HAL_WITH_ESC_TELEM && FRAME_CONFIG != HELI_FRAME
     AP_Int16 takeoff_rpm_min;
     AP_Int16 takeoff_rpm_max;
+#if AP_CPU_IDLE_STATS_ENABLED
+    AP_Float takeoff_cpu_avg_max;
+    AP_Float takeoff_cpu_peak_max;
+#endif
 #endif
 
     // EKF variance filter cutoff

--- a/ArduCopter/takeoff_check.cpp
+++ b/ArduCopter/takeoff_check.cpp
@@ -8,9 +8,27 @@
 void Copter::takeoff_check()
 {
 #if HAL_WITH_ESC_TELEM && FRAME_CONFIG != HELI_FRAME
+    uint32_t now_ms = AP_HAL::millis();
+
+#if AP_CPU_IDLE_STATS_ENABLED
+    // window length for the takeoff CPU overload check
+    static constexpr uint8_t TAKEOFF_CHECK_CPU_WINDOW_S = 2;
+
+    // the load is measured by the idle threads, which only run the measurement
+    // when BRD_IDLE_STATS is enabled, so the check is inactive without it
+    const bool cpu_check_enabled = AP_BoardConfig::use_idle_stats() &&
+                                   (is_positive(g2.takeoff_cpu_avg_max) || is_positive(g2.takeoff_cpu_peak_max));
+
+    // consume the CPU load window on our own cadence whenever the check is
+    // enabled, so a completed window is available when the check runs
+    if (cpu_check_enabled && now_ms - takeoff_load_window_ms >= TAKEOFF_CHECK_CPU_WINDOW_S * 1000U) {
+        takeoff_load_valid = hal.util->consume_system_load(AP_HAL::Util::LoadReader::TAKEOFF, takeoff_load_avg, takeoff_load_peak);
+        takeoff_load_window_ms = now_ms;
+    }
+#endif
+
     // if motors have become unblocked return immediately
     // this ensures the motors can only be blocked immediately after arming
-    uint32_t now_ms = AP_HAL::millis();
     if (!motors->get_spoolup_block()) {
         takeoff_check_warning_ms = now_ms;
         takeoff_check_state.warning_ms = now_ms;
@@ -28,14 +46,20 @@ void Copter::takeoff_check()
     // Run the common motor checks (called early so it can clear its warning timer when disarmed)
     const bool motor_check_passed = motors_takeoff_check(g2.takeoff_rpm_min, g2.takeoff_rpm_max);
 
-    // Check system load
-    float avg_load, peak_load;
+    // Check system load against the enabled thresholds. Fail closed when
+    // enabled without valid window data: an invalid window also means a CPU
+    // so overloaded that the idle threads never ran, which must not pass.
     bool load_adequate = true;
-    if (hal.util->get_system_load(avg_load, peak_load)) {
-        if (avg_load > 95.0f || peak_load > 99.5f) {
+#if AP_CPU_IDLE_STATS_ENABLED
+    if (cpu_check_enabled) {
+        if (!takeoff_load_valid) {
+            load_adequate = false;
+        } else if ((is_positive(g2.takeoff_cpu_avg_max) && takeoff_load_avg > g2.takeoff_cpu_avg_max) ||
+                   (is_positive(g2.takeoff_cpu_peak_max) && takeoff_load_peak > g2.takeoff_cpu_peak_max)) {
             load_adequate = false;
         }
     }
+#endif
 
     // Clear block if all checks passed
     if (motor_check_passed && load_adequate) {
@@ -46,10 +70,16 @@ void Copter::takeoff_check()
     // warn about CPU load every 2 seconds
     if (now_ms - takeoff_check_warning_ms > 2000) {
         takeoff_check_warning_ms = now_ms;
+#if AP_CPU_IDLE_STATS_ENABLED
         const char* prefix_str = "Takeoff blocked:";
         if (!load_adequate) {
-            gcs().send_text(MAV_SEVERITY_CRITICAL, "%s CPU overload (%4.1f%%)", prefix_str, avg_load);
+            if (takeoff_load_valid) {
+                gcs().send_text(MAV_SEVERITY_CRITICAL, "%s CPU overload (%.1f/%.1f%%)", prefix_str, takeoff_load_avg, takeoff_load_peak);
+            } else {
+                gcs().send_text(MAV_SEVERITY_CRITICAL, "%s CPU load unavailable", prefix_str);
+            }
         }
+#endif
     }
 #endif
 }

--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -483,8 +483,9 @@ const AP_Param::GroupInfo AP_BoardConfig::var_info[] = {
 #if AP_CPU_IDLE_STATS_ENABLED
     // @Param: IDLE_STATS
     // @DisplayName: Capture and calculate true CPU load using idle threads
-    // @Description: Capture and calculate true CPU load using idle threads
-    // @Values: 0:Disable,1:Enable
+    // @Description: Bitmask of readers of true CPU load captured using the idle threads. When File is set the average and peak load since the previous read are reported via @SYS/threads.txt. When Log is set the average and peak load since the previous PM2 log message are written to the PM2 log message. Each reader observes its own measurement window.
+    // @Description{Copter}: Bitmask of readers of true CPU load captured using the idle threads. When File is set the average and peak load since the previous read are reported via @SYS/threads.txt. When Log is set the average and peak load since the previous PM2 log message are written to the PM2 log message. Each reader observes its own measurement window. Setting any bit also activates the takeoff CPU load check, see TKOFF_CPU_AVG and TKOFF_CPU_PEAK.
+    // @Bitmask: 0:File,1:Log
     // @RebootRequired: True
     // @User: Advanced
     AP_GROUPINFO("IDLE_STATS", 33, AP_BoardConfig, state.idle_stats, 0),

--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -150,8 +150,18 @@ public:
 #endif
 
 #if AP_CPU_IDLE_STATS_ENABLED
+    // bitmask of readers of idle-thread CPU load stats; each reader
+    // observes its own measurement window
+    enum class IdleStats : uint8_t {
+        TO_FILE = 1U << 0,   // reported via @SYS/threads.txt (reset on read)
+        TO_LOG  = 1U << 1,   // reported via the PM2 log message (reset on log)
+    };
+    static bool idle_stats_enabled(IdleStats opt) {
+        return _singleton && (uint8_t(_singleton->state.idle_stats.get()) & uint8_t(opt)) != 0;
+    }
+    // true if idle load measurement should run from boot (any reader enabled)
     static bool use_idle_stats(void) {
-        return _singleton?_singleton->state.idle_stats.get():0;
+        return _singleton && _singleton->state.idle_stats.get() != 0;
     }
 #endif
 

--- a/libraries/AP_HAL/LogStructure.h
+++ b/libraries/AP_HAL/LogStructure.h
@@ -4,7 +4,8 @@
 #include "UARTDriver.h"
 
 #define LOG_IDS_FROM_HAL \
-    LOG_UART_MSG
+    LOG_UART_MSG, \
+    LOG_PM2_MSG
 
 // @LoggerMessage: UART
 // @Description: UART stats
@@ -22,10 +23,34 @@ struct PACKED log_UART {
     float rx_drop_rate;
 };
 
+// @LoggerMessage: PM2
+// @Description: True CPU load (idle-hook based; requires the Log bit of BRD_IDLE_STATS)
+// @Field: TimeUS: Time since system startup
+// @Field: Avg: Average true CPU load since the previous PM2 message
+// @Field: Peak: Peak true CPU load since the previous PM2 message
+struct PACKED log_PM2 {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    float avg_load;
+    float peak_load;
+};
+
 #if HAL_UART_STATS_ENABLED
-#define LOG_STRUCTURE_FROM_HAL                          \
+#define LOG_STRUCTURE_FROM_HAL_UART                     \
     { LOG_UART_MSG, sizeof(log_UART),                   \
       "UART","QBfff","TimeUS,I,Tx,Rx,RxDp", "s#BBB", "F----" },
 #else
-#define LOG_STRUCTURE_FROM_HAL
+#define LOG_STRUCTURE_FROM_HAL_UART
 #endif
+
+#if AP_CPU_IDLE_STATS_ENABLED
+#define LOG_STRUCTURE_FROM_HAL_CPU_LOAD                 \
+    { LOG_PM2_MSG, sizeof(log_PM2),                     \
+      "PM2","Qff","TimeUS,Avg,Peak", "s%%", "F00" },
+#else
+#define LOG_STRUCTURE_FROM_HAL_CPU_LOAD
+#endif
+
+#define LOG_STRUCTURE_FROM_HAL                          \
+    LOG_STRUCTURE_FROM_HAL_UART                         \
+    LOG_STRUCTURE_FROM_HAL_CPU_LOAD

--- a/libraries/AP_HAL/Util.h
+++ b/libraries/AP_HAL/Util.h
@@ -195,8 +195,19 @@ public:
     virtual void* last_crash_dump_ptr() const { return nullptr; }
 #endif
 
-    // get the system load
-    virtual bool get_system_load(float& avg_load, float& peak_load) const { return false; }
+    // readers of windowed system load statistics; each reader owns one
+    // measurement window and must have exactly one call site
+    enum class LoadReader : uint8_t {
+        LOG,        // PM2 dataflash logging
+        TAKEOFF,    // vehicle takeoff CPU overload check
+    };
+
+    // consume a reader's window of system load statistics: average and peak
+    // load since the reader's previous call. Ends the reader's window, so
+    // the call cadence sets the window length. Returns false when the window
+    // contains no data: either measurement is not running, or the CPU was so
+    // overloaded that the idle threads never ran during the window.
+    virtual bool consume_system_load(LoadReader reader, float& avg_load, float& peak_load) { return false; }
 
 #if HAL_ENABLE_DFU_BOOT
     virtual void boot_to_dfu(void) {}

--- a/libraries/AP_HAL_ChibiOS/HAL_ChibiOS_Class.cpp
+++ b/libraries/AP_HAL_ChibiOS/HAL_ChibiOS_Class.cpp
@@ -232,13 +232,6 @@ static void main_loop()
 {
     daemon_task = chThdGetSelfX();
 
-#if AP_CPU_IDLE_STATS_ENABLED && HAL_USE_LOAD_MEASURE
-    if (AP_BoardConfig::use_idle_stats()) {
-        sysInitLoadMeasure();
-        sysStartLoadMeasure();
-    }
-#endif
-
     /*
       switch to high priority for main loop
      */
@@ -281,6 +274,13 @@ static void main_loop()
     schedulerInstance.hal_initialized();
 
     g_callbacks->setup();
+
+#if AP_CPU_IDLE_STATS_ENABLED && HAL_USE_LOAD_MEASURE
+    if (AP_BoardConfig::use_idle_stats()) {
+        sysInitLoadMeasure();
+        sysStartLoadMeasure();
+    }
+#endif
 
 #if HAL_ENABLE_SAVE_PERSISTENT_PARAMS
     utilInstance.apply_persistent_params();

--- a/libraries/AP_HAL_ChibiOS/Util.cpp
+++ b/libraries/AP_HAL_ChibiOS/Util.cpp
@@ -382,10 +382,13 @@ __RAMFUNC__ void Util::thread_info(ExpandingString &str)
     // a header to allow for machine parsers to determine format
     const uint32_t isr_stack_size = uint32_t((const uint8_t *)&__main_stack_end__ - (const uint8_t *)&__main_stack_base__);
 #if AP_CPU_IDLE_STATS_ENABLED && HAL_USE_LOAD_MEASURE
-    if (AP_BoardConfig::use_idle_stats()) {
+    if (AP_BoardConfig::idle_stats_enabled(AP_BoardConfig::IdleStats::TO_FILE)) {
+        // let BRD_IDLE_STATS start measurement without a reboot; a no-op
+        // once it is running, and the first read after it reports zero
+        sysStartLoadMeasure();
         // LOAD is the current moving average; PEAK is the peak since the
         // previous read, cleared here; the read does not disturb the
-        // measurement
+        // windowed readers or the measurement
         str.printf("%-13.13s LOAD=%4.1f%% PEAK=%4.1f%%\n", "ThreadsV3", (sysGetCPUAverageLoad() / 100.0f), (sysGetCPUPeakLoad() / 100.0f));
         sysClearCPUPeakLoad();
     } else
@@ -444,18 +447,32 @@ __RAMFUNC__ void Util::thread_info(ExpandingString &str)
 }
 #endif // CH_DBG_ENABLE_STACK_CHECK == TRUE
 
-// get the system load
-bool Util::get_system_load(float& avg_load, float& peak_load) const
+// consume a reader's window of system load statistics; ends the reader's
+// window, so the caller's cadence sets the window length
+bool Util::consume_system_load(LoadReader reader, float& avg_load, float& peak_load)
 {
 #if AP_CPU_IDLE_STATS_ENABLED && HAL_USE_LOAD_MEASURE
     if (AP_BoardConfig::use_idle_stats()) {
-        avg_load = sysGetCPUAverageLoad() / 100.0f;
-        peak_load = sysGetCPUPeakLoad() / 100.0f;
-
-        return true;
+        // let BRD_IDLE_STATS start measurement without a reboot; a no-op
+        // once it is running
+        sysStartLoadMeasure();
     }
-#endif
+    sys_cpu_load_t avg = 0, peak = 0;
+    bool have_data = false;
+    switch (reader) {
+    case LoadReader::LOG:
+        have_data = sysReadResetCPULoad(SYS_LOAD_READER_LOG, &avg, &peak);
+        break;
+    case LoadReader::TAKEOFF:
+        have_data = sysReadResetCPULoad(SYS_LOAD_READER_TAKEOFF, &avg, &peak);
+        break;
+    }
+    avg_load = avg * 0.01f;
+    peak_load = peak * 0.01f;
+    return have_data;
+#else
     return false;
+#endif
 }
 
 

--- a/libraries/AP_HAL_ChibiOS/Util.cpp
+++ b/libraries/AP_HAL_ChibiOS/Util.cpp
@@ -383,7 +383,11 @@ __RAMFUNC__ void Util::thread_info(ExpandingString &str)
     const uint32_t isr_stack_size = uint32_t((const uint8_t *)&__main_stack_end__ - (const uint8_t *)&__main_stack_base__);
 #if AP_CPU_IDLE_STATS_ENABLED && HAL_USE_LOAD_MEASURE
     if (AP_BoardConfig::use_idle_stats()) {
+        // LOAD is the current moving average; PEAK is the peak since the
+        // previous read, cleared here; the read does not disturb the
+        // measurement
         str.printf("%-13.13s LOAD=%4.1f%% PEAK=%4.1f%%\n", "ThreadsV3", (sysGetCPUAverageLoad() / 100.0f), (sysGetCPUPeakLoad() / 100.0f));
+        sysClearCPUPeakLoad();
     } else
 #endif
     str.printf("ThreadsV2\n");
@@ -437,12 +441,6 @@ __RAMFUNC__ void Util::thread_info(ExpandingString &str)
                     unsigned(stack_free(tp->wabase)), unsigned(total_stack));
 #endif
     }
-#if AP_CPU_IDLE_STATS_ENABLED && HAL_USE_LOAD_MEASURE
-    if (AP_BoardConfig::use_idle_stats()) {
-        sysStopLoadMeasure();
-        sysStartLoadMeasure();
-    }
-#endif
 }
 #endif // CH_DBG_ENABLE_STACK_CHECK == TRUE
 

--- a/libraries/AP_HAL_ChibiOS/Util.h
+++ b/libraries/AP_HAL_ChibiOS/Util.h
@@ -153,8 +153,8 @@ private:
     void* last_crash_dump_ptr() const override;
 #endif
 
-    // get the system load
-    bool get_system_load(float& avg_load, float& peak_load) const override;
+    // consume a reader's window of system load statistics
+    bool consume_system_load(LoadReader reader, float& avg_load, float& peak_load) override;
 
 #if HAL_ENABLE_DFU_BOOT
     void boot_to_dfu() override;

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/sysperf.c
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/sysperf.c
@@ -106,6 +106,18 @@ sys_cpu_load_t sysGetCPUPeakLoad(void) {
 }
 
 /**
+ * @brief Clear the peak CPU load so it restarts from the current load.
+ * @note  Called from thread context. No locking is needed: the idle hooks
+ *        that update the peak only run when no other thread is runnable.
+ *
+ * @api
+ */
+void sysClearCPUPeakLoad(void) {
+
+  _load.peak = (sys_cpu_load_t)0;
+}
+
+/**
  * @brief Get the moving average of CPU load.
  *
  * @return CPU average load as percentage * 100

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/sysperf.c
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/sysperf.c
@@ -39,6 +39,24 @@ static sys_load_data_t  _load = {
   .state = SYS_MEASURE_STOP
 };
 
+/**
+ * @brief Per-reader load statistics window
+ */
+typedef struct {
+  uint64_t        run_snapshot;     /**< @brief _total_run at window start. */
+  uint64_t        idle_snapshot;    /**< @brief _total_idle at window start.*/
+  sys_cpu_load_t  peak;             /**< @brief peak load in this window.   */
+} sys_load_window_t;
+
+/* Per-reader windows, updated from the idle hooks, read and restarted by
+   each reader independently via sysReadResetCPULoad().*/
+static sys_load_window_t _windows[SYS_LOAD_READER_COUNT];
+
+/* Monotonic totals of measured run and idle cycles, updated from the idle
+   hooks. 64-bit so they never wrap in practice.*/
+static uint64_t _total_run;
+static uint64_t _total_idle;
+
 /*===========================================================================*/
 /* Module local functions.                                                   */
 /*===========================================================================*/
@@ -118,6 +136,44 @@ void sysClearCPUPeakLoad(void) {
 }
 
 /**
+ * @brief Read a reader's windowed average/peak load and restart its window.
+ * @note  Each reader observes the load accumulated since its own previous
+ *        call, without disturbing the other readers or the moving average.
+ * @note  Called from thread context. No locking is needed: the idle hooks
+ *        that update the shared totals only run when no other thread is
+ *        runnable, so they can never interleave with this function.
+ *
+ * @param[in]  reader  the window to read and restart
+ * @param[out] avg     average load over the window (percentage * 100), or NULL
+ * @param[out] peak    peak load over the window (percentage * 100), or NULL
+ *
+ * @return True if the window contained measured cycles. False means no
+ *         data: measurement is stopped or not yet started, or the CPU had
+ *         no idle time at all during the window (the idle hooks never ran).
+ *
+ * @api
+ */
+bool sysReadResetCPULoad(sys_load_reader_t reader,
+                         sys_cpu_load_t *avg, sys_cpu_load_t *peak) {
+
+  sys_load_window_t *w = &_windows[reader];
+  const uint64_t run  = _total_run - w->run_snapshot;
+  const uint64_t idle = _total_idle - w->idle_snapshot;
+
+  if (avg != NULL) {
+    *avg = (run + idle > 0) ?
+           (sys_cpu_load_t)((run * SYS_CPU_MAX_LOAD) / (run + idle)) : 0;
+  }
+  if (peak != NULL) {
+    *peak = w->peak;
+  }
+  w->run_snapshot = _total_run;
+  w->idle_snapshot = _total_idle;
+  w->peak = 0;
+  return (run + idle) > 0;
+}
+
+/**
  * @brief Get the moving average of CPU load.
  *
  * @return CPU average load as percentage * 100
@@ -189,6 +245,7 @@ void sysIdleEnterMeasure(void) {
 
       /* Stop the run measurement.*/
       chTMStopMeasurementX(&_load.run);
+      _total_run += _load.run.last;
 
       /* Calculate current load from idle to run.*/
       rtcnt_t idle = _load.idle.cumulative / _load.idle.n;
@@ -202,6 +259,13 @@ void sysIdleEnterMeasure(void) {
       _load.average = current;
       if (current > _load.peak) {
         _load.peak = current;
+      }
+
+      /* Track the peak for each reader's window.*/
+      for (int i = 0; i < SYS_LOAD_READER_COUNT; i++) {
+        if (current > _windows[i].peak) {
+          _windows[i].peak = current;
+        }
       }
 
       /* Scale TM accumulator every second.*/
@@ -250,6 +314,7 @@ void sysIdleLeaveMeasure(void) {
 
       /* RTOS has exited idle so capture time now.*/
       chTMStopMeasurementX(&_load.idle);
+      _total_idle += _load.idle.last;
 
       /* Scale TM accumulator every second.*/
       if (_load.idle.cumulative > SystemCoreClock) {

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/sysperf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/sysperf.h
@@ -88,6 +88,7 @@ extern "C" {
   bool            sysStartLoadMeasure(void);
   bool            sysStopLoadMeasure(void);
   sys_cpu_load_t  sysGetCPUPeakLoad(void);
+  void            sysClearCPUPeakLoad(void);
   sys_cpu_load_t  sysGetCPUAverageLoad(void);
   msg_t           sysGetCPULoadStatistics(sys_load_stats_t *stats);
 #endif /* HAL_USE_LOAD_MEASURE == TRUE */

--- a/libraries/AP_HAL_ChibiOS/hwdef/common/sysperf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/sysperf.h
@@ -46,6 +46,17 @@
 typedef uint16_t  sys_cpu_load_t;   /**< @brief CPU load in percent * 100.  */
 
 /**
+ * @brief Independent readers of windowed load statistics.
+ * @note  Each reader observes the average and peak load accumulated over its
+ *        own window, delimited by its own calls to sysReadResetCPULoad().
+ */
+typedef enum {
+  SYS_LOAD_READER_LOG = 0,          /**< @brief PM2 dataflash logging.     */
+  SYS_LOAD_READER_TAKEOFF,          /**< @brief vehicle takeoff load check.*/
+  SYS_LOAD_READER_COUNT
+} sys_load_reader_t;
+
+/**
  * @brief Load measurement control structure
  */
 typedef struct {
@@ -90,6 +101,8 @@ extern "C" {
   sys_cpu_load_t  sysGetCPUPeakLoad(void);
   void            sysClearCPUPeakLoad(void);
   sys_cpu_load_t  sysGetCPUAverageLoad(void);
+  bool            sysReadResetCPULoad(sys_load_reader_t reader,
+                                      sys_cpu_load_t *avg, sys_cpu_load_t *peak);
   msg_t           sysGetCPULoadStatistics(sys_load_stats_t *stats);
 #endif /* HAL_USE_LOAD_MEASURE == TRUE */
   void            sysIdleEnterMeasure(void);

--- a/libraries/AP_Scheduler/AP_Scheduler.cpp
+++ b/libraries/AP_Scheduler/AP_Scheduler.cpp
@@ -25,6 +25,7 @@
 
 #include "AP_Scheduler.h"
 
+#include <AP_BoardConfig/AP_BoardConfig.h>
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_Vehicle/AP_Vehicle.h>
@@ -440,6 +441,10 @@ void AP_Scheduler::update_logging()
         AP::logger().should_log(_log_performance_bit)) {
         Log_Write_Performance();
     }
+#if AP_CPU_IDLE_STATS_ENABLED
+    // gated by the Log bit of BRD_IDLE_STATS
+    Log_Write_CPU_Load();
+#endif
     perf_info.set_loop_rate(get_loop_rate_hz());
     perf_info.reset();
     // dynamically update the per-task perf counter
@@ -479,6 +484,29 @@ void AP_Scheduler::Log_Write_Performance()
     };
     AP::logger().WriteCriticalBlock(&pkt, sizeof(pkt));
 }
+
+#if AP_CPU_IDLE_STATS_ENABLED
+// write out PM2 message with windowed true CPU load (avg + peak since the
+// previous message)
+void AP_Scheduler::Log_Write_CPU_Load()
+{
+    // gated by the Log bit of BRD_IDLE_STATS, which also starts load
+    // measurement at boot
+    if (!AP_BoardConfig::idle_stats_enabled(AP_BoardConfig::IdleStats::TO_LOG)) {
+        return;
+    }
+    float cpu_avg = 0, cpu_peak = 0;
+    if (hal.util->consume_system_load(AP_HAL::Util::LoadReader::LOG, cpu_avg, cpu_peak)) {
+        const struct log_PM2 pm2_pkt {
+            LOG_PACKET_HEADER_INIT(LOG_PM2_MSG),
+            time_us   : AP_HAL::micros64(),
+            avg_load  : cpu_avg,
+            peak_load : cpu_peak,
+        };
+        AP::logger().WriteCriticalBlock(&pm2_pkt, sizeof(pm2_pkt));
+    }
+}
+#endif
 #endif  // HAL_LOGGING_ENABLED
 
 // display task statistics as text buffer for @SYS/tasks.txt

--- a/libraries/AP_Scheduler/AP_Scheduler.h
+++ b/libraries/AP_Scheduler/AP_Scheduler.h
@@ -117,6 +117,12 @@ public:
     // write out PERF message to logger
     void Log_Write_Performance();
 
+#if AP_CPU_IDLE_STATS_ENABLED
+    // write out PM2 message with true CPU load when the Log bit of
+    // BRD_IDLE_STATS is set
+    void Log_Write_CPU_Load();
+#endif
+
     // call when one tick has passed
     void tick(void);
 


### PR DESCRIPTION
### Summary

Log true CPU load from https://github.com/ArduPilot/ardupilot/pull/30913

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

### Description

In #30913, Andy mentioned he planned to add this to PM logging. I've decided to take a stab at this since I'd like to log this at Carbonix.

One drive-by bug fix, the original init stuff in `libraries/AP_HAL_ChibiOS/HAL_ChibiOS_Class.cpp‎` was unreachable, since it was checking a param value before the params were initialized (confirmed on a hardware debugger on a CubeOrangePlus)
