### PR TITLE
Sub: fix OutOfRangeHigh case in Auto_TerrainRecover, other small fixes

### DIFF
--- a/ArduSub/mode_auto.cpp
+++ b/ArduSub/mode_auto.cpp
@@ -497,7 +497,7 @@ void ModeAuto::auto_terrain_recover_run()
         break;
 
     case RangeFinder::Status::OutOfRangeHigh:
-        target_climb_rate = sub.wp_nav.get_default_speed_down_cms();
+        target_climb_rate = -sub.wp_nav.get_default_speed_down_cms();
         rangefinder_recovery_ms = 0;
         break;
 
@@ -538,6 +538,7 @@ void ModeAuto::auto_terrain_recover_run()
 #else
     gcs().send_text(MAV_SEVERITY_CRITICAL, "Terrain failsafe recovery failure: No Rangefinder!");
     sub.failsafe_terrain_act();
+    return;
 #endif
 
     // exit on failure (timeout)
@@ -545,6 +546,7 @@ void ModeAuto::auto_terrain_recover_run()
         // Recovery has failed, revert to failsafe action
         gcs().send_text(MAV_SEVERITY_CRITICAL, "Terrain failsafe recovery timeout!");
         sub.failsafe_terrain_act();
+        return;
     }
 
     // run loiter controller

--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -1450,6 +1450,36 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
 
         self.disarm_vehicle()
 
+    def AutoTerrainRecover(self):
+        """Test Auto_TerrainRecover"""
+        self.set_parameter('RNGFND1_MAX', 50)
+
+        # Start at (0, 0, -5)
+        self.dive(-5, mode='ALT_HOLD')
+
+        # Move to (50, 0, 20) in above-terrain frame
+        self.upload_simple_relhome_mission([
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 50, 0, 20, {
+                "frame": mavutil.mavlink.MAV_FRAME_GLOBAL_TERRAIN_ALT,
+            }),
+        ])
+
+        self.change_mode('AUTO')
+        self.delay_sim_time(10, reason="Wait for mission to start")
+
+        # Reduce rangefinder range to trigger failsafe recovery
+        self.context_collect('STATUSTEXT')
+        self.set_parameter("RNGFND1_MAX", 35)
+        self.wait_statustext("Attempting auto failsafe recovery")
+
+        # The vehicle will dive until it recovers
+        self.wait_statustext("Terrain failsafe recovery successful!")
+
+        # Reduce it again, this time recovery will time out, and the vehicle will automatically disarm
+        self.set_parameter("RNGFND1_MAX", 15)
+        self.wait_statustext("Terrain failsafe recovery timeout!")
+        self.wait_statustext("Disarming motors")
+
     def tests(self):
         '''return list of all tests'''
         ret = super(AutoTestSub, self).tests()
@@ -1495,6 +1525,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
             self.UTMGlobalPositionWaypoint,
             self.UpsideDown,
             self.GuidedWP,
+            self.AutoTerrainRecover,
         ])
 
         return ret


### PR DESCRIPTION
### Summary

This PR has 3 small fixes to Auto_TerrainRecover mode for Sub.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Fix 1: If the rangefinder reports `OutOfRangeHigh` during a mission, the vehicle attempts to fix it by ascending, which only makes the problem worse. It should descend instead.

Fixes 2, 3: Calls to `sub.failsafe_terrain_act()` should be followed by `return;` so that `auto_terrain_recover_run` stops updating. This is missing in 2 cases.

There is a new autotest that verifies the fixes.