### PR TITLE
board_types: reserve board IDs for AET-405-Mini, AET-AT405A, AET-U7, …

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -432,6 +432,17 @@ AP_HW_SULILGH7-P1-P2                 2005
 
 AP_HW_AET-H743-Basic                 2024
 
+
+AP_HW_AET-H743-AIR                   2509
+AP_HW_AET-U7                         2510
+AP_HW_AET-AT405A                     2511
+AP_HW_AET-405-Mini                   2512
+
+
+
+
+
+
 AP_HW_BOTWINGF405                    2501
 
 AP_HW_SakuraRC-H743                  2714

--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -432,18 +432,12 @@ AP_HW_SULILGH7-P1-P2                 2005
 
 AP_HW_AET-H743-Basic                 2024
 
+AP_HW_BOTWINGF405                    2501
 
 AP_HW_AET-H743-AIR                   2509
 AP_HW_AET-U7                         2510
 AP_HW_AET-AT405A                     2511
 AP_HW_AET-405-Mini                   2512
-
-
-
-
-
-
-AP_HW_BOTWINGF405                    2501
 
 AP_HW_SakuraRC-H743                  2714
 


### PR DESCRIPTION
…AET-H743-AIR

Reserve IDs:
- AET-405-Mini: 2512
- AET-AT405A: 2511
- AET-U7: 2510
- AET-H743-AIR: 2509

These flight controllers support Remote ID (OpenDroneID).

### Summary

<!-- Put a one or two line summary of what your PR does here -->
Reserve board IDs for AET-405-Mini, AET-AT405A, AET-U7, and AET-H743-AIR flight controllers.

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [X] Non-functional change
- [X ] No-binary change
- [X ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->
These flight controllers are based on STM32H743/STM32F405 and support OpenDroneID (Remote ID). This PR reserves unique board IDs for them as a prerequisite for adding full hardware definitions in the future.

The IDs have been chosen in the 2509–2512 range, which is currently unused according to board_types.txt.

### Description

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
