### PR TITLE
AP_GSOF: validate record length before fixed-offset reads

### DIFF
--- a/libraries/AP_GSOF/AP_GSOF.cpp
+++ b/libraries/AP_GSOF/AP_GSOF.cpp
@@ -95,11 +95,33 @@ AP_GSOF::process_message(MsgTypes& parsed_msgs)
 #endif
             }
 
-            parsed_msgs.set(output_type);
             a++;
+            if (a >= msg.length) {
+                // record header is missing its length byte
+                break;
+            }
             const uint8_t output_length = msg.data[a];
             a++;
-            // TODO handle corruption on output_length causing buffer overrun?
+
+            // bytes each fixed-offset parser reads for this record type
+            uint8_t needed = 0;
+            switch (output_type) {
+            case POS_TIME:     needed = 9;   break;
+            case POS:          needed = 24;  break;
+            case VEL:          needed = 13;  break;
+            case DOP:          needed = 8;   break;
+            case POS_SIGMA:    needed = 20;  break;
+            case INS_FULL_NAV: needed = 104; break;
+            case INS_RMS:      needed = 44;  break;
+            case LLH_MSL:      needed = 36;  break;
+            }
+            if (needed > output_length || a + needed > msg.length) {
+                // record is too short for its type or extends past the packet;
+                // stop before any out-of-bounds read
+                break;
+            }
+
+            parsed_msgs.set(output_type);
 
             switch (output_type) {
             case POS_TIME:

--- a/libraries/AP_GSOF/tests/test_gsof.cpp
+++ b/libraries/AP_GSOF/tests/test_gsof.cpp
@@ -149,4 +149,86 @@ TEST(AP_GSOF, vel_flags_not_valid)
     EXPECT_FLOAT_EQ(gsof.vel.vertical_velocity,   42.0f);
 }
 
+// Wrap a GSOF GENOUT DATA payload in DCOL framing with a valid checksum.
+// Fills pkt[] (which must hold data_len + 6 bytes) and returns the length.
+static size_t make_packet(uint8_t *pkt, const uint8_t *data, uint8_t data_len)
+{
+    const uint8_t status = 0x00;
+    const uint8_t packettype = 0x40;
+    uint8_t checksum = status + packettype + data_len;
+    size_t n = 0;
+    pkt[n++] = 0x02;            // STX
+    pkt[n++] = status;
+    pkt[n++] = packettype;      // PACKETTYPE (GSOF)
+    pkt[n++] = data_len;        // LENGTH
+    for (uint8_t i = 0; i < data_len; i++) {
+        checksum += data[i];
+        pkt[n++] = data[i];
+    }
+    pkt[n++] = checksum;
+    pkt[n++] = 0x03;            // ENDTX
+    return n;
+}
+
+// A checksum-valid GENOUT packet whose INS_FULL_NAV record claims a full
+// record but is truncated must not be parsed: the fixed-offset reads would
+// otherwise run past the received bytes.
+TEST(AP_GSOF, ins_full_nav_truncated)
+{
+    const uint8_t data[] = {
+        0x01, 0x01, 0x01,   // GENOUT header
+        0x31,               // output_type = INS_FULL_NAV (49)
+        0x68,               // output_length = 104 (claimed, not delivered)
+        0x00, 0x00, 0x00, 0x00, 0x00,   // only 5 body bytes present
+    };
+    uint8_t pkt[sizeof(data) + 6];
+    const size_t len = make_packet(pkt, data, sizeof(data));
+
+    AP_GSOF gsof;
+    AP_GSOF::MsgTypes parsed;
+    EXPECT_TRUE(feed_packet(gsof, parsed, pkt, len));
+    EXPECT_FALSE(parsed.get(AP_GSOF::INS_FULL_NAV));
+}
+
+// As above but the INS_FULL_NAV record sits near the end of a long packet, so
+// the unguarded 104-byte read would land past the end of the data[] buffer.
+TEST(AP_GSOF, ins_full_nav_past_buffer)
+{
+    uint8_t data[250] = {};
+    data[0] = 0x01;
+    data[1] = 0x01;
+    data[2] = 0x01;
+    // leading VEL record, used only to advance the parse offset to the end
+    data[3] = 0x08;     // output_type = VEL (8)
+    data[4] = 0xE0;     // output_length = 224
+    // INS_FULL_NAV record header lands deep into the buffer
+    data[5 + 224] = 0x31;   // output_type = INS_FULL_NAV (49)
+    data[6 + 224] = 0x68;   // output_length = 104
+
+    uint8_t pkt[sizeof(data) + 6];
+    const size_t len = make_packet(pkt, data, sizeof(data));
+
+    AP_GSOF gsof;
+    AP_GSOF::MsgTypes parsed;
+    EXPECT_TRUE(feed_packet(gsof, parsed, pkt, len));
+    EXPECT_FALSE(parsed.get(AP_GSOF::INS_FULL_NAV));
+}
+
+// A record whose length byte is missing (output_type is the final data byte)
+// must not be read past the end of the packet.
+TEST(AP_GSOF, record_header_truncated)
+{
+    const uint8_t data[] = {
+        0x01, 0x01, 0x01,   // GENOUT header
+        0x46,               // output_type = LLH_MSL (70), no length byte follows
+    };
+    uint8_t pkt[sizeof(data) + 6];
+    const size_t len = make_packet(pkt, data, sizeof(data));
+
+    AP_GSOF gsof;
+    AP_GSOF::MsgTypes parsed;
+    EXPECT_TRUE(feed_packet(gsof, parsed, pkt, len));
+    EXPECT_FALSE(parsed.get(AP_GSOF::LLH_MSL));
+}
+
 AP_GTEST_MAIN()


### PR DESCRIPTION
### Summary

A configured Trimble GSOF receiver could send a GENOUT record whose fixed-width parser reads past the received packet and the 255-byte data buffer, causing an out-of-bounds read. Reject records that are missing a length byte, shorter than their type requires, or extend past the packet before dispatching to a parser.

Adds tests for truncated, past-buffer and header-truncated records.

fixes https://github.com/orgs/ArduPilot/projects/29?pane=issue&itemId=200267271

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

fix for codex scan item 1

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
