### PR TITLE
GCS_MAVLink: fix SERIAL_CONTROL blocking write over-read

### DIFF
--- a/libraries/GCS_MAVLink/GCS_serial_control.cpp
+++ b/libraries/GCS_MAVLink/GCS_serial_control.cpp
@@ -130,10 +130,10 @@ void GCS_MAVLINK::handle_serial_control(const mavlink_message_t &msg)
                     hal.scheduler->delay(5);
                 }
                 uint16_t n = stream->txspace();
-                if (n > packet.count) {
-                    n = packet.count;
+                if (n > count) {
+                    n = count;
                 }
-                stream->write(data, n);                
+                stream->write(data, n);
                 data += n;
                 count -= n;
             }


### PR DESCRIPTION
### Summary

Fix https://github.com/orgs/ArduPilot/projects/29?pane=issue&itemId=200268558

<!-- Put a one or two line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request


### Description

The blocking write loop clamped each chunk to the original packet.count rather than the remaining count, so after a partial write it could read past the end of packet.data and underflow the uint8_t byte counter, extending the loop. Clamp to the remaining count.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
