### PR TITLE
Tools: adjust hwdef metadata checks

### DIFF
--- a/Tools/scripts/check_branch_conventions.py
+++ b/Tools/scripts/check_branch_conventions.py
@@ -9,8 +9,9 @@ Validates:
   - commit messages have a well-formed subsystem prefix before ':'
   - commit subject lines are <= 160 characters
   - changed markdown files pass markdownlint-cli2
-  - new hwdef board directories include a README.md
-  - new hwdef board READMEs contain at least one local image added in the PR
+  - new hwdef board directories include a README.md, except ODID variants
+  - new hwdef board READMEs contain at least one local image added in the PR,
+    except AP_Periph and ODID variants
 
 AP_FLAKE8_CLEAN
 '''
@@ -27,6 +28,7 @@ import sys
 import urllib.error
 import urllib.request
 
+import board_list
 import build_script_base
 
 DOCS_URL = "https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html"
@@ -56,12 +58,14 @@ SKIP = f"{_YELLOW}~{_RESET}"
 class CheckBranchConventions(build_script_base.BuildScriptBase):
 
     DEFAULT_UPSTREAM = "origin/master"
+    HWDEF_PREFIX = "libraries/AP_HAL_ChibiOS/hwdef/"
 
     def __init__(self, base_branch: str | None = None) -> None:
         super().__init__()
         self.base_branch = base_branch
         repo_root = self.run_git(['rev-parse', '--show-toplevel'], show_output=False).strip()
         self.board_types_path = pathlib.Path(repo_root, 'Tools', 'AP_Bootloader', 'board_types.txt')
+        self._board_list: board_list.BoardList | None = None
 
     def progress_prefix(self) -> str:
         return "CBC"
@@ -72,6 +76,34 @@ class CheckBranchConventions(build_script_base.BuildScriptBase):
             "SCB-GIT", cmd_list,
             show_output=show_output, show_command=False, cwd=source_dir,
         )
+
+    def board_list(self) -> board_list.BoardList:
+        if self._board_list is None:
+            self._board_list = board_list.BoardList()
+        return self._board_list
+
+    def is_odid_board(self, board_name: str) -> bool:
+        try:
+            hwdef = self.board_list().hwdef_for_board(board_name)
+        except KeyError:
+            return False
+        return hwdef.intdefines.get('AP_OPENDRONEID_ENABLED', 0) == 1
+
+    def is_ap_periph_board(self, board_name: str) -> bool:
+        try:
+            return bool(self.board_list().board_by_name(board_name).is_ap_periph)
+        except KeyError:
+            return False
+
+    def check_board_readme_required(self, board_name: str) -> bool:
+        return not self.is_odid_board(board_name)
+
+    def check_board_image_required(self, board_name: str) -> bool:
+        if self.is_odid_board(board_name):
+            return False
+        if self.is_ap_periph_board(board_name):
+            return False
+        return True
 
     def check_merge_commits(self) -> bool:
         merge_commits = self.run_git(
@@ -569,12 +601,11 @@ class CheckBranchConventions(build_script_base.BuildScriptBase):
         ).strip()
         added_files = set(added_raw.splitlines()) if added_raw else set()
 
-        hwdef_prefix = "libraries/AP_HAL_ChibiOS/hwdef/"
         # Board dirs that have at least one newly added file at depth 1 under hwdef/
         candidate_boards = {
             f.split("/")[3]
             for f in added_files
-            if f.startswith(hwdef_prefix) and f.count("/") == 4
+            if f.startswith(self.HWDEF_PREFIX) and f.count("/") == 4
         }
 
         if not candidate_boards:
@@ -584,7 +615,7 @@ class CheckBranchConventions(build_script_base.BuildScriptBase):
         # Determine which of those dirs are genuinely new (absent in base branch)
         existing_raw = self.run_git(
             ["ls-tree", "--name-only", self.base_branch,
-             hwdef_prefix],
+             self.HWDEF_PREFIX],
             show_output=False,
         ).strip()
         existing_boards = {
@@ -600,7 +631,11 @@ class CheckBranchConventions(build_script_base.BuildScriptBase):
 
         ok = True
         for board_name in new_boards:
-            board_prefix = f"{hwdef_prefix}{board_name}/"
+            if not self.check_board_readme_required(board_name):
+                print(f"{PASS} {board_name}: README.md not required for ODID variant.")
+                continue
+
+            board_prefix = f"{self.HWDEF_PREFIX}{board_name}/"
             has_readme = any(
                 os.path.basename(f) == "README.md"
                 for f in added_files
@@ -626,12 +661,11 @@ class CheckBranchConventions(build_script_base.BuildScriptBase):
         ).strip()
         added_files = set(added_raw.splitlines()) if added_raw else set()
 
-        hwdef_prefix = "libraries/AP_HAL_ChibiOS/hwdef/"
         # New READMEs exactly one directory level under hwdef/
         # e.g. libraries/AP_HAL_ChibiOS/hwdef/NewBoard/README.md → 4 slashes
         new_readmes = sorted(
             f for f in added_files
-            if f.startswith(hwdef_prefix)
+            if f.startswith(self.HWDEF_PREFIX)
             and os.path.basename(f) == "README.md"
             and f.count("/") == 4
         )
@@ -645,6 +679,10 @@ class CheckBranchConventions(build_script_base.BuildScriptBase):
         ok = True
         for readme_path in new_readmes:
             board_name = readme_path.split("/")[3]
+
+            if not self.check_board_image_required(board_name):
+                print(f"{PASS} {board_name}: README.md image not required.")
+                continue
 
             if not os.path.exists(readme_path):
                 print(f"{SKIP} {board_name}: README not present locally, skipping image check.")


### PR DESCRIPTION
## Summary
- skip README and image requirements for new ChibiOS -ODID board variants
- keep README required for new AP_Periph boards, but skip the board-image requirement for AP_Periph README files
- reuse board_list metadata to identify AP_Periph boards instead of matching names

Fixes #33400

## Testing
- python3 -m py_compile Tools/scripts/check_branch_conventions.py
- .venv/bin/ruff check Tools/scripts/check_branch_conventions.py
- targeted Python harness covering ODID README exemption, AP_Periph README requirement, AP_Periph image exemption, regular-board image failure, and ODID image exemption
- Tools/scripts/check_branch_conventions.py --base-branch origin/master

## AI Assistance
This contribution was prepared with AI assistance. The human author reviewed the change, ran the listed tests, and is responsible for the submission.