### PR TITLE
board_types: reserve board IDs for AET-H743-AIR, AET-U7, AET-AT405A, …

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -434,6 +434,11 @@ AP_HW_AET-H743-Basic                 2024
 
 AP_HW_BOTWINGF405                    2501
 
+AP_HW_AET-H743-AIR                   2509
+AP_HW_AET-U7                         2510
+AP_HW_AET-AT405A                     2511
+AP_HW_AET-405-Mini                   2512
+
 AP_HW_SakuraRC-H743                  2714
 
 AP_HW_SkyRukh_Surge_H7               2815

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -288,7 +288,7 @@ class Board:
             '-Wextra',
             '-Werror=format',
             '-Wpointer-arith',
-            '-Wcast-align',
+            '-Werror=cast-align',
             '-Wno-missing-field-initializers',
             '-Wno-unused-parameter',
             '-Wno-redundant-decls',
@@ -344,6 +344,7 @@ class Board:
             env.CFLAGS += [
                 '-Wno-format-contains-nul',
                 '-fsingle-precision-constant', # force const vals to be float , not double. so 100.0 means 100.0f
+                '-Wcast-align=strict',
             ]
 
         if cfg.env.DEBUG:
@@ -472,6 +473,7 @@ class Board:
                 '-Werror=unused-but-set-variable',
                 '-fsingle-precision-constant',
                 '-Wno-psabi',
+                '-Wcast-align=strict',
             ]
             if self.cc_version_gte(cfg, 5, 2):
                 env.CXXFLAGS += [


### PR DESCRIPTION
…AET-405-Mini

Reserve IDs:
- AET-H743-AIR: 2509
- AET-U7: 2510
- AET-AT405A: 2511
- AET-405-Mini: 2512

These flight controllers support Remote ID (OpenDroneID).

### Summary

<!-- Put a one or two line summary of what your PR does here -->
Reserve board IDs for four AET flight controllers (AET-H743-AIR, AET-U7, AET-AT405A, AET-405-Mini) with Remote ID support.
### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [X] Non-functional change
- [X] No-binary change
- [X] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
