### PR TITLE
board_types: reserve ODID board IDs for AET-H743-AIR, AET-U7, AET-AT4…

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -608,5 +608,11 @@ AP_HW_CUBEORANGEPLUS_ODID           11063
 AP_HW_SIYI_N7_ODID                  11123
 AP_HW_SIYI-UniFC-6-PICO_ODID        11215
 
+AP_HW_AET-H743-AIR_ODID             12509
+AP_HW_AET-U7_ODID                   12510
+AP_HW_AET-AT405A_ODID               12511
+AP_HW_AET-405-Mini_ODID             12512
+
+
 # do not allocate board IDs above 10,000 for non-ODID boards.
 # do not allocate board IDs above 19,999 in this file.


### PR DESCRIPTION

These IDs (base + 10000) are for OpenDroneID (Remote ID) firmware variants:
- AET-H743-AIR: 12509 (base 2509)
- AET-U7: 12510 (base 2510)
- AET-AT405A: 12511 (base 2511)
- AET-405-Mini: 12512 (base 2512)

### Summary

<!-- Put a one or two line summary of what your PR does here -->
Reserve OpenDroneID (Remote ID) board IDs for AET-H743-AIR, AET-U7, AET-AT405A, and AET-405-Mini flight controllers.
### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [X] Non-functional change
- [X] No-binary change
- [X] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
