### PR TITLE
AP_Bootloader: Add board type AP_HW_KARSHAKH743VTOL with ID 4002

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -441,6 +441,7 @@ AP_HW_SkyRukh_Surge_H7               2815
 
 # IDs 4000-4009 reserved for Karshak Drones
 AP_HW_KRSHKF7_MINI                   4000
+AP_HW_KARSHAKH743VTOL                4002
 
 # IDs 4200-4220 reserved for HAKRC
 AP_HW_HAKRC_F405                     4200


### PR DESCRIPTION
Tools/AP_Bootloader: reserve board id AP_HW_KARSHAKH743VTOL with ID 4002

This commit targets to reserve the board ID 4002 for AP_HW_KARSHAKH743VTOL.