### PR TITLE
AP_AHRS: use results attributes for healthy and initialised

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -659,14 +659,14 @@ void AP_AHRS::update_EKF2(void)
 {
     if (!ekf2.started) {
         // wait 1 second for DCM to output a valid tilt error estimate
-        if (start_time_ms == 0) {
-            start_time_ms = AP_HAL::millis();
+        if (ekf2.start_time_ms == 0) {
+            ekf2.start_time_ms = AP_HAL::millis();
         }
 #if HAL_LOGGING_ENABLED
         // if we're doing Replay logging then don't allow any data
         // into the EKF yet.  Don't allow it to block us for long.
         if (!hal.util->was_watchdog_reset()) {
-            if (AP_HAL::millis() - start_time_ms < 5000) {
+            if (AP_HAL::millis() - ekf2.start_time_ms < 5000) {
                 if (!AP::logger().allow_start_ekf()) {
                     return;
                 }
@@ -674,7 +674,7 @@ void AP_AHRS::update_EKF2(void)
         }
 #endif
 
-        if (AP_HAL::millis() - start_time_ms > startup_delay_ms) {
+        if (AP_HAL::millis() - ekf2.start_time_ms > startup_delay_ms) {
             ekf2.started = ekf2.EKF2.InitialiseFilter();
         }
     }
@@ -710,21 +710,21 @@ void AP_AHRS::update_EKF3(void)
 {
     if (!ekf3.started) {
         // wait 1 second for DCM to output a valid tilt error estimate
-        if (start_time_ms == 0) {
-            start_time_ms = AP_HAL::millis();
+        if (ekf3.start_time_ms == 0) {
+            ekf3.start_time_ms = AP_HAL::millis();
         }
 #if HAL_LOGGING_ENABLED
         // if we're doing Replay logging then don't allow any data
         // into the EKF yet.  Don't allow it to block us for long.
         if (!hal.util->was_watchdog_reset()) {
-            if (AP_HAL::millis() - start_time_ms < 5000) {
+            if (AP_HAL::millis() - ekf3.start_time_ms < 5000) {
                 if (!AP::logger().allow_start_ekf()) {
                     return;
                 }
             }
         }
 #endif
-        if (AP_HAL::millis() - start_time_ms > startup_delay_ms) {
+        if (AP_HAL::millis() - ekf3.start_time_ms > startup_delay_ms) {
             ekf3.started = ekf3.EKF3.InitialiseFilter();
         }
     }
@@ -1702,7 +1702,7 @@ AP_AHRS::EKFType AP_AHRS::_active_EKF_type(void) const
             if (ekf2_faults == 0) {
                 ret = EKFType::TWO;
             }
-        } else if (ekf2.healthy()) {
+        } else if (ekf2_estimates.healthy) {
             ret = EKFType::TWO;
         }
         break;
@@ -1721,7 +1721,7 @@ AP_AHRS::EKFType AP_AHRS::_active_EKF_type(void) const
             if (ekf3_faults == 0) {
                 ret = EKFType::THREE;
             }
-        } else if (ekf3.healthy()) {
+        } else if (ekf3_estimates.healthy) {
             ret = EKFType::THREE;
         }
         break;
@@ -1864,7 +1864,7 @@ AP_AHRS::EKFType AP_AHRS::fallback_active_EKF_type(void) const
 #endif
 
 #if AP_AHRS_EXTERNAL_ENABLED
-    if (external.healthy()) {
+    if (external_estimates.healthy) {
         return EKFType::EXTERNAL;
     }
 #endif
@@ -1933,58 +1933,16 @@ bool AP_AHRS::_get_secondary_EKF_type(EKFType &secondary_ekf_type) const
 */
 bool AP_AHRS::healthy(void) const
 {
-    // If EKF is started we switch away if it reports unhealthy. This could be due to bad
-    // sensor data. If EKF reversion is inhibited, we only switch across if the EKF encounters
-    // an internal processing error, but not for bad sensor data.
-    switch (configured_ekf_type()) {
-
-#if AP_AHRS_DCM_ENABLED
-    case EKFType::DCM:
-        return dcm.healthy();
-#endif
-
-#if HAL_NAVEKF2_AVAILABLE
-    case EKFType::TWO: {
-        if (!ekf2.healthy()) {
-            return false;
-        }
-        if ((_vehicle_class == VehicleClass::FIXED_WING ||
-                _vehicle_class == VehicleClass::GROUND) &&
-                active_EKF_type() != EKFType::TWO) {
-            // on fixed wing we want to be using EKF to be considered
-            // healthy if EKF is enabled
-            return false;
-        }
-        return true;
-    }
-#endif
-
-#if HAL_NAVEKF3_AVAILABLE
-    case EKFType::THREE:
-        if (!ekf3.healthy()) {
-            return false;
-        }
-        if ((_vehicle_class == VehicleClass::FIXED_WING ||
-                _vehicle_class == VehicleClass::GROUND) &&
-                active_EKF_type() != EKFType::THREE) {
-            // on fixed wing we want to be using EKF to be considered
-            // healthy if EKF is enabled
-            return false;
-        }
-        return true;
-#endif
-
-#if AP_AHRS_SIM_ENABLED
-    case EKFType::SIM:
-        return sim.healthy();
-#endif
-#if AP_AHRS_EXTERNAL_ENABLED
-    case EKFType::EXTERNAL:
-        return external.healthy();
-#endif
+    if (!configured_estimates->healthy) {
+        return false;
     }
 
-    return false;
+    // we must be using the configured type to be considered healthy:
+    if (configured_backend != active_backend) {
+        return false;
+    }
+
+    return true;
 }
 
 // returns false if we fail arming checks, in which case the buffer will be populated with a failure message
@@ -2022,39 +1980,6 @@ bool AP_AHRS::pre_arm_check(bool requires_position, char *failure_msg, uint8_t f
 
     return (configured_backend->pre_arm_check(requires_position, failure_msg, failure_msg_len) && ret);
 }
-
-// true if the AHRS has completed initialisation
-bool AP_AHRS::initialised(void) const
-{
-    switch (configured_ekf_type()) {
-#if AP_AHRS_DCM_ENABLED
-    case EKFType::DCM:
-        return true;
-#endif
-
-#if HAL_NAVEKF2_AVAILABLE
-    case EKFType::TWO:
-        // initialisation complete 10sec after ekf has started
-        return (ekf2.started && (AP_HAL::millis() - start_time_ms > AP_AHRS_NAVEKF_SETTLE_TIME_MS));
-#endif
-
-#if HAL_NAVEKF3_AVAILABLE
-    case EKFType::THREE:
-        // initialisation complete 10sec after ekf has started
-        return (ekf3.started && (AP_HAL::millis() - start_time_ms > AP_AHRS_NAVEKF_SETTLE_TIME_MS));
-#endif
-
-#if AP_AHRS_SIM_ENABLED
-    case EKFType::SIM:
-        return true;
-#endif
-#if AP_AHRS_EXTERNAL_ENABLED
-    case EKFType::EXTERNAL:
-        return external.initialised();
-#endif
-    }
-    return false;
-};
 
 // write optical flow data to EKF
 void  AP_AHRS::writeOptFlowMeas(const uint8_t rawFlowQuality, const Vector2f &rawFlowRates, const Vector2f &rawGyroRates, const uint32_t msecFlowMeas, const Vector3f &posOffset, float heightOverride)

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -37,9 +37,6 @@
 // forward declare view class
 class AP_AHRS_View;
 
-#define AP_AHRS_NAVEKF_SETTLE_TIME_MS 20000     // time in milliseconds the ekf needs to settle after being started
-
-
 // fwd declare GSF estimator
 class EKFGSF_yaw;
 
@@ -356,7 +353,9 @@ public:
     bool pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const;
 
     // true if the AHRS has completed initialisation
-    bool initialised() const;
+    bool initialised() const {
+        return configured_estimates->initialised;
+    }
 
 #if AP_AHRS_DCM_ENABLED
     // return true if *DCM* yaw has been initialised
@@ -855,7 +854,6 @@ private:
 #endif
 
     static constexpr uint16_t startup_delay_ms = 1000;
-    uint32_t start_time_ms;
     uint8_t _ekf_flags; // bitmask from Flags enumeration
 
     void update_DCM();

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -61,6 +61,12 @@ public:
         friend class AP_AHRS_NavEKF2;
         friend class AP_AHRS_NavEKF3;
 
+        // is the AHRS subsystem healthy?
+        bool healthy;
+
+        // true if the AHRS has completed initialisation
+        bool initialised;
+
         // inertial sensor information
         uint8_t primary_gyro;
 
@@ -286,17 +292,6 @@ public:
 
     // return true if we will use compass for yaw
     virtual bool use_compass(void) = 0;
-
-    // is the AHRS subsystem healthy?
-    virtual bool healthy(void) const = 0;
-
-    // true if the AHRS has completed initialisation
-    virtual bool initialised(void) const {
-        return true;
-    };
-    virtual bool started(void) const {
-        return initialised();
-    };
 
     // return the amount of yaw angle change due to the last yaw angle reset in radians
     // returns the time of the last yaw angle reset or 0 if no reset has ever occurred

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -143,6 +143,14 @@ AP_AHRS_DCM::update()
 
 void AP_AHRS_DCM::get_results(AP_AHRS_Backend::Estimates &results)
 {
+    const auto now_ms = AP_HAL::millis();
+
+    // always initialised
+    results.initialised = true;
+
+    // consider ourselves healthy if there have been no failures for 5 seconds
+    results.healthy = (_last_failure_ms == 0 || now_ms - _last_failure_ms > 5000);
+
     // not using a specific sensor:
     results.primary_gyro = AP::ins().get_first_usable_gyro();
     results.primary_accel = AP::ins().get_first_usable_accel();
@@ -1208,15 +1216,6 @@ bool AP_AHRS_DCM::get_unconstrained_airspeed_EAS(uint8_t airspeed_index, float &
 }
 
 /*
-  check if the AHRS subsystem is healthy
-*/
-bool AP_AHRS_DCM::healthy(void) const
-{
-    // consider ourselves healthy if there have been no failures for 5 seconds
-    return (_last_failure_ms == 0 || AP_HAL::millis() - _last_failure_ms > 5000);
-}
-
-/*
   return NED velocity if we have GPS lock
  */
 bool AP_AHRS_DCM::get_velocity_NED(Vector3f &vec) const
@@ -1310,17 +1309,6 @@ bool AP_AHRS_DCM::get_vert_pos_rate_D(float &velocity) const
         return true;
     }
     return false;
-}
-
-// returns false if we fail arming checks, in which case the buffer will be populated with a failure message
-// requires_position should be true if horizontal position configuration should be checked (not used)
-bool AP_AHRS_DCM::pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const
-{
-    if (!healthy()) {
-        hal.util->snprintf(failure_msg, failure_msg_len, "Not healthy");
-        return false;
-    }
-    return true;
 }
 
 /*

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -94,12 +94,11 @@ public:
 
     void estimate_wind(void);
 
-    // is the AHRS subsystem healthy?
-    bool healthy() const override;
-
     // returns false if we fail arming checks, in which case the buffer will be populated with a failure message
     // requires_position should be true if horizontal position configuration should be checked (not used)
-    bool pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const override;
+    bool pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const override {
+        return true;
+    }
 
     // relative-origin functions for fallback in AP_InertialNav
     bool get_origin(Location &ret) const override;

--- a/libraries/AP_AHRS/AP_AHRS_External.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_External.cpp
@@ -5,24 +5,18 @@
 #include <AP_ExternalAHRS/AP_ExternalAHRS.h>
 #include <AP_AHRS/AP_AHRS.h>
 
-// true if the AHRS has completed initialisation
-bool AP_AHRS_External::initialised(void) const
-{
-    return AP::externalAHRS().initialised();
-}
-
 void AP_AHRS_External::update()
 {
     AP::externalAHRS().update();
 }
 
-bool AP_AHRS_External::healthy() const {
-    return AP::externalAHRS().healthy();
-}
-
 void AP_AHRS_External::get_results(AP_AHRS_Backend::Estimates &results)
 {
     auto &extahrs = AP::externalAHRS();
+
+    results.initialised = extahrs.initialised();
+
+    results.healthy = extahrs.healthy();
 
 #if AP_INERTIALSENSOR_ENABLED
     const AP_InertialSensor &_ins = AP::ins();

--- a/libraries/AP_AHRS/AP_AHRS_External.h
+++ b/libraries/AP_AHRS/AP_AHRS_External.h
@@ -42,7 +42,6 @@ public:
     void reset_gyro_drift() override {}
 
     // Methods
-    bool            initialised() const override;
     void            update() override;
     void            get_results(Estimates &results) override;
     void            reset() override {}
@@ -59,9 +58,6 @@ public:
     }
 
     void estimate_wind(void);
-
-    // is the AHRS subsystem healthy?
-    bool healthy() const override;
 
     // returns false if we fail arming checks, in which case the buffer will be populated with a failure message
     // requires_position should be true if horizontal position configuration should be checked (not used)

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF2.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF2.cpp
@@ -12,6 +12,13 @@ NavEKF2 AP_AHRS_NavEKF2::EKF2;
 
 void AP_AHRS_NavEKF2::get_results(AP_AHRS_Backend::Estimates &results)
 {
+    const auto now_ms = AP_HAL::millis();
+
+    // initialisation complete some time after ekf has started
+    results.initialised = (started && (now_ms - start_time_ms > 20000));
+
+    results.healthy = started && EKF2.healthy();
+
     const AP_InertialSensor &_ins = AP::ins();
 
     /*

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF2.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF2.h
@@ -35,16 +35,6 @@ public:
 
     const char *shortname() const override { return "EKF2"; }
 
-    bool healthy(void) const override {
-        if (!started) {
-            return false;
-        }
-        if (!EKF2.healthy()) {
-            return false;
-        }
-        return true;
-    }
-
     void reset_gyro_drift() override { EKF2.resetGyroBias(); }
 
     void update() override { EKF2.UpdateFilter(); }
@@ -113,6 +103,7 @@ public:
     static NavEKF2 EKF2;
 
     bool started;
+    uint32_t start_time_ms;  // timer used to delay starting the filter
 };
 
 #endif  // AP_AHRS_NAVEKF2_ENABLED

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
@@ -12,6 +12,13 @@ NavEKF3 AP_AHRS_NavEKF3::EKF3;
 
 void AP_AHRS_NavEKF3::get_results(AP_AHRS_Backend::Estimates &results)
 {
+    const auto now_ms = AP_HAL::millis();
+
+    // initialisation complete some time after ekf has started
+    results.initialised = (started && (now_ms - start_time_ms > 20000));
+
+    results.healthy = started && EKF3.healthy();
+
     const AP_InertialSensor &_ins = AP::ins();
 
     /*

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF3.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF3.h
@@ -35,16 +35,6 @@ public:
 
     const char *shortname() const override { return "EKF3"; }
 
-    bool healthy(void) const override {
-        if (!started) {
-            return false;
-        }
-        if (!EKF3.healthy()) {
-            return false;
-        }
-        return true;
-    }
-
     void reset_gyro_drift() override { EKF3.resetGyroBias(); }
 
     void update() override { EKF3.UpdateFilter(); }
@@ -111,6 +101,7 @@ public:
     static NavEKF3 EKF3;
 
     bool started;
+    uint32_t start_time_ms;  // timer used to delay starting the filter
 };
 
 #endif  // AP_AHRS_NAVEKF3_ENABLED

--- a/libraries/AP_AHRS/AP_AHRS_SIM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_SIM.cpp
@@ -150,6 +150,12 @@ void AP_AHRS_SIM::get_results(AP_AHRS_Backend::Estimates &results)
         }
     }
 
+    // always initialised once sitl pointer is good
+    results.initialised = true;
+
+    // always healthy
+    results.healthy = true;
+
     // not using a specific sensor:
     results.primary_gyro = AP::ins().get_first_usable_gyro();
     results.primary_accel = AP::ins().get_first_usable_accel();

--- a/libraries/AP_AHRS/AP_AHRS_SIM.h
+++ b/libraries/AP_AHRS/AP_AHRS_SIM.h
@@ -75,9 +75,6 @@ public:
 
     bool            use_compass() override { return true; }
 
-    // is the AHRS subsystem healthy?
-    bool healthy() const override { return true; }
-
     // returns false if we fail arming checks, in which case the buffer will be populated with a failure message
     // requires_position should be true if horizontal position configuration should be checked (not used)
     bool pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const override { return true; }


### PR DESCRIPTION
### Summary

Moves healthy and initialised information into the backend results object (directly indicating validity of results)

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                 *                                                   
Durandal                            -160            -152   *           -152    -152              -152   -152   -152
Hitec-Airspeed           *                                 *                                                   
KakuteH7-bdshot                     -160            -152   *           -152    -152              -144   -152   -152
MatekF405                           -160            -152   *           -152    -152              -152   -152   -152
MatekH7A3                           -160            -152   *           -152    -152              -144   -160   -152
Pixhawk1-1M-bdshot                  -168            -152               -152    -152              -152   -152   -152
SITL_x86_64_linux_gnu               -496            -4592              -496    -496              -496   -488   -496
YJUAV_A6SE                          -232            -208   *           -208    -216              -208   -192   -208
f103-QiotekPeriph        *                                 *                                                   
f303-MatekGPS            *                                 *                                                   
f303-Universal           *                                 *                                                   
iomcu                                                                                *                         
mindpx-v2                           -160            -144   *           -152    -152              -144   -144   -144
revo-mini                           -160            -152   *           -152    -152              -152   -152   -152
skyviper-v2450                                                         -152                                    
speedybeef4                         -168            -152   *           -152    -152              -152   -152   -152
```


### Description

Moves the flags into being attributes on the estimates.

Makes clear that EKF2 and EKF3 can be both healthy and not initialised at the same time....

Makes the AHRS unhealthy if you are not using the configured type.  This was being done especially for Plane and Rover if EKF was configured as primary.  But the wider check is better - no other vehicle is actually deemed to be "happy" using DCM anyway!  This is already an explicit pre-arm check.

Removes the unused started() stub in AP_AHRS_Backend.

Exposes the fact the EKFs will go uninitialised for 20 seconds every 2^32 milliseconds (~49 days).  Maybe just replace with a time-since-boot?  Obviously better if we can measure the state rather than guess.
