### PR TITLE
Tradheli: fix stick arming behavior bug in 4.7.0

### DIFF
--- a/ArduCopter/AP_Arming_Copter.cpp
+++ b/ArduCopter/AP_Arming_Copter.cpp
@@ -628,12 +628,14 @@ bool AP_Arming_Copter::arm_checks(AP_Arming::Method method)
                 return false;
             }
             // in manual modes throttle must be at zero
-#if FRAME_CONFIG != HELI_FRAME
+#if FRAME_CONFIG == HELI_FRAME
+            if ((copter.flightmode->has_manual_throttle() || copter.flightmode->mode_number() == Mode::Number::DRIFT) && copter.motors->get_takeoff_collective()) {
+#else
             if ((copter.flightmode->has_manual_throttle() || copter.flightmode->mode_number() == Mode::Number::DRIFT) && copter.channel_throttle->get_control_in() > 0) {
+#endif
                 check_failed(Check::RC, true, "%s too high", rc_item);
                 return false;
             }
-#endif
         }
     }
 

--- a/ArduCopter/radio.cpp
+++ b/ArduCopter/radio.cpp
@@ -41,7 +41,6 @@ void Copter::init_rc_in()
 
     #if FRAME_CONFIG == HELI_FRAME
         static const struct AP_Param::defaults_table_struct heli_defaults_table[] = {
-            { "RC_OPTIONS", 0 },
             { "RC8_OPTION", 32 }
         };
         AP_Param::set_defaults_from_table(heli_defaults_table, ARRAY_SIZE(heli_defaults_table));

--- a/Tools/autotest/helicopter.py
+++ b/Tools/autotest/helicopter.py
@@ -800,6 +800,7 @@ class AutoTestHelicopter(AutoTestCopter):
 
         self.wait_waypoint(1, num_wp-1)
         self.wait_disarmed()
+        self.set_rc(3, 1000)
         self.set_rc(8, 1000)    # Lower rotor speed
 
     # FIXME move this & plane's version to common

--- a/Tools/autotest/helicopter.py
+++ b/Tools/autotest/helicopter.py
@@ -1178,6 +1178,53 @@ class AutoTestHelicopter(AutoTestCopter):
         self.progress("Killing rotor speed")
         self.set_rc(8, 1000)
 
+    def assert_not_stick_armed(self, timeout=10):
+        '''raise if the vehicle stick-arms within timeout seconds'''
+        arming_channel = self.get_stick_arming_channel()
+        self.set_output_to_max(arming_channel)
+        tstart = self.get_sim_time()
+        try:
+            while self.get_sim_time_cached() - tstart < timeout:
+                self.wait_heartbeat()
+                if self.armed():
+                    raise NotAchievedException("Stick-armed when it should not have")
+        finally:
+            self.set_output_to_trim(arming_channel)
+
+    def StickArmingRequiresZeroThrottle(self):
+        '''check that stick (rudder) arming requires the collective at zero'''
+
+        '''
+        Reproduces https://github.com/ArduPilot/ardupilot/issues/33386 :
+        a heli could be stick-armed with the collective/throttle stick
+        raised off the bottom stop, a change in behaviour from 4.6 and
+        prior.  Stick arming must require zero throttle.
+        '''
+
+        # test in stabilize mode with rotor interlock disabled
+        self.change_mode('STABILIZE')
+        self.set_rc(8, 1000)
+
+        # check arming is possible with collective at zero
+        self.start_subtest("Stick arming succeeds with collective at zero")
+        self.set_parameter("RC_OPTIONS", 32) # enable Arming check throttle for 0 input
+        self.zero_throttle()
+        self.wait_ready_to_arm()
+        self.arm_motors_with_rc_input()
+        self.disarm_vehicle()
+
+        # check arming fails with collective raised
+        self.start_subtest("Stick arming is refused with collective raised")
+        self.set_rc(3, 1300)
+        self.assert_not_stick_armed()
+
+        # check arming succeeds with RC_OPTIONS arming check disabled
+        self.start_subtest("Stick arming succeeds with collective raised")
+        self.set_parameter("RC_OPTIONS", 0)
+        self.set_rc(3, 1300)
+        self.arm_motors_with_rc_input()
+        self.disarm_vehicle()
+
     def tests(self):
         '''return list of all tests'''
         ret = vehicle_test_suite.TestSuite.tests(self)
@@ -1201,6 +1248,7 @@ class AutoTestHelicopter(AutoTestCopter):
             self.DDFPTail,
             self.DDVPTail,
             self.MountFailsafeAction,
+            self.StickArmingRequiresZeroThrottle,
         ])
         return ret
 


### PR DESCRIPTION
### Summary

This PR fixes the stick arming behavior change where stick arming can occur with the throttle not zero.  This pr addresses issue https://github.com/ArduPilot/ardupilot/issues/33386.  It is proposed in lieu of PR https://github.com/ArduPilot/ardupilot/pull/33387.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually (e.g. SITL)


### Description

History:
In 2019, Chris Olsen merged a PR that allowed throttle stick above zero when arming through a switch or GCS. This did not affect stick arming in that it still required the throttle to be zero prior to arming.

There was another PR in 2020 by Mark Whitehorn. In this one, the RC_OPTION bit requiring zero throttle (bit 5) was defaulted to checked for copter and kept unchecked for heli. Again this didn't affect this behavior which seems odd but heli stick arming still required zero throttle.

Going from 4.6 to 4.7, changes were made that caused stick arming to no longer require the throttle be zero.

The Fix:
It was decided to error on the side of safety and also bring heli's use of arming options closer to how copter has them implemented.   The first change modifies Chris Olsens original change to now just require collective be below takeoff collective instead completely removing the manual throttle restriction.  The second reverts the RC_OPTIONS change using the default of 32 which requires zero throttle.

The default configuration now enforces throttle stick to be zero for arming (stick and GCS).  This will break some user's setups because it no longer allows non zero throttle for the default configuration.  Users that want the option of allowing the throttle stick to not be on the bottom stop while arming will now have to use the RC_OPTIONS bit to not enforce the zero throttle stick.  This will allow GCS or switch arming in any mode and if in manual throttle modes will enforce the collective blade pitch be below takeoff collective blade pitch (50% hover collective).  Users that are looking to use a sprung throttle (not intending to arm in manual throttle modes) can use the PILOT_THR_BHV bit to allow sprung throttle.  changes should not have affected this.

Testing:  
I have done functional testing to look at these different situations.  I have not pulled Peter Barkers autotests into the PR yet but intend to.  

@Ferruccio1984 I would appreciate your feedback on this implementation
