### PR TITLE
autotest: make SetHomeAltChange reliable

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -7056,7 +7056,13 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             home = self.home_position_as_mav_location()
             target_alt = 20
             self.takeoff(target_alt, mode="TAKEOFF")
-            self.delay_sim_time(20, reason="altitude to stabilise")  # Give some time to altitude to stabilize.
+            self.wait_altitude(
+                home.alt+target_alt-5,
+                home.alt+target_alt+5,
+                relative=False,
+                minimum_duration=20,
+                timeout=60,
+            )
             self.set_rc(3, 1500)
             self.change_mode(mode)
             higher_home = copy.copy(home)


### PR DESCRIPTION
### Summary

Makes SetHomeAltChange test reliable

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<img width="1800" height="960" alt="image" src="https://github.com/user-attachments/assets/7c08015a-4f9f-4e6c-a110-bac8bbeedda0" />

### Description

timing was too tight on the phase after takeoff - vehicle was still recovering its altitude after the takeoff

This makes sure the vehicle is stable rather than having a flat timeout.

~~Investigations into why we're diving hard after mode change.  That looks serious.~~  That's just TECS having a few conniptions when we move from a takeoff-demanded speed (AIRSPEED_CRUISE) to a sitck-demanded airspeed which is lower.  TECS cuts the throttle to dump KE, etc etc...
