### PR TITLE
AP_Baro: add STM's LPS22HH barometer

### DIFF
--- a/libraries/AP_Baro/AP_Baro_LPS2XH.cpp
+++ b/libraries/AP_Baro/AP_Baro_LPS2XH.cpp
@@ -24,7 +24,11 @@ extern const AP_HAL::HAL &hal;
 
 // WHOAMI values
 #define LPS22HB_WHOAMI 0xB1
+#define LPS22HH_WHOAMI 0xB3
 #define LPS25HB_WHOAMI 0xBD
+
+#define LPS22HH_IF_CTRL            0x0E
+#define LPS22HH_I2C_DISABLE        0x01
 
 #define REG_ID                     0x0F
 
@@ -43,6 +47,8 @@ extern const AP_HAL::HAL &hal;
 #define LPS22H_CTRL_REG1_ODR_25HZ  (3 << 4)
 #define LPS22H_CTRL_REG1_ODR_50HZ  (4 << 4)
 #define LPS22H_CTRL_REG1_ODR_75HZ  (5 << 4)
+
+#define LPS22HH_CTRL_REG2_IF_ADD_INC (1 << 4)
 
 #define LPS25H_CTRL_REG1_ADDR      0x20
 #define LPS25H_CTRL_REG2_ADDR      0x21
@@ -156,14 +162,30 @@ bool AP_Baro_LPS2XH::_init()
     	CallTime = 40 * AP_USEC_PER_MSEC;
     }
 
-    if (_lps2xh_type == BARO_LPS22H) {
+    if (_lps2xh_type == BARO_LPS22H || _lps2xh_type == BARO_LPS22HH) {
+        uint8_t i2c_dis_reg;
+        uint8_t i2c_dis_val;
+
         _dev->write_register(LPS22H_CTRL_REG1, 0x00); // turn off for config
-        _dev->write_register(LPS22H_CTRL_REG1, LPS22H_CTRL_REG1_ODR_75HZ|LPS22H_CTRL_REG1_BDU|LPS22H_CTRL_REG1_EN_LPFP|LPS22H_CTRL_REG1_LPFP_CFG);
-        if (_dev->bus_type() == AP_HAL::Device::BUS_TYPE_SPI) {
-            _dev->write_register(LPS22H_CTRL_REG2, 0x18);  // disable i2c
+        if (_lps2xh_type == BARO_LPS22H) {
+            _dev->write_register(LPS22H_CTRL_REG1, LPS22H_CTRL_REG1_ODR_75HZ|
+                                                   LPS22H_CTRL_REG1_BDU|
+                                                   LPS22H_CTRL_REG1_EN_LPFP|
+                                                   LPS22H_CTRL_REG1_LPFP_CFG);
+            i2c_dis_reg = LPS22H_CTRL_REG2;
+            i2c_dis_val = _dev->bus_type() == AP_HAL::Device::BUS_TYPE_SPI ? 0x18 : 0x10;
         } else {
-            _dev->write_register(LPS22H_CTRL_REG2, 0x10);
+            _dev->write_register(LPS22H_CTRL_REG1, LPS22H_CTRL_REG1_ODR_75HZ|
+                                                   LPS22H_CTRL_REG1_BDU|
+                                                   LPS22H_CTRL_REG1_EN_LPFP|
+                                                   LPS22H_CTRL_REG1_LPFP_CFG);
+            _dev->write_register(LPS22H_CTRL_REG2, LPS22HH_CTRL_REG2_IF_ADD_INC);
+            i2c_dis_reg = LPS22HH_IF_CTRL;
+            i2c_dis_val = _dev->bus_type() == AP_HAL::Device::BUS_TYPE_SPI ?
+                                              LPS22HH_I2C_DISABLE : 0x00;
         }
+
+        _dev->write_register(i2c_dis_reg, i2c_dis_val);  // disable i2c
 
         // request 75Hz update
         CallTime = 1000000/75;
@@ -193,6 +215,9 @@ bool AP_Baro_LPS2XH::_check_whoami(void)
     switch(whoami){
     case LPS22HB_WHOAMI:
         _lps2xh_type = BARO_LPS22H;
+        return true;
+    case LPS22HH_WHOAMI:
+        _lps2xh_type = BARO_LPS22HH;
         return true;
     case LPS25HB_WHOAMI:
         _lps2xh_type = BARO_LPS25H;
@@ -248,7 +273,7 @@ void AP_Baro_LPS2XH::_update_temperature(void)
         _temperature = (Temp_Reg_s16 * (1.0/480)) + 42.5;
     }
 
-    if (_lps2xh_type == BARO_LPS22H) {
+    if (_lps2xh_type == BARO_LPS22H || _lps2xh_type == BARO_LPS22HH) {
         _temperature = Temp_Reg_s16 * 0.01;
     }
 }

--- a/libraries/AP_Baro/AP_Baro_LPS2XH.h
+++ b/libraries/AP_Baro/AP_Baro_LPS2XH.h
@@ -21,6 +21,7 @@ public:
     enum LPS2XH_TYPE {
         BARO_LPS22H = 0,
         BARO_LPS25H = 1,
+        BARO_LPS22HH = 2,
     };
 
     AP_Baro_LPS2XH(AP_Baro &baro, AP_HAL::Device &dev);


### PR DESCRIPTION
The LPS22HH barometer has a register map compatible with the lps22hb sensor, already supported by the AP_Baro_LPS2XH driver, at least for the features actually used by the driver, so it can be added as a part number to the supported devices.

### Summary

Add support to STMicroelectronics MEMS LPS22HH pressure sensor to Ardupilot supported barometers

### Classification & Testing (check all that apply and add your own)

- [v] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [v] Tested on hardware
- [ ] Logs attached
- [v] Logs available on request

The test was performed by inserting logs into the driver update function code and verifying that the values ​​reported and sent to the frontend are correct.

### Description
For basic functionality, i.e. reading data from raw registers, configuring filters and ODRs, the LPS22HH sensor has a register map equivalent to the LPS22HB sensor already supported by the AP_Baro_LPS2XH driver, and the temperature and pressure scaling factors are also the same so support for the LPS22HH part number can easily be added to the AP_Baro_LPS2XH driver.

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
