### PR TITLE
Correct VectorNav simulation GPS velocities

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -3413,13 +3413,13 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
                 return "%s not finite (%s)" % (name, value)
             if value < 0:
                 return "%s negative (%f)" % (name, value)
-        # a generous sanity ceiling: these are normalised innovation
-        # variances, so anything in the hundreds indicates a garbage /
-        # mis-assembled field (e.g. uninitialised struct memory) rather
-        # than a merely poorly-converged filter:
-        for name, value in variances.items():
-            if value > 100:
-                return "%s implausibly high (%f)" % (name, value)
+        # the normalised innovation variances should be below 1.0 for a
+        # vehicle established in a loiter (1.0 == the maximum
+        # inconsistency the filter will accept before rejecting the
+        # measurement):
+        for name in "velocity_variance", "pos_horiz_variance", "pos_vert_variance":
+            if variances[name] > 1.0:
+                return "%s too high (%f)" % (name, variances[name])
         # the filter should be healthy and initialised:
         required = (mavutil.mavlink.EKF_ATTITUDE |
                     mavutil.mavlink.EKF_VELOCITY_HORIZ |

--- a/libraries/SITL/SIM_VectorNav.cpp
+++ b/libraries/SITL/SIM_VectorNav.cpp
@@ -223,9 +223,7 @@ void VectorNav::send_ins_gnss_packet(void)
     pkt.posU1[1] = 1;
     pkt.posU1[2] = 1.5;
 
-    pkt.velNed1[0] = 0.05;
-    pkt.velNed1[1] = 0.05;
-    pkt.velNed1[2] = 0.05;
+    pkt.velU1 = 0.05;
     // pkt.dop1 =
     pkt.numSats2 = 18;
     pkt.fix2 = 3;


### PR DESCRIPTION
### Summary

Fixed the NED velocities packed into the VectorNav packets

~~Based on https://github.com/ArduPilot/ardupilot/pull/33383 and should not be reviewed before it goes in.~~ It's in

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Tightens a contraint which was very wide because of this bug.

### Description

fd9d416785 managed to leave stray debug in which zeroed these velocities.
