### PR TITLE
board_types: Add new Accton Godwit board IDs

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -595,7 +595,9 @@ AP_HW_VUAV-TinyV7                    7101
 AP_HW_AEROFOX_H7                     7110
 
 # IDs 7120-7129 reserved for Accton Godwit
-AP_HW_Accton_Godwit_GA1        7120
+AP_HW_Accton_Godwit_GA1              7120
+AP_HW_Accton_Godwit_GFF4             7121
+AP_HW_Accton_Godwit_GFH7             7122
 
 # please fill gaps in the above ranges rather than adding past ID #7199
 


### PR DESCRIPTION
Add new board types for Accton Godwit: G-FF4(7121), G-FH7(7122)

### Summary

<!-- Put a one or two line summary of what your PR does here -->
Accton will launch 2 new flight control boards:
G-FF4, ID 7121, a STM32F405 based FPV board
G-FH7, ID 7122, a STM32H753 based FPV board

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [X] Non-functional change
- [X] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->
G-FF4 can be found https://www.accton-iot.com/godwit/g-ff4.html , A F405 based FPV board
G-FH7 will be introduced soon, a H753 based FPV board

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
