### PR TITLE
AP_Mount: when has_pan_control is false, use a craft-relative 0 degree yaw

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -1030,10 +1030,16 @@ bool AP_Mount_Backend::get_angle_target_to_location(const Location &loc, MountAn
     // calculate roll, pitch, yaw angles
     angle_rad.roll = 0;
     angle_rad.pitch = atan2f(GPS_vector_z, target_distance);
-    angle_rad.yaw = atan2f(GPS_vector_x, GPS_vector_y);
-    angle_rad.yaw_is_ef = true;
     angle_rad.pitch_is_ef = true;
     angle_rad.roll_is_ef = true;
+
+    if (has_pan_control()) {
+        angle_rad.yaw = atan2f(GPS_vector_x, GPS_vector_y);
+        angle_rad.yaw_is_ef = true;
+    } else {
+        angle_rad.yaw = 0;
+        angle_rad.yaw_is_ef = false;
+    }
 
     return true;
 }


### PR DESCRIPTION
### Summary
has_pan_control()==false, should always result in a 0 degree craft relative yaw command.


### Classification & Testing (check all that apply and add your own)

- [X ] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [X ] Tested manually, description below (e.g. SITL)
- [X ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Tested on a Gremsy Pixy LR 3 axis, using firmware's 7.8.0, 7.8.4, 7.8.7, controlled by SITL

### Description

During an ardupilot ROI command, If has_pan_control() is false, fix yaw to 0 degree and switch to a craft relative yaw command.

Gremsy gimbals (tested on Pixy LR 3 axis, multiple firmwares), don't perform a proper Earth relative yaw. Gremsy appears to have internal bugs in their firmware regarding earth relative yaw. 

Craft relative yaw is a simpler command for a gimbal to execute, use it when possible. Ardupilot was not checking has_pan_control() during this ROI command, and was defaulting to the more complex earth relative command. Relying on the gimbal's heading values to calculate a 0 degree yaw, instead of simply sending a 0 degree yaw.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
