### PR TITLE
Make every child of SITL::Aircraft responsible for its battery consumption model

### DIFF
--- a/libraries/AP_HAL_SITL/SITL_State_common.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State_common.cpp
@@ -495,12 +495,8 @@ void SITL_State_Common::update_voltage_current(struct sitl_input &input, float t
                     current += draw;
                 }
             } else {
-                // simulate simple battery setup
-                // lose 0.7V at full throttle
-                voltage = _sitl->batt_voltage - 0.7f * throttle;
-
-                // assume 50A at full throttle
-                current = 50.0f * throttle;
+                voltage = sitl_model->get_battery_voltage();
+                current = sitl_model->get_battery_current();
             }
         } else {
             // FDM provides voltage and current

--- a/libraries/SITL/SIM_AirSim.cpp
+++ b/libraries/SITL/SIM_AirSim.cpp
@@ -346,6 +346,9 @@ void AirSim::recv_fdm(const sitl_input& input)
         rangefinder_m[i] = state.rng.rng_distances.data[i];
     }
 
+    // AirSim does not provide battery information, so use the standard battery model.
+    update_battery();
+
 #if 0
 // @LoggerMessage: ASM1
 // @Description: AirSim simulation data

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -1122,6 +1122,21 @@ bool Aircraft::Clamp::clamped(Aircraft &aircraft, const struct sitl_input &input
     return currently_clamped;
 }
 
+// simple battery consumption model
+// does not support the behavior documented by SIM_BATT_VOLTAGE and SIM_BATT_CAP_AH parameters
+void Aircraft::update_battery()
+{
+    // lose 0.7V at full throttle (from the user-specified voltage)
+    battery_voltage = sitl->batt_voltage - 0.7f * fabsf(sitl->throttle);
+    // assume 50A at full throttle
+    battery_current = 50.0f * fabsf(sitl->throttle);
+}
+
+void Aircraft::update_battery(const struct sitl_input &input)
+{
+    update_battery();
+}
+
 void Aircraft::update_external_payload(const struct sitl_input &input)
 {
     external_payload_mass = 0;

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -179,6 +179,7 @@ public:
 #endif
     float get_battery_voltage() const { return battery_voltage; }
     float get_battery_temperature_degC() const { return battery.get_temperature_degC(); }
+    float get_battery_current() const { return battery_current; }
 
     float ambient_outside_temperature_degC() const;
     float ambient_outside_pressure_Pascal() const;
@@ -360,6 +361,10 @@ protected:
 
     // extrapolate sensors by a given delta time in seconds
     void extrapolate_sensors(float delta_time);
+
+    // update battery
+    virtual void update_battery();
+    virtual void update_battery(const struct sitl_input &input);
 
     // update external payload/sensor dynamic
     void update_external_payload(const struct sitl_input &input);

--- a/libraries/SITL/SIM_BalanceBot.cpp
+++ b/libraries/SITL/SIM_BalanceBot.cpp
@@ -178,6 +178,8 @@ void BalanceBot::update(const struct sitl_input &input)
 
     // update magnetic field
     update_mag_field_bf();
+
+    update_battery();
 }
 
 }// namespace SITL

--- a/libraries/SITL/SIM_Balloon.cpp
+++ b/libraries/SITL/SIM_Balloon.cpp
@@ -74,6 +74,8 @@ void Balloon::update(const struct sitl_input &input)
 
     // update magnetic field
     update_mag_field_bf();
+
+    update_battery();
 }
 
 } // namespace SITL

--- a/libraries/SITL/SIM_Blimp.cpp
+++ b/libraries/SITL/SIM_Blimp.cpp
@@ -380,4 +380,5 @@ void Blimp::update(const struct sitl_input &input)
   update_mag_field_bf();
   rate_hz = sitl->loop_rate_hz;
 
+  update_battery();
 }

--- a/libraries/SITL/SIM_CRRCSim.cpp
+++ b/libraries/SITL/SIM_CRRCSim.cpp
@@ -150,6 +150,7 @@ void CRRCSim::update(const struct sitl_input &input)
 {
     send_servos(input);
     recv_fdm(input);
+    update_battery();
     update_position();
     time_advance();
 

--- a/libraries/SITL/SIM_Calibration.cpp
+++ b/libraries/SITL/SIM_Calibration.cpp
@@ -52,6 +52,8 @@ void SITL::Calibration::update(const struct sitl_input &input)
 
     // update magnetic field
     update_mag_field_bf();
+
+    update_battery();
 }
 
 void SITL::Calibration::_stop_control(const struct sitl_input &input,

--- a/libraries/SITL/SIM_Gazebo.cpp
+++ b/libraries/SITL/SIM_Gazebo.cpp
@@ -162,6 +162,7 @@ void Gazebo::update(const struct sitl_input &input)
 {
     send_servos(input);
     recv_fdm(input);
+    update_battery();
     update_position();
 
     time_advance();

--- a/libraries/SITL/SIM_Glider.cpp
+++ b/libraries/SITL/SIM_Glider.cpp
@@ -369,6 +369,8 @@ void Glider::update(const struct sitl_input &input)
 
     // update magnetic field
     update_mag_field_bf();
+
+    update_battery();
 }
 
 /*

--- a/libraries/SITL/SIM_Helicopter.cpp
+++ b/libraries/SITL/SIM_Helicopter.cpp
@@ -426,6 +426,8 @@ void Helicopter::update(const struct sitl_input &input)
 
     // update magnetic field
     update_mag_field_bf();
+
+    update_battery();
 }
 
 void Helicopter::update_rotor_dynamics(Vector3f gyros, Vector2f ctrl_pos, Vector2f &tpp_angle, float dt)

--- a/libraries/SITL/SIM_JSBSim.cpp
+++ b/libraries/SITL/SIM_JSBSim.cpp
@@ -483,6 +483,7 @@ void JSBSim::update(const struct sitl_input &input)
     }
     send_servos(input);
     recv_fdm(input);
+    update_battery();
     adjust_frame_time(rate_hz);
     sync_frame_time();
     drain_control_socket();

--- a/libraries/SITL/SIM_JSON.cpp
+++ b/libraries/SITL/SIM_JSON.cpp
@@ -490,10 +490,14 @@ void JSON::recv_fdm(const struct sitl_input &input)
 
     // update battery state
     if ((received_bitmask & BAT_VOLT) != 0) {
-        battery_voltage = state.bat_volt; 
+        battery_voltage = state.bat_volt;
+    } else {
+        battery_voltage = sitl->batt_voltage;
     }
     if ((received_bitmask & BAT_AMP) != 0) {
-        battery_current = state.bat_amp; 
+        battery_current = state.bat_amp;
+    } else {
+        battery_current = 0.0f;
     }
 
     double deltat;

--- a/libraries/SITL/SIM_Morse.cpp
+++ b/libraries/SITL/SIM_Morse.cpp
@@ -452,6 +452,7 @@ void Morse::output_pwm(const struct sitl_input &input)
  */
 void Morse::update(const struct sitl_input &input)
 {
+    update_battery();
     if (!connect_sockets()) {
         return;
     }

--- a/libraries/SITL/SIM_NoVehicle.h
+++ b/libraries/SITL/SIM_NoVehicle.h
@@ -29,7 +29,7 @@ class NoVehicle : public Aircraft {
 public:
     NoVehicle(const char *frame_str) : Aircraft(frame_str) {}
 
-    void update(const struct sitl_input &input) override {}
+    void update(const struct sitl_input &input) override { update_battery(); }
 
     /* static object creator */
     static Aircraft *create(const char *frame_str) {

--- a/libraries/SITL/SIM_Rover.cpp
+++ b/libraries/SITL/SIM_Rover.cpp
@@ -136,6 +136,8 @@ void SimRover::update(const struct sitl_input &input)
 
     // update magnetic field
     update_mag_field_bf();
+
+    update_battery();
 }
 
 /*

--- a/libraries/SITL/SIM_Sailboat.cpp
+++ b/libraries/SITL/SIM_Sailboat.cpp
@@ -332,6 +332,7 @@ void Sailboat::update(const struct sitl_input &input)
     // update wave calculations
     update_wave(delta_time);
 
+    update_battery();
 }
 
 } // namespace SITL

--- a/libraries/SITL/SIM_SilentWings.cpp
+++ b/libraries/SITL/SIM_SilentWings.cpp
@@ -311,6 +311,7 @@ void SilentWings::update(const struct sitl_input &input)
     }
 
     update_mag_field_bf();
+    update_battery();
 
     uint32_t now = AP_HAL::millis();
 

--- a/libraries/SITL/SIM_SingleCopter.cpp
+++ b/libraries/SITL/SIM_SingleCopter.cpp
@@ -106,4 +106,6 @@ void SingleCopter::update(const struct sitl_input &input)
 
     // update magnetic field
     update_mag_field_bf();
+
+    update_battery();
 }

--- a/libraries/SITL/SIM_StratoBlimp.cpp
+++ b/libraries/SITL/SIM_StratoBlimp.cpp
@@ -306,6 +306,8 @@ void StratoBlimp::update(const struct sitl_input &input)
 
     // update magnetic field
     update_mag_field_bf();
+
+    update_battery();
 }
 
 #endif // AP_SIM_STRATOBLIMP_ENABLED

--- a/libraries/SITL/SIM_Tracker.cpp
+++ b/libraries/SITL/SIM_Tracker.cpp
@@ -133,6 +133,8 @@ void Tracker::update(const struct sitl_input &input)
 
     // update magnetic field
     update_mag_field_bf();
+
+    update_battery();
 }
 
 } // namespace SITL

--- a/libraries/SITL/SIM_Webots.cpp
+++ b/libraries/SITL/SIM_Webots.cpp
@@ -440,8 +440,10 @@ void Webots::output (const struct sitl_input &input)
   update the Webots simulation by one time step
  */
 void Webots::update(const struct sitl_input &input)
-{   
+{
     static bool first = true;
+    update_battery();
+
     if (!connect_sockets()) {
         return;
     }

--- a/libraries/SITL/SIM_Webots_Python.cpp
+++ b/libraries/SITL/SIM_Webots_Python.cpp
@@ -160,6 +160,7 @@ void WebotsPython::update(const struct sitl_input &input)
 {
     send_servos(input);
     recv_fdm(input);
+    update_battery();
     update_position();
 
     time_advance();

--- a/libraries/SITL/SIM_XPlane.cpp
+++ b/libraries/SITL/SIM_XPlane.cpp
@@ -687,6 +687,8 @@ void XPlane::update(const struct sitl_input &input)
         send_drefs(input);
     }
 
+    update_battery();
+
     uint32_t now = AP_HAL::millis();
     if (report.last_report_ms == 0) {
         report.last_report_ms = now;

--- a/libraries/SITL/SIM_last_letter.cpp
+++ b/libraries/SITL/SIM_last_letter.cpp
@@ -133,6 +133,7 @@ void last_letter::update(const struct sitl_input &input)
 {
     send_servos(input);
     recv_fdm(input);
+    update_battery();
     sync_frame_time();
 
     update_position();


### PR DESCRIPTION
### Summary

This is a big step towards getting battery-consumption into `Aircraft`-children and out of SITL_State_Common.
The same common pattern is applied to many children: Use the simple model provided (now) by `Aircraft`.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] Sim-only change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

This is a big intermediate step towards every child of Aircraft owning its battery usage model.
(Sub is taking a similar step in #33461, currently in review.)

Once every Aircraft owns its battery usage model, we are well-poised to consider on a case-by-case basis:
- Creating a more specific usage model, which specifies current-draw based on state/input.
- Switch to use the internal `SITL::Battery` which complies with our SIM_BATT parameters, and has a realistic voltage sag + energy depletion + temperature behavior.

(I hope most Aircraft eventually use that nice battery class. Currently, they do not support what our user-facing documentation says.)

Finally, I hope `SITL_State_Common::update_voltage_current` will be reduced all the way down to `_set_current_and_voltage_pins()`, so it *only* has responsibility for mapping the sensed amount to the pin value.

This is an important PR towards open issue #10050 .

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
