### PR TITLE
Avoid using hard-coded 5762 for Solo gimbal

### DIFF
--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -49,7 +49,9 @@ void SITL_State::_sitl_setup()
         _update_airspeed(0);
 #if AP_SIM_SOLOGIMBAL_ENABLED
         if (enable_gimbal) {
-            gimbal = NEW_NOTHROW SITL::SoloGimbal();
+            // the gimbal connects back to the vehicle's SERIAL2 MAVLink
+            // port, which is base_port + 2 (offset by the SITL instance):
+            gimbal = NEW_NOTHROW SITL::SoloGimbal(base_port() + 2);
         }
 #endif
 

--- a/libraries/SITL/SIM_SoloGimbal.h
+++ b/libraries/SITL/SIM_SoloGimbal.h
@@ -38,13 +38,16 @@ namespace SITL {
 class SoloGimbal {
 public:
 
-    SoloGimbal() {}
+    // target_port is the vehicle's MAVLink port the gimbal connects back
+    // to (SERIAL2).  It is offset by the SITL instance number, so it must
+    // be supplied rather than hard-coded.
+    SoloGimbal(uint16_t _target_port = 5762) : target_port(_target_port) {}
     void update(const Aircraft &aicraft);
 
 private:
 
     const char *target_address = "127.0.0.1";
-    const uint16_t target_port = 5762;
+    const uint16_t target_port;
 
     // physic simulation of gimbal:
     Gimbal gimbal;


### PR DESCRIPTION
### Summary

Adjusts port to account we may not be instance 0.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Fixes the problem where the port isn't necessarily the one we're supposed to be using because `-I` has been used to shift the ports.
