### PR TITLE
Copter: move AutoTrim support into Copter object

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -164,7 +164,7 @@ const AP_Scheduler::Task Copter::scheduler_tasks[] = {
 #endif
     SCHED_TASK(auto_disarm_check,     10,     50,  27),
 #if AP_COPTER_AHRS_AUTO_TRIM_ENABLED
-    SCHED_TASK_CLASS(RC_Channels_Copter,   &copter.g2.rc_channels,      auto_trim_run,   10,  75,  30),
+    SCHED_TASK_CLASS(AHRSTrimming,       &copter.ahrs_trimming,       auto_run,        10,  75,  30),
 #endif
 #if AP_RANGEFINDER_ENABLED
     SCHED_TASK(read_rangefinder,      20,    100,  33),

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -756,6 +756,21 @@ private:
     void run_custom_controller() { custom_control.update(); }
 #endif
 
+
+    // support for trimming AHRS using RC stick inputs, enabled via an
+    // aux function.  Also support for auto-trimming AHRS via
+    // controller outputs.
+    struct AHRSTrimming {
+#if AP_COPTER_AHRS_AUTO_TRIM_ENABLED
+        void auto_start();
+        void auto_stop();
+        void auto_run();
+        void auto_cancel();
+        bool running;
+#endif  // AP_COPTER_AHRS_AUTO_TRIM_ENABLED
+        void save_trim();
+    } ahrs_trimming;
+
     // avoidance.cpp
     void low_alt_avoidance();
 

--- a/ArduCopter/RC_Channel_Copter.cpp
+++ b/ArduCopter/RC_Channel_Copter.cpp
@@ -222,7 +222,7 @@ bool RC_Channel_Copter::do_aux_function(const AuxFuncTrigger &trigger)
             if ((ch_flag == AuxSwitchPos::HIGH) &&
                 (copter.flightmode->allows_save_trim()) &&
                 (copter.channel_throttle->get_control_in() == 0)) {
-                copter.g2.rc_channels.save_trim();
+                copter.ahrs_trimming.save_trim();
             }
             break;
 
@@ -727,14 +727,14 @@ void RC_Channel_Copter::do_aux_function_change_force_flying(const AuxSwitchPos c
 // note that this is a method on the RC_Channels object, not the
 // individual channel
 // save_trim - adds roll and pitch trims from the radio to ahrs
-void RC_Channels_Copter::save_trim()
+void Copter::AHRSTrimming::save_trim()
 {
     float roll_trim_rad = 0.0;
     float pitch_trim_rad = 0.0;
 
 #if AP_COPTER_AHRS_AUTO_TRIM_ENABLED
-    if (auto_trim.running) {
-        auto_trim.running = false;
+    if (running) {
+        running = false;
     } else {
 #endif
 
@@ -748,61 +748,72 @@ void RC_Channels_Copter::save_trim()
     // save roll and pitch trim
     AP::ahrs().add_trim(roll_trim_rad, pitch_trim_rad);
     LOGGER_WRITE_EVENT(LogEvent::SAVE_TRIM);
-    gcs().send_text(MAV_SEVERITY_INFO, "Trim saved");
+    copter.gcs().send_text(MAV_SEVERITY_INFO, "Trim saved");
 }
 
 #if AP_COPTER_AHRS_AUTO_TRIM_ENABLED
+
+void Copter::AHRSTrimming::auto_start()
+{
+        if (!copter.flightmode->allows_auto_trim()) {
+            copter.gcs().send_text(MAV_SEVERITY_INFO, "AutoTrim not allowed in this mode");
+            return;
+        }
+        copter.gcs().send_text(MAV_SEVERITY_INFO, "AutoTrim running");
+        // flash the leds
+        AP_Notify::flags.save_trim = true;
+        running = true;
+}
+
+void Copter::AHRSTrimming::auto_stop()
+{
+    if (running) {
+        AP_Notify::flags.save_trim = false;
+        save_trim();
+    }
+}
+
 // start/stop ahrs auto trim
 void RC_Channels_Copter::do_aux_function_ahrs_auto_trim(const RC_Channel::AuxSwitchPos ch_flag)
 {
     switch (ch_flag) {
     case RC_Channel::AuxSwitchPos::HIGH:
-        if (!copter.flightmode->allows_auto_trim()) {
-            gcs().send_text(MAV_SEVERITY_INFO, "AutoTrim not allowed in this mode");
-            break;
-        }
-        gcs().send_text(MAV_SEVERITY_INFO, "AutoTrim running");
-        // flash the leds
-        AP_Notify::flags.save_trim = true;
-        auto_trim.running = true;
+        copter.ahrs_trimming.auto_start();
         break;
     case RC_Channel::AuxSwitchPos::MIDDLE:
         break;
     case RC_Channel::AuxSwitchPos::LOW:
-        if (auto_trim.running) {
-            AP_Notify::flags.save_trim = false;
-            save_trim();
-        }
+        copter.ahrs_trimming.auto_stop();
         break;
     }
 }
 
 // auto_trim - slightly adjusts the ahrs.roll_trim and ahrs.pitch_trim towards the current stick positions
 // meant to be called continuously while the pilot attempts to keep the copter level
-void RC_Channels_Copter::auto_trim_cancel()
+void Copter::AHRSTrimming::auto_cancel()
 {
-    auto_trim.running = false;
+    running = false;
     AP_Notify::flags.save_trim = false;
-    gcs().send_text(MAV_SEVERITY_INFO, "AutoTrim cancelled");
+    copter.gcs().send_text(MAV_SEVERITY_INFO, "AutoTrim cancelled");
     // restore original trims
 }
 
-void RC_Channels_Copter::auto_trim_run()
+void Copter::AHRSTrimming::auto_run()
 {
-        if (!auto_trim.running) {
+        if (!running) {
             return;
         }
 
         // only trim in certain modes:
         if (!copter.flightmode->allows_auto_trim()) {
-            auto_trim_cancel();
+            auto_cancel();
             return;
         }
 
         // must be started and stopped mid-air:
         if (copter.ap.land_complete_maybe) {
-            GCS_SEND_TEXT(MAV_SEVERITY_WARNING,"Must be flying to use AUTOTRIM");
-            auto_trim_cancel();
+            copter.gcs().send_text(MAV_SEVERITY_WARNING,"Must be flying to use AUTOTRIM");
+            auto_cancel();
             return;
         }
         // calculate roll trim adjustment, divisor set subjectively to give same "feel" as previous RC input method

--- a/ArduCopter/RC_Channel_Copter.h
+++ b/ArduCopter/RC_Channel_Copter.h
@@ -56,13 +56,7 @@ public:
     // aux function
 #if AP_COPTER_AHRS_AUTO_TRIM_ENABLED
     void do_aux_function_ahrs_auto_trim(const RC_Channel::AuxSwitchPos ch_flag);
-    struct {
-        bool running;
-    } auto_trim;
-    void auto_trim_run();
-    void auto_trim_cancel();
 #endif  // AP_COPTER_AHRS_AUTO_TRIM_ENABLED
-    void save_trim();
 
 protected:
 

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -17638,6 +17638,56 @@ RTL_ALT_M 111
         self.do_land()
         self.set_rc(9, 1000)
 
+    def AHRSTrim(self):
+        '''check RC stick inputs can be used to save an AHRS trim'''
+        # the Save Trim procedure requires the throttle to be at minimum
+        # ("landed").  The pilot holds the roll and pitch sticks to the
+        # desired trim and then raises the aux switch.  Trim is taken from
+        # the stick positions, not the vehicle's attitude.
+        #
+        # save-trim modifies AHRS_TRIM_X/Y directly rather than via a
+        # parameter set, so we must explicitly set them to a known
+        # (non-zero) starting value here for the harness to record and
+        # revert them after the test.  We use the opposite sign to the
+        # trim the sticks will command, so the save has to overcome them.
+        self.set_parameters({
+            'RC9_OPTION': 5,  # save-trim
+            'AHRS_TRIM_X': -0.05,  # ensure parameter-reversion
+            'AHRS_TRIM_Y': 0.05,  # ensure parameter-reversion
+        })
+        self.change_mode('STABILIZE')
+        self.set_rc_from_map({
+            1: 1900,  # roll full right
+            2: 1100,  # pitch full forward
+            3: 1000,  # throttle to minimum so its control_in is zero
+        })
+        self.context_collect('STATUSTEXT')
+        self.set_rc(9, 2000)
+        self.wait_statustext('Trim saved', check_context=True)
+        self.context_stop_collecting('STATUSTEXT')
+
+        # lower the switch and restore the sticks so the trim can't be
+        # applied a second time (e.g. across the reboot below):
+        self.set_rc(9, 1000)
+        self.set_rc_default()
+
+        # trim is taken from the stick positions, so right-roll/forward-pitch
+        # should overcome the starting trims to give a positive roll trim
+        # and a negative pitch trim:
+        trim_x = self.get_parameter('AHRS_TRIM_X')
+        trim_y = self.get_parameter('AHRS_TRIM_Y')
+        if trim_x < math.radians(2):
+            raise NotAchievedException(f"Expected significant +ve roll trim, got {trim_x}")
+        if trim_y > -math.radians(2):
+            raise NotAchievedException(f"Expected significant -ve pitch trim, got {trim_y}")
+
+        # the trim is saved to storage, so should survive a reboot:
+        self.reboot_sitl()
+        self.assert_parameter_values({
+            "AHRS_TRIM_X": trim_x,
+            "AHRS_TRIM_Y": trim_y,
+        }, epsilon=0.0001)
+
     def RTLStoppingDistanceSpeed(self):
         '''test stopping distance unaffected by RTL speed'''
         self.upload_simple_relhome_mission([
@@ -18662,6 +18712,7 @@ return update, 1000
             self.EK3_EXT_NAV_vel_without_vert,
             self.CompassLearnCopyFromEKF,
             self.AHRSAutoTrim,
+            self.AHRSTrim,
             self.Ch6TuningLoitMaxXYSpeed,
             self.IgnorePilotYaw,
             self.TestEKF3CompassFailover,


### PR DESCRIPTION
### Summary

Moves AHRS trimming code out of RC_Channel and into a subobject in Copter

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

The AHRSAutoTrim test does a good job of testing this.

~~I don't believe I have changed the functionality of direct-save-trim - but it also doesn't seem to be function (disabled auto-test added)~~ autotest added for transfer-rc-trims-to-ahrs-trim code

### Description

https://github.com/ArduPilot/ardupilot/pull/32306 and https://github.com/ArduPilot/ardupilot/pull/32592 both moved `save_trim` from RC_Channels_Copter to the Copter namespace.

This didn't really go far enough - all of the trimming functionality should be moved, not just the save step.

To that end I've moved the trimming functionality into the Copter namespace in this PR.  This shows all of the differences - which are cosmetic, there's no functional change.

A follow-up PR will move all of the code elsewhere - I'm going to suggest a new `ahrs_trimming.cpp`
