### PR TITLE
AP_HAL_ChibiOS: add FDCAN3 settings to STM32H723 mcuconf

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stm32h7_type2_mcuconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stm32h7_type2_mcuconf.h
@@ -280,6 +280,7 @@
 
 #define STM32_IRQ_FDCAN1_PRIORITY           10
 #define STM32_IRQ_FDCAN2_PRIORITY           10
+#define STM32_IRQ_FDCAN3_PRIORITY           10
 
 #define STM32_IRQ_MDMA_PRIORITY             9
 #define STM32_IRQ_OCTOSPI1_PRIORITY         10
@@ -345,6 +346,7 @@
  */
 #define STM32_CAN_USE_FDCAN1                FALSE
 #define STM32_CAN_USE_FDCAN2                FALSE
+#define STM32_CAN_USE_FDCAN3                FALSE
 
 /*
  * DAC driver system settings.


### PR DESCRIPTION
### Summary

the H723/H725/H730/H733/H735 parts have FDCAN3 and the updated ChibiOS FDCANv2 driver requires STM32_IRQ_FDCAN3_PRIORITY to be defined. This fixes the build of BotBloxDroneNet


### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

fixed H723 boards from ChibiOS update

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
