### PR TITLE
Sub: add _neu and _cm suffixes to variable names - name change only

### DIFF
--- a/ArduSub/Attitude.cpp
+++ b/ArduSub/Attitude.cpp
@@ -64,7 +64,7 @@ float Sub::get_roi_yaw()
     roi_yaw_counter++;
     if (roi_yaw_counter >= 4) {
         roi_yaw_counter = 0;
-        yaw_look_at_WP_bearing = get_bearing_cd((pos_control.get_pos_estimate_NED_m().xy() * 100.0f).tofloat(), roi_WP.xy());
+        yaw_look_at_WP_bearing = get_bearing_cd((pos_control.get_pos_estimate_NED_m().xy() * 100.0f).tofloat(), roi_WP_neu_cm.xy());
     }
 
     return yaw_look_at_WP_bearing;

--- a/ArduSub/GCS_MAVLink_Sub.cpp
+++ b/ArduSub/GCS_MAVLink_Sub.cpp
@@ -621,35 +621,35 @@ void GCS_MAVLINK_Sub::handle_message(const mavlink_message_t &msg)
         bool yaw_rate_ignore = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_YAW_RATE_IGNORE;
 
         // prepare position
-        Vector3f pos_vector;
+        Vector3f pos_vector_neu_cm;
         if (!pos_ignore) {
             // convert to cm
-            pos_vector = Vector3f(packet.x * 100.0f, packet.y * 100.0f, -packet.z * 100.0f);
+            pos_vector_neu_cm = Vector3f(packet.x * 100.0f, packet.y * 100.0f, -packet.z * 100.0f);
             // rotate from body-frame if necessary
             if (packet.coordinate_frame == MAV_FRAME_BODY_NED ||
                     packet.coordinate_frame == MAV_FRAME_BODY_FRD ||
                     packet.coordinate_frame == MAV_FRAME_BODY_OFFSET_NED) {
-                sub.rotate_body_frame_to_NE(pos_vector.x, pos_vector.y);
+                sub.rotate_body_frame_to_NE(pos_vector_neu_cm.x, pos_vector_neu_cm.y);
             }
             // add body offset if necessary
             if (packet.coordinate_frame == MAV_FRAME_LOCAL_OFFSET_NED ||
                     packet.coordinate_frame == MAV_FRAME_BODY_NED ||
                     packet.coordinate_frame == MAV_FRAME_BODY_FRD ||
                     packet.coordinate_frame == MAV_FRAME_BODY_OFFSET_NED) {
-                Vector3f pos_cm = (sub.pos_control.get_pos_estimate_NED_m() * 100.0f).tofloat();
-                pos_cm.z = -pos_cm.z;
-                pos_vector += pos_cm;
+                Vector3f pos_neu_cm = (sub.pos_control.get_pos_estimate_NED_m() * 100.0f).tofloat();
+                pos_neu_cm.z = -pos_neu_cm.z;
+                pos_vector_neu_cm += pos_neu_cm;
             }
         }
 
         // prepare velocity
-        Vector3f vel_vector;
+        Vector3f vel_vector_neu_cms;
         if (!vel_ignore) {
             // convert to cm
-            vel_vector = Vector3f(packet.vx * 100.0f, packet.vy * 100.0f, -packet.vz * 100.0f);
+            vel_vector_neu_cms = Vector3f(packet.vx * 100.0f, packet.vy * 100.0f, -packet.vz * 100.0f);
             // rotate from body-frame if necessary
             if (packet.coordinate_frame == MAV_FRAME_BODY_NED || packet.coordinate_frame == MAV_FRAME_BODY_FRD || packet.coordinate_frame == MAV_FRAME_BODY_OFFSET_NED) {
-                sub.rotate_body_frame_to_NE(vel_vector.x, vel_vector.y);
+                sub.rotate_body_frame_to_NE(vel_vector_neu_cms.x, vel_vector_neu_cms.y);
             }
         }
 
@@ -667,11 +667,11 @@ void GCS_MAVLINK_Sub::handle_message(const mavlink_message_t &msg)
 
         // send request
         if (!pos_ignore && !vel_ignore && acc_ignore) {
-            sub.mode_guided.guided_set_destination_posvel(pos_vector, vel_vector, !yaw_ignore, yaw_cd, !yaw_rate_ignore, yaw_rate_cds, yaw_relative);
+            sub.mode_guided.guided_set_destination_posvel(pos_vector_neu_cm, vel_vector_neu_cms, !yaw_ignore, yaw_cd, !yaw_rate_ignore, yaw_rate_cds, yaw_relative);
         } else if (pos_ignore && !vel_ignore && acc_ignore) {
-            sub.mode_guided.guided_set_velocity(vel_vector, !yaw_ignore, yaw_cd, !yaw_rate_ignore, yaw_rate_cds, yaw_relative);
+            sub.mode_guided.guided_set_velocity(vel_vector_neu_cms, !yaw_ignore, yaw_cd, !yaw_rate_ignore, yaw_rate_cds, yaw_relative);
         } else if (!pos_ignore && vel_ignore && acc_ignore) {
-            sub.mode_guided.guided_set_destination(pos_vector, !yaw_ignore, yaw_cd, !yaw_rate_ignore, yaw_rate_cds, yaw_relative);
+            sub.mode_guided.guided_set_destination(pos_vector_neu_cm, !yaw_ignore, yaw_cd, !yaw_rate_ignore, yaw_rate_cds, yaw_relative);
         }
 
         break;

--- a/ArduSub/Log.cpp
+++ b/ArduSub/Log.cpp
@@ -185,18 +185,18 @@ struct PACKED log_GuidedTarget {
 };
 
 // Write a Guided mode target
-void Sub::Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target, const Vector3f& vel_target)
+void Sub::Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target_neu_cm, const Vector3f& vel_target_neu_cms)
 {
     struct log_GuidedTarget pkt = {
         LOG_PACKET_HEADER_INIT(LOG_GUIDEDTARGET_MSG),
         time_us         : AP_HAL::micros64(),
         type            : target_type,
-        pos_target_x    : pos_target.x,
-        pos_target_y    : pos_target.y,
-        pos_target_z    : pos_target.z,
-        vel_target_x    : vel_target.x,
-        vel_target_y    : vel_target.y,
-        vel_target_z    : vel_target.z
+        pos_target_x    : pos_target_neu_cm.x,
+        pos_target_y    : pos_target_neu_cm.y,
+        pos_target_z    : pos_target_neu_cm.z,
+        vel_target_x    : vel_target_neu_cms.x,
+        vel_target_y    : vel_target_neu_cms.y,
+        vel_target_z    : vel_target_neu_cms.z
     };
     logger.WriteBlock(&pkt, sizeof(pkt));
 }

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -306,7 +306,7 @@ private:
     bool yaw_rate_only;
 
     // Yaw will point at this location if auto_yaw_mode is set to AUTO_YAW_ROI
-    Vector3f roi_WP;
+    Vector3f roi_WP_neu_cm;
 
     // bearing from current location to the yaw_look_at_WP
     float yaw_look_at_WP_bearing;
@@ -417,7 +417,7 @@ private:
     void Log_Write_Data(LogDataID id, int16_t value);
     void Log_Write_Data(LogDataID id, uint16_t value);
     void Log_Write_Data(LogDataID id, float value);
-    void Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target, const Vector3f& vel_target);
+    void Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target_neu_cm, const Vector3f& vel_target_neu_cms);
     void Log_Write_Vehicle_Startup_Messages();
 #endif
     void load_parameters(void) override;

--- a/ArduSub/commands_logic.cpp
+++ b/ArduSub/commands_logic.cpp
@@ -291,9 +291,9 @@ void Sub::do_loiter_unlimited(const AP_Mission::Mission_Command& cmd)
     // use current location if not provided
     if (target_loc.lat == 0 && target_loc.lng == 0) {
         // To-Do: make this simpler
-        Vector3f temp_pos;
-        wp_nav.get_wp_stopping_point_NE_cm(temp_pos.xy());
-        const Location temp_loc(temp_pos, Location::AltFrame::ABOVE_ORIGIN);
+        Vector3f temp_pos_neu_cm;
+        wp_nav.get_wp_stopping_point_NE_cm(temp_pos_neu_cm.xy());
+        const Location temp_loc(temp_pos_neu_cm, Location::AltFrame::ABOVE_ORIGIN);
         target_loc.lat = temp_loc.lat;
         target_loc.lng = temp_loc.lng;
     }
@@ -481,12 +481,12 @@ bool Sub::verify_circle(const AP_Mission::Mission_Command& cmd)
     // check if we've reached the edge
     if (auto_mode == Auto_CircleMoveToEdge) {
         if (wp_nav.reached_wp_destination()) {
-            Vector3f circle_center;
-            UNUSED_RESULT(cmd.content.location.get_vector_from_origin_NEU_cm(circle_center));
+            Vector3f circle_center_neu_cm;
+            UNUSED_RESULT(cmd.content.location.get_vector_from_origin_NEU_cm(circle_center_neu_cm));
 
             // set lat/lon position if not provided
             if (cmd.content.location.lat == 0 && cmd.content.location.lng == 0) {
-                circle_center.xy() = (sub.pos_control.get_pos_estimate_NED_m().xy() * 100.0f).tofloat();
+                circle_center_neu_cm.xy() = (sub.pos_control.get_pos_estimate_NED_m().xy() * 100.0f).tofloat();
             }
 
             // start circling

--- a/ArduSub/mode.h
+++ b/ArduSub/mode.h
@@ -266,13 +266,13 @@ public:
     void guided_set_angle(const Quaternion &q, float climb_rate_cms, bool use_yaw_rate, float yaw_rate_rads);
     void guided_set_angle(const Quaternion&, float);
     void guided_limit_set(uint32_t timeout_ms, float alt_min_cm, float alt_max_cm, float horiz_max_cm);
-    bool guided_set_destination_posvel(const Vector3f& destination, const Vector3f& velocity);
-    bool guided_set_destination_posvel(const Vector3f& destination, const Vector3f& velocity, bool use_yaw, float yaw_cd, bool use_yaw_rate, float yaw_rate_cds, bool relative_yaw);
-    bool guided_set_destination(const Vector3f& destination);
+    bool guided_set_destination_posvel(const Vector3f& destination_neu_cm, const Vector3f& velocity_neu_cms);
+    bool guided_set_destination_posvel(const Vector3f& destination_neu_cm, const Vector3f& velocity_neu_cms, bool use_yaw, float yaw_cd, bool use_yaw_rate, float yaw_rate_cds, bool relative_yaw);
+    bool guided_set_destination(const Vector3f& destination_neu_cm);
     bool guided_set_destination(const Location&);
-    bool guided_set_destination(const Vector3f& destination, bool use_yaw, float yaw_cd, bool use_yaw_rate, float yaw_rate_cds, bool relative_yaw);
-    void guided_set_velocity(const Vector3f& velocity);
-    void guided_set_velocity(const Vector3f& velocity, bool use_yaw, float yaw_cd, bool use_yaw_rate, float yaw_rate_cds, bool relative_yaw);
+    bool guided_set_destination(const Vector3f& destination_neu_cm, bool use_yaw, float yaw_cd, bool use_yaw_rate, float yaw_rate_cds, bool relative_yaw);
+    void guided_set_velocity(const Vector3f& velocity_neu_cms);
+    void guided_set_velocity(const Vector3f& velocity_neu_cms, bool use_yaw, float yaw_cd, bool use_yaw_rate, float yaw_rate_cds, bool relative_yaw);
     void guided_set_yaw_state(bool use_yaw, float yaw_cd, bool use_yaw_rate, float yaw_rate_cds, bool relative_angle);
     float get_auto_heading();
     void guided_limit_clear();
@@ -315,7 +315,7 @@ public:
     bool allows_arming(bool from_gcs) const override { return true; }
     bool is_autopilot() const override { return true; }
     bool auto_loiter_start();
-    void auto_wp_start(const Vector3f& destination);
+    void auto_wp_start(const Vector3f& destination_neu_cm);
     void auto_wp_start(const Location& dest_loc);
     void auto_circle_movetoedge_start(const Location &circle_center, float radius_m, bool ccw_turn);
     void auto_circle_start();

--- a/ArduSub/mode_auto.cpp
+++ b/ArduSub/mode_auto.cpp
@@ -66,12 +66,12 @@ void ModeAuto::run()
 }
 
 // auto_wp_start - initialises waypoint controller to implement flying to a particular destination
-void ModeAuto::auto_wp_start(const Vector3f& destination)
+void ModeAuto::auto_wp_start(const Vector3f& destination_neu_cm)
 {
     sub.auto_mode = Auto_WP;
 
     // initialise wpnav (no need to check return status because terrain data is not used)
-    sub.wp_nav.set_wp_destination_NEU_cm(destination, false);
+    sub.wp_nav.set_wp_destination_NEU_cm(destination_neu_cm, false);
 
     // initialise yaw
     // To-Do: reset the yaw only when the previous navigation command is not a WP.  this would allow removing the special check for ROI
@@ -401,7 +401,7 @@ void ModeAuto::set_auto_yaw_roi(const Location &roi_location)
 #if HAL_MOUNT_ENABLED
         // check if mount type requires us to rotate the sub
         if (!sub.camera_mount.has_pan_control()) {
-            if (roi_location.get_vector_from_origin_NEU_cm(sub.roi_WP)) {
+            if (roi_location.get_vector_from_origin_NEU_cm(sub.roi_WP_neu_cm)) {
                 set_auto_yaw_mode(AUTO_YAW_ROI);
             }
         }
@@ -416,7 +416,7 @@ void ModeAuto::set_auto_yaw_roi(const Location &roi_location)
         //      4: point at a target given a target id (can't be implemented)
 #else
         // if we have no camera mount aim the sub at the location
-        if (roi_location.get_vector_from_origin_NEU_cm(sub.roi_WP)) {
+        if (roi_location.get_vector_from_origin_NEU_cm(sub.roi_WP_neu_cm)) {
             set_auto_yaw_mode(AUTO_YAW_ROI);
         }
 #endif  // HAL_MOUNT_ENABLED

--- a/ArduSub/mode_guided.cpp
+++ b/ArduSub/mode_guided.cpp
@@ -7,8 +7,8 @@
 #define GUIDED_POSVEL_TIMEOUT_MS    3000    // guided mode's position-velocity controller times out after 3seconds with no new updates
 #define GUIDED_ATTITUDE_TIMEOUT_MS  1000    // guided mode's attitude controller times out after 1 second with no new updates
 
-static Vector3p posvel_pos_target_cm;
-static Vector3f posvel_vel_target_cms;
+static Vector3p posvel_pos_target_neu_cm;
+static Vector3f posvel_vel_target_neu_cms;
 static uint32_t update_time_ms;
 
 struct {
@@ -166,11 +166,11 @@ void ModeGuided::guided_angle_control_start()
 // guided_set_destination - sets guided mode's target destination
 // Returns true if the fence is enabled and guided waypoint is within the fence
 // else return false if the waypoint is outside the fence
-bool ModeGuided::guided_set_destination(const Vector3f& destination)
+bool ModeGuided::guided_set_destination(const Vector3f& destination_neu_cm)
 {
 #if AP_FENCE_ENABLED
     // reject destination if outside the fence
-    const Location dest_loc(destination, Location::AltFrame::ABOVE_ORIGIN);
+    const Location dest_loc(destination_neu_cm, Location::AltFrame::ABOVE_ORIGIN);
     if (!sub.fence.check_location_within_fence(dest_loc)) {
         LOGGER_WRITE_ERROR(LogErrorSubsystem::NAVIGATION, LogErrorCode::DEST_OUTSIDE_FENCE);
         // failure is propagated to GCS with NAK
@@ -184,11 +184,11 @@ bool ModeGuided::guided_set_destination(const Vector3f& destination)
     }
 
     // no need to check return status because terrain data is not used
-    sub.wp_nav.set_wp_destination_NEU_cm(destination, false);
+    sub.wp_nav.set_wp_destination_NEU_cm(destination_neu_cm, false);
 
 #if HAL_LOGGING_ENABLED
     // log target
-    sub.Log_Write_GuidedTarget(sub.guided_mode, destination, Vector3f());
+    sub.Log_Write_GuidedTarget(sub.guided_mode, destination_neu_cm, Vector3f());
 #endif
 
     return true;
@@ -232,11 +232,11 @@ bool ModeGuided::guided_set_destination(const Location& dest_loc)
 // guided_set_destination - sets guided mode's target destination and target heading
 // Returns true if the fence is enabled and guided waypoint is within the fence
 // else return false if the waypoint is outside the fence
-bool ModeGuided::guided_set_destination(const Vector3f& destination, bool use_yaw, float yaw_cd, bool use_yaw_rate, float yaw_rate_cds, bool relative_yaw)
+bool ModeGuided::guided_set_destination(const Vector3f& destination_neu_cm, bool use_yaw, float yaw_cd, bool use_yaw_rate, float yaw_rate_cds, bool relative_yaw)
 {
 #if AP_FENCE_ENABLED
     // reject destination if outside the fence
-    const Location dest_loc(destination, Location::AltFrame::ABOVE_ORIGIN);
+    const Location dest_loc(destination_neu_cm, Location::AltFrame::ABOVE_ORIGIN);
     if (!sub.fence.check_location_within_fence(dest_loc)) {
         LOGGER_WRITE_ERROR(LogErrorSubsystem::NAVIGATION, LogErrorCode::DEST_OUTSIDE_FENCE);
         // failure is propagated to GCS with NAK
@@ -255,18 +255,18 @@ bool ModeGuided::guided_set_destination(const Vector3f& destination, bool use_ya
     update_time_ms = AP_HAL::millis();
 
     // no need to check return status because terrain data is not used
-    sub.wp_nav.set_wp_destination_NEU_cm(destination, false);
+    sub.wp_nav.set_wp_destination_NEU_cm(destination_neu_cm, false);
 
 #if HAL_LOGGING_ENABLED
     // log target
-    sub.Log_Write_GuidedTarget(sub.guided_mode, destination, Vector3f());
+    sub.Log_Write_GuidedTarget(sub.guided_mode, destination_neu_cm, Vector3f());
 #endif
 
     return true;
 }
 
 // guided_set_velocity - sets guided mode's target velocity
-void ModeGuided::guided_set_velocity(const Vector3f& velocity)
+void ModeGuided::guided_set_velocity(const Vector3f& velocity_neu_cms)
 {
     // check we are in velocity control mode
     if (sub.guided_mode != Guided_Velocity) {
@@ -276,11 +276,11 @@ void ModeGuided::guided_set_velocity(const Vector3f& velocity)
     update_time_ms = AP_HAL::millis();
 
     // set position controller velocity target
-    position_control->set_vel_desired_NEU_cms(velocity);
+    position_control->set_vel_desired_NEU_cms(velocity_neu_cms);
 }
 
 // guided_set_velocity - sets guided mode's target velocity
-void ModeGuided::guided_set_velocity(const Vector3f& velocity, bool use_yaw, float yaw_cd, bool use_yaw_rate, float yaw_rate_cds, bool relative_yaw)
+void ModeGuided::guided_set_velocity(const Vector3f& velocity_neu_cms, bool use_yaw, float yaw_cd, bool use_yaw_rate, float yaw_rate_cds, bool relative_yaw)
 {
    // check we are in velocity control mode
     if (sub.guided_mode != Guided_Velocity) {
@@ -293,16 +293,16 @@ void ModeGuided::guided_set_velocity(const Vector3f& velocity, bool use_yaw, flo
     update_time_ms = AP_HAL::millis();
 
     // set position controller velocity target
-    position_control->set_vel_desired_NEU_cms(velocity);
+    position_control->set_vel_desired_NEU_cms(velocity_neu_cms);
 
 }
 
 // set guided mode posvel target
-bool ModeGuided::guided_set_destination_posvel(const Vector3f& destination, const Vector3f& velocity)
+bool ModeGuided::guided_set_destination_posvel(const Vector3f& destination_neu_cm, const Vector3f& velocity_neu_cms)
 {
 #if AP_FENCE_ENABLED
     // reject destination if outside the fence
-    const Location dest_loc(destination, Location::AltFrame::ABOVE_ORIGIN);
+    const Location dest_loc(destination_neu_cm, Location::AltFrame::ABOVE_ORIGIN);
     if (!sub.fence.check_location_within_fence(dest_loc)) {
         LOGGER_WRITE_ERROR(LogErrorSubsystem::NAVIGATION, LogErrorCode::DEST_OUTSIDE_FENCE);
         // failure is propagated to GCS with NAK
@@ -316,28 +316,28 @@ bool ModeGuided::guided_set_destination_posvel(const Vector3f& destination, cons
     }
 
     update_time_ms = AP_HAL::millis();
-    posvel_pos_target_cm = destination.topostype();
-    posvel_vel_target_cms = velocity;
+    posvel_pos_target_neu_cm = destination_neu_cm.topostype();
+    posvel_vel_target_neu_cms = velocity_neu_cms;
 
-    position_control->input_pos_vel_accel_NE_cm(posvel_pos_target_cm.xy(), posvel_vel_target_cms.xy(), Vector2f());
-    float dz = posvel_pos_target_cm.z;
-    position_control->input_pos_vel_accel_U_cm(dz, posvel_vel_target_cms.z, 0);
-    posvel_pos_target_cm.z = dz;
+    position_control->input_pos_vel_accel_NE_cm(posvel_pos_target_neu_cm.xy(), posvel_vel_target_neu_cms.xy(), Vector2f());
+    float dz = posvel_pos_target_neu_cm.z;
+    position_control->input_pos_vel_accel_U_cm(dz, posvel_vel_target_neu_cms.z, 0);
+    posvel_pos_target_neu_cm.z = dz;
 
 #if HAL_LOGGING_ENABLED
     // log target
-    sub.Log_Write_GuidedTarget(sub.guided_mode, destination, velocity);
+    sub.Log_Write_GuidedTarget(sub.guided_mode, destination_neu_cm, velocity_neu_cms);
 #endif
 
     return true;
 }
 
 // set guided mode posvel target
-bool ModeGuided::guided_set_destination_posvel(const Vector3f& destination, const Vector3f& velocity, bool use_yaw, float yaw_cd, bool use_yaw_rate, float yaw_rate_cds, bool relative_yaw)
+bool ModeGuided::guided_set_destination_posvel(const Vector3f& destination_neu_cm, const Vector3f& velocity_neu_cms, bool use_yaw, float yaw_cd, bool use_yaw_rate, float yaw_rate_cds, bool relative_yaw)
 {
     #if AP_FENCE_ENABLED
     // reject destination if outside the fence
-    const Location dest_loc(destination, Location::AltFrame::ABOVE_ORIGIN);
+    const Location dest_loc(destination_neu_cm, Location::AltFrame::ABOVE_ORIGIN);
     if (!sub.fence.check_location_within_fence(dest_loc)) {
         LOGGER_WRITE_ERROR(LogErrorSubsystem::NAVIGATION, LogErrorCode::DEST_OUTSIDE_FENCE);
         // failure is propagated to GCS with NAK
@@ -355,17 +355,17 @@ bool ModeGuided::guided_set_destination_posvel(const Vector3f& destination, cons
 
     update_time_ms = AP_HAL::millis();
 
-    posvel_pos_target_cm = destination.topostype();
-    posvel_vel_target_cms = velocity;
+    posvel_pos_target_neu_cm = destination_neu_cm.topostype();
+    posvel_vel_target_neu_cms = velocity_neu_cms;
 
-    position_control->input_pos_vel_accel_NE_cm(posvel_pos_target_cm.xy(), posvel_vel_target_cms.xy(), Vector2f());
-    float dz = posvel_pos_target_cm.z;
-    position_control->input_pos_vel_accel_U_cm(dz, posvel_vel_target_cms.z, 0);
-    posvel_pos_target_cm.z = dz;
+    position_control->input_pos_vel_accel_NE_cm(posvel_pos_target_neu_cm.xy(), posvel_vel_target_neu_cms.xy(), Vector2f());
+    float dz = posvel_pos_target_neu_cm.z;
+    position_control->input_pos_vel_accel_U_cm(dz, posvel_vel_target_neu_cms.z, 0);
+    posvel_pos_target_neu_cm.z = dz;
 
 #if HAL_LOGGING_ENABLED
     // log target
-    sub.Log_Write_GuidedTarget(sub.guided_mode, destination, velocity);
+    sub.Log_Write_GuidedTarget(sub.guided_mode, destination_neu_cm, velocity_neu_cms);
 #endif
 
     return true;
@@ -632,18 +632,18 @@ void ModeGuided::guided_posvel_control_run()
 
     // set velocity to zero if no updates received for 3 seconds
     uint32_t tnow = AP_HAL::millis();
-    if (tnow - update_time_ms > GUIDED_POSVEL_TIMEOUT_MS && !posvel_vel_target_cms.is_zero()) {
-        posvel_vel_target_cms.zero();
+    if (tnow - update_time_ms > GUIDED_POSVEL_TIMEOUT_MS && !posvel_vel_target_neu_cms.is_zero()) {
+        posvel_vel_target_neu_cms.zero();
     }
 
     // advance position target using velocity target
-    posvel_pos_target_cm += (posvel_vel_target_cms * position_control->get_dt_s()).topostype();
+    posvel_pos_target_neu_cm += (posvel_vel_target_neu_cms * position_control->get_dt_s()).topostype();
 
     // send position and velocity targets to position controller
-    position_control->input_pos_vel_accel_NE_cm(posvel_pos_target_cm.xy(), posvel_vel_target_cms.xy(), Vector2f());
-    float pz = posvel_pos_target_cm.z;
-    position_control->input_pos_vel_accel_U_cm(pz, posvel_vel_target_cms.z, 0);
-    posvel_pos_target_cm.z = pz;
+    position_control->input_pos_vel_accel_NE_cm(posvel_pos_target_neu_cm.xy(), posvel_vel_target_neu_cms.xy(), Vector2f());
+    float pz = posvel_pos_target_neu_cm.z;
+    position_control->input_pos_vel_accel_U_cm(pz, posvel_vel_target_neu_cms.z, 0);
+    posvel_pos_target_neu_cm.z = pz;
 
     // run position controller
     position_control->NE_update_controller();
@@ -789,7 +789,7 @@ float ModeGuided::get_auto_heading()
     switch (sub.auto_yaw_mode) {
 
     case AUTO_YAW_ROI:
-        // point towards a location held in roi_WP
+        // point towards a location held in roi_WP_neu_cm
         return sub.get_roi_yaw();
         break;
 


### PR DESCRIPTION
### Summary

Add `_neu` and `_cm` suffixes to Sub variable names to clarify the existing frame and units.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

~~~
./Tools/scripts/size_compare_branches.py --branch=label_vars --vehicle=sub --board=navigator
...
Board,sub
navigator,*
~~~

This is part 1 of moving Sub to NED and meters. https://github.com/ArduPilot/ardupilot/issues/32876

I looked at existing names in Sub, Location, WPNav, etc. to make sure I am following the same conventions. I didn't find any function names that needed to be changed.