### PR TITLE
Copter: deny arming for Heli with Copter raising when rudder-arming

### DIFF
--- a/ArduCopter/AP_Arming_Copter.cpp
+++ b/ArduCopter/AP_Arming_Copter.cpp
@@ -620,7 +620,17 @@ bool AP_Arming_Copter::arm_checks(AP_Arming::Method method)
 #else
         const char *rc_item = "Throttle";
 #endif
-        // check throttle is not too high - skips checks if arming from GCS/scripting in Guided,Guided_NoGPS or Auto 
+#if FRAME_CONFIG == HELI_FRAME
+        // heli defaults the RC_OPTIONS neutral-throttle check off so that
+        // GCS/switch arming is permitted with the collective raised.  That
+        // same option gates the rudder-arming gesture's throttle check, so
+        // enforce zero collective for stick arming explicitly here.
+        if (method == AP_Arming::Method::RUDDER && copter.channel_throttle->get_control_in() != 0) {
+            check_failed(Check::RC, true, "%s too high", rc_item);
+            return false;
+        }
+#endif  // FRAME_CONFIG == HELI_FRAME
+        // check throttle is not too high - skips checks if arming from GCS/scripting in Guided,Guided_NoGPS or Auto
         if (!((AP_Arming::method_is_GCS(method) || method == AP_Arming::Method::SCRIPTING) && copter.flightmode->allows_GCS_or_SCR_arming_with_throttle_high())) {
             // above top of deadband is too always high
             if (copter.get_pilot_desired_climb_rate_ms() > 0.0f) {

--- a/Tools/autotest/helicopter.py
+++ b/Tools/autotest/helicopter.py
@@ -1178,6 +1178,45 @@ class AutoTestHelicopter(AutoTestCopter):
         self.progress("Killing rotor speed")
         self.set_rc(8, 1000)
 
+    def assert_not_stick_armed(self, timeout=10):
+        '''raise if the vehicle stick-arms within timeout seconds'''
+        arming_channel = self.get_stick_arming_channel()
+        self.set_output_to_max(arming_channel)
+        tstart = self.get_sim_time()
+        try:
+            while self.get_sim_time_cached() - tstart < timeout:
+                self.wait_heartbeat()
+                if self.armed():
+                    raise NotAchievedException("Stick-armed when it should not have")
+        finally:
+            self.set_output_to_trim(arming_channel)
+
+    def StickArmingRequiresZeroThrottle(self):
+        '''check that stick (rudder) arming requires the collective at zero'''
+
+        '''
+        Reproduces https://github.com/ArduPilot/ardupilot/issues/33386 :
+        a heli could be stick-armed with the collective/throttle stick
+        raised off the bottom stop, a change in behaviour from 4.6 and
+        prior.  Stick arming must require zero throttle.
+        '''
+        self.set_rc(8, 1000)  # rotor interlock disabled
+        self.zero_throttle()  # collective on the bottom stop
+        self.wait_ready_to_arm()
+
+        self.start_subtest("Stick arming succeeds with collective at zero")
+        self.arm_motors_with_rc_input()
+        self.disarm_vehicle()
+
+        self.start_subtest("Stick arming is refused with collective raised")
+        self.set_rc(3, 1300)
+        self.assert_not_stick_armed()
+
+        self.start_subtest("GCS arming is permitted with collective raised")
+        self.set_rc(3, 1300)
+        self.arm_vehicle()
+        self.disarm_vehicle()
+
     def tests(self):
         '''return list of all tests'''
         ret = vehicle_test_suite.TestSuite.tests(self)
@@ -1201,6 +1240,7 @@ class AutoTestHelicopter(AutoTestCopter):
             self.DDFPTail,
             self.DDVPTail,
             self.MountFailsafeAction,
+            self.StickArmingRequiresZeroThrottle,
         ])
         return ret
 


### PR DESCRIPTION
### Summary

Stop users being able to rudder-arm with non-zero collective.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

New test fails before / passes afterwards.

### Description

Fixes regression caused by f9660c286c247e77a7ab754fa5557f2cd01772b6 .

Heli deliberately turns off the bit saying "check throttle".  Because it's got a collective instead and wants... different rules.  So we add another rule here.

Fixes https://github.com/ArduPilot/ardupilot/issues/33386
