### PR TITLE
autotest: configure the sitl board when building the Replay tool

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -12934,7 +12934,10 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
     def Replay(self):
         '''test replay correctness'''
         self.progress("Building Replay")
-        util.build_SITL('tool/Replay', clean=False, configure=False)
+        # configure for the sitl board explicitly: another test (e.g. a
+        # CAN/periph test) may have left the shared build directory
+        # configured for a different board, which would fail this build:
+        util.build_SITL('tool/Replay', board='sitl', clean=False, configure=True)
         self.set_parameters({
             "LOG_DARM_RATEMAX": 0,
             "LOG_FILE_RATEMAX": 0,

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -3252,7 +3252,10 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
     def Replay(self):
         '''test replay correctness'''
         self.progress("Building Replay")
-        util.build_SITL('tool/Replay', clean=False, configure=False)
+        # configure for the sitl board explicitly: another test (e.g. a
+        # CAN/periph test) may have left the shared build directory
+        # configured for a different board, which would fail this build:
+        util.build_SITL('tool/Replay', board='sitl', clean=False, configure=True)
         self.set_parameters({
             "LOG_DARM_RATEMAX": 0,
             "LOG_FILE_RATEMAX": 0,


### PR DESCRIPTION
### Summary

configure for sitl before building.  Sometimes the tree may not be configured that way...

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Discovered as part of parallel-testing branch.  May only be an intermediate step, but it it a real flake depending on what your test ordering is.

### Description

The Replay test rebuilt tool/Replay with configure=False, so it used whatever board the shared build directory was last configured for.  A preceding CAN/periph test can leave it configured for another board, which fails the build.  Build explicitly with board='sitl', configure=True.
