### PR TITLE
DDS: Add --use_sim_time for SITL

### DIFF
--- a/Tools/ros2/ardupilot_sitl/src/ardupilot_sitl/launch.py
+++ b/Tools/ros2/ardupilot_sitl/src/ardupilot_sitl/launch.py
@@ -397,6 +397,7 @@ class SITLLaunch:
         instance = LaunchConfiguration("instance").perform(context)
         defaults = LaunchConfiguration("defaults").perform(context)
         use_instance_dir = LaunchConfiguration("use_instance_dir").perform(context)
+        use_sim_time = LaunchConfiguration("use_sim_time").perform(context)
 
         # Display launch arguments.
         print(f"command:          {command}")
@@ -407,6 +408,7 @@ class SITLLaunch:
         print(f"instance:         {instance}")
         print(f"defaults:         {defaults}")
         print(f"use_instance_dir: {use_instance_dir}")
+        print(f"use_sim_time:     {use_sim_time}")
 
         # Required arguments.
         cmd_args = [
@@ -421,6 +423,7 @@ class SITLLaunch:
             f"--sim-address={sim_address} ",
             f"--instance {instance} ",
             f"--defaults {defaults} ",
+            f"--use_sim_time {use_sim_time} ",
         ]
 
         # Optional arguments.
@@ -655,6 +658,12 @@ class SITLLaunch:
                 "use_instance_dir",
                 default_value="False",
                 description="If True create instance directories for the eeprom.bin.",
+                choices=BOOL_STRING_CHOICES,
+            ),
+            DeclareLaunchArgument(
+                "use_sim_time",
+                default_value="True",
+                description="Use simulation time.",
                 choices=BOOL_STRING_CHOICES,
             ),
         ]

--- a/libraries/AP_DDS/AP_DDS_Client.cpp
+++ b/libraries/AP_DDS/AP_DDS_Client.cpp
@@ -1539,6 +1539,14 @@ bool AP_DDS_Client::create()
                 GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s Topic/Pub/Writer session pass for index '%u'", msg_prefix, i);
             }
         } else if (topics[i].topic_rw == Topic_rw::DataReader) {
+#if AP_DDS_CLOCK_SUB_ENABLED && CONFIG_HAL_BOARD == HAL_BOARD_SITL
+            // IF SITL option for use_sim_time is false, don't subscribe to /clock
+            SITL::SIM *sitl = AP::sitl();
+            if (strcmp(topics[i].topic_name, "/clock") == 0 && !sitl->use_dds_sim_time) {
+                GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s Skipping subscription to /clock because use_sim_time is false", msg_prefix);
+                continue;
+            }
+#endif // AP_DDS_CLOCK_SUB_ENABLED && CONFIG_HAL_BOARD == HAL_BOARD_SITL
             // Subscriber
             const uxrObjectId sub_id = {
                 .id = topics[i].sub_id,
@@ -1565,25 +1573,12 @@ bool AP_DDS_Client::create()
                 GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "%s Topic/Sub/Reader session request retry for index '%u'", msg_prefix, i);
             }
             if (!success) {
-                // Don't fail on /clock subscription
-#if AP_DDS_CLOCK_SUB_ENABLED
-                if (i == to_underlying(TopicIndex::CLOCK_SUB)) {
-                    // Optional subscription failed, log warning but continue
-                    GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "%s Optional Topic/Sub/Reader session request failure for index '%u' - continuing without it", msg_prefix, i);
-                    for (uint8_t s = 0 ; s < nRequests; s++) {
-                        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s Status '%d' result '%u'", msg_prefix, s, status[s]);
-                    }
-                } else {
-#endif
-                    GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "%s Topic/Sub/Reader session request failure for index '%u'", msg_prefix, i);
-                    for (uint8_t s = 0 ; s < nRequests; s++) {
-                        GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "%s Status '%d' result '%u'", msg_prefix, s, status[s]);
-                    }
-                    // TODO add a failure log message sharing the status results
-                    return false;
-#if AP_DDS_CLOCK_SUB_ENABLED
+                GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "%s Topic/Sub/Reader session request failure for index '%u'", msg_prefix, i);
+                for (uint8_t s = 0 ; s < nRequests; s++) {
+                    GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "%s Status '%d' result '%u'", msg_prefix, s, status[s]);
                 }
-#endif
+                // TODO add a failure log message sharing the status results
+                return false;
             } else {
                 GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s Topic/Sub/Reader session pass for index '%u'", msg_prefix, i);
                 uxr_buffer_request_data(&session, reliable_out, topics[i].dr_id, reliable_in, &delivery_control);

--- a/libraries/AP_DDS/README.md
+++ b/libraries/AP_DDS/README.md
@@ -314,11 +314,11 @@ publishing #1: ardupilot_msgs.msg.GlobalPosition(header=std_msgs.msg.Header(stam
 When running in a simulated environment, The master simulation clock (usually ``/clock``) needs to be provided to Ardupilot to ensure ArduPilot's topics
 have the correct timestamp. This ensure that any sensor fusion (or similar) nodes in ROS 2 fuse the correct data.
 
-On startup, ArduPilot will automatically attempt to subscribe to ``/clock`` topic. If this is unsuccessful, ArduPilot
-will use it's own internal clock. In either case, ArduPilot will publish the clock to ``/ap/clock``
-(or ``/ap/vN/clock`` if namespacing is used).
+ArduPilot SITL uses the standard ROS2 parameter of ``--use-sim-time <true|false>``. If ``true`` ArduPilot will automatically attempt
+to subscribe to ``/clock`` topic and use this for the timestamping of DDS topics. If this is unsuccessful, ArduPilot
+will use it's own internal clock.
 
-For simulators such as Gazebo, the ``/clock`` topic is published automatically and no further configuration is required.
+In either case, ArduPilot will publish the clock to ``/ap/clock`` (or ``/ap/vN/clock`` if namespacing is used).
 
 ## Contributing to `AP_DDS` library
 

--- a/libraries/AP_HAL_SITL/HAL_SITL_Class.h
+++ b/libraries/AP_HAL_SITL/HAL_SITL_Class.h
@@ -27,6 +27,11 @@ public:
     }
     bool get_storage_fram_enabled() const { return storage_fram_enabled; }
 
+    bool get_dds_use_sim_time() const { return dds_use_sim_time; }
+    void set_dds_use_sim_time(bool _enabled) {
+        dds_use_sim_time = _enabled;
+    }
+
     /*
       instructs the simulation to wipe any storage as it opens it:
      */
@@ -54,6 +59,7 @@ private:
     bool storage_posix_enabled = true;
     bool storage_flash_enabled;
     bool storage_fram_enabled;
+    bool dds_use_sim_time = false;
 
     // set to true if simulation is to wipe storage as it is opened:
     bool wipe_storage;

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -75,6 +75,9 @@ void SITL_State::_sitl_setup()
         _sitl->irlock_port = _irlock_port;
 
         _sitl->rcin_port = _rcin_port;
+
+        fprintf(stdout, "Using \\clock topic for DDS timing: %s\n", _use_dds_sim_time ? "enabled" : "disabled");
+        _sitl->use_dds_sim_time = _use_dds_sim_time;
     }
 
     // start with non-zero clock

--- a/libraries/AP_HAL_SITL/SITL_State.h
+++ b/libraries/AP_HAL_SITL/SITL_State.h
@@ -96,6 +96,8 @@ private:
 
     bool _use_fg_view;
 
+    bool _use_dds_sim_time = false;
+    
     const char *_fg_address;
 
     // simulation model name as given on the command line, for

--- a/libraries/AP_HAL_SITL/SITL_cmdline.cpp
+++ b/libraries/AP_HAL_SITL/SITL_cmdline.cpp
@@ -117,6 +117,7 @@ void SITL_State::_usage(void)
            "\t--start-time TIMESTR     set simulation start time in UNIX timestamp\n"
            "\t--sysid ID               set MAV_SYSID\n"
            "\t--slave number           set the number of JSON slaves\n"
+           "\t--use_sim_time <true|false>  use ROS2 simulation clock for DDS topics. Defaults to false\n"
         );
 }
 
@@ -314,6 +315,9 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
 #if STORAGE_USE_FRAM
         CMDLINE_SET_STORAGE_FRAM_ENABLED,
 #endif
+#if AP_DDS_ENABLED
+        CMDLINE_DDS_USE_SIM_TIME,
+#endif
     };
 
     const struct GetOptLong::option options[] = {
@@ -372,6 +376,9 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
 #endif
 #if STORAGE_USE_FRAM
         {"set-storage-fram-enabled", true,   0, CMDLINE_SET_STORAGE_FRAM_ENABLED},
+#endif
+#if AP_DDS_ENABLED
+        {"use_sim_time",    true,  0, CMDLINE_DDS_USE_SIM_TIME},
 #endif
         {"vehicle",           true,   0, 'v'},
         {0, false, 0, 0}
@@ -553,6 +560,15 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
 #if STORAGE_USE_FRAM
         case CMDLINE_SET_STORAGE_FRAM_ENABLED:
             storage_fram_enabled = atoi(gopt.optarg);
+            break;
+#endif
+#if AP_DDS_ENABLED
+        case CMDLINE_DDS_USE_SIM_TIME:
+            if (strcasecmp(gopt.optarg, "true") == 0) {
+                _use_dds_sim_time = true;
+            } else {
+                _use_dds_sim_time = false;
+            }
             break;
 #endif
         case 'h':

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -10,6 +10,7 @@
 #include <AP_Airspeed/AP_Airspeed.h>
 #include <AP_Common/Location.h>
 #include <AP_Compass/AP_Compass.h>
+#include <AP_DDS/AP_DDS_config.h>
 #include <AP_InertialSensor/AP_InertialSensor.h>
 
 #include "SIM_Buzzer.h"
@@ -263,6 +264,10 @@ public:
     AP_Int16 on_hardware_relay_enable_mask;   // mask of relays passed through to actual hardware
 
     AP_Float uart_byte_loss_pct;
+
+#ifdef AP_DDS_ENABLED
+    bool use_dds_sim_time = false; // use ROS2 simulation time for DDS topics
+#endif
 
 #ifdef SFML_JOYSTICK
     AP_Int8 sfml_joystick_id;


### PR DESCRIPTION
### Summary

This PR adds the ``--use_sim_time`` commandline argument to SITL, to indicate that AP_DDS should subscribe to the ``/clock`` topic for DDS message timesync.

This comes from @srmainwaring's comments in https://github.com/ArduPilot/ardupilot/pull/32303#issuecomment-4572091457.

EDIT:
This ensures that ArduPilot SITL matches ROS2's interpretation of the simulation clock (see https://design.ros2.org/articles/clock_and_time.html)

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [X] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Tested in SITL, using the ardupilot_ros environment.
