### PR TITLE
AP_Bootloader: bound DroneCAN firmware-update path handling

### DIFF
--- a/Tools/AP_Bootloader/can.cpp
+++ b/Tools/AP_Bootloader/can.cpp
@@ -183,7 +183,7 @@ static bool send_fw_read(uint8_t idx)
     r.have_reply = false;
 
     uavcan_protocol_file_ReadRequest pkt {};
-    pkt.path.path.len = strlen((const char *)fw_update.path);
+    pkt.path.path.len = strnlen((const char *)fw_update.path, sizeof(pkt.path.path.data));
     pkt.offset = r.offset;
     memcpy(pkt.path.path.data, fw_update.path, pkt.path.path.len);
 
@@ -758,7 +758,11 @@ bool can_check_update(void)
         for (uint8_t i=0; i<FW_UPDATE_PIPELINE_LEN; i++) {
             fw_update.reads[i].offset = i*sizeof(uavcan_protocol_file_ReadResponse::data.data);
         }
+        static_assert(sizeof(fw_update.path) >= sizeof(uavcan_protocol_file_Path::path.data)+1,
+                      "fw_update.path must hold the full handoff path");
         memcpy(fw_update.path, comms->path, sizeof(uavcan_protocol_file_Path::path.data)+1);
+        // don't trust the app to have terminated the handoff path
+        fw_update.path[sizeof(fw_update.path)-1] = 0;
         ret = true;
         // clear comms region
         memset(comms, 0, sizeof(struct app_bootloader_comms));

--- a/Tools/AP_Periph/can.cpp
+++ b/Tools/AP_Periph/can.cpp
@@ -400,6 +400,10 @@ void AP_Periph_FW::handle_begin_firmware_update(CanardInstance* canard_instance,
     if (comms->server_node_id == 0) {
         comms->server_node_id = transfer->source_node_id;
     }
+    // the decoder bounds path.len to the DSDL maximum; this buffer is sized to
+    // hold it with room for the NUL terminator the bootloader relies on
+    static_assert(sizeof(comms->path) == sizeof(uavcan_protocol_file_Path::path.data)+1,
+                  "comms->path must hold the max DroneCAN path plus a NUL");
     memcpy(comms->path, req.image_file_remote_path.path.data, req.image_file_remote_path.path.len);
     comms->my_node_id = canardGetLocalNodeID(canard_instance);
 


### PR DESCRIPTION
### Summary

Bound the DroneCAN firmware-update path in the bootloader so a stale or unterminated application handoff can't over-read or overflow the read-request buffer.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Automated test(s) verify changes
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [x] Builds: AP_Periph (`sitl_periph_universal`) and CubeOrange bootloader

### Description

Reworked after review (thanks @tpwrules): the DroneCAN decoder already bounds the path length, so the AP_Periph runtime check/terminator is dropped in favour of a `static_assert`. The fix is in the bootloader — `can_check_update()` terminates the handoff path, and `send_fw_read()` bounds the read-request length to the destination buffer. Buffer-size invariants are covered by `static_assert`.

Project item: https://github.com/orgs/ArduPilot/projects/29?pane=issue&itemId=200268589