### PR TITLE
autotest: fix AHRSAutoTrim test to be reliable

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -16736,6 +16736,8 @@ RTL_ALT_M 111
                 'AHRS_TRIM_Y': -0.1,
             })
             self.takeoff(mode=mode)
+            self.progress("Ensuring the bad trims actually cause a drift")
+            self.wait_groundspeed(1.5, 1000, timeout=30)
             self.set_rc(9, 2000)
             tstart = self.get_sim_time()
             while True:
@@ -16744,16 +16746,17 @@ RTL_ALT_M 111
                     raise ValueError(f"Failed to reduce trims in {mode}!")
                 lpn = self.assert_receive_message('LOCAL_POSITION_NED')
                 delta = 40
+                deadband = 0.1  # m/s; don't trim against residual drift
                 roll_input = 1500
-                if lpn.vx > 0:
+                if lpn.vx > deadband:
                     roll_input -= delta
-                elif lpn.vx < 0:
+                elif lpn.vx < -deadband:
                     roll_input += delta
 
                 pitch_input = 1500
-                if lpn.vy > 0:
+                if lpn.vy > deadband:
                     pitch_input += delta
-                elif lpn.vy < 0:
+                elif lpn.vy < -deadband:
                     pitch_input -= delta
                 self.set_rc_from_map({
                     1: roll_input,
@@ -16766,11 +16769,13 @@ RTL_ALT_M 111
                     trim_x = self.get_parameter('AHRS_TRIM_X', verbose=False)
                     trim_y = self.get_parameter('AHRS_TRIM_Y', verbose=False)
                     self.progress(f"trim_x={trim_x} trim_y={trim_y}")
-                    if abs(trim_x) < 0.01 and abs(trim_y) < 0.01:
+                    if abs(trim_x) < 0.005 and abs(trim_y) < 0.005:
                         self.progress("Good AHRS trims")
-                        self.progress(f"vx={lpn.vx} vy={lpn.vy}")
-                        if abs(lpn.vx) > 1 or abs(lpn.vy) > 1:
-                            raise NotAchievedException("Velocity after trimming?!")
+                        self.set_rc_from_map({
+                            1: 1500,
+                            2: 1500,
+                        }, quiet=True)
+                        self.wait_groundspeed(0, 0.3, minimum_duration=5, timeout=30)
                         break
             self.context_collect('STATUSTEXT')
             self.set_rc(9, 1000)


### PR DESCRIPTION
### Summary

Adjusts the test to stop sampling for the velocity, test that a drift problem exists before but not after.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
  ┌─────────────────────┬───────────┬─────────────────┬────────────┬─────────────────────────┐
  │       metric        │   bound   │    mean ± sd    │ worst case │         margin          │
  ├─────────────────────┼───────────┼─────────────────┼────────────┼─────────────────────────┤
  │ drift demo (STAB)   │ > 1.5 m/s │ 4.238 ± 0.011   │ 4.221      │ 2.8×                    │
  ├─────────────────────┼───────────┼─────────────────┼────────────┼─────────────────────────┤
  │ drift demo (AH)     │ > 1.5 m/s │ 4.122 ± 0.003   │ 4.119      │ 2.7×                    │
  ├─────────────────────┼───────────┼─────────────────┼────────────┼─────────────────────────┤
  │ settle speed (STAB) │ < 0.3 m/s │ 0.165 ± 0.011   │ 0.184      │ 1.6×                    │
  ├─────────────────────┼───────────┼─────────────────┼────────────┼─────────────────────────┤
  │ settle speed (AH)   │ < 0.3 m/s │ 0.158 ± 0.009   │ 0.171      │ 1.8×                    │
  ├─────────────────────┼───────────┼─────────────────┼────────────┼─────────────────────────┤
  │ polls to converge   │ < ~30     │ 7.2 ± 0.4       │ 8          │ 3.7×                    │
  ├─────────────────────┼───────────┼─────────────────┼────────────┼─────────────────────────┤
  │ final |trim|        │ < 0.005   │ 0.0033 ± 0.0012 │ 0.0049     │ n/a (sampling artifact) │
  └─────────────────────┴───────────┴─────────────────┴────────────┴─────────────────────────┘
```
### Description

vehicle couldn't be expected to be in a steady state here, give it time to settle.
