### PR TITLE
AP_GPS: include attitude correction in moving-baseline GPS yaw

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -13429,6 +13429,90 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             raise NotAchievedException("Expected to get GPS-from-yaw (want %f got %f)" % (want, m.yaw))
         self.wait_ready_to_arm()
 
+    def GPSForYawAttitudeCorrection(self):
+        '''Moving baseline GPS yaw must correct for vehicle roll/pitch'''
+        # The moving-baseline GPS reports the antenna baseline heading in the
+        # NED horizontal plane.  To recover the vehicle yaw, the GPS backend
+        # must rotate the body-frame antenna offset by the vehicle roll/pitch
+        # before taking its bearing.  We give the baseline a large vertical
+        # (Z) component so that a modest vehicle lean swings the apparent
+        # horizontal bearing by tens of degrees: without the attitude
+        # correction the reported GPS yaw is then wrong by a similar amount.
+        self.context_push()
+        self.load_default_params_file("copter-gps-for-yaw.parm")
+        self.set_parameters({
+            # Use the compass for the EKF/flight yaw so the moving-baseline GPS
+            # yaw under test never feeds back into attitude control: the GPS
+            # backend still computes its yaw and reports it in GPS2_RAW, but a
+            # wrong value cannot destabilise the circle we fly to lean the
+            # vehicle.  This isolates the GPS backend maths.
+            "EK3_SRC1_YAW": 1,
+            # Antenna baseline: small fore-aft (X) plus large vertical (Z)
+            # separation, no lateral (Y).  When level the baseline is on the
+            # nose so the recovered yaw equals the vehicle yaw; under roll the
+            # vertical component projects into the horizontal plane.
+            "GPS1_POS_X": -0.15, "GPS1_POS_Y": 0.0, "GPS1_POS_Z": -0.45,
+            "GPS2_POS_X": 0.15, "GPS2_POS_Y": 0.0, "GPS2_POS_Z": 0.45,
+            "SIM_GPS1_POS_X": -0.15, "SIM_GPS1_POS_Y": 0.0, "SIM_GPS1_POS_Z": -0.45,
+            "SIM_GPS2_POS_X": 0.15, "SIM_GPS2_POS_Y": 0.0, "SIM_GPS2_POS_Z": 0.45,
+            # Remove the simulator's heading lag back-projection so the reported
+            # heading reflects the instantaneous attitude.  Otherwise the steady
+            # turn rate of the circle would add a lag term the backend does not
+            # undo, confounding the comparison against truth.
+            "SIM_GPS1_LAG_MS": 0,
+            "SIM_GPS2_LAG_MS": 0,
+        })
+        self.reboot_sitl()
+
+        self.wait_gps_fix_type_gte(6, message_type="GPS2_RAW", verbose=True)
+        self.wait_ready_to_arm()
+        self.takeoff(20, mode='GUIDED')
+
+        # fly a gentle circle to hold a steady, modest lean angle.  A large
+        # radius keeps the turn rate (and hence any residual yaw lag) small.
+        self.set_parameters({
+            "CIRCLE_RADIUS_M": 50,
+            "CIRCLE_RATE": 12,
+        })
+        self.change_mode('CIRCLE')
+
+        # Sample the reported GPS yaw against truth while the vehicle is
+        # banked.  With the attitude correction in place the error stays
+        # small; without it the error is tens of degrees and this raises.
+        min_roll_deg = 10
+        max_yaw_err_deg = 15
+        wanted_samples = 10
+        good_samples = 0
+        tstart = self.get_sim_time()
+        while True:
+            if self.get_sim_time_cached() - tstart > 90:
+                raise NotAchievedException(
+                    "Only gathered %u/%u banked GPS-yaw samples" % (good_samples, wanted_samples))
+            gps = self.assert_receive_message("GPS2_RAW")
+            if gps.yaw == 0:
+                # 0 means yaw not available (north is reported as 36000)
+                continue
+            sim = self.assert_receive_message("SIMSTATE")
+            roll_deg = math.degrees(sim.roll)
+            if abs(roll_deg) < min_roll_deg:
+                continue
+            gps_yaw_deg = gps.yaw * 0.01
+            true_yaw_deg = math.degrees(sim.yaw)
+            yaw_err_deg = abs(mavextra.wrap_180(gps_yaw_deg - true_yaw_deg))
+            self.progress("roll=%.1f gps_yaw=%.1f true_yaw=%.1f err=%.1f" %
+                          (roll_deg, gps_yaw_deg, true_yaw_deg, yaw_err_deg))
+            if yaw_err_deg > max_yaw_err_deg:
+                raise NotAchievedException(
+                    "GPS yaw not corrected for attitude (roll=%.1f deg, yaw err=%.1f deg)" %
+                    (roll_deg, yaw_err_deg))
+            good_samples += 1
+            if good_samples >= wanted_samples:
+                break
+
+        self.do_RTL()
+        self.context_pop()
+        self.reboot_sitl()
+
     def SMART_RTL_EnterLeave(self):
         '''check SmartRTL behaviour when entering/leaving'''
         # we had a bug where we would consume points when re-entering smartrtl
@@ -17725,6 +17809,7 @@ return update, 1000
             self.DO_WINCH,
             self.SensorErrorFlags,
             self.GPSForYaw,
+            self.GPSForYawAttitudeCorrection,
             self.DefaultIntervalsFromFiles,
             self.GPSTypes,
             self.MultipleGPS,

--- a/libraries/AP_GPS/GPS_Backend.cpp
+++ b/libraries/AP_GPS/GPS_Backend.cpp
@@ -404,7 +404,23 @@ bool AP_GPS_Backend::calculate_moving_base_yaw(AP_GPS::GPS_State &interim_state,
 
         {
             // at this point the offsets are looking okay, go ahead and actually calculate a useful heading
+#if AP_AHRS_ENABLED
+            // The GPS reports the baseline heading in the NED horizontal plane,
+            // so to recover the vehicle yaw we need the bearing of the antenna
+            // offset in that same horizontal plane. Rotate the body-frame offset
+            // by the vehicle's roll and pitch (but not yaw, which is the unknown
+            // we are solving for) to obtain a level-frame offset. This accounts
+            // for both the vehicle attitude and any vertical (z) component of the
+            // antenna offset, both of which change the apparent horizontal
+            // bearing of the baseline when the vehicle is not level.
+            const auto &ahrs = AP::ahrs();
+            Matrix3f rot_body_to_level;
+            rot_body_to_level.from_euler(ahrs.get_roll_rad(), ahrs.get_pitch_rad(), 0.0f);
+            const Vector3f offset_level = rot_body_to_level * offset;
+            const float rotation_offset_rad = Vector2f(-offset_level.x, -offset_level.y).angle();
+#else
             const float rotation_offset_rad = Vector2f(-offset.x, -offset.y).angle();
+#endif // AP_AHRS_ENABLED
             interim_state.gps_yaw = wrap_360(reported_heading_deg - degrees(rotation_offset_rad));
             interim_state.have_gps_yaw = true;
             interim_state.gps_yaw_time_ms = AP_HAL::millis();


### PR DESCRIPTION
### Summary

The moving-baseline GPS yaw calculation in `calculate_moving_base_yaw()` derived vehicle heading by taking the bearing of the antenna offset directly from its body-frame x/y components. This is only correct when the vehicle is level: it implicitly assumes zero roll/pitch and discards the vertical (z) component of the antenna offset entirely.

The GPS reports the baseline heading in the NED horizontal plane, so recovering vehicle yaw requires the antenna offset's bearing in that same horizontal plane. This PR rotates the full 3D offset by the vehicle's roll and pitch before computing the bearing.

### What changed

Before computing the heading, the body-frame antenna offset is rotated into a level frame using the vehicle's roll and pitch (yaw set to 0, since yaw is the value being solved for):

```cpp
rot_body_to_level.from_euler(ahrs.get_roll_rad(), ahrs.get_pitch_rad(), 0.0f);
const Vector3f offset_level = rot_body_to_level * offset;
const float rotation_offset_rad = Vector2f(-offset_level.x, -offset_level.y).angle();
```

Why this is correct: the body→NED rotation factors as

```
R_body→ned = Rz(yaw) · from_euler(roll, pitch, 0)
```

so the heading the GPS reports is `reported_heading = yaw + bearing( from_euler(roll,pitch,0) · offset )` in the horizontal plane. Subtracting `bearing(offset_level)` therefore inverts the relationship and recovers vehicle yaw exactly — for real RELPOSNED hardware as well as for SITL.

- `from_euler(roll, pitch, 0)` yields the tilt-only body→level rotation Ry(pitch) · Rx(roll).
- The resulting `offset_level` correctly accounts for both vehicle attitude and any vertical antenna separation, both of which shift the apparent horizontal bearing of the baseline when the vehicle is tilted (a first-order error that was previously dropped).
- The original `-offset.x / -offset.y` sign convention is preserved, so behaviour is identical to before when the vehicle is level (`offset_level == offset`).
- Guarded by `AP_AHRS_ENABLED`; the `#else` path retains the original level-assumption math for builds without AHRS.

### Testing

Added autotest `Copter.GPSForYawAttitudeCorrection`. It configures a moving-baseline GPS with a small fore-aft (X) plus large vertical (Z) antenna separation, then flies a gentle banked circle and compares the backend's reported `GPS2_RAW.yaw` against ground truth from `SIMSTATE` while the vehicle is leaned over.

Fail-before / pass-after, verified in SITL:

| Source state | Yaw error at ~13° roll | Result |
|---|---|---|
| With this fix | ~0.4° | PASS |
| `GPS_Backend.cpp` reverted to pre-fix | ~28° | FAIL |

Test design notes:
- Sets `SIM_GPS1_LAG_MS = SIM_GPS2_LAG_MS = 0` so the simulator's turn-rate lag back-projection does not confound the comparison — this isolates the geometric attitude correction from the lag limitation noted below.
- Uses `EK3_SRC1_YAW = 1` (compass) for the EKF/flight yaw so the moving-baseline GPS yaw under test never feeds back into attitude control. The backend still computes its yaw and reports it in `GPS2_RAW`, but a wrong (pre-fix) value cannot destabilise the circle being flown, so the field is measured as a pure backend output.

### Notes / limitations

Uses current roll/pitch rather than lag-projected attitude. A point heading estimate can't use the min/max lag window that the adjacent vertical-component check uses, and over the GPS lag (tens of ms) roll/pitch change is small. This matches the existing code comment that full historical-attitude accuracy is "too complex to justify" here.

No functional change for level operation; the improvement is for vehicles operating tilted (forward flight, banking) or with antennas mounted at different heights.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
