### PR TITLE
Tidy up alignment of external ahrs

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -1092,6 +1092,27 @@ bool AP_AHRS::use_compass(void)
     return active_backend->use_compass();
 }
 
+// returns a yaw suitable for aligning an external-nav system to the
+// vehicle's yaw
+bool AP_AHRS::get_extnav_alignment_yaw_rad(float &yaw_rad) const
+{
+    if (active_estimates->attitude_valid && !active_estimates->using_extnav_for_yaw) {
+        // ahrs is healthy and whatever it's using is not from us, so
+        // we can directly use the AHRS result to align ourselves:
+        yaw_rad = active_estimates->yaw_rad;;
+        return true;
+    }
+
+    const auto *secondary_estimates = get_secondary_estimates();
+    if (secondary_estimates != nullptr &&
+        secondary_estimates->attitude_valid && !secondary_estimates->using_extnav_for_yaw) {
+        yaw_rad = secondary_estimates->yaw_rad;
+        return true;
+    }
+
+    return false;
+}
+
 const AP_AHRS_Backend::Estimates *AP_AHRS::get_secondary_estimates() const
 {
     EKFType secondary_ekf_type;
@@ -2749,19 +2770,6 @@ bool AP_AHRS::using_noncompass_for_yaw(void) const
     }
 #endif
     return active_estimates->using_noncompass_for_yaw;
-}
-
-// check if external nav is providing yaw
-bool AP_AHRS::using_extnav_for_yaw(void) const
-{
-#if AP_AHRS_DCM_ENABLED && HAL_NAVEKF3_AVAILABLE
-    // FIXME: DCM uses EKF3's answer (which is not necessarily the
-    // configured type)
-    if (active_estimates == &dcm_estimates) {
-        return ekf3_estimates.using_extnav_for_yaw;
-    }
-#endif
-    return active_estimates->using_extnav_for_yaw;
 }
 
 // set and save the alt noise parameter value

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -498,8 +498,12 @@ public:
     // check if non-compass sensor is providing yaw.  Allows compass pre-arm checks to be bypassed
     bool using_noncompass_for_yaw(void) const;
 
-    // check if external nav is providing yaw
-    bool using_extnav_for_yaw(void) const;
+    // provide a yaw value which could be used to align an external
+    // navigation system such that its absolute yaw aligns with the
+    // vehicle.  Note that this may not come from the primary
+    // estimator, for example in the case that your primary estimator
+    // is using the external estimator as its yaw source.
+    bool get_extnav_alignment_yaw_rad(float &yaw_rad) const;
 
     // active_backend_configured_to_use_gps will be true if the
     // estimator will use GPS data in creating its estimate when the

--- a/libraries/AP_VisualOdom/AP_VisualOdom_IntelT265.cpp
+++ b/libraries/AP_VisualOdom/AP_VisualOdom_IntelT265.cpp
@@ -140,21 +140,12 @@ void AP_VisualOdom_IntelT265::rotate_attitude(Quaternion &attitude) const
 // use sensor provided attitude to calculate rotation to align sensor with AHRS/EKF attitude
 bool AP_VisualOdom_IntelT265::align_yaw_to_ahrs(const Vector3f &position, const Quaternion &attitude)
 {
-    // do not align to ahrs if we are its yaw source
-    if (AP::ahrs().using_extnav_for_yaw()) {
+    float alignment_yaw_rad;
+    if (!AP::ahrs().get_extnav_alignment_yaw_rad(alignment_yaw_rad)) {
         return false;
     }
 
-    // do not align until ahrs yaw initialised
-    if (!AP::ahrs().initialised()
-#if AP_AHRS_DCM_ENABLED
-        || !AP::ahrs().dcm_yaw_initialised()
-#endif
-        ) {
-        return false;
-    }
-
-    align_yaw(position, attitude, AP::ahrs().get_yaw_rad());
+    align_yaw(position, attitude, alignment_yaw_rad);
     return true;
 }
 


### PR DESCRIPTION
### Summary

Moves provision of this into the AHRS - using the each estimate's health to gate whether we use the yaw from that source.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                 *                                                   
Durandal                            8               0      *           8       8                 0      8      0
Hitec-Airspeed           *                                 *                                                   
KakuteH7-bdshot                     8               0      *           0       8                 8      8      0
MatekF405                           *               *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot                  *               *                  *       *                 *      *      *
SITL_x86_64_linux_gnu               8               8                  8       8                 8      16     8
YJUAV_A6SE                          8               8      *           8       -8                8      -8     8
f103-QiotekPeriph        *                                 *                                                   
f303-MatekGPS            *                                 *                                                   
f303-Universal           *                                 *                                                   
iomcu                                                                                *                         
revo-mini                           *               *      *           *       *                 *      *      *
skyviper-v2450                                                         *                                       
speedybeef4                         *               *      *           *       *                 *      *      *
```


### Description

Peeking into the AHRS to see if DCM is alive-and-well is pretty bad.  And the logic around "initialised" and "dcm_yaw_initialised" has previously been buggy.
