### PR TITLE
.github: fix ccache reuse between SITL build and autotest jobs

### DIFF
--- a/.github/workflows/ccache.env
+++ b/.github/workflows/ccache.env
@@ -1,10 +1,17 @@
 # common ccache env vars for CI
-export CCACHE_SLOPPINESS=file_stat_matches
-
+# NOTE: ccache settings go into ccache.conf (a file) rather than env vars so they
+# apply in every build step. An env var exported here would NOT survive into a
+# later "run:" step (each step is a separate shell), which previously left the
+# build job compiling with no sloppiness while the autotest job used a different
+# value via build_ci.sh - breaking ccache reuse between the two jobs.
 mkdir -p ~/.ccache
 echo "base_dir = ${GITHUB_WORKSPACE}" > ~/.ccache/ccache.conf
 echo "compression = true" >> ~/.ccache/ccache.conf
 echo "compression_level = 6" >> ~/.ccache/ccache.conf
 echo "max_size = 400M" >> ~/.ccache/ccache.conf
+# fresh CI checkouts rewrite include-file timestamps every run, so ignore them;
+# time_macros avoids misses from __DATE__/__TIME__. This must be identical across
+# the build and autotest jobs that share a cache.
+echo "sloppiness = file_stat_matches,include_file_ctime,include_file_mtime,time_macros" >> ~/.ccache/ccache.conf
 ccache -s
 ccache -z

--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -33,7 +33,9 @@ export GIT_VERSION="abcdef"
 export GIT_VERSION_EXTENDED="0123456789abcdef"
 export GIT_VERSION_INT="15"
 export CHIBIOS_GIT_VERSION="12345667"
-export CCACHE_SLOPPINESS="include_file_ctime,include_file_mtime"
+if [ -z "$GITHUB_ACTIONS" ] || [ "$GITHUB_ACTIONS" != "true" ]; then
+  export CCACHE_SLOPPINESS="include_file_ctime,include_file_mtime"
+fi
 autotest_args=""
 
 # If CI_BUILD_TARGET is not set, build 4 different ones


### PR DESCRIPTION
### Summary

autotest workflow are not using ccache correctly as they need 3-4min to rebuild the binary when they should have just to use the cache from the build phase...
<img width="724" height="757" alt="image" src="https://github.com/user-attachments/assets/27d6b4c7-7df9-4371-9550-1797ba7e769d" />


Issue was CCACHE_SLOPPINESS exported as an environment variable in the setup ccache step. But env aren't transfert accros steps ... so the build job with ./waf build don't have sloppiness settled. The autotest step use build_ci.sh that got it into the build_ci.sh script. So we got differents parameters for ccache.

So for CI, I move the config to a the sole ccache.conf that is correctly passed accros jobs.
Also add  time_macros to avoid misses from __DATE__/__TIME__.  (suggestion from Claude review on ccache usage)
Then put guard on build_ci.sh to not use CCACHE_SLOPPINESS that would override the ccache.conf config.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
