### PR TITLE
AP_AHRS: drive DCM wind estimation from the DCM backend

### DIFF
--- a/ArduPlane/Plane.cpp
+++ b/ArduPlane/Plane.cpp
@@ -494,9 +494,6 @@ void Plane::update_GPS_10Hz(void)
                 ground_start_count = 0;
             }
         }
-
-        // update wind estimate
-        ahrs.estimate_wind();
     } else if (gps.status() < AP_GPS_FixType::FIX_3D && ground_start_count != 0) {
         // lost 3D fix, start again
         ground_start_count = 5;

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -137,13 +137,6 @@ public:
     // returns forward head-wind component in m/s. Negative means tail-wind
     float head_wind(void) const;
 
-    // instruct DCM to update its wind estimate:
-    void estimate_wind() {
-#if AP_AHRS_DCM_ENABLED
-        dcm.estimate_wind();
-#endif
-    }
-
 #if AP_AHRS_EXTERNAL_WIND_ESTIMATE_ENABLED
     void set_external_wind_estimate(float speed, float direction) {
         dcm.set_external_wind_estimate(speed, direction);

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -102,6 +102,18 @@ AP_AHRS_DCM::update()
     // remember the last origin for fallback support
     IGNORE_RETURN(AP::ahrs().get_origin(last_origin));
 
+    // update our wind estimate when a new GPS sample arrives and we
+    // have a 3D fix; the GPS velocity is what feeds the wind triangle.
+    // estimate_wind itself is rate-limited.
+    const AP_GPS &gps = AP::gps();
+    if (gps.status() >= AP_GPS_FixType::FIX_3D) {
+        const uint32_t last_gps_ms = gps.last_message_time_ms();
+        if (last_gps_ms != _last_wind_gps_ms) {
+            _last_wind_gps_ms = last_gps_ms;
+            estimate_wind();
+        }
+    }
+
 #if HAL_LOGGING_ENABLED
     const uint32_t now_ms = AP_HAL::millis();
     if (now_ms - last_log_ms >= 100) {
@@ -1054,6 +1066,19 @@ void AP_AHRS_DCM::estimate_wind(void)
     if (!AP::ahrs().get_wind_estimation_enabled()) {
         return;
     }
+
+    // the wind-triangle filters below blend a fixed fraction of the new
+    // estimate on each call, and the straight-flight branch does not
+    // update _last_wind_time, so the effective filter time constant is
+    // set by the call rate.  Now that this is driven on each new GPS
+    // sample rather than by a fixed-rate vehicle task, limit to 10Hz
+    // here so the time constant stays sane:
+    const uint32_t now = AP_HAL::millis();
+    if (now - _last_wind_estimate_ms < 100) {
+        return;
+    }
+    _last_wind_estimate_ms = now;
+
     const Vector3f &velocity = _last_velocity;
 
     // this is based on the wind speed estimation code from MatrixPilot by
@@ -1061,7 +1086,6 @@ void AP_AHRS_DCM::estimate_wind(void)
     // See http://gentlenav.googlecode.com/files/WindEstimation.pdf
     const Vector3f fuselageDirection = _dcm_matrix.colx();
     const Vector3f fuselageDirectionDiff = fuselageDirection - _last_fuse;
-    const uint32_t now = AP_HAL::millis();
 
     // scrap our data and start over if we're taking too long to get a direction change
     if (now - _last_wind_time > 10000) {

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -88,8 +88,6 @@ public:
 
     bool            use_compass() override;
 
-    void estimate_wind(void);
-
     // returns false if we fail arming checks, in which case the buffer will be populated with a failure message
     // requires_position should be true if horizontal position configuration should be checked (not used)
     bool pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const override {
@@ -155,6 +153,9 @@ private:
     // DCM matrix from the eulers.  Called internally we may.
     void            reset(bool recover_eulers);
 
+    // update our wind estimate from the latest GPS velocity and attitude:
+    void estimate_wind(void);
+
     // airspeed_ret: will always be filled-in by get_unconstrained_airspeed_EAS which fills in airspeed_ret in this order:
     //               airspeed as filled-in by an enabled airspeed sensor
     //               if no airspeed sensor: airspeed estimated using the GPS speed & wind_speed_estimation
@@ -212,6 +213,9 @@ private:
     // time in millis when we last got a GPS heading
     uint32_t _gps_last_update;
 
+    // GPS message time of the sample last fed to the wind estimator:
+    uint32_t _last_wind_gps_ms;
+
     // state of accel drift correction
     Vector3f _ra_sum[INS_MAX_INSTANCES];
     Vector3f _last_velocity;
@@ -245,6 +249,9 @@ private:
     Vector3f _last_vel;
     uint32_t _last_wind_time;
     float _last_airspeed_TAS;
+
+    // time of last wind estimate update, used to rate-limit estimation:
+    uint32_t _last_wind_estimate_ms;
     uint32_t _last_consistent_heading;
 
     // estimated wind in m/s


### PR DESCRIPTION
### Summary

Drive wind-estimation-via-triangle from within DCM rather than from Plane

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Previously ArduPlane called AP_AHRS::estimate_wind from its 10Hz GPS
update loop.  Drive it from AP_AHRS_DCM::update instead: when a new
GPS sample arrives with a 3D fix - the same gate ArduPlane applied -
DCM feeds its GPS velocity and attitude into the wind triangle.

Because estimation is now triggered per new GPS sample rather than by
a fixed-rate vehicle task, rate-limit estimate_wind to 10Hz internally
so the wind-triangle filter time constant stays sane regardless of GPS
rate.

This puts the wind-estimation trigger next to the data that feeds it,
in preparation for other backends driving their own wind estimates
from their own velocity/attitude samples.

I'm pretty sure we should adjust this to remove the 10Hz limit and instead process for every GPS sample received.  But for now we keep existingis behaviour.
