### PR TITLE
Explicitly manage simulated battery temperature

### DIFF
--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -178,7 +178,7 @@ public:
     void set_dronecan_device(DroneCANDevice *_dronecan) { dronecan = _dronecan; }
 #endif
     float get_battery_voltage() const { return battery_voltage; }
-    float get_battery_temperature_degC() const { return battery.get_temperature_degC(); }
+    float get_battery_temperature_degC() const { return battery_temperature_degC; }
     float get_battery_current() const { return battery_current; }
 
     float ambient_outside_temperature_degC() const;
@@ -241,12 +241,15 @@ protected:
     float airspeed_pitot;                // m/s, EAS airspeed, as seen by fwd pitot tube
     float battery_voltage;
     float battery_current;
+    float battery_temperature_degC;
     float local_ground_level;            // ground level at local position
     bool lock_step_scheduled;
     bool flightaxis_sync_imus_to_frames; // causes the frame counter to be incremented on each timestep, IMUs will then update at the same rate
     uint32_t last_one_hz_ms;
 
-    // battery model
+    // OPTIONAL internal battery model.
+    // ("OPTIONAL" because a child can ignore it and directly set battery_* protected members, exposed publicly via getters.)
+    // (Note that some aircraft get battery-info from an external source, ignoring this "internal" one.)
     Battery battery;
 
     uint32_t motor_mask;

--- a/libraries/SITL/SIM_FlightAxis.cpp
+++ b/libraries/SITL/SIM_FlightAxis.cpp
@@ -656,6 +656,8 @@ void FlightAxis::update(const struct sitl_input &input)
 
     battery_voltage = MAX(state.m_batteryVoltage_VOLTS, 0);
     battery_current = MAX(state.m_batteryCurrentDraw_AMPS, 0);
+    // (temperature is not part of the protocol, so it is explicitly set constant here)
+    battery_temperature_degC = 0.0f;
     rpm[0] = state.m_heliMainRotorRPM;
     rpm[1] = state.m_propRPM;
     motor_mask = 3;

--- a/libraries/SITL/SIM_JSON.cpp
+++ b/libraries/SITL/SIM_JSON.cpp
@@ -499,6 +499,8 @@ void JSON::recv_fdm(const struct sitl_input &input)
     } else {
         battery_current = 0.0f;
     }
+    // (temperature is not part of the protocol, just set it explicitly here)
+    battery_temperature_degC = 0.0f;
 
     double deltat;
     if (state.timestamp_s < last_timestamp_s) {

--- a/libraries/SITL/SIM_Multicopter.cpp
+++ b/libraries/SITL/SIM_Multicopter.cpp
@@ -77,6 +77,7 @@ void MultiCopter::update(const struct sitl_input &input)
     battery.maybe_reset(sitl->batt_voltage, sitl->batt_capacity_ah);
     battery_voltage = battery.get_voltage();
     battery_current = frame->get_current_amp();
+    battery_temperature_degC = battery.get_temperature_degC();
 
     const uint64_t now_us = AP_HAL::micros64();
     battery.consume_energy(battery_current, now_us);

--- a/libraries/SITL/SIM_Plane.cpp
+++ b/libraries/SITL/SIM_Plane.cpp
@@ -520,6 +520,7 @@ void Plane::update(const struct sitl_input &input)
     float throttle = reverse_thrust ? filtered_servo_angle(input, 2) : filtered_servo_range(input, 2);
     battery_voltage = sitl->batt_voltage - 0.7*throttle;
     battery_current = (battery_voltage/sitl->batt_voltage)*50.0f*sq(throttle);
+    battery_temperature_degC = 0.0f;
 
     update_dynamics(rot_accel);
 

--- a/libraries/SITL/SIM_QuadPlane.cpp
+++ b/libraries/SITL/SIM_QuadPlane.cpp
@@ -142,6 +142,7 @@ void QuadPlane::update(const struct sitl_input &input)
     battery.maybe_reset(sitl->batt_voltage, sitl->batt_capacity_ah);
     battery_voltage = battery.get_voltage();
     battery_current = frame->get_current_amp();
+    battery_temperature_degC = battery.get_temperature_degC();
 
     const uint64_t now_us = AP_HAL::micros64();
     battery.consume_energy(battery_current, now_us);

--- a/libraries/SITL/SIM_Scrimmage.cpp
+++ b/libraries/SITL/SIM_Scrimmage.cpp
@@ -117,6 +117,7 @@ void Scrimmage::recv_fdm(const struct sitl_input &input)
 
     battery_voltage = 0;
     battery_current = 0;
+    battery_temperature_degC = 0;
     rpm[0] = 0;
     rpm[1] = 0;
 


### PR DESCRIPTION
### Summary

Each simulated vehicle (child of Aircraft) needs to either utilize the `SITL::Battery`, or overwrite it with an external source. So too for battery temperature.
(This is part of #10050 .)

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
