### PR TITLE
Make using-extnav-for-yaw come from estimates object

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -2770,28 +2770,14 @@ bool AP_AHRS::using_noncompass_for_yaw(void) const
 // check if external nav is providing yaw
 bool AP_AHRS::using_extnav_for_yaw(void) const
 {
-    switch (active_EKF_type()) {
-#if HAL_NAVEKF2_AVAILABLE
-    case EKFType::TWO:
-        return ekf2.EKF2.isExtNavUsedForYaw();
-#endif
-#if AP_AHRS_DCM_ENABLED
-    case EKFType::DCM:
-#endif
-#if HAL_NAVEKF3_AVAILABLE
-    case EKFType::THREE:
-        return ekf3.EKF3.using_extnav_for_yaw();
-#endif
-#if AP_AHRS_SIM_ENABLED
-    case EKFType::SIM:
-#endif
-#if AP_AHRS_EXTERNAL_ENABLED
-    case EKFType::EXTERNAL:
-#endif
-        return false;
+#if AP_AHRS_DCM_ENABLED && HAL_NAVEKF3_AVAILABLE
+    // FIXME: DCM uses EKF3's answer (which is not necessarily the
+    // configured type)
+    if (active_estimates == &dcm_estimates) {
+        return ekf3_estimates.using_extnav_for_yaw;
     }
-    // since there is no default case above, this is unreachable
-    return false;
+#endif
+    return active_estimates->using_extnav_for_yaw;
 }
 
 // set and save the alt noise parameter value

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -2743,28 +2743,14 @@ void AP_AHRS::Log_Write()
 // check if non-compass sensor is providing yaw.  Allows compass pre-arm checks to be bypassed
 bool AP_AHRS::using_noncompass_for_yaw(void) const
 {
-    switch (active_EKF_type()) {
-#if HAL_NAVEKF2_AVAILABLE
-    case EKFType::TWO:
-        return ekf2.EKF2.isExtNavUsedForYaw();
-#endif
-#if AP_AHRS_DCM_ENABLED
-    case EKFType::DCM:
-#endif
-#if HAL_NAVEKF3_AVAILABLE
-    case EKFType::THREE:
-        return ekf3.EKF3.using_noncompass_for_yaw();
-#endif
-#if AP_AHRS_SIM_ENABLED
-    case EKFType::SIM:
-#endif
-#if AP_AHRS_EXTERNAL_ENABLED
-    case EKFType::EXTERNAL:
-#endif
-        return false; 
+#if AP_AHRS_DCM_ENABLED && HAL_NAVEKF3_AVAILABLE
+    // FIXME: DCM uses EKF3's answer (which is not necessarily the
+    // configured type)
+    if (active_estimates == &dcm_estimates) {
+        return ekf3_estimates.using_noncompass_for_yaw;
     }
-    // since there is no default case above, this is unreachable
-    return false;
+#endif
+    return active_estimates->using_noncompass_for_yaw;
 }
 
 // check if external nav is providing yaw

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -160,6 +160,10 @@ public:
         // recognition
         bool using_extnav_for_yaw;
 
+        // if true then however the yaw in these estimates was derived
+        // a compass was not involved:
+        bool using_noncompass_for_yaw;
+
     private:
         bool hagl_valid;
         float hagl;

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -154,6 +154,12 @@ public:
         // navigation origin.
         bool configured_to_use_gps_for_pos_XY;
 
+        // if true, "external navigation" (as provided by MAVLink
+        // messages) is providing the yaw estimate.  e.g. a T265
+        // vision-position-estimate camera tracking yaw via image
+        // recognition
+        bool using_extnav_for_yaw;
+
     private:
         bool hagl_valid;
         float hagl;

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -195,6 +195,9 @@ void AP_AHRS_DCM::get_results(AP_AHRS_Backend::Estimates &results)
     // for this estimator.  Used to decide whether GPS will set
     // the navigation origin.
     results.configured_to_use_gps_for_pos_XY = _gps_use != GPSUse::Disable;
+
+    // are we consuming yaw from an external (e.g. vision-based) source?
+    // results.using_extnav_for_yaw = false;
 }
 
 /*

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -198,6 +198,9 @@ void AP_AHRS_DCM::get_results(AP_AHRS_Backend::Estimates &results)
 
     // are we consuming yaw from an external (e.g. vision-based) source?
     // results.using_extnav_for_yaw = false;
+
+    // are we consuming yaw from a source which is *not* a compass
+    // results.using_noncompass_for_yaw = false;
 }
 
 /*

--- a/libraries/AP_AHRS/AP_AHRS_External.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_External.cpp
@@ -87,6 +87,10 @@ void AP_AHRS_External::get_results(AP_AHRS_Backend::Estimates &results)
     // for this estimator.  Used to decide whether GPS will set
     // the navigation origin.
     results.configured_to_use_gps_for_pos_XY = true;
+
+    // are we consuming yaw from an external (e.g. vision-based) source?
+    // this relates only to external sources being passed in via mavlink
+    // results.using_extnav_for_yaw = false;
 }
 
 bool AP_AHRS_External::get_relative_position_NED_origin(Vector3p &vec) const

--- a/libraries/AP_AHRS/AP_AHRS_External.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_External.cpp
@@ -91,6 +91,9 @@ void AP_AHRS_External::get_results(AP_AHRS_Backend::Estimates &results)
     // are we consuming yaw from an external (e.g. vision-based) source?
     // this relates only to external sources being passed in via mavlink
     // results.using_extnav_for_yaw = false;
+
+    // are we consuming yaw from a source which is *not* a compass
+    // results.using_noncompass_for_yaw = false;
 }
 
 bool AP_AHRS_External::get_relative_position_NED_origin(Vector3p &vec) const

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF2.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF2.cpp
@@ -102,6 +102,9 @@ void AP_AHRS_NavEKF2::get_results(AP_AHRS_Backend::Estimates &results)
     // this estimator.  Used to decide whether GPS will set the
     // navigation origin:
     results.configured_to_use_gps_for_pos_XY = EKF2.configuredToUseGPSForPosXY();
+
+    // are we consuming yaw from an external (e.g. vision-based) source?
+    results.using_extnav_for_yaw = EKF2.isExtNavUsedForYaw();
 }
 
 bool AP_AHRS_NavEKF2::pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF2.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF2.cpp
@@ -105,6 +105,9 @@ void AP_AHRS_NavEKF2::get_results(AP_AHRS_Backend::Estimates &results)
 
     // are we consuming yaw from an external (e.g. vision-based) source?
     results.using_extnav_for_yaw = EKF2.isExtNavUsedForYaw();
+
+    // are we consuming yaw from a source which is *not* a compass
+    results.using_noncompass_for_yaw = EKF2.isExtNavUsedForYaw();
 }
 
 bool AP_AHRS_NavEKF2::pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
@@ -106,6 +106,10 @@ void AP_AHRS_NavEKF3::get_results(AP_AHRS_Backend::Estimates &results)
 
     // are we consuming yaw from an external (e.g. vision-based) source?
     results.using_extnav_for_yaw = EKF3.using_extnav_for_yaw();
+
+    // are we consuming yaw from a source which is *not* a compass
+    // (e.g. the GSF)
+    results.using_noncompass_for_yaw = EKF3.using_noncompass_for_yaw();
 }
 
 bool AP_AHRS_NavEKF3::pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
@@ -103,6 +103,9 @@ void AP_AHRS_NavEKF3::get_results(AP_AHRS_Backend::Estimates &results)
     // for this estimator.  Used to decide whether GPS will set
     // the navigation origin:
     results.configured_to_use_gps_for_pos_XY = EKF3.configuredToUseGPSForPos();
+
+    // are we consuming yaw from an external (e.g. vision-based) source?
+    results.using_extnav_for_yaw = EKF3.using_extnav_for_yaw();
 }
 
 bool AP_AHRS_NavEKF3::pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const

--- a/libraries/AP_AHRS/AP_AHRS_SIM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_SIM.cpp
@@ -240,6 +240,10 @@ void AP_AHRS_SIM::get_results(AP_AHRS_Backend::Estimates &results)
     // are we consuming yaw from an external (e.g. vision-based) source?
     // results.using_extnav_for_yaw = false;
 
+    // are we consuming yaw from a source which is *not* a compass
+    // (e.g. the GSF)
+    // results.using_noncompass_for_yaw = false;
+
 #if HAL_NAVEKF3_AVAILABLE
     if (_sitl->odom_enable) {
         // use SITL states to write body frame odometry data at 20Hz

--- a/libraries/AP_AHRS/AP_AHRS_SIM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_SIM.cpp
@@ -237,6 +237,9 @@ void AP_AHRS_SIM::get_results(AP_AHRS_Backend::Estimates &results)
     // the navigation origin:
     results.configured_to_use_gps_for_pos_XY = true;
 
+    // are we consuming yaw from an external (e.g. vision-based) source?
+    // results.using_extnav_for_yaw = false;
+
 #if HAL_NAVEKF3_AVAILABLE
     if (_sitl->odom_enable) {
         // use SITL states to write body frame odometry data at 20Hz


### PR DESCRIPTION
### Summary

Groups the result of the "is the active backend using an external yaw source" call with the other results (like... estimated yaw....)

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                 *                                                   
Durandal                            56              24     *           32      128               48     24     48
Hitec-Airspeed           *                                 *                                                   
KakuteH7-bdshot                     32              8      *           8       24                -16    8      -128
MatekF405                           64              48     *           40      48                136    48     40
MatekH7A3                           56              24     *           56      32                112    24     24
Pixhawk1-1M-bdshot                  48              16                 48      40                120    -64    -88
SITL_x86_64_linux_gnu               72              0                  0       0                 0      0      0
YJUAV_A6SE                          32              16     *           24      -8                0      -8     8
f103-QiotekPeriph        *                                 *                                                   
f303-MatekGPS            *                                 *                                                   
f303-Universal           *                                 *                                                   
iomcu                                                                                *                         
mindpx-v2                           64              48     *           24      24                16     8      -144
revo-mini                           80              48     *           72      72                48     64     56
skyviper-v2450                                                         40                                      
speedybeef4                         88              48     *           48      64                216    40     64
```
(updated the usage for the extra patch)


### Description

Uses the active backend estimates for what they are good for.

With bonus hackery for DCM-bootstrapping for yaw alignment.  That hackery is deliberate and has been in there since the start.

We should probably revisit why DCM is involved in these decisions.  Quite possibly DCM was being used because the yaw source was un-aligned and thus yaw not available to the EKF3 and thus EKF3 not available.  So this would essentially be bootstrapping the EKF from DCM's yaw.  If we want a bootstrap yaw we should probably add a method to get that - which would step through each of the backends in turn and return the yaw estimate from the first good backend it finds.  THis will allow e.g. CINS to be used in place of DCM for a backup estimator, for example.  Once we get secondary/tertiary estimators we would probably check them for a yaw estimate before iterating the backends.

Alternatively we could expect people to bootstrap the EKF's yaw from an alternate source set (source sets postdate the T265 support, I think).
