### PR TITLE
GitHub cache tidy

### DIFF
--- a/.github/actions/save-ccache/action.yml
+++ b/.github/actions/save-ccache/action.yml
@@ -1,0 +1,72 @@
+name: save-ccache
+description: >
+  Save a fresh ccache entry then delete stale ones. Only runs on pushes to
+  master — PR builds restore the cache for fast builds but do not write back,
+  keeping total cache storage within the 10 GB limit.
+  Save happens before delete so a cancellation between the two steps never
+  leaves master with no cache. The job needs "permissions: actions: write".
+
+inputs:
+  key-suffix:
+    description: Cache key suffix, matching the setup-ccache call in the same job.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: save ccache (unix)
+      if: (github.ref == 'refs/heads/master' && github.event_name == 'push') && runner.os != 'Windows'
+      uses: actions/cache/save@v5
+      with:
+        path: ~/.ccache
+        key: ${{ github.workflow }}-ccache-${{ inputs.key-suffix }}-master-${{ github.run_id }}
+
+    - name: save ccache (windows)
+      if: (github.ref == 'refs/heads/master' && github.event_name == 'push') && runner.os == 'Windows'
+      uses: actions/cache/save@v5
+      with:
+        path: D:/a/${{ github.event.repository.name }}/${{ github.event.repository.name }}/ccache
+        key: ${{ github.workflow }}-ccache-${{ inputs.key-suffix }}-master-${{ github.run_id }}
+
+    - name: delete stale ccache entries
+      if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        WORKFLOW: ${{ github.workflow }}
+        KEY_SUFFIX: ${{ inputs.key-suffix }}
+        GIT_REF: ${{ github.ref }}
+        RUN_ID: ${{ github.run_id }}
+        REPOSITORY: ${{ github.repository }}
+      run: |
+        python3 - <<'EOF'
+        import os, urllib.parse, urllib.request, json
+
+        token      = os.environ["GH_TOKEN"]
+        workflow   = os.environ["WORKFLOW"]
+        key_suffix = os.environ["KEY_SUFFIX"]
+        git_ref    = os.environ["GIT_REF"]
+        run_id     = os.environ["RUN_ID"]
+        repository = os.environ["REPOSITORY"]
+
+        prefix      = f"{workflow}-ccache-{key_suffix}-master-"
+        current_key = f"{prefix}{run_id}"
+        base_url    = f"https://api.github.com/repos/{repository}/actions/caches"
+        headers     = {"Authorization": f"Bearer {token}", "X-GitHub-Api-Version": "2022-11-28"}
+
+        params = urllib.parse.urlencode({"key": prefix, "ref": git_ref, "per_page": 100})
+        req = urllib.request.Request(f"{base_url}?{params}", headers=headers)
+        with urllib.request.urlopen(req) as r:
+            caches = json.load(r)["actions_caches"]
+
+        for cache in caches:
+            if cache["key"] == current_key:
+                continue
+            params = urllib.parse.urlencode({"key": cache["key"], "ref": git_ref})
+            req = urllib.request.Request(f"{base_url}?{params}", method="DELETE", headers=headers)
+            try:
+                urllib.request.urlopen(req)
+                print(f"Deleted stale cache: {cache['key']}")
+            except Exception as e:
+                print(f"Failed to delete {cache['key']}: {e}")
+        EOF

--- a/.github/actions/setup-ccache/action.yml
+++ b/.github/actions/setup-ccache/action.yml
@@ -1,0 +1,40 @@
+name: setup-ccache
+description: >
+  Restore the ccache directory from the GitHub Actions cache and apply the
+  shared ccache configuration. This only restores; jobs that should persist the
+  cache call the save-ccache action after their build step. Autotest/test jobs
+  use this action alone (read-only).
+
+inputs:
+  key-suffix:
+    description: >
+      Suffix appended to the cache key, e.g. the toolchain ("base"). Jobs that
+      consume a build job's cache must pass the same suffix it saved with, and a
+      job that saves must pass the same suffix to setup-ccache and save-ccache.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: restore ccache (unix)
+      if: runner.os != 'Windows'
+      uses: actions/cache/restore@v5
+      with:
+        path: ~/.ccache
+        # one entry per branch/PR; restore-keys falls back to the latest cache
+        # for this suffix (this branch, then master) to warm a fresh branch.
+        key: ${{ github.workflow }}-ccache-${{ inputs.key-suffix }}-${{ github.head_ref || github.ref_name }}
+        restore-keys: ${{ github.workflow }}-ccache-${{ inputs.key-suffix }}-
+
+    - name: restore ccache (windows)
+      if: runner.os == 'Windows'
+      uses: actions/cache/restore@v5
+      with:
+        path: D:/a/${{ github.event.repository.name }}/${{ github.event.repository.name }}/ccache
+        key: ${{ github.workflow }}-ccache-${{ inputs.key-suffix }}-${{ github.head_ref || github.ref_name }}
+        restore-keys: ${{ github.workflow }}-ccache-${{ inputs.key-suffix }}-
+
+    - name: setup ccache
+      if: runner.os != 'Windows'
+      shell: bash
+      run: . "$GITHUB_WORKSPACE/.github/workflows/ccache.env"

--- a/.github/workflows/colcon.yml
+++ b/.github/workflows/colcon.yml
@@ -138,35 +138,34 @@ concurrency:
   group: ci-${{github.workflow}}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read  # checkout; build-test adds actions:write per-job
+
 jobs:
   build-test:
+    permissions:
+      contents: read
+      actions: write  # save/prune ccache on master
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     container:
       image: ardupilot/ardupilot-dev-ros:latest
-    strategy:
-      fail-fast: false  # don't cancel if a job from the matrix fails
     steps:
+      # Sparse checkout to make .github/actions/* available without polluting the colcon workspace
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          sparse-checkout: .github
+          sparse-checkout-cone-mode: false
       # git checkout the PR
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
           path: src/ardupilot
-      # Put ccache into github cache for faster build
-      - name: Prepare ccache timestamp
-        id: ccache_cache_timestamp
-        run: |
-          NOW=$(date -u +"%F-%T")
-          echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
-      - name: ccache cache files
-        uses: actions/cache@v5
+      - uses: ./.github/actions/setup-ccache
         with:
-          path: ~/.ccache
-          key: ${{github.workflow}}-ccache-${{steps.ccache_cache_timestamp.outputs.timestamp}}
-          restore-keys: ${{github.workflow}}-ccache-  # restore ccache from either previous build on this branch or on master
-      - name: setup ccache
-        run: |
-          . src/ardupilot/.github/workflows/ccache.env
+          key-suffix: ros
       # https://ardupilot.org/dev/docs/ros2.html#installation-ubuntu
       - name: Pull in repos with vcs
         run: |
@@ -203,6 +202,9 @@ jobs:
           source /opt/ros/humble/setup.bash
           PATH="/tmp/Micro-XRCE-DDS-Gen/scripts:$PATH"
           colcon build --packages-up-to ardupilot_dds_tests --cmake-args -DBUILD_TESTING=ON
+      - uses: ./.github/actions/save-ccache
+        with:
+          key-suffix: ros
       - name: Test with colcon
         shell: 'bash'
         run: |

--- a/.github/workflows/cygwin_build.yml
+++ b/.github/workflows/cygwin_build.yml
@@ -142,24 +142,20 @@ concurrency:
   group: ci-${{github.workflow}}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read  # checkout; build adds actions:write per-job
+
 jobs:
   build:
+    permissions:
+      contents: read
+      actions: write  # save/prune ccache on master
     runs-on: 'windows-latest'
 
     steps:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      - name: Prepare ccache timestamp
-        id: ccache_cache_timestamp
-        shell: bash
-        run: |
-          NOW=$(date -u +"%F-%T")
-          echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
-          WORKFLOWNAME="${{github.workflow}}"
-          NAME_DASHED=${WORKFLOWNAME//+( )/_}
-          echo "cache-key=${NAME_DASHED}" >> $GITHUB_OUTPUT
-
       - uses: cygwin/cygwin-install-action@v6
         with:
           packages: cygwin64 gcc-g++=13.4.0-1 ccache python312 python312-pip git procps gettext
@@ -181,12 +177,7 @@ jobs:
           echo "export CCACHE_MAXSIZE=400M" >> ~/ccache.conf &&
           source ~/ccache.conf &&
           ccache -s
-      - name: ccache cache files
-        uses: actions/cache@v5
-        with:
-          path: D:/a/ardupilot/ardupilot/ccache
-          key: ${{ steps.ccache_cache_timestamp.outputs.cache-key }}-ccache-${{steps.ccache_cache_timestamp.outputs.timestamp}}
-          restore-keys: ${{ steps.ccache_cache_timestamp.outputs.cache-key }}-ccache-  # restore ccache from either previous build on this branch or on base branch
+      - uses: ./.github/actions/setup-ccache
       - name: Prepare Python environment
         env:
           PATH: /usr/bin:$(cygpath ${SYSTEMROOT})/system32
@@ -213,6 +204,7 @@ jobs:
           source ~/ccache.conf &&
           Tools/scripts/cygwin_build.sh &&
           ccache -s
+      - uses: ./.github/actions/save-ccache
 
       - name: Check build files
         id: check_files

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -137,8 +137,14 @@ concurrency:
   group: ci-${{github.workflow}}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read  # checkout; jobs that save ccache add actions:write per-job
+
 jobs:
   build:
+    permissions:
+      contents: read
+      actions: write  # save-ccache prunes the previous cache entry
     runs-on: macos-latest
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
@@ -160,22 +166,9 @@ jobs:
           fi
           Tools/environment_install/install-prereqs-mac.sh -y
           source ~/.bash_profile
-      # Put ccache into github cache for faster build
-      - name: Prepare ccache timestamp
-        id: ccache_cache_timestamp
-        shell: bash
-        run: |
-          NOW=$(date -u +"%F-%T")
-          echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
-      - name: ccache cache files
-        uses: actions/cache@v5
+      - uses: ./.github/actions/setup-ccache
         with:
-          path: ~/.ccache
-          key: ${{github.workflow}}-ccache-${{matrix.config}}-${{steps.ccache_cache_timestamp.outputs.timestamp}}
-          restore-keys: ${{github.workflow}}-ccache-${{matrix.config}} # restore ccache from either previous build on this branch or on master
-      - name: setup ccache
-        run: |
-          . .github/workflows/ccache.env
+          key-suffix: ${{ matrix.config }}
       - name: test build ${{matrix.config}}
         env:
           CI_BUILD_TARGET: ${{matrix.config}}
@@ -190,3 +183,6 @@ jobs:
           ./waf
           ccache -s
           ccache -z
+      - uses: ./.github/actions/save-ccache
+        with:
+          key-suffix: ${{ matrix.config }}

--- a/.github/workflows/test_chibios.yml
+++ b/.github/workflows/test_chibios.yml
@@ -132,8 +132,14 @@ concurrency:
   group: ci-${{github.workflow}}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read  # checkout; jobs that save ccache add actions:write per-job
+
 jobs:
   build:
+    permissions:
+      contents: read
+      actions: write  # save-ccache prunes the previous cache entry
     runs-on: ubuntu-22.04
     container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.1.3
     strategy:
@@ -177,21 +183,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      # Put ccache into github cache for faster build
-      - name: Prepare ccache timestamp
-        id: ccache_cache_timestamp
-        run: |
-          NOW=$(date -u +"%F-%T")
-          echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
-      - name: ccache cache files
-        uses: actions/cache@v5
+      - uses: ./.github/actions/setup-ccache
         with:
-          path: ~/.ccache
-          key: ${{github.workflow}}-ccache-${{matrix.config}}-${{ matrix.toolchain }}-${{ matrix.gcc }}-${{steps.ccache_cache_timestamp.outputs.timestamp}}
-          restore-keys: ${{github.workflow}}-ccache-${{matrix.config}}-${{ matrix.toolchain }}-${{ matrix.gcc }}  # restore ccache from either previous build on this branch or on master
-      - name: setup ccache
-        run: |
-          . .github/workflows/ccache.env
+          key-suffix: ${{ matrix.config }}-${{ matrix.toolchain }}-${{ matrix.gcc }}
       - name: test ${{matrix.config}} ${{ matrix.toolchain }} gcc-${{matrix.gcc}}
         env:
           CI_BUILD_TARGET: ${{matrix.config}}
@@ -207,3 +201,6 @@ jobs:
           Tools/scripts/build_ci.sh
           ccache -s
           ccache -z
+      - uses: ./.github/actions/save-ccache
+        with:
+          key-suffix: ${{ matrix.config }}-${{ matrix.toolchain }}-${{ matrix.gcc }}

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -11,8 +11,14 @@ concurrency:
   group: ci-${{github.workflow}}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read  # checkout; jobs that save ccache add actions:write per-job
+
 jobs:
   build:
+    permissions:
+      contents: read
+      actions: write  # save-ccache prunes the previous cache entry
     runs-on: ubuntu-22.04
     container:
       image: ardupilot/ardupilot-dev-${{ matrix.type }}:v0.1.3
@@ -41,21 +47,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      # Put ccache into github cache for faster build
-      - name: Prepare ccache timestamp
-        id: ccache_cache_timestamp
-        run: |
-          NOW=$(date -u +"%F-%T")
-          echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
-      - name: ccache cache files
-        uses: actions/cache@v5
+      - uses: ./.github/actions/setup-ccache
         with:
-          path: ~/.ccache
-          key: ${{github.workflow}}-ccache-${{ matrix.toolchain }}-${{steps.ccache_cache_timestamp.outputs.timestamp}}
-          restore-keys: ${{github.workflow}}-ccache-${{ matrix.toolchain }}-  # restore ccache from either previous build on this branch or on master
-      - name: setup ccache
-        run: |
-          . .github/workflows/ccache.env
+          key-suffix: ${{ matrix.toolchain }}-${{ matrix.config }}
       - name: test ${{matrix.config}} ${{ matrix.toolchain }}
         env:
           CI_BUILD_TARGET: ${{matrix.config}}
@@ -78,6 +72,9 @@ jobs:
             Tools/autotest/autotest.py test.CAN --debug --coverage
             Tools/scripts/run_coverage.py -u
           fi
+      - uses: ./.github/actions/save-ccache
+        with:
+          key-suffix: ${{ matrix.toolchain }}-${{ matrix.config }}
 
       - name: Coveralls
         uses: coverallsapp/github-action@master

--- a/.github/workflows/test_dds.yml
+++ b/.github/workflows/test_dds.yml
@@ -138,8 +138,14 @@ concurrency:
   group: ci-${{github.workflow}}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read  # checkout; jobs that save ccache add actions:write per-job
+
 jobs:
   build:
+    permissions:
+      contents: read
+      actions: write  # save-ccache prunes the previous cache entry
     runs-on: ubuntu-22.04
     container:
       image: ardupilot/ardupilot-dev-ros:latest
@@ -156,21 +162,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      # Put ccache into github cache for faster build
-      - name: Prepare ccache timestamp
-        id: ccache_cache_timestamp
-        run: |
-          NOW=$(date -u +"%F-%T")
-          echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
-      - name: ccache cache files
-        uses: actions/cache@v5
+      - uses: ./.github/actions/setup-ccache
         with:
-          path: ~/.ccache
-          key: ${{github.workflow}}-ccache-${{ matrix.config }}-${{steps.ccache_cache_timestamp.outputs.timestamp}}
-          restore-keys: ${{github.workflow}}-ccache-${{ matrix.config }}-  # restore ccache from either previous build on this branch or on master
-      - name: setup ccache
-        run: |
-          . .github/workflows/ccache.env
+          key-suffix: ${{ matrix.config }}
       # install Micro-XRCE-DDS-Gen from source until image is updated
       - name: install Micro-XRCE-DDS-Gen from source
         run: |
@@ -188,6 +182,9 @@ jobs:
           PATH="/tmp/Micro-XRCE-DDS-Gen/scripts:$PATH"
           which microxrceddsgen
           Tools/scripts/build_ci.sh
+      - uses: ./.github/actions/save-ccache
+        with:
+          key-suffix: ${{ matrix.config }}
 
       - name: Archive buildlog artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/test_linux_sbc.yml
+++ b/.github/workflows/test_linux_sbc.yml
@@ -133,8 +133,14 @@ concurrency:
   group: ci-${{github.workflow}}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read  # checkout; jobs that save ccache add actions:write per-job
+
 jobs:
   build:
+    permissions:
+      contents: read
+      actions: write  # save-ccache prunes the previous cache entry
     runs-on: ubuntu-22.04
     container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.1.3
     strategy:
@@ -178,21 +184,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      # Put ccache into github cache for faster build
-      - name: Prepare ccache timestamp
-        id: ccache_cache_timestamp
-        run: |
-          NOW=$(date -u +"%F-%T")
-          echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
-      - name: ccache cache files
-        uses: actions/cache@v5
+      - uses: ./.github/actions/setup-ccache
         with:
-          path: ~/.ccache
-          key: ${{github.workflow}}-ccache-${{matrix.config}}-${{ matrix.toolchain }}-${{steps.ccache_cache_timestamp.outputs.timestamp}}
-          restore-keys: ${{github.workflow}}-ccache-${{matrix.config}}-${{ matrix.toolchain }}-  # restore ccache from either previous build on this branch or on master
-      - name: setup ccache
-        run: |
-          . .github/workflows/ccache.env
+          key-suffix: ${{ matrix.config }}-${{ matrix.toolchain }}
       - name: test ${{matrix.config}} ${{ matrix.toolchain }}
         env:
           CI_BUILD_TARGET: ${{matrix.config}}
@@ -207,3 +201,6 @@ jobs:
           Tools/scripts/build_ci.sh
           ccache -s
           ccache -z
+      - uses: ./.github/actions/save-ccache
+        with:
+          key-suffix: ${{ matrix.config }}-${{ matrix.toolchain }}

--- a/.github/workflows/test_replay.yml
+++ b/.github/workflows/test_replay.yml
@@ -148,8 +148,14 @@ concurrency:
   group: ci-${{github.workflow}}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read  # checkout; jobs that save ccache add actions:write per-job
+
 jobs:
   build:
+    permissions:
+      contents: read
+      actions: write  # save-ccache prunes the previous cache entry
     runs-on: ubuntu-22.04
     container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.1.3
     strategy:
@@ -167,21 +173,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      # Put ccache into github cache for faster build
-      - name: Prepare ccache timestamp
-        id: ccache_cache_timestamp
-        run: |
-          NOW=$(date -u +"%F-%T")
-          echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
-      - name: ccache cache files
-        uses: actions/cache@v5
+      - uses: ./.github/actions/setup-ccache
         with:
-          path: ~/.ccache
-          key: ${{github.workflow}}-ccache-${{ matrix.toolchain }}-${{steps.ccache_cache_timestamp.outputs.timestamp}}
-          restore-keys: ${{github.workflow}}-ccache-${{ matrix.toolchain }}-  # restore ccache from either previous build on this branch or on master
-      - name: setup ccache
-        run: |
-          . .github/workflows/ccache.env
+          key-suffix: ${{ matrix.toolchain }}
       - name: test ${{matrix.config}} ${{ matrix.toolchain }}
         env:
           CI_BUILD_TARGET: ${{matrix.config}}
@@ -194,6 +188,9 @@ jobs:
           fi
           PATH="/github/home/.local/bin:$PATH"
           Tools/scripts/build_ci.sh
+      - uses: ./.github/actions/save-ccache
+        with:
+          key-suffix: ${{ matrix.toolchain }}
 
       - name: Archive buildlog artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/test_sitl_blimp.yml
+++ b/.github/workflows/test_sitl_blimp.yml
@@ -167,6 +167,10 @@ concurrency:
   group: ci-${{github.workflow}}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read  # checkout
+  actions: write  # save-ccache deletes the previous cache entry before saving
+
 jobs:
   build:
     runs-on: ubuntu-22.04
@@ -182,21 +186,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      # Put ccache into github cache for faster build
-      - name: Prepare ccache timestamp
-        id: ccache_cache_timestamp
-        run: |
-          NOW=$(date -u +"%F-%T")
-          echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
-      - name: ccache cache files
-        uses: actions/cache@v5
+      - uses: ./.github/actions/setup-ccache
         with:
-          path: ~/.ccache
-          key: ${{github.workflow}}-ccache-${{ matrix.toolchain }}-${{steps.ccache_cache_timestamp.outputs.timestamp}}
-          restore-keys: ${{github.workflow}}-ccache-${{ matrix.toolchain }}-  # restore ccache from either previous build on this branch or on master
-      - name: setup ccache
-        run: |
-          . .github/workflows/ccache.env
+          key-suffix: ${{ matrix.toolchain }}
       - name: build blimp ${{ matrix.toolchain }}
         shell: bash
         run: |
@@ -206,6 +198,9 @@ jobs:
           ./waf build --target bin/blimp
           ccache -s
           ccache -z
+      - uses: ./.github/actions/save-ccache
+        with:
+          key-suffix: ${{ matrix.toolchain }}
 
   autotest:
     needs: build  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
@@ -225,21 +220,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      # Put ccache into github cache for faster build
-      - name: Prepare ccache timestamp
-        id: ccache_cache_timestamp
-        run: |
-          NOW=$(date -u +"%F-%T")
-          echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
-      - name: ccache cache files
-        uses: actions/cache/restore@v5
+      - uses: ./.github/actions/setup-ccache
         with:
-          path: ~/.ccache
-          key: ${{github.workflow}}-ccache-base-${{steps.ccache_cache_timestamp.outputs.timestamp}}
-          restore-keys: ${{github.workflow}}-ccache-base-  # restore ccache from either previous build on this branch or on master
-      - name: setup ccache
-        run: |
-          . .github/workflows/ccache.env
+          key-suffix: base
       - name: test ${{matrix.config}}
         env:
           CI_BUILD_TARGET: ${{matrix.config}}

--- a/.github/workflows/test_sitl_blimp.yml
+++ b/.github/workflows/test_sitl_blimp.yml
@@ -168,19 +168,18 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read  # checkout
-  actions: write  # save-ccache deletes the previous cache entry before saving
+  contents: read  # checkout; jobs that save ccache add actions:write per-job
 
 jobs:
-  build:
+  build-test:
+    permissions:
+      contents: read
+      actions: write  # save-ccache prunes the previous cache entry
     runs-on: ubuntu-22.04
-    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.1.3
-    strategy:
-      fail-fast: false  # don't cancel if a job from the matrix fails
-      matrix:
-        toolchain: [
-            base,  # GCC
-        ]
+    container:
+      image: ardupilot/ardupilot-dev-base:v0.1.3
+      options: --privileged --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --security-opt seccomp=unconfined
+
     steps:
       # git checkout the PR
       - uses: actions/checkout@v6
@@ -188,8 +187,8 @@ jobs:
           submodules: 'recursive'
       - uses: ./.github/actions/setup-ccache
         with:
-          key-suffix: ${{ matrix.toolchain }}
-      - name: build blimp ${{ matrix.toolchain }}
+          key-suffix: base
+      - name: build blimp
         shell: bash
         run: |
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
@@ -200,32 +199,10 @@ jobs:
           ccache -z
       - uses: ./.github/actions/save-ccache
         with:
-          key-suffix: ${{ matrix.toolchain }}
-
-  autotest:
-    needs: build  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
-    runs-on: ubuntu-22.04
-    container:
-      image: ardupilot/ardupilot-dev-base:v0.1.3
-      options: --privileged --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --security-opt seccomp=unconfined
-    strategy:
-      fail-fast: false  # don't cancel if a job from the matrix fails
-      matrix:
-        config: [
-            sitltest-blimp,
-        ]
-
-    steps:
-      # git checkout the PR
-      - uses: actions/checkout@v6
-        with:
-          submodules: 'recursive'
-      - uses: ./.github/actions/setup-ccache
-        with:
           key-suffix: base
-      - name: test ${{matrix.config}}
+      - name: test sitltest-blimp
         env:
-          CI_BUILD_TARGET: ${{matrix.config}}
+          CI_BUILD_TARGET: sitltest-blimp
         shell: bash
         run: |
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
@@ -236,7 +213,7 @@ jobs:
         uses: actions/upload-artifact@v7
         if: failure()
         with:
-           name: ${{ github.workflow }}-fail-${{matrix.config}}
+           name: ${{ github.workflow }}-fail-sitltest-blimp
            path: |
              /tmp/buildlogs
              /__w/ardupilot/ardupilot/logs
@@ -249,7 +226,7 @@ jobs:
       - name: Archive .bin artifacts
         uses: actions/upload-artifact@v7
         with:
-           name: ${{ github.workflow }}-BIN-${{matrix.config}}
+           name: ${{ github.workflow }}-BIN-sitltest-blimp
            path: /__w/ardupilot/ardupilot/logs
            retention-days: 7
 

--- a/.github/workflows/test_sitl_copter.yml
+++ b/.github/workflows/test_sitl_copter.yml
@@ -161,8 +161,14 @@ concurrency:
   group: ci-${{github.workflow}}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read  # checkout; jobs that save ccache add actions:write per-job
+
 jobs:
   build:
+    permissions:
+      contents: read
+      actions: write  # save-ccache prunes the previous cache entry
     runs-on: ubuntu-22.04
     container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.1.3
     strategy:
@@ -177,21 +183,9 @@ jobs:
         with:
           submodules: 'recursive'
 
-      # Put ccache into github cache for faster build
-      - name: Prepare ccache timestamp
-        id: ccache_cache_timestamp
-        run: |
-          NOW=$(date -u +"%F-%T")
-          echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
-      - name: ccache cache files
-        uses: actions/cache@v5
+      - uses: ./.github/actions/setup-ccache
         with:
-          path: ~/.ccache
-          key: ${{github.workflow}}-ccache-${{ matrix.toolchain }}-${{steps.ccache_cache_timestamp.outputs.timestamp}}
-          restore-keys: ${{github.workflow}}-ccache-${{ matrix.toolchain }}-  # restore ccache from either previous build on this branch or on master
-      - name: setup ccache
-        run: |
-          . .github/workflows/ccache.env
+          key-suffix: ${{ matrix.toolchain }}
       - name: build copter ${{ matrix.toolchain }}
         shell: bash
         run: |
@@ -201,6 +195,9 @@ jobs:
           ./waf build --target bin/arducopter
           ccache -s
           ccache -z
+      - uses: ./.github/actions/save-ccache
+        with:
+          key-suffix: ${{ matrix.toolchain }}
 
   autotest:
     needs: build  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
@@ -239,21 +236,9 @@ jobs:
       - name: Register autotest fail matcher
         run: echo "::add-matcher::.github/problem-matchers/autotestfail.json"
 
-      # Put ccache into github cache for faster build
-      - name: Prepare ccache timestamp
-        id: ccache_cache_timestamp
-        run: |
-          NOW=$(date -u +"%F-%T")
-          echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
-      - name: ccache cache files
-        uses: actions/cache/restore@v5
+      - uses: ./.github/actions/setup-ccache
         with:
-          path: ~/.ccache
-          key: ${{github.workflow}}-ccache-base-${{steps.ccache_cache_timestamp.outputs.timestamp}}
-          restore-keys: ${{github.workflow}}-ccache-base-  # restore ccache from either previous build on this branch or on master
-      - name: setup ccache
-        run: |
-          . .github/workflows/ccache.env
+          key-suffix: base
       - name: test ${{matrix.config}}
         env:
           CI_BUILD_TARGET: ${{matrix.config}}
@@ -285,6 +270,9 @@ jobs:
            retention-days: 7
 
   build-gcc-heli:
+    permissions:
+      contents: read
+      actions: write  # save-ccache prunes the previous cache entry
     runs-on: ubuntu-22.04
     container:
       image: ardupilot/ardupilot-dev-base:v0.1.3
@@ -294,21 +282,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      # Put ccache into github cache for faster build
-      - name: Prepare ccache timestamp
-        id: ccache_cache_timestamp
-        run: |
-          NOW=$(date -u +"%F-%T")
-          echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
-      - name: ccache cache files
-        uses: actions/cache@v5
+      - uses: ./.github/actions/setup-ccache
         with:
-          path: ~/.ccache
-          key: ${{github.workflow}}-ccache-base-${{steps.ccache_cache_timestamp.outputs.timestamp}}
-          restore-keys: ${{github.workflow}}-ccache-base-  # restore ccache from either previous build on this branch or on master
-      - name: setup ccache
-        run: |
-          . .github/workflows/ccache.env
+          key-suffix: heli
       - name: build heli
         shell: bash
         run: |
@@ -318,6 +294,9 @@ jobs:
           ./waf build --target bin/arducopter-heli
           ccache -s
           ccache -z
+      - uses: ./.github/actions/save-ccache
+        with:
+          key-suffix: heli
 
   autotest-heli:
     needs: build-gcc-heli  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
@@ -335,21 +314,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      # Put ccache into github cache for faster build
-      - name: Prepare ccache timestamp
-        id: ccache_cache_timestamp
-        run: |
-          NOW=$(date -u +"%F-%T")
-          echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
-      - name: ccache cache files
-        uses: actions/cache/restore@v5
+      - uses: ./.github/actions/setup-ccache
         with:
-          path: ~/.ccache
-          key: ${{github.workflow}}-ccache-base-${{steps.ccache_cache_timestamp.outputs.timestamp}}
-          restore-keys: ${{github.workflow}}-ccache-base-  # restore ccache from either previous build on this branch or on master
-      - name: setup ccache
-        run: |
-          . .github/workflows/ccache.env
+          key-suffix: heli
       - name: test ${{matrix.config}}
         env:
           CI_BUILD_TARGET: ${{matrix.config}}

--- a/.github/workflows/test_sitl_copter.yml
+++ b/.github/workflows/test_sitl_copter.yml
@@ -290,7 +290,7 @@ jobs:
         run: |
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
           PATH="/github/home/.local/bin:$PATH"
-          ./waf configure --board sitl
+          ./waf configure --board sitl --debug
           ./waf build --target bin/arducopter-heli
           ccache -s
           ccache -z

--- a/.github/workflows/test_sitl_periph.yml
+++ b/.github/workflows/test_sitl_periph.yml
@@ -160,6 +160,10 @@ concurrency:
   group: ci-${{github.workflow}}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read  # checkout
+  actions: write  # save-ccache deletes the previous cache entry before saving
+
 jobs:
   build-gcc-ap_periph:
     runs-on: ubuntu-22.04
@@ -169,21 +173,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      # Put ccache into github cache for faster build
-      - name: Prepare ccache timestamp
-        id: ccache_cache_timestamp
-        run: |
-          NOW=$(date -u +"%F-%T")
-          echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
-      - name: ccache cache files
-        uses: actions/cache@v5
+      - uses: ./.github/actions/setup-ccache
         with:
-          path: ~/.ccache
-          key: ${{github.workflow}}-ccache-${{steps.ccache_cache_timestamp.outputs.timestamp}}
-          restore-keys: ${{github.workflow}}-ccache-  # restore ccache from either previous build on this branch or on master
-      - name: setup ccache
-        run: |
-          . .github/workflows/ccache.env
+          key-suffix: periph
 
       - name: run dronecan dsdlc generator test
         run: |
@@ -200,11 +192,14 @@ jobs:
           ./waf build --target bin/AP_Periph
           ccache -s
           ccache -z
+      - uses: ./.github/actions/save-ccache
+        with:
+          key-suffix: periph
 
   autotest-can:
     needs: build-gcc-ap_periph  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
     runs-on: ubuntu-22.04
-    container: 
+    container:
       image: ardupilot/ardupilot-dev-periph:v0.1.3
       options: --privileged
     strategy:
@@ -219,21 +214,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      # Put ccache into github cache for faster build
-      - name: Prepare ccache timestamp
-        id: ccache_cache_timestamp
-        run: |
-          NOW=$(date -u +"%F-%T")
-          echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
-      - name: ccache cache files
-        uses: actions/cache@v5
+      - uses: ./.github/actions/setup-ccache
         with:
-          path: ~/.ccache
-          key: ${{github.workflow}}-ccache-${{steps.ccache_cache_timestamp.outputs.timestamp}}
-          restore-keys: ${{github.workflow}}-ccache-  # restore ccache from either previous build on this branch or on master
-      - name: setup ccache
-        run: |
-          . .github/workflows/ccache.env
+          key-suffix: periph
       - name: test ${{matrix.config}}
         env:
           CI_BUILD_TARGET: ${{matrix.config}}

--- a/.github/workflows/test_sitl_periph.yml
+++ b/.github/workflows/test_sitl_periph.yml
@@ -161,13 +161,17 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read  # checkout
-  actions: write  # save-ccache deletes the previous cache entry before saving
+  contents: read  # checkout; jobs that save ccache add actions:write per-job
 
 jobs:
-  build-gcc-ap_periph:
+  build-test:
+    permissions:
+      contents: read
+      actions: write  # save-ccache prunes the previous cache entry
     runs-on: ubuntu-22.04
-    container: ardupilot/ardupilot-dev-periph:v0.1.3
+    container:
+      image: ardupilot/ardupilot-dev-periph:v0.1.3
+      options: --privileged
     steps:
       # git checkout the PR
       - uses: actions/checkout@v6
@@ -196,30 +200,9 @@ jobs:
         with:
           key-suffix: periph
 
-  autotest-can:
-    needs: build-gcc-ap_periph  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
-    runs-on: ubuntu-22.04
-    container:
-      image: ardupilot/ardupilot-dev-periph:v0.1.3
-      options: --privileged
-    strategy:
-      fail-fast: false  # don't cancel if a job from the matrix fails
-      matrix:
-        config: [
-            sitltest-can,
-        ]
-
-    steps:
-      # git checkout the PR
-      - uses: actions/checkout@v6
-        with:
-          submodules: 'recursive'
-      - uses: ./.github/actions/setup-ccache
-        with:
-          key-suffix: periph
-      - name: test ${{matrix.config}}
+      - name: test sitltest-can
         env:
-          CI_BUILD_TARGET: ${{matrix.config}}
+          CI_BUILD_TARGET: sitltest-can
         shell: bash
         run: |
           git config --global --add safe.directory ${GITHUB_WORKSPACE}

--- a/.github/workflows/test_sitl_plane.yml
+++ b/.github/workflows/test_sitl_plane.yml
@@ -188,10 +188,11 @@ jobs:
           key-suffix: ${{ matrix.toolchain }}
       - name: build plane ${{ matrix.toolchain }}
         shell: bash
+        # Need --num-aux-imus=2 to match build_ci.sh build phase
         run: |
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
           PATH="/github/home/.local/bin:$PATH"
-          ./waf configure --board sitl --debug
+          ./waf configure --board sitl --debug --num-aux-imus=2
           ./waf build --target bin/arduplane
           ccache -s
           ccache -z

--- a/.github/workflows/test_sitl_plane.yml
+++ b/.github/workflows/test_sitl_plane.yml
@@ -162,8 +162,14 @@ concurrency:
   group: ci-${{github.workflow}}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read  # checkout; jobs that save ccache add actions:write per-job
+
 jobs:
   build:
+    permissions:
+      contents: read
+      actions: write  # save-ccache prunes the previous cache entry
     runs-on: ubuntu-22.04
     container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.1.3
     strategy:
@@ -177,21 +183,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      # Put ccache into github cache for faster build
-      - name: Prepare ccache timestamp
-        id: ccache_cache_timestamp
-        run: |
-          NOW=$(date -u +"%F-%T")
-          echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
-      - name: ccache cache files
-        uses: actions/cache@v5
+      - uses: ./.github/actions/setup-ccache
         with:
-          path: ~/.ccache
-          key: ${{github.workflow}}-ccache-${{ matrix.toolchain }}-${{steps.ccache_cache_timestamp.outputs.timestamp}}
-          restore-keys: ${{github.workflow}}-ccache-${{ matrix.toolchain }}-  # restore ccache from either previous build on this branch or on master
-      - name: setup ccache
-        run: |
-          . .github/workflows/ccache.env
+          key-suffix: ${{ matrix.toolchain }}
       - name: build plane ${{ matrix.toolchain }}
         shell: bash
         run: |
@@ -201,6 +195,9 @@ jobs:
           ./waf build --target bin/arduplane
           ccache -s
           ccache -z
+      - uses: ./.github/actions/save-ccache
+        with:
+          key-suffix: ${{ matrix.toolchain }}
 
   autotest:
     needs: build  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
@@ -223,21 +220,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      # Put ccache into github cache for faster build
-      - name: Prepare ccache timestamp
-        id: ccache_cache_timestamp
-        run: |
-          NOW=$(date -u +"%F-%T")
-          echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
-      - name: ccache cache files
-        uses: actions/cache/restore@v5
+      - uses: ./.github/actions/setup-ccache
         with:
-          path: ~/.ccache
-          key: ${{github.workflow}}-ccache-base-${{steps.ccache_cache_timestamp.outputs.timestamp}}
-          restore-keys: ${{github.workflow}}-ccache-base-  # restore ccache from either previous build on this branch or on master
-      - name: setup ccache
-        run: |
-          . .github/workflows/ccache.env
+          key-suffix: base
       - name: test ${{matrix.config}}
         env:
           CI_BUILD_TARGET: ${{matrix.config}}

--- a/.github/workflows/test_sitl_rover.yml
+++ b/.github/workflows/test_sitl_rover.yml
@@ -160,8 +160,14 @@ concurrency:
   group: ci-${{github.workflow}}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read  # checkout; jobs that save ccache add actions:write per-job
+
 jobs:
   build:
+    permissions:
+      contents: read
+      actions: write  # save-ccache prunes the previous cache entry
     runs-on: ubuntu-22.04
     container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.1.3
     strategy:
@@ -175,23 +181,12 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      # Put ccache into github cache for faster build
-      - name: Prepare ccache timestamp
-        id: ccache_cache_timestamp
-        run: |
-          NOW=$(date -u +"%F-%T")
-          echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
-      - name: ccache cache files
-        uses: actions/cache@v5
+      - uses: ./.github/actions/setup-ccache
         with:
-          path: ~/.ccache
-          key: ${{github.workflow}}-ccache-${{ matrix.toolchain }}-${{steps.ccache_cache_timestamp.outputs.timestamp}}
-          restore-keys: ${{github.workflow}}-ccache-${{ matrix.toolchain }}-  # restore ccache from either previous build on this branch or on master
-      - name: setup ccache
-        run: |
-          . .github/workflows/ccache.env
+          key-suffix: ${{ matrix.toolchain }}
       - name: build rover ${{ matrix.toolchain }}
         shell: bash
+        # Need --enable-math-check-indexes to match build_ci.sh build phase
         run: |
           sudo apt-get update || true
           sudo apt-get -y install ppp || true
@@ -202,6 +197,9 @@ jobs:
           ./waf build --target bin/ardurover
           ccache -s
           ccache -z
+      - uses: ./.github/actions/save-ccache
+        with:
+          key-suffix: ${{ matrix.toolchain }}
 
   autotest:
     needs: build  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
@@ -236,21 +234,9 @@ jobs:
       - name: Register autotest fail matcher
         run: echo "::add-matcher::.github/problem-matchers/autotestfail.json"
 
-      # Put ccache into github cache for faster build
-      - name: Prepare ccache timestamp
-        id: ccache_cache_timestamp
-        run: |
-          NOW=$(date -u +"%F-%T")
-          echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
-      - name: ccache cache files
-        uses: actions/cache/restore@v5
+      - uses: ./.github/actions/setup-ccache
         with:
-          path: ~/.ccache
-          key: ${{github.workflow}}-ccache-base-${{steps.ccache_cache_timestamp.outputs.timestamp}}
-          restore-keys: ${{github.workflow}}-ccache-base-  # restore ccache from either previous build on this branch or on master
-      - name: setup ccache
-        run: |
-          . .github/workflows/ccache.env
+          key-suffix: base
       - name: test ${{matrix.config}}
         env:
           CI_BUILD_TARGET: ${{matrix.config}}

--- a/.github/workflows/test_sitl_sub.yml
+++ b/.github/workflows/test_sitl_sub.yml
@@ -164,6 +164,10 @@ concurrency:
   group: ci-${{github.workflow}}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read  # checkout
+  actions: write  # save-ccache deletes the previous cache entry before saving
+
 jobs:
   build:
     runs-on: ubuntu-22.04
@@ -180,21 +184,9 @@ jobs:
         with:
           submodules: 'recursive'
 
-      # Put ccache into github cache for faster build
-      - name: Prepare ccache timestamp
-        id: ccache_cache_timestamp
-        run: |
-          NOW=$(date -u +"%F-%T")
-          echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
-      - name: ccache cache files
-        uses: actions/cache@v5
+      - uses: ./.github/actions/setup-ccache
         with:
-          path: ~/.ccache
-          key: ${{github.workflow}}-ccache-${{ matrix.toolchain }}-${{steps.ccache_cache_timestamp.outputs.timestamp}}
-          restore-keys: ${{github.workflow}}-ccache-${{ matrix.toolchain }}-  # restore ccache from either previous build on this branch or on master
-      - name: setup ccache
-        run: |
-          . .github/workflows/ccache.env
+          key-suffix: ${{ matrix.toolchain }}
       - name: build sub ${{ matrix.toolchain }}
         shell: bash
         run: |
@@ -204,6 +196,9 @@ jobs:
           ./waf build --target bin/ardusub
           ccache -s
           ccache -z
+      - uses: ./.github/actions/save-ccache
+        with:
+          key-suffix: ${{ matrix.toolchain }}
 
   autotest:
     needs: build  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
@@ -236,21 +231,9 @@ jobs:
       - name: Register autotest fail matcher
         run: echo "::add-matcher::.github/problem-matchers/autotestfail.json"
 
-      # Put ccache into github cache for faster build
-      - name: Prepare ccache timestamp
-        id: ccache_cache_timestamp
-        run: |
-          NOW=$(date -u +"%F-%T")
-          echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
-      - name: ccache cache files
-        uses: actions/cache/restore@v5
+      - uses: ./.github/actions/setup-ccache
         with:
-          path: ~/.ccache
-          key: ${{github.workflow}}-ccache-base-${{steps.ccache_cache_timestamp.outputs.timestamp}}
-          restore-keys: ${{github.workflow}}-ccache-base-  # restore ccache from either previous build on this branch or on master
-      - name: setup ccache
-        run: |
-          . .github/workflows/ccache.env
+          key-suffix: base
       - name: test ${{matrix.config}}
         env:
           CI_BUILD_TARGET: ${{matrix.config}}

--- a/.github/workflows/test_sitl_sub.yml
+++ b/.github/workflows/test_sitl_sub.yml
@@ -165,53 +165,17 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read  # checkout
-  actions: write  # save-ccache deletes the previous cache entry before saving
+  contents: read  # checkout; jobs that save ccache add actions:write per-job
 
 jobs:
-  build:
-    runs-on: ubuntu-22.04
-    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.1.3
-    strategy:
-      fail-fast: false  # don't cancel if a job from the matrix fails
-      matrix:
-        toolchain: [
-            base,  # GCC
-        ]
-    steps:
-      # git checkout the PR
-      - uses: actions/checkout@v6
-        with:
-          submodules: 'recursive'
-
-      - uses: ./.github/actions/setup-ccache
-        with:
-          key-suffix: ${{ matrix.toolchain }}
-      - name: build sub ${{ matrix.toolchain }}
-        shell: bash
-        run: |
-          git config --global --add safe.directory ${GITHUB_WORKSPACE}
-          PATH="/github/home/.local/bin:$PATH"
-          ./waf configure --board sitl --debug
-          ./waf build --target bin/ardusub
-          ccache -s
-          ccache -z
-      - uses: ./.github/actions/save-ccache
-        with:
-          key-suffix: ${{ matrix.toolchain }}
-
-  autotest:
-    needs: build  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
+  build-test:
+    permissions:
+      contents: read
+      actions: write  # save-ccache prunes the previous cache entry
     runs-on: ubuntu-22.04
     container:
       image: ardupilot/ardupilot-dev-base:v0.1.3
       options: --privileged --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --security-opt seccomp=unconfined
-    strategy:
-      fail-fast: false  # don't cancel if a job from the matrix fails
-      matrix:
-        config: [
-            sitltest-sub
-        ]
 
     steps:
       # git checkout the PR
@@ -234,9 +198,21 @@ jobs:
       - uses: ./.github/actions/setup-ccache
         with:
           key-suffix: base
-      - name: test ${{matrix.config}}
+      - name: build sub
+        shell: bash
+        run: |
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}
+          PATH="/github/home/.local/bin:$PATH"
+          ./waf configure --board sitl --debug
+          ./waf build --target bin/ardusub
+          ccache -s
+          ccache -z
+      - uses: ./.github/actions/save-ccache
+        with:
+          key-suffix: base
+      - name: test sitltest-sub
         env:
-          CI_BUILD_TARGET: ${{matrix.config}}
+          CI_BUILD_TARGET: sitltest-sub
         shell: bash
         run: |
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
@@ -247,7 +223,7 @@ jobs:
         uses: actions/upload-artifact@v7
         if: failure()
         with:
-           name: ${{ github.workflow }}-fail-${{matrix.config}}
+           name: ${{ github.workflow }}-fail-sitltest-sub
            path: |
              /tmp/buildlogs
              /__w/ardupilot/ardupilot/logs
@@ -260,7 +236,7 @@ jobs:
       - name: Archive .bin artifacts
         uses: actions/upload-artifact@v7
         with:
-           name: ${{ github.workflow }}-BIN-${{matrix.config}}
+           name: ${{ github.workflow }}-BIN-sitltest-sub
            path: /__w/ardupilot/ardupilot/logs
            retention-days: 7
 

--- a/.github/workflows/test_sitl_tracker.yml
+++ b/.github/workflows/test_sitl_tracker.yml
@@ -164,6 +164,10 @@ concurrency:
   group: ci-${{github.workflow}}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read  # checkout
+  actions: write  # save-ccache deletes the previous cache entry before saving
+
 jobs:
   build:
     runs-on: ubuntu-22.04
@@ -179,21 +183,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      # Put ccache into github cache for faster build
-      - name: Prepare ccache timestamp
-        id: ccache_cache_timestamp
-        run: |
-          NOW=$(date -u +"%F-%T")
-          echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
-      - name: ccache cache files
-        uses: actions/cache@v5
+      - uses: ./.github/actions/setup-ccache
         with:
-          path: ~/.ccache
-          key: ${{github.workflow}}-ccache-${{ matrix.toolchain }}-${{steps.ccache_cache_timestamp.outputs.timestamp}}
-          restore-keys: ${{github.workflow}}-ccache-${{ matrix.toolchain }}-  # restore ccache from either previous build on this branch or on master
-      - name: setup ccache
-        run: |
-          . .github/workflows/ccache.env
+          key-suffix: ${{ matrix.toolchain }}
       - name: build tracker ${{ matrix.toolchain }}
         shell: bash
         run: |
@@ -203,6 +195,9 @@ jobs:
           ./waf build --target bin/antennatracker
           ccache -s
           ccache -z
+      - uses: ./.github/actions/save-ccache
+        with:
+          key-suffix: ${{ matrix.toolchain }}
 
   autotest:
     needs: build  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
@@ -222,21 +217,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      # Put ccache into github cache for faster build
-      - name: Prepare ccache timestamp
-        id: ccache_cache_timestamp
-        run: |
-          NOW=$(date -u +"%F-%T")
-          echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
-      - name: ccache cache files
-        uses: actions/cache/restore@v5
+      - uses: ./.github/actions/setup-ccache
         with:
-          path: ~/.ccache
-          key: ${{github.workflow}}-ccache-base-${{steps.ccache_cache_timestamp.outputs.timestamp}}
-          restore-keys: ${{github.workflow}}-ccache-base-  # restore ccache from either previous build on this branch or on master
-      - name: setup ccache
-        run: |
-          . .github/workflows/ccache.env
+          key-suffix: base
       - name: test ${{matrix.config}}
         env:
           CI_BUILD_TARGET: ${{matrix.config}}

--- a/.github/workflows/test_sitl_tracker.yml
+++ b/.github/workflows/test_sitl_tracker.yml
@@ -165,19 +165,18 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read  # checkout
-  actions: write  # save-ccache deletes the previous cache entry before saving
+  contents: read  # checkout; jobs that save ccache add actions:write per-job
 
 jobs:
-  build:
+  build-test:
+    permissions:
+      contents: read
+      actions: write  # save-ccache prunes the previous cache entry
     runs-on: ubuntu-22.04
-    container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.1.3
-    strategy:
-      fail-fast: false  # don't cancel if a job from the matrix fails
-      matrix:
-        toolchain: [
-            base,  # GCC
-        ]
+    container:
+      image: ardupilot/ardupilot-dev-base:v0.1.3
+      options: --privileged --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --security-opt seccomp=unconfined
+
     steps:
       # git checkout the PR
       - uses: actions/checkout@v6
@@ -185,8 +184,8 @@ jobs:
           submodules: 'recursive'
       - uses: ./.github/actions/setup-ccache
         with:
-          key-suffix: ${{ matrix.toolchain }}
-      - name: build tracker ${{ matrix.toolchain }}
+          key-suffix: base
+      - name: build tracker
         shell: bash
         run: |
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
@@ -197,32 +196,10 @@ jobs:
           ccache -z
       - uses: ./.github/actions/save-ccache
         with:
-          key-suffix: ${{ matrix.toolchain }}
-
-  autotest:
-    needs: build  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
-    runs-on: ubuntu-22.04
-    container:
-      image: ardupilot/ardupilot-dev-base:v0.1.3
-      options: --privileged --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --security-opt seccomp=unconfined
-    strategy:
-      fail-fast: false  # don't cancel if a job from the matrix fails
-      matrix:
-        config: [
-            sitltest-tracker
-        ]
-
-    steps:
-      # git checkout the PR
-      - uses: actions/checkout@v6
-        with:
-          submodules: 'recursive'
-      - uses: ./.github/actions/setup-ccache
-        with:
           key-suffix: base
-      - name: test ${{matrix.config}}
+      - name: test sitltest-tracker
         env:
-          CI_BUILD_TARGET: ${{matrix.config}}
+          CI_BUILD_TARGET: sitltest-tracker
         shell: bash
         run: |
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
@@ -233,7 +210,7 @@ jobs:
         uses: actions/upload-artifact@v7
         if: failure()
         with:
-           name: ${{ github.workflow }}-fail-${{matrix.config}}
+           name: ${{ github.workflow }}-fail-sitltest-tracker
            path: |
              /tmp/buildlogs
              /__w/ardupilot/ardupilot/logs
@@ -246,7 +223,7 @@ jobs:
       - name: Archive .bin artifacts
         uses: actions/upload-artifact@v7
         with:
-           name: ${{ github.workflow }}-BIN-${{matrix.config}}
+           name: ${{ github.workflow }}-BIN-sitltest-tracker
            path: /__w/ardupilot/ardupilot/logs
            retention-days: 7
 

--- a/.github/workflows/test_size.yml
+++ b/.github/workflows/test_size.yml
@@ -127,6 +127,7 @@ jobs:
     container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.1.3
     permissions:
       contents: read
+      actions: write  # save-ccache deletes the previous cache entry before saving
     env:
       BASE_REF: ${{ github.event.pull_request.base.ref || inputs.base_ref || github.event.repository.default_branch }}
       BASE_REPO: ${{ github.event.pull_request.base.repo.full_name || inputs.base_repo || github.repository }}
@@ -155,27 +156,23 @@ jobs:
           - config: disco
             toolchain: chibios
     steps:
+      # Sparse checkout to make .github/actions/* available without a full clone
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          sparse-checkout: .github
+          sparse-checkout-cone-mode: false
       - uses: actions/checkout@v6
         with:
           ref: ${{ env.BASE_REF }}
           path: base_branch
           submodules: 'recursive'
           persist-credentials: false
-      # Put ccache into github cache for faster build
-      - name: Prepare ccache timestamp
-        id: ccache_cache_timestamp
-        run: |
-          NOW=$(date -u +"%F-%T")
-          echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
-      - name: ccache cache files
-        uses: actions/cache@v5
+
+      - uses: ./.github/actions/setup-ccache
         with:
-          path: ~/.ccache
-          key: ${{github.workflow}}-ccache-${{ matrix.toolchain }}-${{steps.ccache_cache_timestamp.outputs.timestamp}}
-          restore-keys: ${{github.workflow}}-ccache-${{ matrix.toolchain }}-  # restore ccache from either previous build on this branch or on base branch
-      - name: setup ccache
-        run: |
-          . base_branch/.github/workflows/ccache.env
+          key-suffix: ${{ matrix.toolchain }}
       - name: Build ${{ env.BASE_REF }} ${{matrix.config}} ${{ matrix.toolchain }}
         env:
           CI_BUILD_TARGET: ${{matrix.config}}
@@ -370,6 +367,10 @@ jobs:
           else
             echo "No differences found."
           fi
+
+      - uses: ./.github/actions/save-ccache
+        with:
+          key-suffix: ${{ matrix.toolchain }}
 
   global-summary:
     needs: build

--- a/.github/workflows/test_unit_tests.yml
+++ b/.github/workflows/test_unit_tests.yml
@@ -101,8 +101,14 @@ concurrency:
   group: ci-${{github.workflow}}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read  # checkout; jobs that save ccache add actions:write per-job
+
 jobs:
   build:
+    permissions:
+      contents: read
+      actions: write  # save-ccache prunes the previous cache entry
     runs-on: ubuntu-22.04
     container:
       image: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.1.3
@@ -124,21 +130,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: 'recursive'
-      # Put ccache into github cache for faster build
-      - name: Prepare ccache timestamp
-        id: ccache_cache_timestamp
-        run: |
-          NOW=$(date -u +"%F-%T")
-          echo "timestamp=${NOW}" >> $GITHUB_OUTPUT
-      - name: ccache cache files
-        uses: actions/cache@v5
+      - uses: ./.github/actions/setup-ccache
         with:
-          path: ~/.ccache
-          key: ${{github.workflow}}-ccache-${{ matrix.toolchain }}-${{steps.ccache_cache_timestamp.outputs.timestamp}}
-          restore-keys: ${{github.workflow}}-ccache-${{ matrix.toolchain }}-  # restore ccache from either previous build on this branch or on master
-      - name: setup ccache
-        run: |
-          . .github/workflows/ccache.env
+          key-suffix: ${{ matrix.toolchain }}-${{ matrix.config }}
       - name: test ${{matrix.config}} ${{ matrix.toolchain }}
         env:
           CI_BUILD_TARGET: ${{matrix.config}}
@@ -151,6 +145,9 @@ jobs:
           fi
           PATH="/github/home/.local/bin:$PATH"
           Tools/scripts/build_ci.sh
+      - uses: ./.github/actions/save-ccache
+        with:
+          key-suffix: ${{ matrix.toolchain }}-${{ matrix.config }}
 
       - name: Unittest extract_param_defaults
         env:


### PR DESCRIPTION
### Summary

cleanup and simplify cache management on CI

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

This bring multiple improvement : 
centralize cache into its own file, cygwin and colcon workflow have different change because of their shell and the path they are using tht prevent to use the composite file...

make cache key unique . This allow to have one key per jobs and not multiple the cache saving each push.  This bring a new issue, as github action cache are immuable so we canno't update them. Therefore we need to delete the old one's to push an update.

Change strategy to have cache save only on master branch. So all will restore the cache from master even on successive push on a PR. This come from the fact that we are limited to 10GB cache storage and we are over it in a days. When we pass 10GB, github delete the oldest and we don't want to lose the cache from the master branch. So we now only save the master branch cache.
On downside, it will make build, specially after a push, a bit slower are the reference will be only master. But this will solve the issue that most jobs are currently running without any cache to use. So on overall we are winning from consistancy.

having cache update on master with old cache deletion should allow us to have only 1 cache version for master on each job and not pass the 10GB

Fix the wrong flags on some tests

From this changes, we can track how much cache we need for master to store. 

If we can have some space left, we could enable cache passing on vehicle test suite as currently we got the build phase and then the autotest phase. But the autotest trigger a rebuild.... 
For this, we cannot use artifact passing as the limit is even lower than cache one's. The build phase was keept as it will prevent to run all the autotest job in case compilation doesn't pass. On some workflow (blimp, periph, sub, tracker), we had only one autotest job, so the build phase was removed as useless guard, this remove on build job.

This work was done with the help of Claude with carrefull planning and step progress resulting to those splitted commits