### PR TITLE
Tools: add board_list.BoardList.hwdef_for_board

### DIFF
--- a/Tools/scripts/board_list.py
+++ b/Tools/scripts/board_list.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 
 import fnmatch
+import importlib
 import os
 import re
+import sys
 
 from collections.abc import Collection
 
@@ -13,12 +15,23 @@ AP_FLAKE8_CLEAN
 '''
 
 
+# Maps Board.hal to the hwdef scripts module name and HWDef subclass name.
+_HAL_HWDEF = {
+    'ChibiOS': ('chibios_hwdef', 'ChibiOSHWDef'),
+    'Linux':   ('linux_hwdef',   'LinuxHWDef'),
+    'ESP32':   ('esp32_hwdef',   'ESP32HWDef'),
+    'QURT':    ('qurt_hwdef',    'QURTHWDef'),
+    'SITL':    ('sitl_hwdef',    'SITLHWDef'),
+}
+
+
 class Board(object):
     def __init__(self, name):
         self.name = name
         self.is_ap_periph = False
         self.toolchain = 'arm-none-eabi'  # FIXME: try to remove this?
         self.hal = None  # filled in below
+        self.hwdef_path = None  # filled in below
         self.autobuild_targets = [
             'Tracker',
             'Blimp',
@@ -28,6 +41,19 @@ class Board(object):
             'Rover',
             'Sub',
         ]
+
+    def get_hwdef(self):
+        '''Return a processed HWDef subclass instance appropriate for this board's HAL.'''
+        # hwdef_path is .../AP_HAL_XXX/hwdef/BOARDNAME/hwdef.dat;
+        # the HAL's hwdef scripts live two levels up under scripts/
+        scripts_dir = os.path.join(os.path.dirname(os.path.dirname(self.hwdef_path)), 'scripts')
+        if scripts_dir not in sys.path:
+            sys.path.insert(0, scripts_dir)
+        module_name, class_name = _HAL_HWDEF[self.hal]
+        cls = getattr(importlib.import_module(module_name), class_name)
+        h = cls(hwdef=[self.hwdef_path], quiet=True)
+        h.process_hwdefs()
+        return h
 
 
 def in_boardlist(boards : Collection[str], board : str) -> bool:
@@ -97,6 +123,7 @@ class BoardList(object):
             text = self.read_hwdef(filepath)
 
             board = Board(adir)
+            board.hwdef_path = filepath
             self.boards.append(board)
             board_toolchain_set = False
             for line in text:
@@ -162,6 +189,10 @@ class BoardList(object):
             else:
                 ret += [line]
         return ret
+
+    def hwdef_for_board(self, board_name: str):
+        '''return a processed HWDef subclass instance for the named board'''
+        return self.board_by_name(board_name).get_hwdef()
 
     def board_by_name(self, name: str) -> Board:
         '''return the Board object for the given board name, raises KeyError if not found'''


### PR DESCRIPTION
### Summary

Adds a convenience method for getting a HWDef for a board by that board's name

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

I've been using this locally for various concepts

### Description

Adds a convenience method for getting a HWDef, which will then let you query various attributes of the board directly rather than grepping through the boards like https://github.com/ArduPilot/ardupilot/pull/33415
