### PR TITLE
Tools: autotest: Copter: add test for time-constant change during a maneuver

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -17651,6 +17651,40 @@ return update, 1000
             if pname in all_params:
                 raise ValueError(f"{pname} in fetched-all-parameters when it should have gone away")
 
+    def inputShapingOvershoot(self):
+        '''test time constant increase during a maneuver'''
+
+        self.takeoff()
+
+        # Lower the accel limit and reduce the time constant
+        self.context_push()
+        self.set_parameter("ATC_ACC_R_MAX", 500)
+        self.set_parameter("ATC_INPUT_TC", 0.1)
+
+        # Lean over to the left
+        self.set_rc(1, 1000)
+        self.wait_attitude(desroll=-30)
+
+        # Start leaning right
+        self.set_rc(1, 2000, timeout=None)
+
+        # Change the time-constant
+        self.set_parameter("ATC_INPUT_TC", 1)
+
+        # See if attitude overshoots
+        try:
+            self.wait_attitude(desroll=90)
+            raise NotAchievedException("Should not reach 90 deg roll!")
+        except AutoTestTimeoutException:
+            pass
+        except Exception as e:
+            raise e
+
+        self.set_rc(1, 1500)
+        self.context_pop()
+
+        self.land_and_disarm()
+
     def tests2b(self):  # this block currently around 9.5mins here
         '''return list of all tests'''
         ret = ([
@@ -17820,6 +17854,7 @@ return update, 1000
             self.UTMGlobalPosition,
             self.UTMGlobalPositionWaypoint,
             self.HomeAltResetTest,
+            self.inputShapingOvershoot,
         ])
         return ret
 


### PR DESCRIPTION
### Summary

<!-- Put a one or two line summary of what your PR does here -->

This is a copter reproduction of a issue hit when testing plane's new input shaping PR https://github.com/ArduPilot/ardupilot/pull/32743#issuecomment-4713740594. The results are very timing dependent, but it is possible to get the copter to do a full roll in stabilize mode.

<img width="1068" height="507" alt="image" src="https://github.com/user-attachments/assets/576f37f3-4698-435a-893b-748b6897d99e" />

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->

This happens because the input shaping position, velocity and acceleration are continuous. So you can build a very high velocity and acceleration when the time constant is low, then when the time constant is increased it takes a long time for those high values to reduce back to a reasonable range. This is not a inherent issue with a high time constant, if the value is changed when there is low velocity and acceleration demand they will never build to value that take a long time to decay.

I'm not really sure of the best way to fix this, or even if we have to. It maybe sufficient to say "don't change the time constant in flight". One method to fix would be to track time-constant changes and reset the input shaping velocity and accel to zero. 

The new "SCurve" input shaping is more vulnerable to this because it tracks and maintains continuous acceleration. A similar issue would exist in 4.6 if you were to build a high velocity and then change to a low acceleration limit. 