### PR TITLE
AP_DDS: Print status code failures if participant creation requests fails

### DIFF
--- a/libraries/AP_DDS/AP_DDS_Client.cpp
+++ b/libraries/AP_DDS/AP_DDS_Client.cpp
@@ -1455,7 +1455,9 @@ bool AP_DDS_Client::create()
     uint8_t statusParticipant[nRequestsParticipant];
     if (!uxr_run_session_until_all_status(&session, requestTimeoutParticipantMs, requestsParticipant, statusParticipant, nRequestsParticipant)) {
         GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "%s Participant session request failure", msg_prefix);
-        // TODO add a failure log message sharing the status results
+        for (uint8_t s = 0; s < nRequestsParticipant; s++) {
+            GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "%s Status '%d' result '%u'", msg_prefix, s, statusParticipant[s]);
+        }
         return false;
     }
 
@@ -1509,10 +1511,9 @@ bool AP_DDS_Client::create()
             }
             if (!success) {
                 GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "%s Topic/Pub/Writer session request failure for index '%u'", msg_prefix, i);
-                for (uint8_t s = 0 ; s < nRequests; s++) {
+                for (uint8_t s = 0; s < nRequests; s++) {
                     GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "%s Status '%d' result '%u'", msg_prefix, s, status[s]);
                 }
-                // TODO add a failure log message sharing the status results
                 return false;
             } else {
                 GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s Topic/Pub/Writer session pass for index '%u'", msg_prefix, i);
@@ -1549,16 +1550,15 @@ bool AP_DDS_Client::create()
                 if (i == to_underlying(TopicIndex::CLOCK_SUB)) {
                     // Optional subscription failed, log warning but continue
                     GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "%s Optional Topic/Sub/Reader session request failure for index '%u' - continuing without it", msg_prefix, i);
-                    for (uint8_t s = 0 ; s < nRequests; s++) {
+                    for (uint8_t s = 0; s < nRequests; s++) {
                         GCS_SEND_TEXT(MAV_SEVERITY_INFO, "%s Status '%d' result '%u'", msg_prefix, s, status[s]);
                     }
                 } else {
 #endif
                     GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "%s Topic/Sub/Reader session request failure for index '%u'", msg_prefix, i);
-                    for (uint8_t s = 0 ; s < nRequests; s++) {
+                    for (uint8_t s = 0; s < nRequests; s++) {
                         GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "%s Status '%d' result '%u'", msg_prefix, s, status[s]);
                     }
-                    // TODO add a failure log message sharing the status results
                     return false;
 #if AP_DDS_CLOCK_SUB_ENABLED
                 }


### PR DESCRIPTION

### Summary

Print the status code if we fail to create particpants.
Creating participants is the first thing that will fail in the creation chain.
If there are races for bootup, we will now know have a better idea that's actually ocuring rather than an AI hallucinating it.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

 This will help us narrow in CI failures  that https://github.com/ArduPilot/ardupilot/pull/33324 implements a retry mechanism on.

While CI will now pass with Peter's PR, this PR will show us in logs whether it's actually a timeout (something a retry would fix) or something else.

The code here matches existing patterns that were implemented when @stephendade  implemented retry. It's not clear why we don't have retry on this sequence, but we can add that later.


