### PR TITLE
Sub: support Guided_WP terrain following via SET_POSITION_TARGET_GLOBAL_INT

### DIFF
--- a/ArduSub/GCS_MAVLink_Sub.cpp
+++ b/ArduSub/GCS_MAVLink_Sub.cpp
@@ -706,8 +706,7 @@ void GCS_MAVLINK_Sub::handle_message(const mavlink_message_t &msg)
             break;
         }
 
-        Vector3f pos_neu_cm;  // position (North, East, Up coordinates) in centimeters
-
+        Location loc;
         if (!pos_ignore) {
             // sanity check location
             if (!check_latlng(packet.lat_int, packet.lon_int)) {
@@ -718,23 +717,24 @@ void GCS_MAVLINK_Sub::handle_message(const mavlink_message_t &msg)
                 // unknown coordinate frame
                 break;
             }
-            const Location loc{
+            loc = {
                 packet.lat_int,
                 packet.lon_int,
                 int32_t(packet.alt*100),
                 frame,
             };
-            if (!loc.get_vector_from_origin_NEU_cm(pos_neu_cm)) {
-                break;
-            }
         }
 
         if (!pos_ignore && !vel_ignore && acc_ignore) {
+            Vector3f pos_neu_cm;
+            if (!loc.get_vector_from_origin_NEU_cm(pos_neu_cm)) {
+                break;
+            }
             sub.mode_guided.guided_set_destination_posvel(pos_neu_cm, Vector3f(packet.vx * 100.0f, packet.vy * 100.0f, -packet.vz * 100.0f));
         } else if (pos_ignore && !vel_ignore && acc_ignore) {
             sub.mode_guided.guided_set_velocity(Vector3f(packet.vx * 100.0f, packet.vy * 100.0f, -packet.vz * 100.0f));
         } else if (!pos_ignore && vel_ignore && acc_ignore) {
-            sub.mode_guided.guided_set_destination(pos_neu_cm);
+            sub.mode_guided.guided_set_destination(loc);
         }
 
         break;

--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -18,6 +18,7 @@ from pymavlink import mavutil
 
 import vehicle_test_suite
 
+from pysim import util
 from vehicle_test_suite import NotAchievedException
 
 # get location of scripts
@@ -1353,6 +1354,106 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
 
         self.disarm_vehicle()
 
+    def GuidedWP(self):
+        """Test Guided_WP mode"""
+
+        pos_mode = (mavutil.mavlink.POSITION_TARGET_TYPEMASK_VX_IGNORE |
+                    mavutil.mavlink.POSITION_TARGET_TYPEMASK_VY_IGNORE |
+                    mavutil.mavlink.POSITION_TARGET_TYPEMASK_VZ_IGNORE |
+                    mavutil.mavlink.POSITION_TARGET_TYPEMASK_AX_IGNORE |
+                    mavutil.mavlink.POSITION_TARGET_TYPEMASK_AY_IGNORE |
+                    mavutil.mavlink.POSITION_TARGET_TYPEMASK_AZ_IGNORE |
+                    mavutil.mavlink.POSITION_TARGET_TYPEMASK_YAW_IGNORE |
+                    mavutil.mavlink.POSITION_TARGET_TYPEMASK_YAW_RATE_IGNORE)
+
+        seafloor_depth = 50
+        speed = 0.5
+
+        # Load the synthetic seafloor, this will push a context and reboot
+        self.prepare_synthetic_seafloor_test(seafloor_depth, 10)  # rf_target is not used
+
+        self.set_parameter('WP_SPD', speed)
+
+        self.dive(-15)
+
+        # GLOBAL_POSITION_INT will be our clock
+        self.context_set_message_rate_hz('GLOBAL_POSITION_INT', 10)
+
+        # Run back and forth between 2 locations
+        distance = 30
+        timeout = distance / speed + 20  # Add time to accelerate and decelerate
+
+        runs = [{
+            # Hold depth as the terrain rises
+            'frame': mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT,
+            'bearing': 180,
+            'target_alt': -15,  # Altitude above origin
+            'max_error_allowed': 1.0,
+        }, {
+            # Hold range as the terrain falls
+            'frame': mavutil.mavlink.MAV_FRAME_GLOBAL_TERRAIN_ALT,
+            'bearing': 0,
+            'target_alt': 25,  # Distance to seafloor
+            'max_error_allowed': 1.0,
+        }]
+
+        # Stay in GUIDED mode for the duration
+        self.change_mode('GUIDED')
+
+        for run in runs:
+            msg = self.assert_receive_message('GLOBAL_POSITION_INT')
+            start_loc = (msg.lat * 1e-7, msg.lon * 1e-7)
+            dest_loc = util.gps_newpos(start_loc[0], start_loc[1], run['bearing'], distance)
+
+            # current_alt = range (distance to seafloor) or altitude (distance above origin), depending on the frame
+            current_alt = None
+            max_error = 0.0
+
+            # Set the target
+            self.mav.mav.set_position_target_global_int_send(
+                0, 1, 1, run['frame'], pos_mode,
+                int(dest_loc[0] * 1e7), int(dest_loc[1] * 1e7), run['target_alt'],
+                0, 0, 0, 0, 0, 0, 0, 0)
+
+            start_time = self.get_sim_time()
+            while True:
+                msg = self.assert_receive_message(['GLOBAL_POSITION_INT', 'STATUSTEXT'])
+                # Get ground truth (sans noise) from the terrain generator
+                if msg.get_type() == 'STATUSTEXT':
+                    if run['frame'] == mavutil.mavlink.MAV_FRAME_GLOBAL_TERRAIN_ALT:
+                        match = RE_TR_SEARCH.search(msg.text)
+                        if match:
+                            current_alt = float(match.group(1))
+                    continue
+
+                current_loc = (msg.lat * 1e-7, msg.lon * 1e-7)
+                distance_remaining = util.gps_distance(
+                    dest_loc[0], dest_loc[1],
+                    current_loc[0], current_loc[1])
+
+                if run['frame'] == mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT:
+                    current_alt = msg.relative_alt * 0.001
+
+                if distance_remaining < 0.5:
+                    self.progress('Frame %u reached destination at time %f, max_error %f' %
+                                  (run['frame'], self.get_sim_time_cached() - start_time, max_error))
+                    break
+                elif self.get_sim_time_cached() - start_time > timeout:
+                    raise NotAchievedException('Frame %u took too long to reach the destination' % run['frame'])
+
+                if current_alt is None:
+                    continue
+
+                alt_error = abs(current_alt - run['target_alt'])
+                if alt_error > run['max_error_allowed']:
+                    raise NotAchievedException('Alt incorrect on frame %d: want %.2f (+/- %.2f) got=%.2f'
+                                               % (run['frame'], run['target_alt'], run['max_error_allowed'], current_alt))
+
+                if alt_error > max_error:
+                    max_error = alt_error
+
+        self.disarm_vehicle()
+
     def tests(self):
         '''return list of all tests'''
         ret = super(AutoTestSub, self).tests()
@@ -1397,6 +1498,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
             self.UTMGlobalPosition,
             self.UTMGlobalPositionWaypoint,
             self.UpsideDown,
+            self.GuidedWP,
         ])
 
         return ret


### PR DESCRIPTION
### Summary

Guided_WP mode supports terrain following, but it is only accessible via MAV_CMD_DO_REPOSITION. This PR adds support via SET_POSITION_TARGET_GLOBAL_INT.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Guided_WP mode already has several `guided_set_destination()` methods, including:
* `guided_set_destination(Vector3) // assumes Location::AltFrame::ABOVE_ORIGIN`
* `guided_set_destination(Location) // supports any frame that WPNav supports`

MAV_CMD_DO_REPOSITION calls `guided_set_destination(Location)`.

SET_POSITION_TARGET_GLOBAL_INT calls `guided_set_destination(Vector3)`. This PR changes that to `guided_set_destination(Location)`.

Autotest added.

Resolves https://github.com/ArduPilot/ardupilot/issues/32961