### PR TITLE
autotest: remove unnecessary contexts

### DIFF
--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -8,6 +8,7 @@ AP_FLAKE8_CLEAN
 '''
 
 import os
+import re
 
 from math import degrees
 from math import radians
@@ -23,6 +24,9 @@ from vehicle_test_suite import NotAchievedException
 testdir = os.path.dirname(os.path.realpath(__file__))
 
 SITL_START_LOCATION = mavutil.location(33.810313, -118.393867, 0, 185)
+
+# Extract true range from STATUSTEXT messages sent by sub_test_synthetic_seafloor.lua
+RE_TR_SEARCH = re.compile(r'#TR#\s*([-+]?\d*\.?\d+)')
 
 
 class Joystick():
@@ -96,8 +100,6 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
     def WaterDepth(self):
         """Check WATER_DEPTH MAVLink message support for ArduSub"""
 
-        self.context_push()
-
         # Setup rangefinders
         self.customise_SITL_commandline([
             "--serial7=sim:nmea", # NMEA Rangefinder
@@ -130,7 +132,6 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.assert_message_rate_hz('WATER_DEPTH', 2)
 
         self.disarm_vehicle()
-        self.context_pop()
 
     def is_sub(self):
         return True
@@ -274,7 +275,6 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.wait_ready_to_arm()
         self.arm_vehicle()
         self.set_parameter("MAV_GCS_SYSID", self.mav.source_system)
-        self.context_push()
         self.setGCSfailsafe(4)
         self.set_heartbeat_rate(0)
         self.wait_mode("SURFACE")
@@ -282,13 +282,11 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.wait_statustext("GCS Failsafe Cleared", timeout=60)
         self.progress("GSC Failsafe OK")
         self.disarm_vehicle()
-        self.context_pop()
 
     # Tests actions and logic behind the radio failsafe
     def ThrottleFailsafe(self):
         '''Test RC and RC Failsafe'''
         # disable GCS and enable RC
-        self.context_push()
         self.set_parameter('FS_GCS_ENABLE', 0)
         self.set_parameter('RC_PROTOCOLS', 1)
         self.set_heartbeat_rate(0)
@@ -300,7 +298,6 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         # Switch RC failsafe action to SURFACE, should take action since we are in RC failsafe
         self.set_parameter('FS_THR_ENABLE', 2)
         self.wait_mode("SURFACE")
-        self.context_pop()
         self.progress("Completed Radio failsafe disabled test")
 
     def Surftrak(self):
@@ -309,7 +306,6 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.assert_parameter_value('RNGFND1_MAX', 30)
 
         # Something closer to Bar30 noise
-        self.context_push()
         self.set_parameter("SIM_BARO_RND", 0.01)
 
         # Dive to -5m, outside of rangefinder range, will act like ALT_HOLD
@@ -346,7 +342,6 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.watch_distance_maintained()
 
         self.disarm_vehicle()
-        self.context_pop()
 
     def prepare_synthetic_seafloor_test(self, sea_floor_depth, rf_target):
         self.set_parameters({
@@ -373,13 +368,11 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
 
         def get_true_distance():
             """Return the True distance from the simulated range finder"""
-            m_true = self.mav.recv_match(type='STATUSTEXT', blocking=True, timeout=3.0)
-            if m_true is None:
-                return m_true
-            idx_tr = m_true.text.find('#TR#')
-            if idx_tr < 0:
+            m_true = self.assert_receive_message('STATUSTEXT', timeout=3.0)
+            match = RE_TR_SEARCH.search(m_true.text)
+            if not match:
                 return None
-            return float(m_true.text[(idx_tr+4):(idx_tr+12)])
+            return float(match.group(1))
 
         tstart = self.get_sim_time_cached()
         self.progress('Distance to be watched: %.2f (+/- %.2f)' % (match_distance, delta))
@@ -420,7 +413,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         end_altitude = start_altitude - 10
         validation_delta = 1.5  # Largest allowed distance between sub height and desired height
 
-        self.context_push()
+        # Load the synthetic seafloor, this will push a context and reboot
         self.prepare_synthetic_seafloor_test(sea_floor_depth, match_distance)
 
         # Dive to match_distance off the bottom in preparation for the mission
@@ -452,9 +445,8 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
 
         self.set_rc(Joystick.Forward, 1500)
 
+        # Disarm before context pop
         self.disarm_vehicle()
-        self.context_pop()
-        self.reboot_sitl()  # e.g. revert rangefinder configuration
 
     def SimTerrainMission(self):
         """Mission at a constant height above synthetic sea floor"""
@@ -465,7 +457,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         end_altitude = start_altitude - 10
         validation_delta = 1.5  # Largest allowed distance between sub height and desired height
 
-        self.context_push()
+        # Load the synthetic seafloor, this will push a context and reboot
         self.prepare_synthetic_seafloor_test(sea_floor_depth, match_distance)
 
         # The synthetic seafloor has an east-west ridge south of the sub.
@@ -484,9 +476,8 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.wait_altitude(altitude_min=end_altitude-validation_delta/2, altitude_max=end_altitude+validation_delta/2,
                            relative=False, timeout=1)
 
+        # Disarm before context pop
         self.disarm_vehicle()
-        self.context_pop()
-        self.reboot_sitl()  # e.g. revert rangefinder configuration
 
     def ModeChanges(self, delta=0.2):
         """Check if alternating between ALTHOLD, STABILIZE, POSHOLD and SURFTRAK (mode 21) affects altitude"""
@@ -935,7 +926,6 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
 
     def SetGlobalOrigin(self):
         """Test SET_GPS_GLOBAL_ORIGIN mav msg"""
-        self.context_push()
         self.set_parameters({
             'GPS1_TYPE': 0,             # Disable the GPS
             'EK3_SRC1_POSXY': 0,        # Make sure EK3_SRC parameters do not refer to a GPS
@@ -961,15 +951,9 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         if num_mavlink_origin_msgs != 1:
             raise NotAchievedException("Expected 1 GPS_GLOBAL_ORIGIN message, found %d" % num_mavlink_origin_msgs)
 
-        self.context_pop()
-
-        # restart GPS driver
-        self.reboot_sitl()
-
     def BackupOrigin(self):
         """Test AHRS_ORIGIN_LAT and AHRS_ORIGIN_LON parameters"""
 
-        self.context_push()
         self.set_parameters({
             'GPS1_TYPE': 0,             # Disable GPS
             'EK3_SRC1_POSXY': 0,        # Make sure EK3_SRC parameters do not refer to GPS
@@ -988,8 +972,6 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         # check that origin has been logged
         if not self.current_onboard_log_contains_message('ORGN'):
             raise NotAchievedException("Did not find expected ORGN message")
-
-        self.context_pop()
 
     def assert_mag_fusion_selection(self, expect_sel):
         """Get the most recent XKFS message and check the MAG_FUSION value"""
@@ -1274,7 +1256,6 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.wait_altitude(altitude_min=-10, altitude_max=-9, relative=False, timeout=60)
         self.set_rc(Joystick.Throttle, 1500)
 
-        self.context_push()
         self.setGCSfailsafe(4)
         self.set_parameter("SIM_BARO_DISABLE", 1)
         self.set_heartbeat_rate(0)
@@ -1286,7 +1267,6 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.wait_statustext("GCS Failsafe Cleared", timeout=60)
         self.progress("Baro-less Surface mode OK")
         self.disarm_vehicle()
-        self.context_pop()
 
     def UTMGlobalPositionWaypoint(self):
         '''test UTM_GLOBAL_POSITION waypoint fields in AUTO'''


### PR DESCRIPTION
### Summary

Remove unnecessary calls to `context_push`, `context_pop` and `reboot_sitl` in Sub autotests.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

This pulls in the autotest changes that were approved in https://github.com/ArduPilot/ardupilot/pull/27767 but unrelated to the purpose of that PR. Summarizing those changes:
* Extra calls to `context_push`, `context_pop` and `reboot_sitl` were removed from  several tests.
* `watch_true_distance_maintained` was changed to use `re`.

I also examined all other Sub tests and removed more unnecessary calls to `context_push`, `context_pop` and `reboot_sitl`. I think I found them all.