### PR TITLE
Move sending of EKF status report to AHRS frontend

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -3396,6 +3396,107 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.fly_mission("ap1.txt", mission_timeout=120)
         self.disarm_vehicle(force=True)
 
+    def check_ekf_status_report(self, ahrs_type, m):
+        '''return None if EKF_STATUS_REPORT m looks healthy, else a string
+        describing the problem'''
+        variances = {
+            "velocity_variance": m.velocity_variance,
+            "pos_horiz_variance": m.pos_horiz_variance,
+            "pos_vert_variance": m.pos_vert_variance,
+            "compass_variance": m.compass_variance,
+            "terrain_alt_variance": m.terrain_alt_variance,
+            "airspeed_variance": m.airspeed_variance,
+        }
+        # all variance fields must be finite and non-negative:
+        for name, value in variances.items():
+            if not math.isfinite(value):
+                return "%s not finite (%s)" % (name, value)
+            if value < 0:
+                return "%s negative (%f)" % (name, value)
+        # a generous sanity ceiling: these are normalised innovation
+        # variances, so anything in the hundreds indicates a garbage /
+        # mis-assembled field (e.g. uninitialised struct memory) rather
+        # than a merely poorly-converged filter:
+        for name, value in variances.items():
+            if value > 100:
+                return "%s implausibly high (%f)" % (name, value)
+        # the filter should be healthy and initialised:
+        required = (mavutil.mavlink.EKF_ATTITUDE |
+                    mavutil.mavlink.EKF_VELOCITY_HORIZ |
+                    mavutil.mavlink.EKF_POS_HORIZ_ABS)
+        if (m.flags & required) != required:
+            return "missing health flags (flags=0x%x)" % m.flags
+        if m.flags & mavutil.mavlink.EKF_UNINITIALIZED:
+            return "reports EKF_UNINITIALIZED (flags=0x%x)" % m.flags
+        return None
+
+    def wait_ekf_status_report_ok(self, ahrs_type, timeout=15):
+        '''wait for a fresh EKF_STATUS_REPORT which passes the sanity checks'''
+        tstart = self.get_sim_time()
+        problem = "no EKF_STATUS_REPORT received"
+        while self.get_sim_time_cached() - tstart < timeout:
+            m = self.assert_receive_message("EKF_STATUS_REPORT", timeout=5)
+            problem = self.check_ekf_status_report(ahrs_type, m)
+            if problem is None:
+                self.progress("AHRS_EKF_TYPE=%u: EKF_STATUS_REPORT OK (flags=0x%x)" %
+                              (ahrs_type, m.flags))
+                return
+        raise NotAchievedException(
+            "AHRS_EKF_TYPE=%u: EKF_STATUS_REPORT not OK: %s" % (ahrs_type, problem))
+
+    def EKF_STATUS_REPORT(self):
+        '''check EKF_STATUS_REPORT is assembled correctly for each AHRS_EKF_TYPE'''
+        # bring up a VectorNav external AHRS on serial4 so that
+        # AHRS_EKF_TYPE=11 (EXTERNAL) is a valid selection.  EK2/EK3 are
+        # enabled so that AHRS_EKF_TYPE=2 and =3 also have a running
+        # backend to report on:
+        self.customise_SITL_commandline(["--serial4=sim:VectorNav"])
+        self.set_parameters({
+            "EAHRS_TYPE": 1,            # VectorNav
+            "SERIAL4_PROTOCOL": 36,
+            "SERIAL4_BAUD": 230400,
+            "GPS1_TYPE": 21,           # GPS from the external AHRS
+            "EK2_ENABLE": 1,
+            "EK3_ENABLE": 1,
+            "AHRS_EKF_TYPE": 11,
+            "INS_GYR_CAL": 1,
+        })
+        self.reboot_sitl()
+        self.delay_sim_time(5, reason="external AHRS to initialise")
+
+        self.progress("Running accelcal")
+        self.run_cmd(
+            mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION,
+            p5=4,
+            timeout=5,
+        )
+
+        # request EKF_STATUS_REPORT often enough to be responsive to
+        # AHRS_EKF_TYPE changes:
+        self.set_message_rate_hz(mavutil.mavlink.MAVLINK_MSG_ID_EKF_STATUS_REPORT, 10)
+
+        self.wait_ready_to_arm()
+        self.takeoff(70, mode='TAKEOFF')
+        self.change_mode('LOITER')
+        self.delay_sim_time(10, reason="settle into loiter")
+
+        # 0=DCM (deliberately sends no report), 2=EKF2, 3=EKF3,
+        # 10=SIM, 11=EXTERNAL:
+        for ahrs_type in [0, 2, 3, 10, 11]:
+            self.start_subtest("Checking EKF_STATUS_REPORT for AHRS_EKF_TYPE=%u" % ahrs_type)
+            self.set_parameter("AHRS_EKF_TYPE", ahrs_type)
+            # allow the configured backend to switch over and produce a
+            # fresh report before we look at it:
+            self.delay_sim_time(3, reason="AHRS_EKF_TYPE change to take effect")
+            self.drain_mav()
+            if ahrs_type == 0:
+                # DCM does not emit an EKF_STATUS_REPORT
+                self.assert_not_receive_message("EKF_STATUS_REPORT", timeout=5)
+                continue
+            self.wait_ekf_status_report_ok(ahrs_type)
+
+        self.fly_home_land_and_disarm()
+
     def GpsSensorPreArmEAHRS(self):
         '''Test pre-arm checks related to EAHRS_SENSORS using the MicroStrain7 driver'''
         self.customise_SITL_commandline(["--serial4=sim:MicroStrain7"])
@@ -8205,6 +8306,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.KebniSensAItionExternalINS,
             self.KebniSensAItionExternalIMU,
             self.GpsSensorPreArmEAHRS,
+            self.EKF_STATUS_REPORT,
             self.Deadreckoning,
             self.EKFlaneswitch,
             self.AirspeedDrivers,

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -2312,11 +2312,81 @@ void AP_AHRS::resetHeightDatum(void)
     }
 }
 
+#if HAL_GCS_ENABLED
 // send a EKF_STATUS_REPORT for configured EKF
 void AP_AHRS::send_ekf_status_report(GCS_MAVLINK &link) const
 {
-    configured_backend->send_ekf_status_report(link);
+    // get filter status
+    union nav_filter_status filterStatus;
+    if (!configured_backend->get_filter_status(filterStatus)) {
+        return;
+    }
+
+    // get variances
+    float velVar = 0, posVar = 0, hgtVar = 0, tasVar = 0;
+    Vector3f magVar;
+    if (!configured_backend->get_variances(velVar, posVar, hgtVar, magVar, tasVar)) {
+        return;
+    }
+
+    float terrain_alt_variance;
+    if (!configured_backend->get_terrain_alt_variance(terrain_alt_variance)) {
+        return;
+    }
+
+    // prepare flags
+    uint16_t flags = 0;
+    if (filterStatus.flags.attitude) {
+        flags |= EKF_ATTITUDE;
+    }
+    if (filterStatus.flags.horiz_vel) {
+        flags |= EKF_VELOCITY_HORIZ;
+    }
+    if (filterStatus.flags.vert_vel) {
+        flags |= EKF_VELOCITY_VERT;
+    }
+    if (filterStatus.flags.horiz_pos_rel) {
+        flags |= EKF_POS_HORIZ_REL;
+    }
+    if (filterStatus.flags.horiz_pos_abs) {
+        flags |= EKF_POS_HORIZ_ABS;
+    }
+    if (filterStatus.flags.vert_pos) {
+        flags |= EKF_POS_VERT_ABS;
+    }
+    if (filterStatus.flags.terrain_alt) {
+        flags |= EKF_POS_VERT_AGL;
+    }
+    if (filterStatus.flags.const_pos_mode) {
+        flags |= EKF_CONST_POS_MODE;
+    }
+    if (filterStatus.flags.pred_horiz_pos_rel) {
+        flags |= EKF_PRED_POS_HORIZ_REL;
+    }
+    if (filterStatus.flags.pred_horiz_pos_abs) {
+        flags |= EKF_PRED_POS_HORIZ_ABS;
+    }
+    if (!filterStatus.flags.initalized) {
+        flags |= EKF_UNINITIALIZED;
+    }
+    if (filterStatus.flags.gps_glitching) {
+        flags |= (1<<15);
+    }
+
+    const mavlink_ekf_status_report_t packet{
+        velVar,
+        posVar,
+        hgtVar,
+        fmaxf(fmaxf(magVar.x,magVar.y),magVar.z),
+        terrain_alt_variance,
+        flags,
+        tasVar
+    };
+
+    // send message
+    mavlink_msg_ekf_status_report_send_struct(link.get_chan(), &packet);
 }
+#endif  // HAL_GCS_ENABLED
 
 // return origin for a specified EKF type
 bool AP_AHRS::_get_origin(EKFType type, Location &ret) const

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -303,6 +303,7 @@ void AP_AHRS::update_configured_ekf_type()
     if (new_backend != nullptr) {
         state.configured_ekf_type = new_type;
         configured_backend = new_backend;
+        configured_estimates = estimates_for_type(new_type);
         return;
     }
     INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
@@ -682,9 +683,7 @@ void AP_AHRS::update_EKF2(void)
         ekf2_estimates = {};
         ekf2.get_results(ekf2_estimates);
         if (_active_EKF_type() == EKFType::TWO) {
-            nav_filter_status filt_state;
-            ekf2.get_filter_status(filt_state);
-            update_notify_from_filter_status(filt_state);
+            update_notify_from_filter_status(ekf2_estimates.filter_status);
         }
 
         /*
@@ -734,9 +733,7 @@ void AP_AHRS::update_EKF3(void)
         ekf3_estimates = {};
         ekf3.get_results(ekf3_estimates);
         if (_active_EKF_type() == EKFType::THREE) {
-            nav_filter_status filt_state;
-            ekf3.get_filter_status(filt_state);
-            update_notify_from_filter_status(filt_state);
+            update_notify_from_filter_status(ekf3_estimates.filter_status);
         }
         /*
           if we now have an origin then set in all backends
@@ -1755,24 +1752,24 @@ AP_AHRS::EKFType AP_AHRS::_active_EKF_type(void) const
             break;
 #if HAL_NAVEKF2_AVAILABLE
         case EKFType::TWO:
-            ekf2.get_filter_status(filt_state);
+            filt_state = ekf2_estimates.filter_status;
             should_use_gps = ekf2.EKF2.configuredToUseGPSForPosXY();
             break;
 #endif
 #if HAL_NAVEKF3_AVAILABLE
         case EKFType::THREE:
-            ekf3.get_filter_status(filt_state);
+            filt_state = ekf3_estimates.filter_status;
             should_use_gps = ekf3.EKF3.configuredToUseGPSForPosXY();
             break;
 #endif
 #if AP_AHRS_SIM_ENABLED
         case EKFType::SIM:
-            get_filter_status(filt_state);
+            filt_state = sim_estimates.filter_status;
             break;
 #endif
 #if AP_AHRS_EXTERNAL_ENABLED
         case EKFType::EXTERNAL:
-            get_filter_status(filt_state);
+            filt_state = external_estimates.filter_status;
             should_use_gps = true;
             break;
 #endif
@@ -2317,70 +2314,66 @@ void AP_AHRS::resetHeightDatum(void)
 void AP_AHRS::send_ekf_status_report(GCS_MAVLINK &link) const
 {
     // get filter status
-    union nav_filter_status filterStatus;
-    if (!configured_backend->get_filter_status(filterStatus)) {
+    if (!configured_estimates->filter_status_valid) {
         return;
     }
 
     // get variances
-    float velVar = 0, posVar = 0, hgtVar = 0, tasVar = 0;
-    Vector3f magVar;
-    if (!configured_backend->get_variances(velVar, posVar, hgtVar, magVar, tasVar)) {
+    if (!configured_estimates->variances_valid) {
         return;
     }
 
-    float terrain_alt_variance;
-    if (!configured_backend->get_terrain_alt_variance(terrain_alt_variance)) {
+    if (!configured_estimates->terrain_alt_variance_valid) {
         return;
     }
 
     // prepare flags
     uint16_t flags = 0;
-    if (filterStatus.flags.attitude) {
+    if (configured_estimates->filter_status.flags.attitude) {
         flags |= EKF_ATTITUDE;
     }
-    if (filterStatus.flags.horiz_vel) {
+    if (configured_estimates->filter_status.flags.horiz_vel) {
         flags |= EKF_VELOCITY_HORIZ;
     }
-    if (filterStatus.flags.vert_vel) {
+    if (configured_estimates->filter_status.flags.vert_vel) {
         flags |= EKF_VELOCITY_VERT;
     }
-    if (filterStatus.flags.horiz_pos_rel) {
+    if (configured_estimates->filter_status.flags.horiz_pos_rel) {
         flags |= EKF_POS_HORIZ_REL;
     }
-    if (filterStatus.flags.horiz_pos_abs) {
+    if (configured_estimates->filter_status.flags.horiz_pos_abs) {
         flags |= EKF_POS_HORIZ_ABS;
     }
-    if (filterStatus.flags.vert_pos) {
+    if (configured_estimates->filter_status.flags.vert_pos) {
         flags |= EKF_POS_VERT_ABS;
     }
-    if (filterStatus.flags.terrain_alt) {
+    if (configured_estimates->filter_status.flags.terrain_alt) {
         flags |= EKF_POS_VERT_AGL;
     }
-    if (filterStatus.flags.const_pos_mode) {
+    if (configured_estimates->filter_status.flags.const_pos_mode) {
         flags |= EKF_CONST_POS_MODE;
     }
-    if (filterStatus.flags.pred_horiz_pos_rel) {
+    if (configured_estimates->filter_status.flags.pred_horiz_pos_rel) {
         flags |= EKF_PRED_POS_HORIZ_REL;
     }
-    if (filterStatus.flags.pred_horiz_pos_abs) {
+    if (configured_estimates->filter_status.flags.pred_horiz_pos_abs) {
         flags |= EKF_PRED_POS_HORIZ_ABS;
     }
-    if (!filterStatus.flags.initalized) {
+    if (!configured_estimates->filter_status.flags.initalized) {
         flags |= EKF_UNINITIALIZED;
     }
-    if (filterStatus.flags.gps_glitching) {
+    if (configured_estimates->filter_status.flags.gps_glitching) {
         flags |= (1<<15);
     }
 
     const mavlink_ekf_status_report_t packet{
-        velVar,
-        posVar,
-        hgtVar,
-        fmaxf(fmaxf(magVar.x,magVar.y),magVar.z),
-        terrain_alt_variance,
+        configured_estimates->velVar,
+        configured_estimates->posVar,
+        configured_estimates->hgtVar,
+        fmaxf(fmaxf(configured_estimates->magVar.x, configured_estimates->magVar.y), configured_estimates->magVar.z),
+        configured_estimates->terrain_alt_variance,
         flags,
-        tasVar
+        configured_estimates->tasVar
     };
 
     // send message

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -367,7 +367,8 @@ public:
 
     // get_filter_status - returns filter status as a series of flags
     bool get_filter_status(nav_filter_status &status) const {
-        return configured_backend->get_filter_status(status);
+        status = configured_estimates->filter_status;
+        return configured_estimates->filter_status_valid;
     }
 
     // get compass offset estimates
@@ -429,7 +430,12 @@ public:
     // inconsistency that will be accepted by the filter
     // boolean false is returned if variances are not available
     bool get_variances(float &velVar, float &posVar, float &hgtVar, Vector3f &magVar, float &tasVar) const {
-        return configured_backend->get_variances(velVar, posVar, hgtVar, magVar, tasVar);
+        velVar = configured_estimates->velVar;
+        posVar = configured_estimates->posVar;
+        hgtVar = configured_estimates->hgtVar;
+        magVar = configured_estimates->magVar;
+        tasVar = configured_estimates->tasVar;
+        return configured_estimates->variances_valid;
     }
 
     // get 1-sigma position and velocity uncertainty derived from the EKF state error covariance matrix P
@@ -1143,6 +1149,7 @@ private:
     // configured_backend is the backend the user wants to use as
     // indicated by parameter values
     AP_AHRS_Backend *configured_backend;
+    AP_AHRS_Backend::Estimates *configured_estimates;
 
     // active_backend is the backend which is currently providing
     // results (e.g. this may be a fallback estimator if the

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -326,7 +326,8 @@ public:
         return false;
     }
 
-    virtual void send_ekf_status_report(class GCS_MAVLINK &link) const = 0;
+    // return a terrain altitude variance
+    virtual bool get_terrain_alt_variance(float &terrain_alt_variance) const { return false; }
 
     virtual void get_control_limits(float &ekfGndSpdLimit, float &controlScaleXY) const = 0;
 };

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -26,6 +26,7 @@
 #include <AP_InertialSensor/AP_InertialSensor.h>
 #include <AP_Common/Location.h>
 #include <AP_NavEKF/AP_NavEKF_Source.h>
+#include <AP_NavEKF/AP_Nav_Common.h>
 
 #define AP_AHRS_TRIM_LIMIT 10.0f        // maximum trim angle in degrees
 #define AP_AHRS_RP_P_MIN   0.05f        // minimum value for AHRS_RP_P parameter
@@ -163,6 +164,24 @@ public:
         // if true then however the yaw in these estimates was derived
         // a compass was not involved:
         bool using_noncompass_for_yaw;
+
+        /*
+         * filter status and estimates quality values:
+         */
+        nav_filter_status filter_status;
+        bool filter_status_valid;
+
+        // the innovations normalised using the innovation variance
+        // where a value of 0 indicates perfect consistency between
+        // the measurement and the EKF solution and a value of 1 is
+        // the maximum inconsistency that will be accepted by the
+        // filter:
+        float velVar, posVar, hgtVar, tasVar;
+        Vector3f magVar;
+        bool variances_valid;
+
+        float terrain_alt_variance;
+        bool terrain_alt_variance_valid;
 
     private:
         bool hagl_valid;
@@ -313,21 +332,6 @@ public:
     virtual bool get_innovations(Vector3f &velInnov, Vector3f &posInnov, Vector3f &magInnov, float &tasInnov, float &yawInnov) const {
         return false;
     }
-
-    virtual bool get_filter_status(union nav_filter_status &status) const {
-        return false;
-    }
-
-    // get_variances - provides the innovations normalised using the innovation variance where a value of 0
-    // indicates perfect consistency between the measurement and the EKF solution and a value of 1 is the maximum
-    // inconsistency that will be accepted by the filter
-    // boolean false is returned if variances are not available
-    virtual bool get_variances(float &velVar, float &posVar, float &hgtVar, Vector3f &magVar, float &tasVar) const {
-        return false;
-    }
-
-    // return a terrain altitude variance
-    virtual bool get_terrain_alt_variance(float &terrain_alt_variance) const { return false; }
 
     virtual void get_control_limits(float &ekfGndSpdLimit, float &controlScaleXY) const = 0;
 };

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -1359,10 +1359,6 @@ bool AP_AHRS_DCM::get_relative_position_D_origin(postype_t &posD) const
     return true;
 }
 
-void AP_AHRS_DCM::send_ekf_status_report(GCS_MAVLINK &link) const
-{
-}
-
 // return true if DCM has a yaw source available
 bool AP_AHRS_DCM::yaw_source_available(void) const
 {

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -201,6 +201,17 @@ void AP_AHRS_DCM::get_results(AP_AHRS_Backend::Estimates &results)
 
     // are we consuming yaw from a source which is *not* a compass
     // results.using_noncompass_for_yaw = false;
+
+    /*
+     * filter status and estimates quality values:
+     */
+    // getFilterStatus(results.filter_status);
+    // results.filter_status_valid = false;
+
+    // provides the innovations normalised between 0 and 1:
+    // results.variances_valid = false;
+
+    // terrain_alt_variance_valid = false;
 }
 
 /*

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -107,8 +107,6 @@ public:
     bool get_relative_position_NE_origin(Vector2p &posNE) const override;
     bool get_relative_position_D_origin(postype_t &posD) const override;
 
-    void send_ekf_status_report(class GCS_MAVLINK &link) const override;
-
     // return true if DCM has a yaw source
     bool yaw_source_available(void) const;
 

--- a/libraries/AP_AHRS/AP_AHRS_External.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_External.cpp
@@ -152,11 +152,6 @@ bool AP_AHRS_External::get_variances(float &velVar, float &posVar, float &hgtVar
     return AP::externalAHRS().get_variances(velVar, posVar, hgtVar, magVar, tasVar);
 }
 
-void AP_AHRS_External::send_ekf_status_report(GCS_MAVLINK &link) const
-{
-    AP::externalAHRS().send_status_report(link);
-}
-
 bool AP_AHRS_External::get_origin(Location &ret) const
 {
     return AP::externalAHRS().get_origin(ret);

--- a/libraries/AP_AHRS/AP_AHRS_External.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_External.cpp
@@ -94,6 +94,18 @@ void AP_AHRS_External::get_results(AP_AHRS_Backend::Estimates &results)
 
     // are we consuming yaw from a source which is *not* a compass
     // results.using_noncompass_for_yaw = false;
+
+    /*
+     * filter status and estimates quality values:
+     */
+    AP::externalAHRS().get_filter_status(results.filter_status);
+    results.filter_status_valid = true;
+
+    // provides the innovations normalised between 0 and 1:
+    results.variances_valid = AP::externalAHRS().get_variances(results.velVar, results.posVar, results.hgtVar, results.magVar, results.tasVar);
+
+    results.terrain_alt_variance = 0;
+    results.terrain_alt_variance_valid = true;
 }
 
 bool AP_AHRS_External::get_relative_position_NED_origin(Vector3p &vec) const
@@ -139,17 +151,6 @@ bool AP_AHRS_External::get_relative_position_D_origin(postype_t &posD) const
 bool AP_AHRS_External::pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const
 {
     return AP::externalAHRS().pre_arm_check(failure_msg, failure_msg_len);
-}
-
-bool AP_AHRS_External::get_filter_status(nav_filter_status &status) const
-{
-    AP::externalAHRS().get_filter_status(status);
-    return true;
-}
-
-bool AP_AHRS_External::get_variances(float &velVar, float &posVar, float &hgtVar, Vector3f &magVar, float &tasVar) const
-{
-    return AP::externalAHRS().get_variances(velVar, posVar, hgtVar, magVar, tasVar);
 }
 
 bool AP_AHRS_External::get_origin(Location &ret) const

--- a/libraries/AP_AHRS/AP_AHRS_External.h
+++ b/libraries/AP_AHRS/AP_AHRS_External.h
@@ -73,13 +73,6 @@ public:
     bool get_relative_position_NE_origin(Vector2p &posNE) const override;
     bool get_relative_position_D_origin(postype_t &posD) const override;
 
-    bool get_filter_status(nav_filter_status &status) const override;
-    bool get_variances(float &velVar, float &posVar, float &hgtVar, Vector3f &magVar, float &tasVar) const override;
-    bool get_terrain_alt_variance(float &variance) const override {
-        variance = 0;
-        return true;
-    }
-
     void get_control_limits(float &ekfGndSpdLimit, float &controlScaleXY) const override;
 };
 

--- a/libraries/AP_AHRS/AP_AHRS_External.h
+++ b/libraries/AP_AHRS/AP_AHRS_External.h
@@ -75,7 +75,10 @@ public:
 
     bool get_filter_status(nav_filter_status &status) const override;
     bool get_variances(float &velVar, float &posVar, float &hgtVar, Vector3f &magVar, float &tasVar) const override;
-    void send_ekf_status_report(class GCS_MAVLINK &link) const override;
+    bool get_terrain_alt_variance(float &variance) const override {
+        variance = 0;
+        return true;
+    }
 
     void get_control_limits(float &ekfGndSpdLimit, float &controlScaleXY) const override;
 };

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF2.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF2.cpp
@@ -108,6 +108,18 @@ void AP_AHRS_NavEKF2::get_results(AP_AHRS_Backend::Estimates &results)
 
     // are we consuming yaw from a source which is *not* a compass
     results.using_noncompass_for_yaw = EKF2.isExtNavUsedForYaw();
+
+    /*
+     * filter status and estimates quality values:
+     */
+    EKF2.getFilterStatus(results.filter_status);
+    results.filter_status_valid = true;
+
+    // provides the innovations normalised between 0 and 1:
+    Vector2f offset;
+    results.variances_valid = EKF2.getVariances(results.velVar, results.posVar, results.hgtVar, results.magVar, results.tasVar, offset);
+
+    results.terrain_alt_variance_valid = EKF2.getTerrainAltVariance(results.terrain_alt_variance);
 }
 
 bool AP_AHRS_NavEKF2::pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF2.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF2.h
@@ -96,26 +96,10 @@ public:
         return EKF2.getEkfControlLimits(ekfGndSpdLimit, controlScaleXY);
     }
 
-    // // get_filter_status - returns filter status as a series of flags
-    bool get_filter_status(nav_filter_status &status) const override {
-        EKF2.getFilterStatus(status);
-        return true;
-    }
-
     // // return the innovations for the specified instance
     // // An out of range instance (eg -1) returns data for the primary instance
     bool get_innovations(Vector3f &velInnov, Vector3f &posInnov, Vector3f &magInnov, float &tasInnov, float &yawInnov) const override {
         return EKF2.getInnovations(velInnov, posInnov, magInnov, tasInnov, yawInnov);
-    }
-
-    bool get_variances(float &velVar, float &posVar, float &hgtVar, Vector3f &magVar, float &tasVar) const override {
-        Vector2f offset;
-        return EKF2.getVariances(velVar, posVar, hgtVar, magVar, tasVar, offset);
-    }
-
-    // return a terrain altitude variance
-    virtual bool get_terrain_alt_variance(float &terrain_alt_variance) {
-        return EKF2.getTerrainAltVariance(terrain_alt_variance);
     }
 
     void request_yaw_reset(void) override {

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF2.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF2.h
@@ -96,10 +96,6 @@ public:
         return EKF2.getEkfControlLimits(ekfGndSpdLimit, controlScaleXY);
     }
 
-    void send_ekf_status_report(class GCS_MAVLINK &link) const override {
-        EKF2.send_status_report(link);
-    }
-
     // // get_filter_status - returns filter status as a series of flags
     bool get_filter_status(nav_filter_status &status) const override {
         EKF2.getFilterStatus(status);
@@ -115,6 +111,11 @@ public:
     bool get_variances(float &velVar, float &posVar, float &hgtVar, Vector3f &magVar, float &tasVar) const override {
         Vector2f offset;
         return EKF2.getVariances(velVar, posVar, hgtVar, magVar, tasVar, offset);
+    }
+
+    // return a terrain altitude variance
+    virtual bool get_terrain_alt_variance(float &terrain_alt_variance) {
+        return EKF2.getTerrainAltVariance(terrain_alt_variance);
     }
 
     void request_yaw_reset(void) override {

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
@@ -110,6 +110,18 @@ void AP_AHRS_NavEKF3::get_results(AP_AHRS_Backend::Estimates &results)
     // are we consuming yaw from a source which is *not* a compass
     // (e.g. the GSF)
     results.using_noncompass_for_yaw = EKF3.using_noncompass_for_yaw();
+
+    /*
+     * filter status and estimates quality values:
+     */
+    EKF3.getFilterStatus(results.filter_status);
+    results.filter_status_valid = true;
+
+    // provides the innovations normalised between 0 and 1:
+    Vector2f offset;
+    results.variances_valid = EKF3.getVariances(results.velVar, results.posVar, results.hgtVar, results.magVar, results.tasVar, offset);
+
+    results.terrain_alt_variance_valid = EKF3.getTerrainAltVariance(results.terrain_alt_variance);
 }
 
 bool AP_AHRS_NavEKF3::pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF3.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF3.h
@@ -100,9 +100,6 @@ public:
     void get_control_limits(float &ekfGndSpdLimit, float &controlScaleXY) const override {
         return EKF3.getEkfControlLimits(ekfGndSpdLimit, controlScaleXY);
     }
-    void send_ekf_status_report(class GCS_MAVLINK &link) const override {
-        EKF3.send_status_report(link);
-    }
 
     // get_filter_status - returns filter status as a series of flags
     bool get_filter_status(nav_filter_status &status) const override {
@@ -119,6 +116,11 @@ public:
     bool get_variances(float &velVar, float &posVar, float &hgtVar, Vector3f &magVar, float &tasVar) const override {
         Vector2f offset;
         return EKF3.getVariances(velVar, posVar, hgtVar, magVar, tasVar, offset);
+    }
+
+    // return a terrain altitude variance
+    bool get_terrain_alt_variance(float &terrain_alt_variance) const override {
+        return EKF3.getTerrainAltVariance(terrain_alt_variance);
     }
 
     // this is out here so parameters can be poked into it

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF3.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF3.h
@@ -101,26 +101,10 @@ public:
         return EKF3.getEkfControlLimits(ekfGndSpdLimit, controlScaleXY);
     }
 
-    // get_filter_status - returns filter status as a series of flags
-    bool get_filter_status(nav_filter_status &status) const override {
-        EKF3.getFilterStatus(status);
-        return true;
-    }
-
     // return the innovations for the specified instance
     // An out of range instance (eg -1) returns data for the primary instance
     bool get_innovations(Vector3f &velInnov, Vector3f &posInnov, Vector3f &magInnov, float &tasInnov, float &yawInnov) const override {
         return EKF3.getInnovations(velInnov, posInnov, magInnov, tasInnov, yawInnov);
-    }
-
-    bool get_variances(float &velVar, float &posVar, float &hgtVar, Vector3f &magVar, float &tasVar) const override {
-        Vector2f offset;
-        return EKF3.getVariances(velVar, posVar, hgtVar, magVar, tasVar, offset);
-    }
-
-    // return a terrain altitude variance
-    bool get_terrain_alt_variance(float &terrain_alt_variance) const override {
-        return EKF3.getTerrainAltVariance(terrain_alt_variance);
     }
 
     // this is out here so parameters can be poked into it

--- a/libraries/AP_AHRS/AP_AHRS_SIM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_SIM.cpp
@@ -103,7 +103,9 @@ bool AP_AHRS_SIM::get_filter_status(nav_filter_status &status) const
     status.flags.vert_pos = true;
     status.flags.pred_horiz_pos_rel = true;
     status.flags.pred_horiz_pos_abs = true;
+    status.flags.initalized = true;
     status.flags.using_gps = true;
+    status.flags.terrain_alt = true;
 
     return true;
 }
@@ -113,25 +115,6 @@ void AP_AHRS_SIM::get_control_limits(float &ekfGndSpdLimit, float &ekfNavVelGain
     // same as EKF2 for no optical flow
     ekfGndSpdLimit = 400.0f;
     ekfNavVelGainScaler = 1.0f;
-}
-
-void AP_AHRS_SIM::send_ekf_status_report(GCS_MAVLINK &link) const
-{
-#if HAL_GCS_ENABLED
-    // send status report with everything looking good
-    const uint16_t flags =
-        EKF_ATTITUDE | /* Set if EKF's attitude estimate is good. | */
-        EKF_VELOCITY_HORIZ | /* Set if EKF's horizontal velocity estimate is good. | */
-        EKF_VELOCITY_VERT | /* Set if EKF's vertical velocity estimate is good. | */
-        EKF_POS_HORIZ_REL | /* Set if EKF's horizontal position (relative) estimate is good. | */
-        EKF_POS_HORIZ_ABS | /* Set if EKF's horizontal position (absolute) estimate is good. | */
-        EKF_POS_VERT_ABS | /* Set if EKF's vertical position (absolute) estimate is good. | */
-        EKF_POS_VERT_AGL | /* Set if EKF's vertical position (above ground) estimate is good. | */
-        //EKF_CONST_POS_MODE | /* EKF is in constant position mode and does not know it's absolute or relative position. | */
-        EKF_PRED_POS_HORIZ_REL | /* Set if EKF's predicted horizontal position (relative) estimate is good. | */
-        EKF_PRED_POS_HORIZ_ABS; /* Set if EKF's predicted horizontal position (absolute) estimate is good. | */
-    mavlink_msg_ekf_status_report_send(link.get_chan(), flags, 0, 0, 0, 0, 0, 0);
-#endif // HAL_GCS_ENABLED
 }
 
 bool AP_AHRS_SIM::get_origin(Location &ret) const
@@ -166,6 +149,12 @@ bool AP_AHRS_SIM::get_variances(float &velVar, float &posVar, float &hgtVar, Vec
     magVar.zero();
     tasVar = 0;
 
+    return true;
+}
+
+bool AP_AHRS_SIM::get_terrain_alt_variance(float &terrain_alt_variance) const
+{
+    terrain_alt_variance = 0;
     return true;
 }
 

--- a/libraries/AP_AHRS/AP_AHRS_SIM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_SIM.cpp
@@ -141,23 +141,6 @@ bool AP_AHRS_SIM::get_innovations(Vector3f &velInnov, Vector3f &posInnov, Vector
     return true;
 }
 
-bool AP_AHRS_SIM::get_variances(float &velVar, float &posVar, float &hgtVar, Vector3f &magVar, float &tasVar) const
-{
-    velVar = 0;
-    posVar = 0;
-    hgtVar = 0;
-    magVar.zero();
-    tasVar = 0;
-
-    return true;
-}
-
-bool AP_AHRS_SIM::get_terrain_alt_variance(float &terrain_alt_variance) const
-{
-    terrain_alt_variance = 0;
-    return true;
-}
-
 void AP_AHRS_SIM::get_results(AP_AHRS_Backend::Estimates &results)
 {
     if (_sitl == nullptr) {
@@ -232,6 +215,22 @@ void AP_AHRS_SIM::get_results(AP_AHRS_Backend::Estimates &results)
     // are we consuming yaw from a source which is *not* a compass
     // (e.g. the GSF)
     // results.using_noncompass_for_yaw = false;
+
+    /*
+     * filter status and estimates quality values:
+     */
+    results.filter_status_valid = get_filter_status(results.filter_status);
+
+    // provides the innovations normalised between 0 and 1:
+    // velVar = 0;
+    // posVar = 0;
+    // hgtVar = 0;
+    // magVar.zero();
+    // tasVar = 0;
+    results.variances_valid = true;
+
+    // terrain_alt_variance = 0;
+    results.terrain_alt_variance_valid = true;
 
 #if HAL_NAVEKF3_AVAILABLE
     if (_sitl->odom_enable) {

--- a/libraries/AP_AHRS/AP_AHRS_SIM.h
+++ b/libraries/AP_AHRS/AP_AHRS_SIM.h
@@ -85,17 +85,18 @@ public:
     // get_filter_status - returns filter status as a series of flags
     bool get_filter_status(nav_filter_status &status) const override;
 
+    bool get_variances(float &velVar, float &posVar, float &hgtVar, Vector3f &magVar, float &tasVar) const override;
+
+    bool get_terrain_alt_variance(float &terrain_alt_variance) const override;
+
     // relative-origin functions for fallback in AP_InertialNav
     bool get_origin(Location &ret) const override;
     bool get_relative_position_NED_origin(Vector3p &vec) const override;
     bool get_relative_position_NE_origin(Vector2p &posNE) const override;
     bool get_relative_position_D_origin(postype_t &posD) const override;
 
-    void send_ekf_status_report(class GCS_MAVLINK &link) const override;
-
     void get_control_limits(float &ekfGndSpdLimit, float &controlScaleXY) const override;
     bool get_innovations(Vector3f &velInnov, Vector3f &posInnov, Vector3f &magInnov, float &tasInnov, float &yawInnov) const override;
-    bool get_variances(float &velVar, float &posVar, float &hgtVar, Vector3f &magVar, float &tasVar) const override;
 
 private:
 

--- a/libraries/AP_AHRS/AP_AHRS_SIM.h
+++ b/libraries/AP_AHRS/AP_AHRS_SIM.h
@@ -82,13 +82,6 @@ public:
     // requires_position should be true if horizontal position configuration should be checked (not used)
     bool pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const override { return true; }
 
-    // get_filter_status - returns filter status as a series of flags
-    bool get_filter_status(nav_filter_status &status) const override;
-
-    bool get_variances(float &velVar, float &posVar, float &hgtVar, Vector3f &magVar, float &tasVar) const override;
-
-    bool get_terrain_alt_variance(float &terrain_alt_variance) const override;
-
     // relative-origin functions for fallback in AP_InertialNav
     bool get_origin(Location &ret) const override;
     bool get_relative_position_NED_origin(Vector3p &vec) const override;
@@ -99,6 +92,9 @@ public:
     bool get_innovations(Vector3f &velInnov, Vector3f &posInnov, Vector3f &magInnov, float &tasInnov, float &yawInnov) const override;
 
 private:
+
+    // get_filter_status - returns filter status as a series of flags
+    bool get_filter_status(nav_filter_status &status) const;
 
     // dead-reckoning support
     bool get_location(Location &loc) const;

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS.cpp
@@ -353,61 +353,6 @@ bool AP_ExternalAHRS::get_accel(Vector3f &accel)
     return true;
 }
 
-// send an EKF_STATUS message to GCS
-void AP_ExternalAHRS::send_status_report(GCS_MAVLINK &link) const
-{
-    float velVar, posVar, hgtVar, tasVar;
-    Vector3f magVar;
-    if (backend == nullptr || !backend->get_variances(velVar, posVar, hgtVar, magVar, tasVar)) {
-        return;
-    }
-
-    uint16_t flags = 0;
-    nav_filter_status filterStatus {};
-    get_filter_status(filterStatus);
-
-    if (filterStatus.flags.attitude) {
-        flags |= EKF_ATTITUDE;
-    }
-    if (filterStatus.flags.horiz_vel) {
-        flags |= EKF_VELOCITY_HORIZ;
-    }
-    if (filterStatus.flags.vert_vel) {
-        flags |= EKF_VELOCITY_VERT;
-    }
-    if (filterStatus.flags.horiz_pos_rel) {
-        flags |= EKF_POS_HORIZ_REL;
-    }
-    if (filterStatus.flags.horiz_pos_abs) {
-        flags |= EKF_POS_HORIZ_ABS;
-    }
-    if (filterStatus.flags.vert_pos) {
-        flags |= EKF_POS_VERT_ABS;
-    }
-    if (filterStatus.flags.terrain_alt) {
-        flags |= EKF_POS_VERT_AGL;
-    }
-    if (filterStatus.flags.const_pos_mode) {
-        flags |= EKF_CONST_POS_MODE;
-    }
-    if (filterStatus.flags.pred_horiz_pos_rel) {
-        flags |= EKF_PRED_POS_HORIZ_REL;
-    }
-    if (filterStatus.flags.pred_horiz_pos_abs) {
-        flags |= EKF_PRED_POS_HORIZ_ABS;
-    }
-    if (!filterStatus.flags.initalized) {
-        flags |= EKF_UNINITIALIZED;
-    }
-
-    const float mag_var = MAX(magVar.x, MAX(magVar.y, magVar.z));
-    mavlink_msg_ekf_status_report_send(link.get_chan(), flags,
-                                       velVar,
-                                       posVar,
-                                       hgtVar,
-                                       mag_var, 0, 0);
-}
-
 void AP_ExternalAHRS::update(void)
 {
     if (backend) {

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS.h
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS.h
@@ -129,7 +129,6 @@ public:
     void get_filter_status(nav_filter_status &status) const;
     bool get_gyro(Vector3f &gyro);
     bool get_accel(Vector3f &accel);
-    void send_status_report(class GCS_MAVLINK &link) const;
     bool get_variances(float &velVar, float &posVar, float &hgtVar, Vector3f &magVar, float &tasVar) const;
 
     // update backend

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -1295,11 +1295,12 @@ void  NavEKF2::getFilterGpsStatus(nav_gps_status &status) const
 }
 
 // send an EKF_STATUS_REPORT message to GCS
-void NavEKF2::send_status_report(GCS_MAVLINK &link) const
+bool NavEKF2::getTerrainAltVariance(float &terrainAltVar) const
 {
     if (core) {
-        core[primary].send_status_report(link);
+        return core[primary].getTerrainAltVariance(terrainAltVar);
     }
+    return false;
 }
 
 // provides the height limit to be observed by the control loops

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -217,8 +217,8 @@ public:
     */
     void  getFilterStatus(nav_filter_status &status) const;
 
-    // send an EKF_STATUS_REPORT message to GCS
-    void send_status_report(class GCS_MAVLINK &link) const;
+    // return a terrain altitude variance
+    bool getTerrainAltVariance(float &terrain_alt_variance) const;
 
     // provides the height limit to be observed by the control loops
     // returns false if no height limiting is required

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -498,68 +498,21 @@ void  NavEKF2_core::getFilterGpsStatus(nav_gps_status &faults) const
     faults.flags.bad_horiz_vel      = gpsCheckStatus.bad_horiz_vel; // The GPS horizontal speed is excessive (check assumes the vehicle is static)
 }
 
-#if HAL_GCS_ENABLED
-// send an EKF_STATUS message to GCS
-void NavEKF2_core::send_status_report(GCS_MAVLINK &link) const
+// return a terrain altitude variance
+bool NavEKF2_core::getTerrainAltVariance(float &temp) const
 {
-    // prepare flags
-    uint16_t flags = 0;
-    if (filterStatus.flags.attitude) {
-        flags |= EKF_ATTITUDE;
-    }
-    if (filterStatus.flags.horiz_vel) {
-        flags |= EKF_VELOCITY_HORIZ;
-    }
-    if (filterStatus.flags.vert_vel) {
-        flags |= EKF_VELOCITY_VERT;
-    }
-    if (filterStatus.flags.horiz_pos_rel) {
-        flags |= EKF_POS_HORIZ_REL;
-    }
-    if (filterStatus.flags.horiz_pos_abs) {
-        flags |= EKF_POS_HORIZ_ABS;
-    }
-    if (filterStatus.flags.vert_pos) {
-        flags |= EKF_POS_VERT_ABS;
-    }
-    if (filterStatus.flags.terrain_alt) {
-        flags |= EKF_POS_VERT_AGL;
-    }
-    if (filterStatus.flags.const_pos_mode) {
-        flags |= EKF_CONST_POS_MODE;
-    }
-    if (filterStatus.flags.pred_horiz_pos_rel) {
-        flags |= EKF_PRED_POS_HORIZ_REL;
-    }
-    if (filterStatus.flags.pred_horiz_pos_abs) {
-        flags |= EKF_PRED_POS_HORIZ_ABS;
-    }
-    if (!filterStatus.flags.initalized) {
-        flags |= EKF_UNINITIALIZED;
-    }
-
-    // get variances
-    float velVar = 0, posVar = 0, hgtVar = 0, tasVar = 0;
-    Vector3f magVar;
-    Vector2f offset;
-    getVariances(velVar, posVar, hgtVar, magVar, tasVar, offset);
-
-    const float mag_max = fmaxF(fmaxF(magVar.x,magVar.y),magVar.z);
-
     // Only report range finder normalised innovation levels if the EKF needs the data for primary
     // height estimation or optical flow operation. This prevents false alarms at the GCS if a
     // range finder is fitted for other applications
-    float temp;
     if (((frontend->_useRngSwHgt > 0) && activeHgtSource == HGT_SOURCE_RNG) || (PV_AidingMode == AID_RELATIVE && flowDataValid)) {
         temp = sqrtF(auxRngTestRatio);
     } else {
         temp = 0.0f;
     }
-
-    // send message
-    mavlink_msg_ekf_status_report_send(link.get_chan(), flags, velVar, posVar, hgtVar, mag_max, temp, tasVar);
+    // we always successfully return a value, even if that value is a
+    // "nothing to look at here" 0 value:
+    return true;
 }
-#endif  // HAL_GCS_ENABLED
 
 // report the reason for why the backend is refusing to initialise
 const char *NavEKF2_core::prearm_failure_reason(void) const

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -256,8 +256,8 @@ public:
     */
     void  getFilterStatus(nav_filter_status &status) const;
 
-    // send an EKF_STATUS_REPORT message to GCS
-    void send_status_report(class GCS_MAVLINK &link) const;
+    // return a terrain altitude variance
+    bool getTerrainAltVariance(float &terrain_alt_variance) const;
 
     // provides the height limit to be observed by the control loops
     // returns false if no height limiting is required

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -1917,11 +1917,12 @@ void NavEKF3::getFilterStatus(nav_filter_status &status) const
 }
 
 // send an EKF_STATUS_REPORT message to GCS
-void NavEKF3::send_status_report(GCS_MAVLINK &link) const
+bool NavEKF3::getTerrainAltVariance(float &terrainAltVar) const
 {
     if (core) {
-        core[primary].send_status_report(link);
+        return core[primary].getTerrainAltVariance(terrainAltVar);
     }
+    return false;
 }
 
 // provides the height limit to be observed by the control loops

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -296,8 +296,8 @@ public:
     */
     void getFilterStatus(nav_filter_status &status) const;
 
-    // send an EKF_STATUS_REPORT message to GCS
-    void send_status_report(class GCS_MAVLINK &link) const;
+    // return a terrain altitude variance
+    bool getTerrainAltVariance(float &terrain_alt_variance) const;
 
     // provides the height limit to be observed by the control loops
     // returns false if no height limiting is required

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
@@ -610,78 +610,21 @@ void  NavEKF3_core::getFilterStatus(nav_filter_status &status) const
     status = filterStatus;
 }
 
-#if HAL_GCS_ENABLED
-// send an EKF_STATUS message to GCS
-void NavEKF3_core::send_status_report(GCS_MAVLINK &link) const
+// return a terrain altitude variance
+bool NavEKF3_core::getTerrainAltVariance(float &temp) const
 {
-    // prepare flags
-    uint16_t flags = 0;
-    if (filterStatus.flags.attitude) {
-        flags |= EKF_ATTITUDE;
-    }
-    if (filterStatus.flags.horiz_vel) {
-        flags |= EKF_VELOCITY_HORIZ;
-    }
-    if (filterStatus.flags.vert_vel) {
-        flags |= EKF_VELOCITY_VERT;
-    }
-    if (filterStatus.flags.horiz_pos_rel) {
-        flags |= EKF_POS_HORIZ_REL;
-    }
-    if (filterStatus.flags.horiz_pos_abs) {
-        flags |= EKF_POS_HORIZ_ABS;
-    }
-    if (filterStatus.flags.vert_pos) {
-        flags |= EKF_POS_VERT_ABS;
-    }
-    if (filterStatus.flags.terrain_alt) {
-        flags |= EKF_POS_VERT_AGL;
-    }
-    if (filterStatus.flags.const_pos_mode) {
-        flags |= EKF_CONST_POS_MODE;
-    }
-    if (filterStatus.flags.pred_horiz_pos_rel) {
-        flags |= EKF_PRED_POS_HORIZ_REL;
-    }
-    if (filterStatus.flags.pred_horiz_pos_abs) {
-        flags |= EKF_PRED_POS_HORIZ_ABS;
-    }
-    if (!filterStatus.flags.initalized) {
-        flags |= EKF_UNINITIALIZED;
-    }
-    if (filterStatus.flags.gps_glitching) {
-        flags |= (1<<15);
-    }
-
-    // get variances
-    float velVar = 0, posVar = 0, hgtVar = 0, tasVar = 0;
-    Vector3f magVar;
-    Vector2f offset;
-    getVariances(velVar, posVar, hgtVar, magVar, tasVar, offset);
-
-
     // Only report range finder normalised innovation levels if the EKF needs the data for primary
     // height estimation or optical flow operation. This prevents false alarms at the GCS if a
     // range finder is fitted for other applications
-    float temp = 0;
     if (((frontend->_useRngSwHgt > 0) && activeHgtSource == AP_NavEKF_Source::SourceZ::RANGEFINDER) || (PV_AidingMode == AID_RELATIVE && flowDataValid)) {
         temp = sqrtF(auxRngTestRatio);
+    } else {
+        temp = 0;
     }
-
-    const mavlink_ekf_status_report_t packet{
-        velVar,
-        posVar,
-        hgtVar,
-        fmaxf(fmaxf(magVar.x,magVar.y),magVar.z),
-        temp,
-        flags,
-        tasVar
-    };
-
-    // send message
-    mavlink_msg_ekf_status_report_send_struct(link.get_chan(), &packet);
+    // we always successfully return a value, even if that value is a
+    // "nothing to look at here" 0 value:
+    return true;
 }
-#endif  // HAL_GCS_ENABLED
 
 // report the reason for why the backend is refusing to initialise
 const char *NavEKF3_core::prearm_failure_reason(void) const

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -393,8 +393,8 @@ public:
     */
     void getFilterStatus(nav_filter_status &status) const;
 
-    // send an EKF_STATUS_REPORT message to GCS
-    void send_status_report(class GCS_MAVLINK &link) const;
+    // return a terrain altitude variance
+    bool getTerrainAltVariance(float &terrain_alt_variance) const;
 
     // provides the height limit to be observed by the control loops
     // returns false if no height limiting is required


### PR DESCRIPTION
### Summary

Have the base AP_AHRS::send_ekf_status_report assemble the packet to be sent to the GCS rather than delegating to the AHRS backends.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Added an autotest for this message.

```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli   iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                 *                                                    
Durandal                            0               -96    *           -792    -640               32     -8     -104
Hitec-Airspeed           *                                 *                                                    
KakuteH7-bdshot                     16              -88    *           -24     -112               152    -8     -40
MatekF405                           0               -64    *           0       24                 -592   8      24
MatekH7A3                           -32             16     *           -200    -56                -32    -96    -88
Pixhawk1-1M-bdshot                  24              48                 -32     -48                -104   -152   0
SITL_x86_64_linux_gnu               -5416           -1376              -5416   -5416              -1320  -5416  -1320
YJUAV_A6SE                          -256            -344   *           -352    -312               -632   -288   -344
f103-QiotekPeriph        *                                 *                                                    
f303-MatekGPS            *                                 *                                                    
f303-Universal           *                                 *                                                    
iomcu                                                                                 *                         
mindpx-v2                           48              -40    *           -112    -8                 192    -16    16
revo-mini                           40              -80    *           -32     -24                -64    -8     40
skyviper-v2450                                                         -8                                       
speedybeef4                         96              -56    *           -24     0                  -200   8      56
```

### Description

The backends already mostly supplied the data required to send this report out - the data is used elsewhere in ArduPilot.

Also moves the variances and whatnot into the backends structure.
