### PR TITLE
AP_AHRS_DCM: correct guard around set_external_wind_estimate

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -1116,7 +1116,7 @@ void AP_AHRS_DCM::estimate_wind(void)
 #endif
 }
 
-#ifdef AP_AHRS_EXTERNAL_WIND_ESTIMATE_ENABLED
+#if AP_AHRS_EXTERNAL_WIND_ESTIMATE_ENABLED
 void AP_AHRS_DCM::set_external_wind_estimate(float speed, float direction) {
     _wind.x = -cosf(radians(direction)) * speed;
     _wind.y = -sinf(radians(direction)) * speed;

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -74,7 +74,9 @@ public:
         return _error_yaw;
     }
 
+#if AP_AHRS_EXTERNAL_WIND_ESTIMATE_ENABLED
     void set_external_wind_estimate(float speed, float direction);
+#endif
 
     // return an airspeed estimate if available. return true
     // if we have an estimate


### PR DESCRIPTION
### Summary

Corrects use of an always-enabled define

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change (see below)
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

This was using #ifdef on a macro which is always defined by AP_AHRS_config.h, so the method was compiled in even when the feature was disabled.  Also guard the declaration.

```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                 *                                                   
Durandal                            *               *      *           *       *                 *      *      *
Hitec-Airspeed           *                                 *                                                   
KakuteH7-bdshot                     *               *      *           *       *                 *      *      *
MatekF405                           *               *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot                  *               *                  *       *                 *      *      *
SITL_x86_64_linux_gnu               *               *                  *       *                 *      *      *
YJUAV_A6SE                          *               *      *           *       *                 *      *      *
f103-QiotekPeriph        *                                 *                                                   
f303-MatekGPS            *                                 *                                                   
f303-Universal           *                                 *                                                   
iomcu                                                                                *                         
revo-mini                           *               *      *           *       *                 *      *      *
skyviper-v2450                                                         *                                       
speedybeef4                         *               *      *           *       *                 *      *      *
```

And with a hwdef which disabled the feature:
```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                 *                                                   
Durandal                            -152            -152   *           -160    -160              -152   -136   -144
Hitec-Airspeed           *                                 *                                                   
KakuteH7-bdshot                     -136            -136   *           -128    -136              -136   -136   -136
MatekF405                           8               16     *           8       16                16     8      8
Pixhawk1-1M-bdshot                  16              16                 16      16                16     16     16
SITL_x86_64_linux_gnu               -72             -4168              -72     -72               -72    -72    -72
YJUAV_A6SE                          -144            -152   *           -160    -176              -160   -152   -152
f103-QiotekPeriph        *                                 *                                                   
f303-MatekGPS            *                                 *                                                   
f303-Universal           *                                 *                                                   
iomcu                                                                                *                         
revo-mini                           16              16     *           16      16                16     16     16
skyviper-v2450                                                         -160                                    
speedybeef4                         16              16     *           16      16                16     16     16
```
