### PR TITLE
AP_FlashStorage: Add support for XTX XT25F128F nor flash chip

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem_FlashMemory_LittleFS.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_FlashMemory_LittleFS.cpp
@@ -622,6 +622,7 @@ void AP_Filesystem_FlashMemory_LittleFS::mark_dead()
 #define JEDEC_ID_FMSH_FM25Q64          0xA14017
 #define JEDEC_ID_FMSH_FM25Q128A        0xA14018
 #define JEDEC_ID_FMSH_FM25Q256         0xA14019
+#define JEDEC_ID_XTX_XT25F128F         0x0B4018
 
 /* Hardware-specific constants */
 
@@ -795,6 +796,7 @@ uint32_t AP_Filesystem_FlashMemory_LittleFS::find_block_size_and_count() {
     case JEDEC_ID_CYPRESS_S25FL128L:
     case JEDEC_ID_ZBIT_ZB25VQ128:   
     case JEDEC_ID_FMSH_FM25Q128A:
+    case JEDEC_ID_XTX_XT25F128F:
         block_count = 256;    /* 16MiB */
         break;
 

--- a/libraries/AP_Logger/AP_Logger_Flash_JEDEC.cpp
+++ b/libraries/AP_Logger/AP_Logger_Flash_JEDEC.cpp
@@ -62,6 +62,7 @@ extern const AP_HAL::HAL& hal;
 #define JEDEC_ID_FMSH_FM25Q64          0xA14017
 #define JEDEC_ID_FMSH_FM25Q128A        0xA14018
 #define JEDEC_ID_FMSH_FM25Q256         0xA14019
+#define JEDEC_ID_XTX_XT25F128F         0x0B4018
 
 void AP_Logger_Flash_JEDEC::Init()
 {
@@ -154,6 +155,7 @@ bool AP_Logger_Flash_JEDEC::getSectorCount(void)
     case JEDEC_ID_FMSH_FM25Q128A:
     case JEDEC_ID_CYPRESS_S25FL128L:
     case JEDEC_ID_ZBIT_ZB25VQ128:   
+    case JEDEC_ID_XTX_XT25F128F:
         blocks = 256;
         df_PagePerBlock = 256;
         df_PagePerSector = 16;


### PR DESCRIPTION
Summary
[Y] Checked by a human programmer
[Y] Non-functional change
[Y] No-binary change
[Y] Tested on hardware(SPEDIXF405)

Description
Verified on SPEDIXF405 target.
Datasheet:https://www.xtxtech.com/Products/info_productModel_XT25F128FSSIGT.html