### PR TITLE
AP_AHRS: move EKF start code into the relevant backends

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -648,28 +648,6 @@ void AP_AHRS::update_notify_from_filter_status(const nav_filter_status &status)
 #if HAL_NAVEKF2_AVAILABLE
 void AP_AHRS::update_EKF2(void)
 {
-    if (!ekf2.started) {
-        // wait 1 second for DCM to output a valid tilt error estimate
-        if (ekf2.start_time_ms == 0) {
-            ekf2.start_time_ms = AP_HAL::millis();
-        }
-#if HAL_LOGGING_ENABLED
-        // if we're doing Replay logging then don't allow any data
-        // into the EKF yet.  Don't allow it to block us for long.
-        if (!hal.util->was_watchdog_reset()) {
-            if (AP_HAL::millis() - ekf2.start_time_ms < 5000) {
-                if (!AP::logger().allow_start_ekf()) {
-                    return;
-                }
-            }
-        }
-#endif
-
-        if (AP_HAL::millis() - ekf2.start_time_ms > startup_delay_ms) {
-            ekf2.started = ekf2.EKF2.InitialiseFilter();
-        }
-    }
-    if (ekf2.started) {
         ekf2.update();
         ekf2_estimates = {};
         ekf2.get_results(ekf2_estimates);
@@ -692,34 +670,12 @@ void AP_AHRS::update_EKF2(void)
 #endif
             }
         }
-    }
 }
 #endif
 
 #if HAL_NAVEKF3_AVAILABLE
 void AP_AHRS::update_EKF3(void)
 {
-    if (!ekf3.started) {
-        // wait 1 second for DCM to output a valid tilt error estimate
-        if (ekf3.start_time_ms == 0) {
-            ekf3.start_time_ms = AP_HAL::millis();
-        }
-#if HAL_LOGGING_ENABLED
-        // if we're doing Replay logging then don't allow any data
-        // into the EKF yet.  Don't allow it to block us for long.
-        if (!hal.util->was_watchdog_reset()) {
-            if (AP_HAL::millis() - ekf3.start_time_ms < 5000) {
-                if (!AP::logger().allow_start_ekf()) {
-                    return;
-                }
-            }
-        }
-#endif
-        if (AP_HAL::millis() - ekf3.start_time_ms > startup_delay_ms) {
-            ekf3.started = ekf3.EKF3.InitialiseFilter();
-        }
-    }
-    if (ekf3.started) {
         ekf3.update();
         ekf3_estimates = {};
         ekf3.get_results(ekf3_estimates);
@@ -741,7 +697,6 @@ void AP_AHRS::update_EKF3(void)
 #endif
             }
         }
-    }
 }
 #endif
 

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -853,7 +853,6 @@ private:
     void update_EKF3(void);
 #endif
 
-    static constexpr uint16_t startup_delay_ms = 1000;
     uint8_t _ekf_flags; // bitmask from Flags enumeration
 
     void update_DCM();

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF2.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF2.cpp
@@ -5,10 +5,52 @@
 #include "AP_AHRS_NavEKF2.h"
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_HAL/AP_HAL.h>
+#include <AP_Logger/AP_Logger.h>
 
 extern const AP_HAL::HAL& hal;
 
 NavEKF2 AP_AHRS_NavEKF2::EKF2;
+
+bool AP_AHRS_NavEKF2::start()
+{
+    const auto now_ms = AP_HAL::millis();
+
+    if (start_time_ms == 0) {
+        start_time_ms = now_ms;
+    }
+
+#if HAL_LOGGING_ENABLED
+    // if we're doing Replay logging then don't allow any data
+    // into the EKF yet.  Don't allow it to block us for long.
+    if (!hal.util->was_watchdog_reset()) {
+        if (now_ms - start_time_ms < 5000) {
+            if (!AP::logger().allow_start_ekf()) {
+                return false;
+            }
+        }
+    }
+#endif
+
+    // wait 1 second for DCM to output a valid tilt error estimate
+    // FIXME: work out whether this is still required!
+    if (now_ms - start_time_ms <= 1000) {
+        return false;
+    }
+
+    // try to start the filter:
+    return EKF2.InitialiseFilter();
+}
+
+void AP_AHRS_NavEKF2::update()
+{
+    if (!started) {
+        started = start();
+    }
+    if (!started) {
+        return;
+    }
+    EKF2.UpdateFilter();
+}
 
 void AP_AHRS_NavEKF2::get_results(AP_AHRS_Backend::Estimates &results)
 {

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF2.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF2.h
@@ -37,7 +37,7 @@ public:
 
     void reset_gyro_drift() override { EKF2.resetGyroBias(); }
 
-    void update() override { EKF2.UpdateFilter(); }
+    void update() override;
 
     void get_results(Estimates &results) override;
     void reset() override {
@@ -96,6 +96,7 @@ public:
     // this is out here so parameters can be poked into it
     static NavEKF2 EKF2;
 
+    bool start();
     bool started;
     uint32_t start_time_ms;  // timer used to delay starting the filter
 };

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
@@ -5,10 +5,51 @@
 #include "AP_AHRS_NavEKF3.h"
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_HAL/AP_HAL.h>
+#include <AP_Logger/AP_Logger.h>
 
 extern const AP_HAL::HAL& hal;
 
 NavEKF3 AP_AHRS_NavEKF3::EKF3;
+
+bool AP_AHRS_NavEKF3::start()
+{
+    const auto now_ms = AP_HAL::millis();
+
+    if (start_time_ms == 0) {
+        start_time_ms = now_ms;
+    }
+
+#if HAL_LOGGING_ENABLED
+    // if we're doing Replay logging then don't allow any data
+    // into the EKF yet.  Don't allow it to block us for long.
+    if (!hal.util->was_watchdog_reset()) {
+        if (now_ms - start_time_ms < 5000) {
+            if (!AP::logger().allow_start_ekf()) {
+                return false;
+            }
+        }
+    }
+#endif
+
+    // wait 1 second for DCM to output a valid tilt error estimate
+    // FIXME: work out whether this is still required!
+    if (now_ms - start_time_ms <= 1000) {
+        return false;
+    }
+
+    return EKF3.InitialiseFilter();
+}
+
+void AP_AHRS_NavEKF3::update()
+{
+    if (!started) {
+        started = start();
+    }
+    if (!started) {
+        return;
+    }
+    EKF3.UpdateFilter();
+}
 
 void AP_AHRS_NavEKF3::get_results(AP_AHRS_Backend::Estimates &results)
 {

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF3.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF3.h
@@ -37,7 +37,7 @@ public:
 
     void reset_gyro_drift() override { EKF3.resetGyroBias(); }
 
-    void update() override { EKF3.UpdateFilter(); }
+    void update() override;
 
     void get_results(Estimates &results) override;
     void reset() override {
@@ -95,6 +95,7 @@ public:
     // this is out here so parameters can be poked into it
     static NavEKF3 EKF3;
 
+    bool start();
     bool started;
     uint32_t start_time_ms;  // timer used to delay starting the filter
 };


### PR DESCRIPTION
### Summary

Move "start the EKF, but on a timeline" code into the relevant AP_AHRS_NavEKFx backend.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                 *
Durandal                            16              16     *           16      16                16     16     16
Hitec-Airspeed           *                                 *
KakuteH7-bdshot                     16              16     *           16      16                16     16     16
MatekF405                           16              16     *           16      16                16     16     16
Pixhawk1-1M-bdshot                  16              16                 16      16                16     16     16
SITL_x86_64_linux_gnu               0               -4096              0       0                 0      0      0
YJUAV_A6SE                          16              16     *           16      16                16     16     16
f103-QiotekPeriph        *                                 *
f303-MatekGPS            *                                 *
f303-Universal           *                                 *
iomcu                                                                                *
revo-mini                           16              16     *           16      16                16     16     16
skyviper-v2450                                                         16
speedybeef4                         16              16     *           16      16                16     16     16
```

### Description

Moves the EKF startup code out of the update function in the EKF into the update function on the individual backend.

This helps to make the `update_EKF2` and `update_EKF3` methods look much more similar to the identical `update_SITL`, `update_DCM` and more similar to `update_exernal`.  All of these AP_AHRS methods will go away and we'll be using iteration in the future, but this bespoke code has to go first.

I've broken out a boolean `start` function to hold the start logic.  I'm not convinced that we need to a bunch of this stuff, and @rishabsingh3003 has been trying to reduce startup times.  At least it's a bit more broken out now so perhaps we can actively sense what the EKF is up to and decide to `InitialiseFilter` depending on the EKF's state rather than a fixed timeout.  IIUC some of the delay was due to weird sensor data coming in early in the boot process, so perhaps that's no longer an issue.

The one major structural change is that we will populate the backend results regardless of EKF start.  Our flows for determining an active EKF type are very strict about not letting the backend become active when its EKF has not started, so the notify call will never be made.  The results will similarly be unused at the moment, but we should probably set attitude-valid etc to one of `results.healthy`, `results.started` or `results.initialised` before we restructure the backend selection code (this may become very important when DCM can be entirely compiled out so there *is* no fallback estimator!)
