### PR TITLE
Move the sub-specific battery model into Sub

### DIFF
--- a/libraries/AP_HAL_SITL/SITL_Periph_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_Periph_State.cpp
@@ -134,7 +134,8 @@ void SITL_State::wait_clock(uint64_t wait_time_usec)
             struct sitl_input input {};
             sitl_model->update(input); // delays up to 1 millisecond
             sim_update();
-            update_voltage_current(input, 0);
+            constexpr float throttle = 0.0f;
+            update_voltage_current(throttle);
         } else {
             usleep(1000);
         }

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -375,7 +375,7 @@ void SITL_State::_simulator_servos(struct sitl_input &input)
     }
     _sitl->throttle = throttle;
 
-    update_voltage_current(input, throttle);
+    update_voltage_current(throttle);
 }
 
 void SITL_State::init(int argc, char * const argv[])

--- a/libraries/AP_HAL_SITL/SITL_State_common.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State_common.cpp
@@ -475,7 +475,7 @@ void SITL_State_Common::sim_update(void)
 /*
   update voltage and current pins
  */
-void SITL_State_Common::update_voltage_current(struct sitl_input &input, float throttle)
+void SITL_State_Common::update_voltage_current(float throttle)
 {
     float voltage = 0;
     float current = 0;
@@ -483,17 +483,8 @@ void SITL_State_Common::update_voltage_current(struct sitl_input &input, float t
     if (_sitl != nullptr) {
         if (_sitl->state.battery_voltage <= 0) {
             if (_vehicle == ArduSub) {
-                voltage = _sitl->batt_voltage;
-                for (uint8_t i=0; i<6; i++) {
-                    float pwm = input.servos[i];
-                    //printf("i: %d, pwm: %.2f\n", i, pwm);
-                    float fraction = fabsf((pwm - 1500) / 500.0f);
-
-                    voltage -= fraction * 0.5f;
-
-                    float draw = fraction * 15;
-                    current += draw;
-                }
+                voltage = sitl_model->get_battery_voltage();
+                current = sitl_model->get_battery_current();
             } else {
                 voltage = sitl_model->get_battery_voltage();
                 current = sitl_model->get_battery_current();

--- a/libraries/AP_HAL_SITL/SITL_State_common.h
+++ b/libraries/AP_HAL_SITL/SITL_State_common.h
@@ -228,7 +228,7 @@ protected:
 
     SITL::SIM *_sitl;
 
-    void update_voltage_current(struct sitl_input &input, float throttle);
+    void update_voltage_current(float throttle);
 };
 
 #endif // CONFIG_HAL_BOARD == HAL_BOARD_SITL

--- a/libraries/SITL/SIM_Submarine.cpp
+++ b/libraries/SITL/SIM_Submarine.cpp
@@ -120,6 +120,22 @@ void Submarine::calculate_forces(const struct sitl_input &input, Vector3f &rot_a
     add_shove_forces(rot_accel, body_accel);
 }
 
+// Note: Sub does not comply with SIM_BATT_CAP_AH, instead it always
+// uses an unlimited-capacity battery model.
+void Submarine::update_battery(const struct sitl_input &input)
+{
+    battery_voltage = sitl->batt_voltage;
+    battery_current = 0.0f;
+    // Model battery usage via linear voltage-sag and current draw for every actuator
+    constexpr float voltage_sag_scaler_volts = 0.5f;
+    constexpr float current_draw_scaler_amps = 15.0f;
+    for (uint8_t i=0; i<6; i++) {
+        const float pwm = input.servos[i];
+        const float fraction = fabsf(pwm - 1500) / 500.0f;
+        battery_voltage -= fraction * voltage_sag_scaler_volts;
+        battery_current += fraction * current_draw_scaler_amps;
+    }
+}
 
 /**
  * @brief Calculate the torque induced by buoyancy foam
@@ -239,6 +255,7 @@ void Submarine::update(const struct sitl_input &input)
     Vector3f rot_accel;
 
     calculate_forces(input, rot_accel, accel_body);
+    update_battery(input);
 
     update_dynamics(rot_accel);
     update_external_payload(input);

--- a/libraries/SITL/SIM_Submarine.h
+++ b/libraries/SITL/SIM_Submarine.h
@@ -21,6 +21,7 @@
 #include "SIM_Aircraft.h"
 #include "SIM_Motor.h"
 #include "SIM_Frame.h"
+#include <AP_InternalError/AP_InternalError.h>
 
 namespace SITL {
 
@@ -105,6 +106,11 @@ protected:
     void calculate_angular_drag_torque(const Vector3f &angular_velocity, const Vector3f &drag_coefficient, Vector3f &torque) const;
     // calculate torque induced by buoyancy foams
     void calculate_buoyancy_torque(Vector3f &torque);
+    // compute and set battery usage
+    void update_battery(const struct sitl_input &input) override;
+    // Sub needs the sitl_input, should never use the parent's input-free version.
+    // (Using it would be using the wrong battery model, but it would silently work.)
+    void update_battery() override { INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control); };
 
     Frame *frame;
     Thruster* thrusters;


### PR DESCRIPTION
### Summary

Sub's custom battery-usage model was located in `SITL_State_common` but it belongs more naturally in `Submarine` now that the simulated battery cleanup has completed. This PR moves it.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] Simulation-only change (and _should_ have no notable impact on behavior)
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Run SITL locally and observe that the battery sags as expected.
(In detail: `BATTERY_STATUS` voltage[0] drops in proportion to how far `rc 3` is set away from 1500. Also see current_consumed growing, as expected.)

### Description

Merely moves sub-specific code to a more appropriate place, and adds comments & clarity.

This contributes towards the #10050 effort.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
