### PR TITLE
board_types: reserve board IDs for AET-H743-AIR, AET-U7, AET-AT405A, …

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -435,6 +435,11 @@ AP_HW_AET-H743-Basic                 2024
 
 AP_HW_BOTWINGF405                    2501
 
+AP_HW_AET-H743-AIR                   2509
+AP_HW_AET-U7                         2510
+AP_HW_AET-AT405A                     2511
+AP_HW_AET-405-Mini                   2512
+
 AP_HW_SakuraRC-H743                  2714
 
 AP_HW_SkyRukh_Surge_H7               2815


### PR DESCRIPTION
…AET-405-Mini

Reserve IDs:
- AET-H743-AIR: 2509
- AET-U7: 2510
- AET-AT405A: 2511
- AET-405-Mini: 2512

These flight controllers support Remote ID (OpenDroneID).

### Summary

<!-- Put a one or two line summary of what your PR does here -->
Reserve board IDs for AET-H743-AIR, AET-U7, AET-AT405A, and AET-405-Mini flight controllers (Remote ID support).

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [X] Non-functional change
- [X] No-binary change
- [X] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->
N/A - only board ID reservation, no functional changes.

### Description

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
