### PR TITLE
AP_AHRS: update AP_Notify based on active backend filter status

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -581,6 +581,9 @@ void AP_AHRS::update(bool skip_ins_update)
     update_configured_ekf_type();
     update_active_EKF_type();
 
+    // update blinking lights, buzzer etc bsaed on active EKF type:
+    update_notify_from_filter_status(active_estimates->filter_status);
+
 #if HAL_GCS_ENABLED
     if (state.active_EKF_type != last_active_ekf_type) {
         last_active_ekf_type = state.active_EKF_type;
@@ -651,9 +654,6 @@ void AP_AHRS::update_EKF2(void)
         ekf2.update();
         ekf2_estimates = {};
         ekf2.get_results(ekf2_estimates);
-        if (_active_EKF_type() == EKFType::TWO) {
-            update_notify_from_filter_status(ekf2_estimates.filter_status);
-        }
 
         /*
           if we now have an origin then set in all backends
@@ -679,9 +679,6 @@ void AP_AHRS::update_EKF3(void)
         ekf3.update();
         ekf3_estimates = {};
         ekf3.get_results(ekf3_estimates);
-        if (_active_EKF_type() == EKFType::THREE) {
-            update_notify_from_filter_status(ekf3_estimates.filter_status);
-        }
         /*
           if we now have an origin then set in all backends
         */


### PR DESCRIPTION
### Summary

Sets the AP_Notify state based on the active backend rather than EKF2 (if it is active) or EKF3 (if it is active)

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

This means that DCM is in charge you will get DCM's filter status, not have your library locked on to whatever the last thing that the EKF spat out.

We could potentially change this to `configured_ekf_type` rather than the active one?!

In the future we could potentially add something to Notify so we can complain about the active not being the configured so it might try to represent that information...
