### PR TITLE
AP_AHRS: remove stale init method

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -357,14 +357,6 @@ void AP_AHRS::init()
     update_configured_ekf_type();
     update_active_EKF_type();
 
-    // init backends
-#if AP_AHRS_DCM_ENABLED
-    dcm.init();
-#endif
-#if AP_AHRS_EXTERNAL_ENABLED
-    external.init();
-#endif
-
 #if AP_CUSTOMROTATIONS_ENABLED
     // convert to new custom rotation
     // PARAMETER_CONVERSION - Added: Nov-2021

--- a/libraries/AP_AHRS/AP_AHRS_Backend.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.cpp
@@ -27,10 +27,6 @@
 
 extern const AP_HAL::HAL& hal;
 
-void AP_AHRS_Backend::init()
-{
-}
-
 // return a smoothed and corrected gyro vector using the latest ins data (which may not have been consumed by the EKF yet)
 Vector3f AP_AHRS::get_gyro_latest(void) const
 {

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -188,9 +188,6 @@ public:
         float hagl;
     };
 
-    // init sets up INS board orientation
-    virtual void init();
-
     // Methods
     virtual void update() = 0;
 


### PR DESCRIPTION
### Summary

Removes empty method and its invocations

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board,copter
CubeOrange,-16
MatekF405,-16
```

### Description

no longer used.

The DCM init shows that this is probably better done with the equivalent of `init_done` state updated as part of the update() call rather than as a separate call by the frontend.
