### PR TITLE
AP_AHRS: move wind estimate into backend results

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -454,7 +454,6 @@ void AP_AHRS::update_state(void)
     state.primary_accel = active_estimates->primary_accel;
 
     state.primary_core = _get_primary_core_index();
-    state.wind_estimate_ok = active_backend->wind_estimate(state.wind_estimate);
     state.EAS2TAS = AP_AHRS_Backend::get_EAS2TAS();
     state.airspeed_EAS_ok = _airspeed_EAS(state.airspeed_EAS, state.airspeed_estimate_type);
     state.airspeed_TAS_ok = _airspeed_TAS(state.airspeed_TAS);
@@ -932,7 +931,8 @@ bool AP_AHRS::_airspeed_EAS(float &airspeed_ret, AirspeedEstimateType &airspeed_
 
 #if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE:
-        have_wind = ekf3.wind_estimate(wind_vel);
+        wind_vel = ekf3_estimates.wind;
+        have_wind = ekf3_estimates.wind_valid;
         break;
 #endif
 
@@ -2806,11 +2806,11 @@ bool AP_AHRS::get_location(Location &loc) const
     return state.location_ok;
 }
 
-// return a wind estimation vector, in m/s; returns 0,0,0 on failure
+// return a wind estimation vector in "wind" (m/s); returns false on failure
 bool AP_AHRS::wind_estimate(Vector3f &wind) const
 {
-    wind = state.wind_estimate;
-    return state.wind_estimate_ok;
+    wind = active_estimates->wind;
+    return active_estimates->wind_valid;
 }
 
 // return an airspeed estimate if available. return true

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -126,7 +126,7 @@ public:
     bool get_wind_estimation_enabled() const { return wind_estimation_enabled; }
 
     // return a wind estimation vector, in m/s; returns 0,0,0 on failure
-    const Vector3f &wind_estimate() const { return state.wind_estimate; }
+    const Vector3f &wind_estimate() const { return active_estimates->wind; }
 
     // return a wind estimation vector, in m/s; returns 0,0,0 on failure
     bool wind_estimate(Vector3f &wind) const;
@@ -1032,8 +1032,6 @@ private:
         Vector3f gyro_drift;
         Vector3f accel_ef;
         Vector3f accel_bias;
-        Vector3f wind_estimate;
-        bool wind_estimate_ok;
         float EAS2TAS;
         bool airspeed_EAS_ok;
         float airspeed_EAS;

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -143,6 +143,13 @@ public:
         }
 
         /*
+         * air data estimates
+         */
+        // estimated wind in m/s, NED frame
+        Vector3f wind;
+        bool wind_valid;
+
+        /*
          * Sensor-related information
          */
 
@@ -212,9 +219,6 @@ public:
 
     // reset the current attitude, used on new IMU calibration
     virtual void reset() = 0;
-
-    // return a wind estimation vector, in m/s
-    virtual bool wind_estimate(Vector3f &wind) const = 0;
 
     // return an airspeed estimate if available. return true
     // if we have an estimate

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -186,6 +186,12 @@ void AP_AHRS_DCM::get_results(AP_AHRS_Backend::Estimates &results)
     // results.hagl = 0;
 
     /*
+     * air data estimates
+     */
+    results.wind = _wind;
+    results.wind_valid = true;
+
+    /*
      * Sensor-related information
      */
     // true if the estimator will use GPS data in creating its
@@ -1240,9 +1246,7 @@ Vector2f AP_AHRS_DCM::groundspeed_vector(void)
     const bool gotGPS = (AP::gps().status() >= AP_GPS_FixType::FIX_2D);
     if (gotAirspeed) {
         const Vector2f airspeed_vector{_cos_yaw * airspeed, _sin_yaw * airspeed};
-        Vector3f wind;
-        UNUSED_RESULT(wind_estimate(wind));
-        gndVelADS = airspeed_vector + wind.xy();
+        gndVelADS = airspeed_vector + _wind.xy();
     }
 
     // Generate estimate of ground speed vector using GPS
@@ -1287,10 +1291,7 @@ Vector2f AP_AHRS_DCM::groundspeed_vector(void)
         Vector2f ret{_cos_yaw, _sin_yaw};
         ret *= airspeed;
         // adjust for estimated wind
-        Vector3f wind;
-        UNUSED_RESULT(wind_estimate(wind));
-        ret.x += wind.x;
-        ret.y += wind.y;
+        ret += _wind.xy();
         return ret;
     }
 

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -74,12 +74,6 @@ public:
         return _error_yaw;
     }
 
-    // return a wind estimation vector, in m/s
-    bool wind_estimate(Vector3f &wind) const override {
-        wind = _wind;
-        return true;
-    }
-
     void set_external_wind_estimate(float speed, float direction);
 
     // return an airspeed estimate if available. return true

--- a/libraries/AP_AHRS/AP_AHRS_External.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_External.cpp
@@ -78,6 +78,13 @@ void AP_AHRS_External::get_results(AP_AHRS_Backend::Estimates &results)
     // results.hagl = 0;
 
     /*
+     * air data estimates
+     */
+    // wind estimate is not supplied:
+    // results.wind = {};
+    // results.wind_valid = false;
+
+    /*
      * Sensor-related information
      */
     // true if the estimator will use GPS data in creating its

--- a/libraries/AP_AHRS/AP_AHRS_External.h
+++ b/libraries/AP_AHRS/AP_AHRS_External.h
@@ -47,11 +47,6 @@ public:
     void            get_results(Estimates &results) override;
     void            reset() override {}
 
-    // return a wind estimation vector, in m/s
-    bool wind_estimate(Vector3f &ret) const override {
-        return false;
-    }
-
     bool            use_compass() override {
         // this is actually never called at the moment; we use dcm's
         // return value.

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF2.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF2.cpp
@@ -93,6 +93,12 @@ void AP_AHRS_NavEKF2::get_results(AP_AHRS_Backend::Estimates &results)
     results.hagl_valid = EKF2.getHAGL(results.hagl);
 
     /*
+     * air data estimates
+     */
+    EKF2.getWind(results.wind);
+    results.wind_valid = true;
+
+    /*
      * Sensor-related information
      */
     // true if the estimator will use GPS data in creating its

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF2.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF2.h
@@ -64,12 +64,6 @@ public:
         return EKF2.setOriginLLH(loc);
     }
 
-    // // return a wind estimation vector, in m/s
-    bool wind_estimate(Vector3f &wind) const override {
-        EKF2.getWind(wind);
-        return true;
-    }
-
     bool use_compass() override {
         return EKF2.use_compass();
     }

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
@@ -94,6 +94,11 @@ void AP_AHRS_NavEKF3::get_results(AP_AHRS_Backend::Estimates &results)
     results.hagl_valid = EKF3.getHAGL(results.hagl);
 
     /*
+     * air data estimates
+     */
+    results.wind_valid = EKF3.getWind(results.wind);
+
+    /*
      * Sensor-related information
      */
     // true if the estimator will use GPS data in creating its

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF3.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF3.h
@@ -64,11 +64,6 @@ public:
         return EKF3.setOriginLLH(loc);
     }
 
-    // return a wind estimation vector, in m/s
-    bool wind_estimate(Vector3f &wind) const override {
-        return EKF3.getWind(wind);
-    }
-
     bool            use_compass() override {
         return EKF3.use_compass();
     }

--- a/libraries/AP_AHRS/AP_AHRS_SIM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_SIM.cpp
@@ -19,16 +19,6 @@ bool AP_AHRS_SIM::get_location(Location &loc) const
     return true;
 }
 
-bool AP_AHRS_SIM::wind_estimate(Vector3f &wind) const
-{
-    if (_sitl == nullptr) {
-        return false;
-    }
-
-    wind = _sitl->state.wind_ef;
-    return true;
-}
-
 bool AP_AHRS_SIM::airspeed_EAS(float &airspeed_ret) const
 {
     if (_sitl == nullptr) {
@@ -197,6 +187,12 @@ void AP_AHRS_SIM::get_results(AP_AHRS_Backend::Estimates &results)
 
     results.hagl_valid = true;
     results.hagl = _sitl->state.altitude - AP::ahrs().get_home().alt*0.01f;
+
+    /*
+     * air data estimates
+     */
+    results.wind = _sitl->state.wind_ef;
+    results.wind_valid = true;
 
     /*
      * Sensor-related information

--- a/libraries/AP_AHRS/AP_AHRS_SIM.h
+++ b/libraries/AP_AHRS/AP_AHRS_SIM.h
@@ -62,9 +62,6 @@ public:
     void            get_results(Estimates &results) override;
     void            reset() override { return; }
 
-    // return a wind estimation vector, in m/s
-    bool wind_estimate(Vector3f &wind) const override;
-
     // return an airspeed estimate if available. return true
     // if we have an estimate
     bool airspeed_EAS(float &airspeed_ret) const override;


### PR DESCRIPTION
### Summary

Moves the wind estimates

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                 *                                                   
Durandal                            -80             -80    *           -168    -48               -24    -96    -80
Hitec-Airspeed           *                                 *                                                   
KakuteH7-bdshot                     -72             -64    *           -56     -72               -88    -56    -48
MatekF405                           -56             -104   *           -80     -48               -64    -96    -96
Pixhawk1-1M-bdshot                  -88             -88                -88     -88               -176   -96    -48
SITL_x86_64_linux_gnu               -360            -360               -368    -360              -368   -360   -360
YJUAV_A6SE                          -64             -48    *           -16     -144              40     -80    -80
f103-QiotekPeriph        *                                 *                                                   
f303-MatekGPS            *                                 *                                                   
f303-Universal           *                                 *                                                   
iomcu                                                                                *                         
revo-mini                           -96             -80    *           -40     -48               -16    -80    -40
skyviper-v2450                                                         -96                                     
speedybeef4                         -104            -96    *           -96     -120              -1128  -104   -80
```

### Description

Each backend fills its wind estimate into the Estimates structure in get_results; the frontend returns it directly from the active backend's results rather than calling through to the backends, and no longer keeps a copy in its state structure.  The wind_estimate method is removed from the backends.
