### PR TITLE
Tools: build_options.py: RPM_DRONECAN does not need GENERATOR!

### DIFF
--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -394,7 +394,7 @@ BUILD_OPTIONS = [
     Feature('Sensors', 'RPM_HARMONIC_NOTCH', 'AP_RPM_HARMONICNOTCH_ENABLED', 'Enable RPM Harmonic Notch sensors', 0, 'RPM,HarmonicNotches'),  # noqa
     Feature('Sensors', 'RPM_PIN', 'AP_RPM_PIN_ENABLED', 'Enable RPM Pin-based sensors', 0, 'RPM'),
     Feature('Sensors', 'RPM_GENERATOR', 'AP_RPM_GENERATOR_ENABLED', 'Enable Generator RPM sensors', 0, 'RPM,GENERATOR'),
-    Feature('Sensors', 'RPM_DRONECAN', 'AP_RPM_DRONECAN_ENABLED', 'Enable DroneCAN-based RPM sensors', 0, 'RPM,GENERATOR,DroneCAN'),  # noqa
+    Feature('Sensors', 'RPM_DRONECAN', 'AP_RPM_DRONECAN_ENABLED', 'Enable DroneCAN-based RPM sensors', 0, 'RPM,DroneCAN'),  # noqa
 
     Feature('Sensors', 'TEMP', 'AP_TEMPERATURE_SENSOR_ENABLED', 'Enable Temperature Sensors', 0, None),
     Feature('Sensors', 'TEMP_TSYS01', 'AP_TEMPERATURE_SENSOR_TSYS01_ENABLED', 'Enable Temp Sensor - TSYS01', 0, "TEMP"),


### PR DESCRIPTION
### Summary

Correct deps to remove saying if you supported dronecan RPM sources then you had to have generator

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
./Tools/autotest/test_build_options.py --board=CubeOrangePlus --define-match-glob AP_RPM_DRONECAN_ENABLED

###### Enabling RPM_DRONECAN(AP_RPM_DRONECAN_ENABLED) on copter costs -800 bytes
###### Enabling RPM_DRONECAN(AP_RPM_DRONECAN_ENABLED) on plane costs -800 bytes
###### Enabling RPM_DRONECAN(AP_RPM_DRONECAN_ENABLED) on rover costs -808 bytes
###### Enabling RPM_DRONECAN(AP_RPM_DRONECAN_ENABLED) on antennatracker costs -800 bytes
###### Enabling RPM_DRONECAN(AP_RPM_DRONECAN_ENABLED) on sub costs -816 bytes
###### Enabling RPM_DRONECAN(AP_RPM_DRONECAN_ENABLED) on blimp costs -808 bytes

./Tools/autotest/test_build_options.py --board=CubeOrangePlus --define-match-glob HAL_GENERATOR_ENABLED
###### Enabling GENERATOR(HAL_GENERATOR_ENABLED) on copter costs -7928 bytes
###### Enabling GENERATOR(HAL_GENERATOR_ENABLED) on plane costs -7880 bytes
###### Enabling GENERATOR(HAL_GENERATOR_ENABLED) on rover costs -8040 bytes
###### Enabling GENERATOR(HAL_GENERATOR_ENABLED) on antennatracker costs -8080 bytes
###### Enabling GENERATOR(HAL_GENERATOR_ENABLED) on sub costs -8168 bytes
###### Enabling GENERATOR(HAL_GENERATOR_ENABLED) on blimp costs -7936 bytes

```

### Description

This bad dep has been in for years - since the line was created and we didn't notice.

@shiv-tyagi 