### PR TITLE
AP_MAVLinkCAN: reject negative CAN bus index in filter modify

### DIFF
--- a/libraries/AP_CANManager/AP_MAVLinkCAN.cpp
+++ b/libraries/AP_CANManager/AP_MAVLinkCAN.cpp
@@ -207,7 +207,7 @@ void AP_MAVLinkCAN::_handle_can_filter_modify(const mavlink_message_t &msg)
     mavlink_can_filter_modify_t p;
     mavlink_msg_can_filter_modify_decode(&msg, &p);
     const int8_t bus = int8_t(p.bus)-1;
-    if (bus >= HAL_NUM_CAN_IFACES || hal.can[bus] == nullptr) {
+    if (bus < 0 || bus >= HAL_NUM_CAN_IFACES || hal.can[bus] == nullptr) {
         return;
     }
     if (p.num_ids > ARRAY_SIZE(p.ids)) {


### PR DESCRIPTION
### Summary

<!-- Put a one or two line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

In the same vein as https://github.com/ArduPilot/ardupilot/pull/33376

A malformed CAN_FILTER_MODIFY message with a bus value of zero produces bus == -1 after the off-by-one adjustment. The existing bounds check only tested the upper bound, so hal.can[-1] was dereferenced before validation. Add a lower-bound check, matching the fix applied to MAV_CMD_CAN_FORWARD.
