### PR TITLE
Tools: Autotest: use f-strings on all ardusub tests

### DIFF
--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -83,7 +83,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         return os.path.realpath(__file__)
 
     def set_current_test_name(self, name):
-        self.current_test_name_directory = "ArduSub_Tests/" + name + "/"
+        self.current_test_name_directory = f"ArduSub_Tests/{name}/"
 
     def default_mode(self):
         return 'MANUAL'
@@ -146,16 +146,15 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         """
         tstart = self.get_sim_time_cached()
         previous_altitude = self.assert_receive_message('VFR_HUD').alt
-        self.progress('Altitude to be watched: %f' % (previous_altitude))
+        self.progress(f'Altitude to be watched: {previous_altitude}')
         while True:
             m = self.assert_receive_message('VFR_HUD')
             if self.get_sim_time_cached() - tstart > timeout:
-                self.progress('Altitude hold done: %f' % (previous_altitude))
+                self.progress(f'Altitude hold done: {previous_altitude}')
                 return
             if abs(m.alt - previous_altitude) > delta:
                 raise NotAchievedException(
-                    "Altitude not maintained: want %.2f (+/- %.2f) got=%.2f" %
-                    (previous_altitude, delta, m.alt))
+                    f"Altitude not maintained: want {previous_altitude:.2f} (+/- {delta:.2f}) got={m.alt:.2f}")
 
     def dive(self, alt, mode='MANUAL', timeout=120):
         """Dive to a target altitude."""
@@ -241,7 +240,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         found_failure = self.statustext_in_collections(failure_str)
 
         if found_failure is not None:
-            raise NotAchievedException("RngfndQuality test failed: " + found_failure.text)
+            raise NotAchievedException(f"RngfndQuality test failed: {found_failure.text}")
 
     def watch_distance_maintained(self, delta=0.3, timeout=5.0):
         """Watch and wait for the rangefinder reading to be maintained"""
@@ -250,22 +249,20 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.context_set_message_rate_hz('RANGEFINDER', self.sitl_streamrate())
         previous_distance = self.assert_receive_message('RANGEFINDER').distance
         previous_distance_ds = self.assert_receive_message('DISTANCE_SENSOR').current_distance * 0.01  # cm -> m
-        self.progress('Distance to be watched: %.2f' % previous_distance)
+        self.progress(f'Distance to be watched: {previous_distance:.2f}')
         while True:
             if self.get_sim_time_cached() - tstart > timeout:
-                self.progress('Distance hold done: %f' % previous_distance)
+                self.progress(f'Distance hold done: {previous_distance}')
                 self.context_pop()
                 return
             m = self.assert_receive_message('RANGEFINDER')
             if abs(m.distance - previous_distance) > delta:
                 raise NotAchievedException(
-                    "Distance not maintained: want %.2f (+/- %.2f) got=%.2f" %
-                    (previous_distance, delta, m.distance))
+                    f"Distance not maintained: want {previous_distance:.2f} (+/- {delta:.2f}) got={m.distance:.2f}")
             m = self.assert_receive_message('DISTANCE_SENSOR')
             if abs(m.current_distance*0.01 - previous_distance_ds) > delta:
                 raise NotAchievedException(
-                    "Distance not maintained: want %.2f (+/- %.2f) got=%.2f" %
-                    (previous_distance, delta, m.distance))
+                    f"Distance not maintained: want {previous_distance:.2f} (+/- {delta:.2f}) got={m.distance:.2f}")
 
     def GCSFailsafe(self):
         '''Test GCSFailsafe'''
@@ -372,7 +369,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
             return float(match.group(1))
 
         tstart = self.get_sim_time_cached()
-        self.progress('Distance to be watched: %.2f (+/- %.2f)' % (match_distance, delta))
+        self.progress(f'Distance to be watched: {match_distance:.2f} (+/- {delta:.2f})')
         max_delta = 0.0
 
         while True:
@@ -380,10 +377,10 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
             # If final_waypoint>0 then timeout is failure, otherwise success
             if timed_out and final_waypoint > 0:
                 raise NotAchievedException(
-                    "Mission not complete: want waypoint %i, only made it to waypoint %i" %
-                    (final_waypoint, self.mav.waypoint_current()))
+                    f"Mission not complete: want waypoint {final_waypoint}, "
+                    f"only made it to waypoint {self.mav.waypoint_current()}")
             if timed_out:
-                self.progress('Distance hold done. Max delta:%.2fm' % max_delta)
+                self.progress(f'Distance hold done. Max delta:{max_delta:.2f}m')
                 return
 
             true_distance = get_true_distance()
@@ -394,11 +391,11 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
                 max_delta = match_delta
             if match_delta > delta:
                 raise NotAchievedException(
-                    "Distance not maintained: want %.2f (+/- %.2f) got=%.2f (%.2f)" %
-                    (match_distance, delta, true_distance, match_delta))
+                    f"Distance not maintained: want {match_distance:.2f} (+/- {delta:.2f}) "
+                    f"got={true_distance:.2f} ({match_delta:.2f})")
             if final_waypoint > 0:
                 if self.mav.waypoint_current() >= final_waypoint:
-                    self.progress('Distance hold during mission done. Max delta:%.2fm' % max_delta)
+                    self.progress(f'Distance hold during mission done. Max delta:{max_delta:.2f}m')
                     return
 
     def SimTerrainSurftrak(self):
@@ -512,8 +509,8 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         final_altitude = self.assert_receive_message('VFR_HUD').alt
         if abs(previous_altitude - final_altitude) > delta:
             raise NotAchievedException(
-                "Changing modes affected depth with no throttle input!, started at {}, ended at {}"
-                .format(previous_altitude, final_altitude)
+                f"Changing modes affected depth with no throttle input!, "
+                f"started at {previous_altitude}, ended at {final_altitude}"
             )
 
     def PositionHold(self):
@@ -538,7 +535,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.delay_sim_time(10, reason="position hold measurement period")
         distance_m = self.get_distance(start_pos, self.mav.location())
         if distance_m > 1:
-            raise NotAchievedException("Position Hold was unable to keep position in calm waters within 1 meter after 10 seconds, drifted {} meters".format(distance_m))  # noqa
+            raise NotAchievedException(f"Position Hold was unable to keep position in calm waters within 1 meter after 10 seconds, drifted {distance_m} meters")  # noqa
 
         # Hold in 1 m/s current
         self.progress("Testing position hold in current")
@@ -547,7 +544,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.delay_sim_time(10, reason="drift measurement in 1m/s current")
         distance_m = self.get_distance(start_pos, self.mav.location())
         if distance_m > 1:
-            raise NotAchievedException("Position Hold was unable to keep position in 1m/s current within 1 meter after 10 seconds, drifted {} meters".format(distance_m))  # noqa
+            raise NotAchievedException(f"Position Hold was unable to keep position in 1m/s current within 1 meter after 10 seconds, drifted {distance_m} meters")  # noqa
 
         # Move forward slowly in 1 m/s current
         start_pos = self.mav.location()
@@ -557,7 +554,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         distance_m = self.get_distance(start_pos, self.mav.location())
         bearing = self.get_bearing(start_pos, self.mav.location())
         if distance_m < 2 or (bearing > 30 and bearing < 330):
-            raise NotAchievedException("Position Hold was unable to move north 2 meters, moved {} at {} degrees instead".format(distance_m, bearing))  # noqa
+            raise NotAchievedException(f"Position Hold was unable to move north 2 meters, moved {distance_m} at {bearing} degrees instead")  # noqa
         self.disarm_vehicle()
 
     def MotorThrustHoverParameterIgnore(self):
@@ -566,7 +563,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         # Test default parameter value
         mot_thst_hover_value = self.get_parameter("MOT_THST_HOVER")
         if mot_thst_hover_value != 0.5:
-            raise NotAchievedException("Unexpected default MOT_THST_HOVER parameter value {}".format(mot_thst_hover_value))
+            raise NotAchievedException(f"Unexpected default MOT_THST_HOVER parameter value {mot_thst_hover_value}")
 
         # Test if parameter is being ignored
         for value in [0.25, 0.75]:
@@ -607,12 +604,12 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         # Note this temperature matches the output of the Atmospheric Model for Air currently
         # And should be within 1 deg C of 40 degC
         if (m.temperature < 3900) or (4100 < m.temperature):
-            raise NotAchievedException("Did not get correct TSYS01 temperature: Got %f" % m.temperature)
+            raise NotAchievedException(f"Did not get correct TSYS01 temperature: Got {m.temperature}")
 
     def DiveMission(self):
         '''Dive mission'''
         filename = "sub_mission.txt"
-        self.progress("Executing mission %s" % filename)
+        self.progress(f"Executing mission {filename}")
         self.load_mission(filename)
         self.set_rc_default()
 
@@ -677,7 +674,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
                 raise NotAchievedException("Did not move far enough")
             pos = self.assert_receive_message('GLOBAL_POSITION_INT')
             delta = self.get_distance_int(startpos, pos)
-            self.progress("delta=%f (want >10)" % delta)
+            self.progress(f"delta={delta} (want >10)")
             if delta > 10:
                 break
         self.change_mode('MANUAL')
@@ -768,7 +765,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
             self.wait_heading(expected_yaw_deg)
         except NotAchievedException as e:
             raise NotAchievedException(
-                "Expected to get yaw consumed and at ATTITUDE (want %f got %f)" % (expected_yaw_deg, achieved_yaw_deg)
+                f"Expected to get yaw consumed and at ATTITUDE (want {expected_yaw_deg} got {achieved_yaw_deg})"
             ) from e
 
     def VisoForYaw(self):
@@ -879,7 +876,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.assert_parameter_value('RNGFND1_MAX', 30)
 
         filename = "terrain_mission.txt"
-        self.progress("Executing mission %s" % filename)
+        self.progress(f"Executing mission {filename}")
         self.load_mission(filename)
         self.set_rc_default()
         self.arm_vehicle()
@@ -911,14 +908,14 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         start = self.get_sim_time()
         self.wait_ekf_happy_const_pos(timeout=timeout)
         armable_time = self.get_sim_time() - start
-        self.progress("Took %u seconds to become armable" % armable_time)
+        self.progress(f"Took {armable_time} seconds to become armable")
         self.total_waiting_to_arm_time += armable_time
         self.waiting_to_arm_count += 1
 
     def collected_msgs(self, msg_type):
         c = self.context_get()
         if msg_type not in c.collections:
-            raise NotAchievedException("Not collecting (%s)" % str(msg_type))
+            raise NotAchievedException(f"Not collecting ({msg_type})")
         return c.collections[msg_type]
 
     def SetGlobalOrigin(self):
@@ -946,7 +943,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
 
         num_mavlink_origin_msgs = len(self.collected_msgs('GPS_GLOBAL_ORIGIN'))
         if num_mavlink_origin_msgs != 1:
-            raise NotAchievedException("Expected 1 GPS_GLOBAL_ORIGIN message, found %d" % num_mavlink_origin_msgs)
+            raise NotAchievedException(f"Expected 1 GPS_GLOBAL_ORIGIN message, found {num_mavlink_origin_msgs}")
 
     def BackupOrigin(self):
         """Test AHRS_ORIGIN_LAT and AHRS_ORIGIN_LON parameters"""
@@ -972,7 +969,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
 
     def assert_mag_fusion_selection(self, expect_sel):
         """Get the most recent XKFS message and check the MAG_FUSION value"""
-        self.progress("Expect mag fusion selection %d" % expect_sel)
+        self.progress(f"Expect mag fusion selection {expect_sel}")
         mlog = self.dfreader_for_current_onboard_log()
         found_sel = MagFuseSel.NOT_FUSING
         while True:
@@ -981,7 +978,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
                 break
             found_sel = m.MAG_FUSION
         if found_sel != expect_sel:
-            raise NotAchievedException("Expected mag fusion selection %d, found %d" % (expect_sel, found_sel))
+            raise NotAchievedException(f"Expected mag fusion selection {expect_sel}, found {found_sel}")
 
     def FuseMag(self):
         """Test EK3_MAG_CAL values"""
@@ -1081,12 +1078,12 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
             dcurr = self.get_distance(lstart, self.mav.location())
 
             if dcurr - dmax < -0.2:
-                raise NotAchievedException("Bounced back from %.2fm to %.2fm" % (dmax, dcurr))
+                raise NotAchievedException(f"Bounced back from {dmax:.2f}m to {dcurr:.2f}m")
             if dcurr > dmax:
                 dmax = dcurr
 
             if abs(dcurr - dprev) < 0.1:
-                self.progress("Stopping distance %.2fm, less than %.2fs" % (dcurr, self.get_sim_time_cached() - tstart))
+                self.progress(f"Stopping distance {dcurr:.2f}m, less than {self.get_sim_time_cached() - tstart:.2f}s")
                 return
 
             if self.get_sim_time_cached() - tstart > 10:
@@ -1114,7 +1111,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
 
             # try different stick values, resulting speed is ~ max_speed * effort * gain
             for pwm in range(1700, 1901, 100):
-                self.progress('PILOT_SPEED %d, forward pwm %d' % (pilot_speed, pwm))
+                self.progress(f'PILOT_SPEED {pilot_speed}, forward pwm {pwm}')
                 self.set_rc(Joystick.Forward, pwm)
                 self.delay_sim_time(3, reason="forward movement")
                 self.set_rc(Joystick.Forward, 1500)
@@ -1431,19 +1428,20 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
                     current_alt = msg.relative_alt * 0.001
 
                 if distance_remaining < 0.5:
-                    self.progress('Frame %u reached destination at time %f, max_error %f' %
-                                  (run['frame'], self.get_sim_time_cached() - start_time, max_error))
+                    self.progress(f'Frame {run["frame"]} reached destination at time '
+                                  f'{self.get_sim_time_cached() - start_time}, max_error {max_error}')
                     break
                 elif self.get_sim_time_cached() - start_time > timeout:
-                    raise NotAchievedException('Frame %u took too long to reach the destination' % run['frame'])
+                    raise NotAchievedException(f'Frame {run["frame"]} took too long to reach the destination')
 
                 if current_alt is None:
                     continue
 
                 alt_error = abs(current_alt - run['target_alt'])
                 if alt_error > run['max_error_allowed']:
-                    raise NotAchievedException('Alt incorrect on frame %d: want %.2f (+/- %.2f) got=%.2f'
-                                               % (run['frame'], run['target_alt'], run['max_error_allowed'], current_alt))
+                    raise NotAchievedException(
+                        f'Alt incorrect on frame {run["frame"]}: want {run["target_alt"]:.2f} '
+                        f'(+/- {run["max_error_allowed"]:.2f}) got={current_alt:.2f}')
 
                 if alt_error > max_error:
                     max_error = alt_error


### PR DESCRIPTION
### Summary

Changes all strings formatting/concatenation in ardusub.py to use f-strings

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request