### PR TITLE
AP_MAVLinkCAN: reject negative CAN bus indices

### DIFF
--- a/libraries/AP_CANManager/AP_MAVLinkCAN.cpp
+++ b/libraries/AP_CANManager/AP_MAVLinkCAN.cpp
@@ -78,7 +78,7 @@ bool AP_MAVLinkCAN::_handle_can_forward(mavlink_channel_t chan, const mavlink_co
         return true;
     }
 
-    if (bus >= HAL_NUM_CAN_IFACES || hal.can[bus] == nullptr) {
+    if (bus < 0 || bus >= HAL_NUM_CAN_IFACES || hal.can[bus] == nullptr) {
         return false;
     }
 

--- a/libraries/AP_CANManager/AP_MAVLinkCAN.cpp
+++ b/libraries/AP_CANManager/AP_MAVLinkCAN.cpp
@@ -82,7 +82,7 @@ bool AP_MAVLinkCAN::_handle_can_forward(mavlink_channel_t chan, const mavlink_co
         return false;
     }
 
-    if (can_forward.callback_id != 0 && can_forward.callback_bus != bus) {
+    if (can_forward.callback_id != 0 && can_forward.callback_bus != bus && can_forward.callback_bus < HAL_NUM_CAN_IFACES) {
         /*
           the client is changing which bus they are monitoring, unregister from the previous bus
          */


### PR DESCRIPTION
### Summary

<!-- Put a one or two line summary of what your PR does here -->

AP_MAVLinkCAN converts the requested CAN bus to a signed integer in some functions, which can cause an out of bounds access before the `hal.can` array, more details blow. This change adds a lower bounds check where it is treated as a signed index.

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [X] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [X] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

Tested with the reproducible script below with ardupilot running in SITL with gdb to verify that the change now blocks the under-read from happening.

### Description

<!-- Describe the PR's content here -->

Currently, `AP_MAVLinkCAN::_handle_can_forward` translates the requested CAN bus to a signed index:
`const int8_t bus = int8_t(packet.param1)-1;`

However, there is no lower bounds check before accessing `hal.can[bus]`. There is an upper bounds check for `bus` and a NULL check for `hal.can[bus]`, however certain negative values for `bus` pass the NULL check and cause a segmentation fault on the later call to `!hal.can[bus]->register_frame_callback(...)`

The change rejects a `bus < 0` after the existing case of `bus == -1` to prevent this error.

`AP_MAVLinkCAN::_handle_can_filter_modify` contains the same signed index translation, but doesn't actually use it to access any memory apart from the NULL check, so I decided to leave it out of this change.

To verify this issue, I created this script, which reproduces the fault running SITL on master. I tested all of the main vehicles which all produce the same error.

```
from pymavlink import mavutil
import time

mav = mavutil.mavlink_connection(
    "tcp:127.0.0.1:5760",
    dialect="ardupilotmega",
)

mav.mav.command_int_send(
    0,      # target_system
    0,      # target_component
    0,      # frame
    32000,  # command, MAV_CMD_CAN_FORWARD
    0,      # current
    0,      # autocontinue

    244,    # param1, bus == -13 after int8_t conversion
    0,      # param2
    0,      # param3
    0,      # param4

    0,  # x
    0,  # y
    0,  # z
)

time.sleep(10)
```

I decided to make a pull request instead of an issue since it is a very minor change, however if this was the wrong call let me know and I can close the pull request and open an issue instead.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
