### PR TITLE
Plane: widen FBWB_CLIMB_RATE to float

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1478,6 +1478,9 @@ void Plane::load_parameters(void)
 
     g.use_reverse_thrust.convert_parameter_width(AP_PARAM_INT16);
 
+    // PARAMETER_CONVERSION - Added: Jun-2026 for FBWB_CLIMB_RATE width change
+    g.flybywire_climb_rate.convert_parameter_width(AP_PARAM_INT8);
+
 #if AP_AIRSPEED_ENABLED
     // PARAMETER_CONVERSION - Added: Jan-2022
     {

--- a/ArduPlane/Parameters.h
+++ b/ArduPlane/Parameters.h
@@ -400,7 +400,7 @@ public:
     // Fly-by-wire
     //
     AP_Int8 flybywire_elev_reverse;
-    AP_Int8 flybywire_climb_rate;
+    AP_Float flybywire_climb_rate;
 
     // Throttle
     //


### PR DESCRIPTION
### Summary

Make FBWB_CLIMB_RATE a float instead of an int, to match the existing documentation.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

Tested the param conversion and param behavior in SITL.

### Description

Integer steps of meters per second for a plane climb rate is a bit big, and given the param metadata suggesting a 0.1 increment, I believe this param was originally intended to be a float, and this had gone unnoticed since it went in.

Alternatively, we could change the doc to increase the increment and warn that this is an integer, but this PR felt more appropriate.