### PR TITLE
Add option bit to accept commands to any component, change default to ignoring

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -6614,6 +6614,51 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self._Parachute(self.run_cmd)
         self._Parachute(self.run_cmd_int)
 
+    def _ParachuteCommandForNonAutopilotComponent(self, command):
+        '''test parachute release addressed at another component'''
+        # 142 is an arbitrary component ID which is not the autopilot's.
+        # Messages addressed to another component are not acted upon by
+        # default, but parachute commands are an exception to that; we
+        # would much rather deploy than discard a mis-addressed release.
+        non_autopilot_compid = 142
+
+        self.set_rc(9, 1000)
+        self.set_parameters({
+            "CHUTE_ENABLED": 1,
+            "CHUTE_TYPE": 10,
+            "SERVO9_FUNCTION": 27,
+            "SIM_PARA_ENABLE": 1,
+            "SIM_PARA_PIN": 9,
+            # not left over from a previous pass through this test;
+            # RC9 low would otherwise disable the chute at each boot:
+            "RC9_OPTION": 0,
+        })
+
+        # show that this component ID really is being gated; an ordinary
+        # command sent to it is ignored:
+        self.drain_mav()
+        self.send_poll_message('AUTOPILOT_VERSION', target_compid=non_autopilot_compid)
+        self.assert_not_receive_message('AUTOPILOT_VERSION', timeout=5)
+
+        self.takeoff(20)
+        self.context_collect('STATUSTEXT')
+        command(
+            mavutil.mavlink.MAV_CMD_DO_PARACHUTE,
+            p1=mavutil.mavlink.PARACHUTE_RELEASE,
+            target_compid=non_autopilot_compid,
+        )
+        # check_context: the BANG can arrive while command() is still
+        # draining messages awaiting its COMMAND_ACK
+        self.wait_statustext('BANG', timeout=60, check_context=True)
+        self.context_stop_collecting('STATUSTEXT')
+        self.disarm_vehicle(force=True)
+        self.reboot_sitl()
+
+    def ParachuteCommandForNonAutopilotComponent(self):
+        '''Test parachute commands are acted on regardless of target component'''
+        self._ParachuteCommandForNonAutopilotComponent(self.run_cmd)
+        self._ParachuteCommandForNonAutopilotComponent(self.run_cmd_int)
+
     def PrecisionLanding(self):
         """Use PrecLand backends precision messages to land aircraft."""
 
@@ -16666,6 +16711,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
              self.SurfaceTracking2,
              self.SurfaceTrackingCornerCases,
              self.Parachute,
+             self.ParachuteCommandForNonAutopilotComponent,
              self.ParameterChecks,
              self.ManualThrottleModeChange,
              self.MANUAL_CONTROL,

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -8316,6 +8316,11 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
     def PreflightRebootComponent(self):
         '''Ensure that PREFLIGHT_REBOOT commands sent to components don't reboot Autopilot'''
+        # by default the routing code does not act on a command addressed
+        # to a component which is not the autopilot's, so opt in to acting
+        # on it to ensure the reboot handler itself still refuses to reboot
+        # the autopilot:
+        self.set_parameter("MAV_OPTIONS", 1 << 1)  # ACCEPT_MESSAGES_FOR_OTHER_COMPONENTS
         self.run_cmd_int(
             mavutil.mavlink.MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN,
             p1=1, # Reboot autopilot

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -9246,6 +9246,11 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
     def PreflightRebootComponent(self):
         '''Ensure that PREFLIGHT_REBOOT commands sent to components don't reboot Autopilot'''
+        # by default the routing code does not act on a command addressed
+        # to a component which is not the autopilot's, so opt in to acting
+        # on it to ensure the reboot handler itself still refuses to reboot
+        # the autopilot:
+        self.set_parameter("MAV_OPTIONS", 1 << 1)  # ACCEPT_COMMANDS_FOR_OTHER_COMPONENTS
         self.run_cmd_int(
             mavutil.mavlink.MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN,
             p1=1, # Reboot autopilot

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -7594,7 +7594,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self._MAV_CMD_DO_GO_AROUND(self.run_cmd)
         self._MAV_CMD_DO_GO_AROUND(self.run_cmd_int)
 
-    def _MAV_CMD_DO_FLIGHTTERMINATION(self, command):
+    def _MAV_CMD_DO_FLIGHTTERMINATION(self, command, target_compid=None):
         self.set_parameters({
             "AFS_ENABLE": 1,
             "MAV_GCS_SYSID": self.mav.source_system,
@@ -7605,7 +7605,8 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.wait_ready_to_arm()
         self.arm_vehicle()
         self.context_collect('STATUSTEXT')
-        command(mavutil.mavlink.MAV_CMD_DO_FLIGHTTERMINATION, p1=1)
+        command(mavutil.mavlink.MAV_CMD_DO_FLIGHTTERMINATION, p1=1,
+                target_compid=target_compid)
         self.wait_disarmed()
         self.wait_text('Terminating due to GCS request', check_context=True)
         self.reboot_sitl()
@@ -7614,6 +7615,24 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         '''test MAV_CMD_DO_FLIGHTTERMINATION works on Plane'''
         self._MAV_CMD_DO_FLIGHTTERMINATION(self.run_cmd)
         self._MAV_CMD_DO_FLIGHTTERMINATION(self.run_cmd_int)
+
+    def MAV_CMD_DO_FLIGHTTERMINATION_for_other_component(self):
+        '''test MAV_CMD_DO_FLIGHTTERMINATION is acted on when addressed at another component'''
+        # 142 is an arbitrary component ID which is not the autopilot's.
+        # Commands addressed to another component are not acted upon by
+        # default; terminating the flight is an exception, as losing a
+        # termination command is worse than acting on one which was meant
+        # for somebody else.
+        non_autopilot_compid = 142
+
+        # show that this component ID really is being gated; an ordinary
+        # command sent to it is ignored:
+        self.drain_mav()
+        self.send_poll_message('AUTOPILOT_VERSION', target_compid=non_autopilot_compid)
+        self.assert_not_receive_message('AUTOPILOT_VERSION', timeout=5)
+
+        self._MAV_CMD_DO_FLIGHTTERMINATION(self.run_cmd, target_compid=non_autopilot_compid)
+        self._MAV_CMD_DO_FLIGHTTERMINATION(self.run_cmd_int, target_compid=non_autopilot_compid)
 
     def MAV_CMD_DO_FLIGHTTERMINATION_unterminate(self):
         '''unterminate a terminated vehicle'''
@@ -9487,6 +9506,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.MAV_CMD_DO_AUTOTUNE_ENABLE,
             self.MAV_CMD_DO_GO_AROUND,
             self.MAV_CMD_DO_FLIGHTTERMINATION,
+            self.MAV_CMD_DO_FLIGHTTERMINATION_for_other_component,
             self.MAV_CMD_DO_FLIGHTTERMINATION_unterminate,
             self.MAV_CMD_DO_LAND_START,
             self.MAV_CMD_NAV_ALTITUDE_WAIT,

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -6511,6 +6511,9 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         # AUTOPILOT_VERSION in response to MAV_CMD_REQUEST_MESSAGE.
         non_autopilot_compid = 142
 
+        # opt in to acting on messages addressed to other components:
+        self.set_parameter("MAV_OPTIONS", 1 << 1)  # ACCEPT_MESSAGES_FOR_OTHER_COMPONENTS
+
         self.drain_mav()
         self.send_poll_message('AUTOPILOT_VERSION', target_compid=non_autopilot_compid)
         m = self.assert_receive_message('AUTOPILOT_VERSION', timeout=10)
@@ -6525,6 +6528,16 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 "AUTOPILOT_VERSION came from %u/%u (want %u/%u)" %
                 (m.get_srcSystem(), m.get_srcComponent(),
                  self.sysid_thismav(), mavutil.mavlink.MAV_COMP_ID_AUTOPILOT1))
+
+    def CommandForNonAutopilotComponentIgnored(self):
+        '''ensure a command addressed to a non-autopilot component is ignored by default'''
+        # without MAV_OPTIONS ACCEPT_MESSAGES_FOR_OTHER_COMPONENTS the
+        # autopilot does not act on a command addressed to a component
+        # which is not its own, so no AUTOPILOT_VERSION is emitted:
+        non_autopilot_compid = 142
+        self.drain_mav()
+        self.send_poll_message('AUTOPILOT_VERSION', target_compid=non_autopilot_compid)
+        self.assert_not_receive_message('AUTOPILOT_VERSION', timeout=5)
 
     def MAV_CMD_DO_SET_REVERSE(self):
         '''test MAV_CMD_DO_SET_REVERSE command'''
@@ -7605,6 +7618,7 @@ return update()
             self.BeaconPosition,
             self.PrivateChannel,
             self.CommandForNonAutopilotComponent,
+            self.CommandForNonAutopilotComponentIgnored,
             self.GCSFailsafe,
             self.RoverInitialMode,
             self.DriveMaxRCIN,

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -6503,6 +6503,29 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             # both the vehicle and this tests's special heartbeat
             raise NotAchievedException("Got heartbeat on private channel from non-vehicle")
 
+    def CommandForNonAutopilotComponent(self):
+        '''ensure a command sent to a component which isn't the autopilot is still handled'''
+        # 142 is an arbitrary component ID which the autopilot does not
+        # know a route to.  As nothing else claims the message the
+        # autopilot processes it locally; here we show it emits
+        # AUTOPILOT_VERSION in response to MAV_CMD_REQUEST_MESSAGE.
+        non_autopilot_compid = 142
+
+        self.drain_mav()
+        self.send_poll_message('AUTOPILOT_VERSION', target_compid=non_autopilot_compid)
+        m = self.assert_receive_message('AUTOPILOT_VERSION', timeout=10)
+        # assert current behaviour: the AUTOPILOT_VERSION reply is stamped
+        # with the autopilot's own system and component IDs even though the
+        # command was addressed to a different component.  Arguably it
+        # should come from the targeted component, but this is existing
+        # behaviour and is not something we fix here.
+        if (m.get_srcSystem() != self.sysid_thismav() or
+                m.get_srcComponent() != mavutil.mavlink.MAV_COMP_ID_AUTOPILOT1):
+            raise NotAchievedException(
+                "AUTOPILOT_VERSION came from %u/%u (want %u/%u)" %
+                (m.get_srcSystem(), m.get_srcComponent(),
+                 self.sysid_thismav(), mavutil.mavlink.MAV_COMP_ID_AUTOPILOT1))
+
     def MAV_CMD_DO_SET_REVERSE(self):
         '''test MAV_CMD_DO_SET_REVERSE command'''
         self.change_mode('GUIDED')
@@ -7581,6 +7604,7 @@ return update()
             self.AutoDock,
             self.BeaconPosition,
             self.PrivateChannel,
+            self.CommandForNonAutopilotComponent,
             self.GCSFailsafe,
             self.RoverInitialMode,
             self.DriveMaxRCIN,

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -6539,6 +6539,30 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.send_poll_message('AUTOPILOT_VERSION', target_compid=non_autopilot_compid)
         self.assert_not_receive_message('AUTOPILOT_VERSION', timeout=5)
 
+    def ParamSetForNonAutopilotComponent(self):
+        '''ensure a PARAM_SET addressed to a non-autopilot component is ignored'''
+        # a PARAM_SET is not a command, so this shows the component gating
+        # covers more than just COMMAND_INT/COMMAND_LONG: a parameter set
+        # addressed to a component which is not the autopilot's must not be
+        # acted upon.
+        non_autopilot_compid = 142
+        param = "CRUISE_SPEED"
+        original = self.get_parameter(param)
+        self.drain_mav()
+        self.mav.mav.param_set_send(
+            self.sysid_thismav(),
+            non_autopilot_compid,
+            param.encode('ascii'),
+            original + 1,
+            mavutil.mavlink.MAV_PARAM_TYPE_REAL32)
+        self.delay_sim_time(2)
+        current = self.get_parameter(param)
+        if abs(current - original) > 0.0001:
+            raise NotAchievedException(
+                "PARAM_SET addressed to component %u was acted upon "
+                "(%s changed %f -> %f)" %
+                (non_autopilot_compid, param, original, current))
+
     def MAV_CMD_DO_SET_REVERSE(self):
         '''test MAV_CMD_DO_SET_REVERSE command'''
         self.change_mode('GUIDED')
@@ -7619,6 +7643,7 @@ return update()
             self.PrivateChannel,
             self.CommandForNonAutopilotComponent,
             self.CommandForNonAutopilotComponentIgnored,
+            self.ParamSetForNonAutopilotComponent,
             self.GCSFailsafe,
             self.RoverInitialMode,
             self.DriveMaxRCIN,

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -6512,6 +6512,29 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             # both the vehicle and this tests's special heartbeat
             raise NotAchievedException("Got heartbeat on private channel from non-vehicle")
 
+    def CommandForNonAutopilotComponent(self):
+        '''ensure a command sent to a component which isn't the autopilot is still handled'''
+        # 142 is an arbitrary component ID which the autopilot does not
+        # know a route to.  As nothing else claims the message the
+        # autopilot processes it locally; here we show it emits
+        # AUTOPILOT_VERSION in response to MAV_CMD_REQUEST_MESSAGE.
+        non_autopilot_compid = 142
+
+        self.drain_mav()
+        self.send_poll_message('AUTOPILOT_VERSION', target_compid=non_autopilot_compid)
+        m = self.assert_receive_message('AUTOPILOT_VERSION', timeout=10)
+        # assert current behaviour: the AUTOPILOT_VERSION reply is stamped
+        # with the autopilot's own system and component IDs even though the
+        # command was addressed to a different component.  Arguably it
+        # should come from the targeted component, but this is existing
+        # behaviour and is not something we fix here.
+        if (m.get_srcSystem() != self.sysid_thismav() or
+                m.get_srcComponent() != mavutil.mavlink.MAV_COMP_ID_AUTOPILOT1):
+            raise NotAchievedException(
+                "AUTOPILOT_VERSION came from %u/%u (want %u/%u)" %
+                (m.get_srcSystem(), m.get_srcComponent(),
+                 self.sysid_thismav(), mavutil.mavlink.MAV_COMP_ID_AUTOPILOT1))
+
     def MAV_CMD_DO_SET_REVERSE(self):
         '''test MAV_CMD_DO_SET_REVERSE command'''
         self.change_mode('GUIDED')
@@ -7614,6 +7637,7 @@ return update()
             self.AutoDock,
             self.BeaconPosition,
             self.PrivateChannel,
+            self.CommandForNonAutopilotComponent,
             self.GCSFailsafe,
             self.RoverInitialMode,
             self.DriveMaxRCIN,

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -6538,6 +6538,16 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 (m.get_srcSystem(), m.get_srcComponent(),
                  self.sysid_thismav(), mavutil.mavlink.MAV_COMP_ID_AUTOPILOT1))
 
+    def CommandForNonAutopilotComponentIgnored(self):
+        '''ensure a command addressed to a non-autopilot component is ignored by default'''
+        # without MAV_OPTIONS ACCEPT_COMMANDS_FOR_OTHER_COMPONENTS the
+        # autopilot does not act on a command addressed to a component
+        # which is not its own, so no AUTOPILOT_VERSION is emitted:
+        non_autopilot_compid = 142
+        self.drain_mav()
+        self.send_poll_message('AUTOPILOT_VERSION', target_compid=non_autopilot_compid)
+        self.assert_not_receive_message('AUTOPILOT_VERSION', timeout=5)
+
     def MAV_CMD_DO_SET_REVERSE(self):
         '''test MAV_CMD_DO_SET_REVERSE command'''
         self.change_mode('GUIDED')
@@ -7641,6 +7651,7 @@ return update()
             self.BeaconPosition,
             self.PrivateChannel,
             self.CommandForNonAutopilotComponent,
+            self.CommandForNonAutopilotComponentIgnored,
             self.GCSFailsafe,
             self.RoverInitialMode,
             self.DriveMaxRCIN,

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -6617,6 +6617,33 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         # follows this one, so lose it:
         self.reboot_sitl()
 
+    def ParamSetForNonAutopilotComponent(self):
+        '''ensure a PARAM_SET addressed to a non-autopilot component is ignored'''
+        # a PARAM_SET is not a command, so this shows the component gating
+        # covers more than just COMMAND_INT/COMMAND_LONG: a parameter set
+        # addressed to a component which is not the autopilot's must not be
+        # acted upon.
+        non_autopilot_compid = 142
+        param = "CRUISE_SPEED"
+        # the PARAM_SET is sent directly, so the context does not know to
+        # put the parameter back if it is acted upon:
+        self.context_preserve_parameters([param])
+        original = self.get_parameter(param)
+        self.drain_mav()
+        self.mav.mav.param_set_send(
+            self.sysid_thismav(),
+            non_autopilot_compid,
+            param.encode('ascii'),
+            original + 1,
+            mavutil.mavlink.MAV_PARAM_TYPE_REAL32)
+        self.delay_sim_time(2, reason="any PARAM_SET to be acted upon")
+        current = self.get_parameter(param)
+        if abs(current - original) > 0.0001:
+            raise NotAchievedException(
+                "PARAM_SET addressed to component %u was acted upon "
+                "(%s changed %f -> %f)" %
+                (non_autopilot_compid, param, original, current))
+
     def MAV_CMD_DO_SET_REVERSE(self):
         '''test MAV_CMD_DO_SET_REVERSE command'''
         self.change_mode('GUIDED')
@@ -7722,6 +7749,7 @@ return update()
             self.CommandForNonAutopilotComponent,
             self.CommandForNonAutopilotComponentIgnored,
             self.CommandForNonAutopilotComponentBroadcastSystem,
+            self.ParamSetForNonAutopilotComponent,
             self.GCSFailsafe,
             self.RoverInitialMode,
             self.DriveMaxRCIN,

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -6644,6 +6644,148 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 "(%s changed %f -> %f)" %
                 (non_autopilot_compid, param, original, current))
 
+    def ComponentAgnosticCommandRouting(self):
+        '''safety commands for another component are acted on only when we have no route to that component'''
+        # parachute and flight-termination commands addressed to another
+        # component are acted upon unless we send them on to that
+        # component; if we do know a route to it then the command is
+        # forwarded there and we keep out of it.  Neither command does
+        # anything much on Rover - the ACK is what is being tested here,
+        # as it shows the command reached a handler.
+        non_autopilot_compid = 142
+        other_compid = mavutil.mavlink.MAV_COMP_ID_ONBOARD_COMPUTER
+        commands = [
+            mavutil.mavlink.MAV_CMD_DO_PARACHUTE,
+            mavutil.mavlink.MAV_CMD_DO_FLIGHTTERMINATION,
+        ]
+        # both addressed to our system and to all systems:
+        target_sysids = [self.sysid_thismav(), 0]
+
+        def command_name(command):
+            return mavutil.mavlink.enums["MAV_CMD"][command].name
+
+        def assert_acted_upon(command):
+            self.assert_receive_message(
+                'COMMAND_ACK',
+                timeout=5,
+                condition='COMMAND_ACK.command==%u' % command)
+
+        def assert_not_acted_upon(command):
+            self.assert_not_receive_message(
+                'COMMAND_ACK',
+                timeout=5,
+                condition='COMMAND_ACK.command==%u' % command)
+
+        def assert_forwarded(command):
+            self.assert_receive_message(
+                'COMMAND_LONG',
+                mav=mav2,
+                timeout=5,
+                condition='COMMAND_LONG.command==%u' % command)
+
+        for target_sysid in target_sysids:
+            for command in commands:
+                self.progress("%s for %u/%u with no routes" %
+                              (command_name(command), target_sysid, non_autopilot_compid))
+                self.drain_mav()
+                self.send_cmd(command, target_sysid=target_sysid, target_compid=non_autopilot_compid)
+                assert_acted_upon(command)
+
+        # bring up a link with a different component on it.  Messages
+        # for all systems are forwarded there, but that is not the
+        # component the commands are addressed to:
+        mav2 = mavutil.mavlink_connection(self.sitl_serial_endpoint(2),
+                                          robust_parsing=True,
+                                          source_system=self.sysid_thismav(),
+                                          source_component=other_compid)
+
+        # MAV_CMD_DO_SET_REVERSE is not one of the commands we act on
+        # for other components.  One addressed to a component of ours
+        # is forwarded only to that component, one addressed to all
+        # systems is forwarded to every route; so the autopilot
+        # forwarding one tells us the route we want has been learned:
+        probe_command = mavutil.mavlink.MAV_CMD_DO_SET_REVERSE
+
+        def learn_route(compid, probe_sysid, sysid=None):
+            if sysid is None:
+                sysid = self.sysid_thismav()
+            mav2.mav.srcSystem = sysid
+            mav2.mav.srcComponent = compid
+            # don't mistake a probe forwarded earlier for a new one:
+            self.drain_mav(mav2)
+            tstart = self.get_sim_time()
+            while True:
+                if self.get_sim_time_cached() - tstart > 30:
+                    raise NotAchievedException("No route learned to component %u" % compid)
+                mav2.mav.heartbeat_send(
+                    mavutil.mavlink.MAV_TYPE_ONBOARD_CONTROLLER,
+                    mavutil.mavlink.MAV_AUTOPILOT_INVALID,
+                    0,
+                    0,
+                    0)
+                self.send_cmd(probe_command,
+                              target_sysid=probe_sysid,
+                              target_compid=non_autopilot_compid,
+                              quiet=True)
+                m = mav2.recv_match(type='COMMAND_LONG', blocking=True, timeout=1)
+                if m is not None and m.command == probe_command:
+                    break
+            self.progress("Route to component %u learned" % compid)
+
+        learn_route(other_compid, 0)
+
+        for target_sysid in target_sysids:
+            for command in commands:
+                self.progress("%s for %u/%u with a route only to component %u" %
+                              (command_name(command), target_sysid, non_autopilot_compid, other_compid))
+                self.drain_mav()
+                self.drain_mav(mav2)
+                self.send_cmd(command, target_sysid=target_sysid, target_compid=non_autopilot_compid)
+                if target_sysid == 0:
+                    # a command for all systems goes to every route...
+                    assert_forwarded(command)
+                # ... but the addressed component has not been sent it,
+                # so we must act on it:
+                assert_acted_upon(command)
+
+        # now have a component with the addressed ID appear on that link,
+        # but on another system.  A command for all systems is forwarded
+        # to it, but it is not our component, so we must still act on it:
+        other_sysid = self.sysid_thismav() + 1
+        learn_route(non_autopilot_compid, other_sysid, sysid=other_sysid)
+
+        for target_sysid in target_sysids:
+            for command in commands:
+                self.progress("%s for %u/%u with a route only to component %u of system %u" %
+                              (command_name(command), target_sysid, non_autopilot_compid, non_autopilot_compid, other_sysid))
+                self.drain_mav()
+                self.drain_mav(mav2)
+                self.send_cmd(command, target_sysid=target_sysid, target_compid=non_autopilot_compid)
+                if target_sysid == 0:
+                    assert_forwarded(command)
+                assert_acted_upon(command)
+
+        # now have the addressed component itself appear on that link:
+        learn_route(non_autopilot_compid, self.sysid_thismav())
+
+        for target_sysid in target_sysids:
+            for command in commands:
+                self.progress("%s for %u/%u with a route to component %u" %
+                              (command_name(command), target_sysid, non_autopilot_compid, non_autopilot_compid))
+                self.drain_mav()
+                self.drain_mav(mav2)
+                self.send_cmd(command, target_sysid=target_sysid, target_compid=non_autopilot_compid)
+                # the command must be forwarded to the component it was
+                # addressed to....
+                assert_forwarded(command)
+                # ... and must not have been acted upon by the autopilot:
+                assert_not_acted_upon(command)
+
+        mav2.close()
+        # the learned routes would change the behaviour of any test
+        # which follows this one, so lose them:
+        self.reboot_sitl()
+
     def MAV_CMD_DO_SET_REVERSE(self):
         '''test MAV_CMD_DO_SET_REVERSE command'''
         self.change_mode('GUIDED')
@@ -7750,6 +7892,7 @@ return update()
             self.CommandForNonAutopilotComponentIgnored,
             self.CommandForNonAutopilotComponentBroadcastSystem,
             self.ParamSetForNonAutopilotComponent,
+            self.ComponentAgnosticCommandRouting,
             self.GCSFailsafe,
             self.RoverInitialMode,
             self.DriveMaxRCIN,

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -6548,6 +6548,75 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.send_poll_message('AUTOPILOT_VERSION', target_compid=non_autopilot_compid)
         self.assert_not_receive_message('AUTOPILOT_VERSION', timeout=5)
 
+    def CommandForNonAutopilotComponentBroadcastSystem(self):
+        '''commands for all systems addressed to another component are acted on only if MAV_OPTIONS says so'''
+        # a message addressed to all systems is forwarded to every
+        # route we know.  Historically it was also processed locally
+        # whatever component it was addressed to, forwarded or not.  By
+        # default we no longer act on one addressed to a component which
+        # is not ours, but MAV_OPTIONS ACCEPT_COMMANDS_FOR_OTHER_COMPONENTS
+        # must restore the old behaviour - including when the message
+        # was forwarded.
+        non_autopilot_compid = 142
+
+        # bring up a link with another component on it, so the
+        # autopilot has a route to forward messages for all systems to:
+        mav2 = mavutil.mavlink_connection(self.sitl_serial_endpoint(2),
+                                          robust_parsing=True,
+                                          source_system=self.sysid_thismav(),
+                                          source_component=mavutil.mavlink.MAV_COMP_ID_ONBOARD_COMPUTER)
+
+        request_message = mavutil.mavlink.MAV_CMD_REQUEST_MESSAGE
+
+        def send_poll():
+            self.send_poll_message('AUTOPILOT_VERSION',
+                                   target_sysid=0,
+                                   target_compid=non_autopilot_compid,
+                                   quiet=True)
+
+        def assert_forwarded():
+            self.assert_receive_message(
+                'COMMAND_LONG',
+                mav=mav2,
+                timeout=5,
+                condition='COMMAND_LONG.command==%u' % request_message)
+
+        tstart = self.get_sim_time()
+        while True:
+            if self.get_sim_time_cached() - tstart > 30:
+                raise NotAchievedException("No route learned to link 2")
+            mav2.mav.heartbeat_send(
+                mavutil.mavlink.MAV_TYPE_ONBOARD_CONTROLLER,
+                mavutil.mavlink.MAV_AUTOPILOT_INVALID,
+                0,
+                0,
+                0)
+            send_poll()
+            m = mav2.recv_match(type='COMMAND_LONG', blocking=True, timeout=1)
+            if m is not None and m.command == request_message:
+                break
+        self.progress("Route to link 2 learned")
+
+        self.progress("Default: forwarded but not acted upon")
+        self.drain_mav()
+        self.drain_mav(mav2)
+        send_poll()
+        assert_forwarded()
+        self.assert_not_receive_message('AUTOPILOT_VERSION', timeout=5)
+
+        self.progress("ACCEPT_COMMANDS_FOR_OTHER_COMPONENTS: forwarded and acted upon")
+        self.set_parameter("MAV_OPTIONS", 1 << 1)  # ACCEPT_COMMANDS_FOR_OTHER_COMPONENTS
+        self.drain_mav()
+        self.drain_mav(mav2)
+        send_poll()
+        assert_forwarded()
+        self.assert_receive_message('AUTOPILOT_VERSION', timeout=5)
+
+        mav2.close()
+        # the learned route would change the behaviour of any test which
+        # follows this one, so lose it:
+        self.reboot_sitl()
+
     def MAV_CMD_DO_SET_REVERSE(self):
         '''test MAV_CMD_DO_SET_REVERSE command'''
         self.change_mode('GUIDED')
@@ -7652,6 +7721,7 @@ return update()
             self.PrivateChannel,
             self.CommandForNonAutopilotComponent,
             self.CommandForNonAutopilotComponentIgnored,
+            self.CommandForNonAutopilotComponentBroadcastSystem,
             self.GCSFailsafe,
             self.RoverInitialMode,
             self.DriveMaxRCIN,

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -6520,6 +6520,9 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         # AUTOPILOT_VERSION in response to MAV_CMD_REQUEST_MESSAGE.
         non_autopilot_compid = 142
 
+        # opt in to acting on messages addressed to other components:
+        self.set_parameter("MAV_OPTIONS", 1 << 1)  # ACCEPT_COMMANDS_FOR_OTHER_COMPONENTS
+
         self.drain_mav()
         self.send_poll_message('AUTOPILOT_VERSION', target_compid=non_autopilot_compid)
         m = self.assert_receive_message('AUTOPILOT_VERSION', timeout=10)

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -6878,6 +6878,50 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 # neither acted on nor discarded:
                 self.assert_no_other_component_warning(command, non_autopilot_compid)
 
+        # now send the commands from a GCS on the same link as the
+        # addressed component.  That component has already been sent the
+        # command by the link itself, and we never forward a message back
+        # out of the link it arrived on, so as far as we know nothing else
+        # will receive it: we act on it as well.
+        mav2.mav.srcSystem = self.mav.mav.srcSystem
+        mav2.mav.srcComponent = self.mav.mav.srcComponent
+        for target_sysid in target_sysids:
+            for command in commands:
+                self.progress("%s for %u/%u from the link with the only route to component %u" %
+                              (command_name(command), target_sysid, non_autopilot_compid, non_autopilot_compid))
+                self.expire_other_component_warning_rate_limit()
+                self.drain_mav()
+                self.drain_mav(mav2)
+                self.send_cmd(command,
+                              target_sysid=target_sysid,
+                              target_compid=non_autopilot_compid,
+                              mav=mav2)
+                self.assert_receive_message(
+                    'COMMAND_ACK',
+                    mav=mav2,
+                    timeout=5,
+                    condition='COMMAND_ACK.command==%u' % command)
+                assert_acting_warning(command)
+
+        # any other command from that link for that component is ignored,
+        # but the component has been sent it by the link, so there is
+        # nothing to warn about:
+        for target_sysid in target_sysids:
+            self.progress("%s for %u/%u from the link with the only route to component %u" %
+                          (command_name(probe_command), target_sysid, non_autopilot_compid, non_autopilot_compid))
+            self.expire_other_component_warning_rate_limit()
+            self.drain_mav(mav2)
+            self.send_cmd(probe_command,
+                          target_sysid=target_sysid,
+                          target_compid=non_autopilot_compid,
+                          mav=mav2)
+            self.assert_not_receive_message(
+                'COMMAND_ACK',
+                mav=mav2,
+                timeout=5,
+                condition='COMMAND_ACK.command==%u' % probe_command)
+            self.assert_no_other_component_warning(probe_command, non_autopilot_compid)
+
         self.context_stop_collecting('STATUSTEXT')
 
         mav2.close()

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -6512,6 +6512,21 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             # both the vehicle and this tests's special heartbeat
             raise NotAchievedException("Got heartbeat on private channel from non-vehicle")
 
+    def expire_other_component_warning_rate_limit(self):
+        '''the warning about a command for another component is sent at
+        most once every 10 seconds; wait that out, so that whether the
+        next such command is warned about means something'''
+        # the extra second allows for our idea of the simulation time
+        # lagging the autopilot's
+        self.delay_sim_time(11, reason="other-component warning rate limit to expire")
+        self.context_clear_collection('STATUSTEXT')
+
+    def assert_no_other_component_warning(self, command, compid):
+        '''assert we have not been warned about command for compid (either acting on or ignoring it)'''
+        self.delay_sim_time(2, reason="any warning to arrive")
+        if self.statustext_in_collections("cmd %u for compid %u" % (command, compid)):
+            raise NotAchievedException("Warned about cmd %u for compid %u" % (command, compid))
+
     def CommandForNonAutopilotComponent(self):
         '''ensure a command sent to a component which isn't the autopilot is still handled'''
         # 142 is an arbitrary component ID which the autopilot does not
@@ -6523,9 +6538,15 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         # opt in to acting on messages addressed to other components:
         self.set_parameter("MAV_OPTIONS", 1 << 1)  # ACCEPT_COMMANDS_FOR_OTHER_COMPONENTS
 
+        self.context_collect('STATUSTEXT')
+        self.expire_other_component_warning_rate_limit()
         self.drain_mav()
         self.send_poll_message('AUTOPILOT_VERSION', target_compid=non_autopilot_compid)
         m = self.assert_receive_message('AUTOPILOT_VERSION', timeout=10)
+        # we have been told to expect such commands, so acting on one is
+        # not warned about:
+        self.assert_no_other_component_warning(mavutil.mavlink.MAV_CMD_REQUEST_MESSAGE, non_autopilot_compid)
+        self.context_stop_collecting('STATUSTEXT')
         # assert current behaviour: the AUTOPILOT_VERSION reply is stamped
         # with the autopilot's own system and component IDs even though the
         # command was addressed to a different component.  Arguably it
@@ -6544,9 +6565,28 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         # autopilot does not act on a command addressed to a component
         # which is not its own, so no AUTOPILOT_VERSION is emitted:
         non_autopilot_compid = 142
+        warning = "ignoring cmd %u for compid %u" % (mavutil.mavlink.MAV_CMD_REQUEST_MESSAGE, non_autopilot_compid)
+        self.context_collect('STATUSTEXT')
+        self.expire_other_component_warning_rate_limit()
         self.drain_mav()
         self.send_poll_message('AUTOPILOT_VERSION', target_compid=non_autopilot_compid)
+        # discarding a command for another component is warned about:
+        self.wait_statustext(warning, timeout=5, check_context=True)
+
+        # ... but not every time; a second one straight away is not.
+        # Send it before checking the first was not acted upon, as the
+        # rate limit is only 10 seconds long:
+        self.context_clear_collection('STATUSTEXT')
+        self.send_poll_message('AUTOPILOT_VERSION', target_compid=non_autopilot_compid)
+        # neither poll was acted upon:
         self.assert_not_receive_message('AUTOPILOT_VERSION', timeout=5)
+        self.assert_no_other_component_warning(mavutil.mavlink.MAV_CMD_REQUEST_MESSAGE, non_autopilot_compid)
+
+        # ... until the rate limit has expired:
+        self.expire_other_component_warning_rate_limit()
+        self.send_poll_message('AUTOPILOT_VERSION', target_compid=non_autopilot_compid)
+        self.wait_statustext(warning, timeout=5, check_context=True)
+        self.context_stop_collecting('STATUSTEXT')
 
     def CommandForNonAutopilotComponentBroadcastSystem(self):
         '''commands for all systems addressed to another component are acted on only if MAV_OPTIONS says so'''
@@ -6597,20 +6637,35 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 break
         self.progress("Route to link 2 learned")
 
+        # polls sent before the route was learned were discarded, and
+        # warned about; don't let those warnings be collected below, nor
+        # the rate limit hide a warning we should not get:
+        self.context_collect('STATUSTEXT')
+        self.expire_other_component_warning_rate_limit()
+
         self.progress("Default: forwarded but not acted upon")
         self.drain_mav()
         self.drain_mav(mav2)
         send_poll()
         assert_forwarded()
         self.assert_not_receive_message('AUTOPILOT_VERSION', timeout=5)
+        # it was forwarded, but not to the component it is addressed to,
+        # so as far as we know nothing acted on it; that is warned about:
+        self.wait_statustext("ignoring cmd %u for compid %u" % (request_message, non_autopilot_compid),
+                             timeout=5,
+                             check_context=True)
 
         self.progress("ACCEPT_COMMANDS_FOR_OTHER_COMPONENTS: forwarded and acted upon")
         self.set_parameter("MAV_OPTIONS", 1 << 1)  # ACCEPT_COMMANDS_FOR_OTHER_COMPONENTS
+        self.expire_other_component_warning_rate_limit()
         self.drain_mav()
         self.drain_mav(mav2)
         send_poll()
         assert_forwarded()
         self.assert_receive_message('AUTOPILOT_VERSION', timeout=5)
+        # MAV_OPTIONS told us to act on it, so that is not warned about:
+        self.assert_no_other_component_warning(request_message, non_autopilot_compid)
+        self.context_stop_collecting('STATUSTEXT')
 
         mav2.close()
         # the learned route would change the behaviour of any test which
@@ -6629,6 +6684,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         # put the parameter back if it is acted upon:
         self.context_preserve_parameters([param])
         original = self.get_parameter(param)
+        self.context_collect('STATUSTEXT')
+        self.expire_other_component_warning_rate_limit()
         self.drain_mav()
         self.mav.mav.param_set_send(
             self.sysid_thismav(),
@@ -6636,6 +6693,13 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             param.encode('ascii'),
             original + 1,
             mavutil.mavlink.MAV_PARAM_TYPE_REAL32)
+        # discarding a message for another component is warned about,
+        # commands or not:
+        self.wait_statustext("ignoring msg %u for compid %u" %
+                             (mavutil.mavlink.MAVLINK_MSG_ID_PARAM_SET, non_autopilot_compid),
+                             timeout=5,
+                             check_context=True)
+        self.context_stop_collecting('STATUSTEXT')
         self.delay_sim_time(2, reason="any PARAM_SET to be acted upon")
         current = self.get_parameter(param)
         if abs(current - original) > 0.0001:
@@ -6683,13 +6747,38 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 timeout=5,
                 condition='COMMAND_LONG.command==%u' % command)
 
+        self.context_collect('STATUSTEXT')
+
+        def assert_acting_warning(command):
+            # acting on a command for another component is warned about:
+            self.wait_statustext("acting on cmd %u for compid %u" % (command, non_autopilot_compid),
+                                 timeout=5,
+                                 check_context=True)
+
+        # acting on and discarding a message are rate limited separately;
+        # a stream of messages being discarded must not hide our acting on
+        # one of these commands:
+        self.progress("Warning about ignoring a command does not hide acting on one")
+        self.expire_other_component_warning_rate_limit()
+        self.drain_mav()
+        self.send_poll_message('AUTOPILOT_VERSION', target_compid=non_autopilot_compid)
+        self.wait_statustext("ignoring cmd %u for compid %u" %
+                             (mavutil.mavlink.MAV_CMD_REQUEST_MESSAGE, non_autopilot_compid),
+                             timeout=5,
+                             check_context=True)
+        self.send_cmd(commands[0], target_compid=non_autopilot_compid)
+        assert_acted_upon(commands[0])
+        assert_acting_warning(commands[0])
+
         for target_sysid in target_sysids:
             for command in commands:
                 self.progress("%s for %u/%u with no routes" %
                               (command_name(command), target_sysid, non_autopilot_compid))
+                self.expire_other_component_warning_rate_limit()
                 self.drain_mav()
                 self.send_cmd(command, target_sysid=target_sysid, target_compid=non_autopilot_compid)
                 assert_acted_upon(command)
+                assert_acting_warning(command)
 
         # bring up a link with a different component on it.  Messages
         # for all systems are forwarded there, but that is not the
@@ -6738,6 +6827,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             for command in commands:
                 self.progress("%s for %u/%u with a route only to component %u" %
                               (command_name(command), target_sysid, non_autopilot_compid, other_compid))
+                self.expire_other_component_warning_rate_limit()
                 self.drain_mav()
                 self.drain_mav(mav2)
                 self.send_cmd(command, target_sysid=target_sysid, target_compid=non_autopilot_compid)
@@ -6747,6 +6837,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 # ... but the addressed component has not been sent it,
                 # so we must act on it:
                 assert_acted_upon(command)
+                assert_acting_warning(command)
 
         # now have a component with the addressed ID appear on that link,
         # but on another system.  A command for all systems is forwarded
@@ -6758,12 +6849,14 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             for command in commands:
                 self.progress("%s for %u/%u with a route only to component %u of system %u" %
                               (command_name(command), target_sysid, non_autopilot_compid, non_autopilot_compid, other_sysid))
+                self.expire_other_component_warning_rate_limit()
                 self.drain_mav()
                 self.drain_mav(mav2)
                 self.send_cmd(command, target_sysid=target_sysid, target_compid=non_autopilot_compid)
                 if target_sysid == 0:
                     assert_forwarded(command)
                 assert_acted_upon(command)
+                assert_acting_warning(command)
 
         # now have the addressed component itself appear on that link:
         learn_route(non_autopilot_compid, self.sysid_thismav())
@@ -6772,6 +6865,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             for command in commands:
                 self.progress("%s for %u/%u with a route to component %u" %
                               (command_name(command), target_sysid, non_autopilot_compid, non_autopilot_compid))
+                self.expire_other_component_warning_rate_limit()
                 self.drain_mav()
                 self.drain_mav(mav2)
                 self.send_cmd(command, target_sysid=target_sysid, target_compid=non_autopilot_compid)
@@ -6780,6 +6874,11 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 assert_forwarded(command)
                 # ... and must not have been acted upon by the autopilot:
                 assert_not_acted_upon(command)
+                # ... so there is nothing to warn about, either; it was
+                # neither acted on nor discarded:
+                self.assert_no_other_component_warning(command, non_autopilot_compid)
+
+        self.context_stop_collecting('STATUSTEXT')
 
         mav2.close()
         # the learned routes would change the behaviour of any test

--- a/libraries/AP_HAL_ChibiOS/hwdef/skyviper-v2450/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/skyviper-v2450/hwdef.dat
@@ -356,4 +356,9 @@ define AP_MISSION_NAV_PAYLOAD_PLACE_ENABLED 0
 # don't need so many servo outputs (~850 bytes!)
 define NUM_SERVO_CHANNELS 15
 
+# do not act on safety commands - parachute release, flight termination
+# - which were addressed at some other component; this vehicle has no
+# parachute and should only terminate when told to directly:
+define AP_MAVLINK_COMMANDS_FOR_OTHER_COMPONENTS_ENABLED 0
+
 AUTOBUILD_TARGETS Copter

--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -61,7 +61,7 @@ const AP_Param::GroupInfo GCS::var_info[] {
     // @Param: _OPTIONS
     // @DisplayName: MAVLink Options
     // @Description: Alters various behaviour of the MAVLink interface
-    // @Bitmask: 0:Accept MAVLink only from system IDs given by MAV_SYSID_GCS and MAV_SYSID_GCS_HI
+    // @Bitmask: 0:Accept MAVLink only from system IDs given by MAV_SYSID_GCS and MAV_SYSID_GCS_HI,1:Act on messages addressed to component IDs other than the autopilot's
     // @User: Advanced
     AP_GROUPINFO("_OPTIONS",    3,      GCS, mav_options, 0),
 

--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -61,7 +61,7 @@ const AP_Param::GroupInfo GCS::var_info[] {
     // @Param: _OPTIONS
     // @DisplayName: MAVLink Options
     // @Description: Alters various behaviour of the MAVLink interface
-    // @Bitmask: 0:Accept MAVLink only from system IDs given by MAV_SYSID_GCS and MAV_SYSID_GCS_HI
+    // @Bitmask: 0:Accept MAVLink only from system IDs given by MAV_SYSID_GCS and MAV_SYSID_GCS_HI,1:Act on MAVLink commands with any component id
     // @User: Advanced
     AP_GROUPINFO("_OPTIONS",    3,      GCS, mav_options, 0),
 

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -1236,6 +1236,7 @@ public:
 
     enum class Option {
       GCS_SYSID_ENFORCE = (1U << 0),
+      ACCEPT_MESSAGES_FOR_OTHER_COMPONENTS = (1U << 1),
     };
     bool option_is_enabled(Option option) const {
         return (mav_options & (uint16_t)option) != 0;

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -1242,6 +1242,7 @@ public:
 
     enum class Option {
       GCS_SYSID_ENFORCE = (1U << 0),
+      ACCEPT_COMMANDS_FOR_OTHER_COMPONENTS = (1U << 1),
     };
     bool option_is_enabled(Option option) const {
         return (mav_options & (uint16_t)option) != 0;

--- a/libraries/GCS_MAVLink/GCS_config.h
+++ b/libraries/GCS_MAVLink/GCS_config.h
@@ -131,6 +131,17 @@
 #define AP_MAVLINK_COMMAND_LONG_ENABLED 1
 #endif
 
+// some commands addressed to a component of our system which we have
+// never seen are acted upon rather than discarded; releasing the
+// parachute is a last-resort, safety-of-life action, and nothing else
+// can be listening for a command sent to a component which does not
+// appear to exist.  A command we forward on to the addressed component
+// is not acted upon.  The commands are listed in
+// MAVLink_routing::message_is_component_agnostic().
+#ifndef AP_MAVLINK_COMMANDS_FOR_OTHER_COMPONENTS_ENABLED
+#define AP_MAVLINK_COMMANDS_FOR_OTHER_COMPONENTS_ENABLED HAL_GCS_ENABLED
+#endif
+
 #ifndef AP_MAVLINK_MSG_HIGHRES_IMU_ENABLED
 #define AP_MAVLINK_MSG_HIGHRES_IMU_ENABLED (HAL_PROGRAM_SIZE_LIMIT_KB > 1024) && AP_INERTIALSENSOR_ENABLED
 #endif

--- a/libraries/GCS_MAVLink/GCS_config.h
+++ b/libraries/GCS_MAVLink/GCS_config.h
@@ -131,12 +131,12 @@
 #define AP_MAVLINK_COMMAND_LONG_ENABLED 1
 #endif
 
-// some commands addressed to a component of our system which we have
-// never seen are acted upon rather than discarded; releasing the
-// parachute is a last-resort, safety-of-life action, and nothing else
-// can be listening for a command sent to a component which does not
-// appear to exist.  A command we forward on to the addressed component
-// is not acted upon.  The commands are listed in
+// a handful of commands addressed to a component of our system which we
+// have never seen are acted upon rather than discarded; they are
+// last-resort, safety-of-life actions, and nothing else can be
+// listening for a command sent to a component which does not appear to
+// exist.  A command we forward on to the addressed component is not
+// acted upon.  The commands are listed in
 // MAVLink_routing::message_is_component_agnostic().
 #ifndef AP_MAVLINK_COMMANDS_FOR_OTHER_COMPONENTS_ENABLED
 #define AP_MAVLINK_COMMANDS_FOR_OTHER_COMPONENTS_ENABLED HAL_GCS_ENABLED

--- a/libraries/GCS_MAVLink/MAVLink_routing.cpp
+++ b/libraries/GCS_MAVLink/MAVLink_routing.cpp
@@ -245,8 +245,17 @@ bool MAVLink_routing::forward(GCS_MAVLINK &in_link,
         }
     }
 
-    if ((!forwarded && match_system) ||
-        broadcast_system) {
+    if (broadcast_system ||
+        (!forwarded && match_system &&
+         (broadcast_component ||
+          target_component == mavlink_system.compid ||
+          gcs().option_is_enabled(GCS::Option::ACCEPT_MESSAGES_FOR_OTHER_COMPONENTS)))) {
+        // process locally if the message is for everyone, or is for our
+        // system and either targets our component (or all components) or
+        // we could not forward it on to the addressed component.  By
+        // default a message explicitly addressed to another component is
+        // not acted on; ACCEPT_MESSAGES_FOR_OTHER_COMPONENTS restores the
+        // historical behaviour of handling it ourselves.
         process_locally = true;
     }
 

--- a/libraries/GCS_MAVLink/MAVLink_routing.cpp
+++ b/libraries/GCS_MAVLink/MAVLink_routing.cpp
@@ -218,13 +218,13 @@ static bool compid_is_ours(int16_t compid)
   to a component of our system other than our own which we have never
   seen a message from.
 
-  Releasing the parachute is a last-resort, safety-of-life action; if a
-  GCS addresses the command at a component which does not appear to
-  exist then acting on it ourselves is much better than discarding it.
-  If the command is forwarded on to the addressed component then we keep
-  out of it.  A component we only know of on the link the command
-  arrived on has already been sent the command, so it is not forwarded
-  and we act on it as well.
+  These are the last-resort, safety-of-life actions; if a GCS addresses
+  one at a component which does not appear to exist then acting on it
+  ourselves is much better than discarding it.  If the command is
+  forwarded on to the addressed component then we keep out of it.  A
+  component we only know of on the link the command arrived on has
+  already been sent the command, so it is not forwarded and we act on it
+  as well.
  */
 static bool message_is_component_agnostic(const mavlink_message_t &msg)
 {
@@ -242,6 +242,7 @@ static bool message_is_component_agnostic(const mavlink_message_t &msg)
 
     switch (command) {
     case MAV_CMD_DO_PARACHUTE:
+    case MAV_CMD_DO_FLIGHTTERMINATION:
         return true;
     }
 
@@ -265,8 +266,8 @@ bool MAVLink_routing::forward(GCS_MAVLINK &in_link,
     bool process_locally = match_system && match_component;
 
 #if AP_MAVLINK_COMMANDS_FOR_OTHER_COMPONENTS_ENABLED
-    // parachute commands are acted upon when they are addressed to
-    // another component of our system which we have no route to:
+    // a few commands are acted upon when they are addressed to another
+    // component of our system which we have no route to:
     const bool component_agnostic = (match_system && !match_component &&
                                      message_is_component_agnostic(msg));
 #else
@@ -283,8 +284,8 @@ bool MAVLink_routing::forward(GCS_MAVLINK &in_link,
     }
 #endif
     if (should_process_locally) {
-        // nothing is forwarded from a private channel, so such a
-        // command is handled here or not at all.
+        // nothing is forwarded from a private channel, so the
+        // component-agnostic commands are handled here or not at all.
         // Note that this changes once a GoPro is detected on a Solo
         // gimbal; the channel then forwards like any other, so a
         // command for a component we have a route to stops being
@@ -356,10 +357,10 @@ bool MAVLink_routing::forward(GCS_MAVLINK &in_link,
     }
 
     if (component_agnostic && !forwarded_to_component) {
-        // a parachute command for another component of our system is
-        // handled regardless of MAV_OPTIONS unless we sent it on to that
-        // component.  Note that it may still have been forwarded
-        // elsewhere, e.g. to every link if it is for all systems.
+        // the component-agnostic commands for another component of our
+        // system are handled regardless of MAV_OPTIONS unless we sent
+        // them on to that component.  Note that they may still have been
+        // forwarded elsewhere, e.g. to every link if for all systems.
         process_locally = true;
     }
 

--- a/libraries/GCS_MAVLink/MAVLink_routing.cpp
+++ b/libraries/GCS_MAVLink/MAVLink_routing.cpp
@@ -212,6 +212,24 @@ static bool compid_is_ours(int16_t compid)
     return false;
 }
 
+/*
+  return true if this message is a command, filling in the command it
+  carries
+ */
+static bool command_from_message(const mavlink_message_t &msg, uint16_t &command)
+{
+    switch (msg.msgid) {
+    case MAVLINK_MSG_ID_COMMAND_LONG:
+        command = mavlink_msg_command_long_get_command(&msg);
+        return true;
+    case MAVLINK_MSG_ID_COMMAND_INT:
+        command = mavlink_msg_command_int_get_command(&msg);
+        return true;
+    }
+
+    return false;
+}
+
 #if AP_MAVLINK_COMMANDS_FOR_OTHER_COMPONENTS_ENABLED
 /*
   return true if this message must be acted upon when it is addressed
@@ -229,14 +247,7 @@ static bool compid_is_ours(int16_t compid)
 static bool message_is_component_agnostic(const mavlink_message_t &msg)
 {
     uint16_t command;
-    switch (msg.msgid) {
-    case MAVLINK_MSG_ID_COMMAND_LONG:
-        command = mavlink_msg_command_long_get_command(&msg);
-        break;
-    case MAVLINK_MSG_ID_COMMAND_INT:
-        command = mavlink_msg_command_int_get_command(&msg);
-        break;
-    default:
+    if (!command_from_message(msg, command)) {
         return false;
     }
 
@@ -290,7 +301,13 @@ bool MAVLink_routing::forward(GCS_MAVLINK &in_link,
         // gimbal; the channel then forwards like any other, so a
         // command for a component we have a route to stops being
         // handled here.
-        return process_locally || component_agnostic;
+        if (component_agnostic) {
+            process_locally = true;
+        }
+        if (match_system && !match_component) {
+            warn_about_message_for_other_component(msg, process_locally, target_component);
+        }
+        return process_locally;
     }
 
     if (process_locally && !broadcast_system && !broadcast_component) {
@@ -304,6 +321,9 @@ bool MAVLink_routing::forward(GCS_MAVLINK &in_link,
     // is addressed to; a message for all systems is forwarded to every
     // route, so "forwarded" alone does not tell us that
     bool forwarded_to_component = false;
+    // true if the link the message arrived on reaches the component of
+    // our system it is addressed to; that component has been sent it
+    bool target_component_on_in_link = false;
     bool sent_to_chan[MAVLINK_COMM_NUM_BUFFERS];
     memset(sent_to_chan, 0, sizeof(sent_to_chan));
     // true if the message was sent on the channel, i.e. it fitted in the
@@ -353,6 +373,9 @@ bool MAVLink_routing::forward(GCS_MAVLINK &in_link,
             if (route_to_target_component && queued_on_chan[routes[i].channel]) {
                 forwarded_to_component = true;
             }
+            if (route_to_target_component && &in_link == out_link) {
+                target_component_on_in_link = true;
+            }
         }
     }
 
@@ -375,7 +398,63 @@ bool MAVLink_routing::forward(GCS_MAVLINK &in_link,
         process_locally = true;
     }
 
+    // When we discard a message addressed to another component we
+    // deliberately remain absolutely silent towards its sender: no
+    // COMMAND_ACK, NACK or any other reply is sent.  Anything we sent
+    // would claim to come from us about a message which was never ours,
+    // and the component it was addressed to may yet answer it.  The
+    // rate-limited STATUSTEXT below is for the user, not a reply.
+    //
+    // A message we sent on to the component it is addressed to was
+    // neither acted on nor discarded, so there is nothing to warn about.
+    // Nor is there when we discard a message for a component which the
+    // link it arrived on reaches (e.g. a GCS and a camera sharing a
+    // companion computer's link to us), as that component has been sent
+    // it too.  We do still warn about acting on one:
+    if (match_system && !match_component &&
+        (process_locally || !(forwarded_to_component || target_component_on_in_link))) {
+        warn_about_message_for_other_component(msg, process_locally, target_component);
+    }
+
     return process_locally;
+}
+
+/*
+  tell the user about a message addressed at a component other than our
+  own which we are either acting on or discarding; the sender is talking
+  to something which is not us, and that is worth knowing about.  If
+  MAV_OPTIONS says to act on such messages then acting on one is
+  expected, so is not warned about.  A GCS may well send such messages
+  continuously, so warn at most once every 10 seconds.  Acting on and
+  discarding are rate limited separately so that a stream of messages
+  being discarded cannot hide our acting on a parachute or flight
+  termination command.
+ */
+void MAVLink_routing::warn_about_message_for_other_component(const mavlink_message_t &msg,
+                                                             bool process_locally,
+                                                             int16_t target_component)
+{
+    if (process_locally &&
+        gcs().option_is_enabled(GCS::Option::ACCEPT_COMMANDS_FOR_OTHER_COMPONENTS)) {
+        return;
+    }
+    uint32_t &last_warning_ms = process_locally ? last_acting_on_warning_ms : last_ignoring_warning_ms;
+    const uint32_t now_ms = AP_HAL::millis();
+    if (last_warning_ms != 0 &&
+        now_ms - last_warning_ms < 10000) {
+        return;
+    }
+    last_warning_ms = now_ms;
+    const char *action = process_locally ? "acting on" : "ignoring";
+    // for a command the command ID is much more useful than the message ID:
+    uint16_t command;
+    if (command_from_message(msg, command)) {
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "MAV: %s cmd %u for compid %d",
+                      action, command, target_component);
+        return;
+    }
+    GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "MAV: %s msg %u for compid %d",
+                  action, (unsigned)msg.msgid, target_component);
 }
 
 /*

--- a/libraries/GCS_MAVLink/MAVLink_routing.cpp
+++ b/libraries/GCS_MAVLink/MAVLink_routing.cpp
@@ -71,6 +71,11 @@ MAVLink_routing::MAVLink_routing(void) : num_routes(0) {}
         is the historical behaviour; by default a message addressed to
         another component is not processed locally
 
+    1f) the message has a target_system of zero or the flight
+        controllers target system, is one of a few safety-of-life
+        commands (see message_is_component_agnostic()) and was not
+        forwarded to its target_component on another link
+
   When a flight controller receives a message it should forward it
   onto another different link if any of these conditions hold for that
   link: 
@@ -207,6 +212,43 @@ static bool compid_is_ours(int16_t compid)
     return false;
 }
 
+#if AP_MAVLINK_COMMANDS_FOR_OTHER_COMPONENTS_ENABLED
+/*
+  return true if this message must be acted upon when it is addressed
+  to a component of our system other than our own which we have never
+  seen a message from.
+
+  Releasing the parachute is a last-resort, safety-of-life action; if a
+  GCS addresses the command at a component which does not appear to
+  exist then acting on it ourselves is much better than discarding it.
+  If the command is forwarded on to the addressed component then we keep
+  out of it.  A component we only know of on the link the command
+  arrived on has already been sent the command, so it is not forwarded
+  and we act on it as well.
+ */
+static bool message_is_component_agnostic(const mavlink_message_t &msg)
+{
+    uint16_t command;
+    switch (msg.msgid) {
+    case MAVLINK_MSG_ID_COMMAND_LONG:
+        command = mavlink_msg_command_long_get_command(&msg);
+        break;
+    case MAVLINK_MSG_ID_COMMAND_INT:
+        command = mavlink_msg_command_int_get_command(&msg);
+        break;
+    default:
+        return false;
+    }
+
+    switch (command) {
+    case MAV_CMD_DO_PARACHUTE:
+        return true;
+    }
+
+    return false;
+}
+#endif  // AP_MAVLINK_COMMANDS_FOR_OTHER_COMPONENTS_ENABLED
+
 bool MAVLink_routing::forward(GCS_MAVLINK &in_link,
                               const mavlink_message_t &msg)
 {
@@ -222,6 +264,15 @@ bool MAVLink_routing::forward(GCS_MAVLINK &in_link,
                                             compid_is_ours(target_component));
     bool process_locally = match_system && match_component;
 
+#if AP_MAVLINK_COMMANDS_FOR_OTHER_COMPONENTS_ENABLED
+    // parachute commands are acted upon when they are addressed to
+    // another component of our system which we have no route to:
+    const bool component_agnostic = (match_system && !match_component &&
+                                     message_is_component_agnostic(msg));
+#else
+    const bool component_agnostic = false;
+#endif
+
     // don't ever forward data from a private channel
     // unless a Gopro camera is connected to a Solo gimbal
     const bool from_private_channel = in_link.is_private();
@@ -232,7 +283,13 @@ bool MAVLink_routing::forward(GCS_MAVLINK &in_link,
     }
 #endif
     if (should_process_locally) {
-        return process_locally;
+        // nothing is forwarded from a private channel, so such a
+        // command is handled here or not at all.
+        // Note that this changes once a GoPro is detected on a Solo
+        // gimbal; the channel then forwards like any other, so a
+        // command for a component we have a route to stops being
+        // handled here.
+        return process_locally || component_agnostic;
     }
 
     if (process_locally && !broadcast_system && !broadcast_component) {
@@ -242,8 +299,16 @@ bool MAVLink_routing::forward(GCS_MAVLINK &in_link,
 
     // forward on any channels matching the targets
     bool forwarded = false;
+    // true if the message was sent to the component of our system it
+    // is addressed to; a message for all systems is forwarded to every
+    // route, so "forwarded" alone does not tell us that
+    bool forwarded_to_component = false;
     bool sent_to_chan[MAVLINK_COMM_NUM_BUFFERS];
     memset(sent_to_chan, 0, sizeof(sent_to_chan));
+    // true if the message was sent on the channel, i.e. it fitted in the
+    // transmit buffer; never true for the channel it arrived on
+    bool queued_on_chan[MAVLINK_COMM_NUM_BUFFERS];
+    memset(queued_on_chan, 0, sizeof(queued_on_chan));
     for (uint8_t i=0; i<num_routes; i++) {
 
         // Skip if channel is private and the target system or component IDs do not match
@@ -264,7 +329,8 @@ bool MAVLink_routing::forward(GCS_MAVLINK &in_link,
                                   !match_system))) {
 
             if (&in_link != out_link && !sent_to_chan[routes[i].channel]) {
-                if (out_link->check_payload_size(msg.len)) {
+                queued_on_chan[routes[i].channel] = out_link->check_payload_size(msg.len);
+                if (queued_on_chan[routes[i].channel]) {
 #if ROUTING_DEBUG
                     ::printf("fwd msg %u from chan %u on chan %u sysid=%d compid=%d\n",
                              msg.msgid,
@@ -278,7 +344,23 @@ bool MAVLink_routing::forward(GCS_MAVLINK &in_link,
                 sent_to_chan[routes[i].channel] = true;
                 forwarded = true;
             }
+            // a component with the same ID on another system is not the
+            // one the message is addressed to, even if the message is
+            // for all systems:
+            const bool route_to_target_component = (routes[i].sysid == mavlink_system.sysid &&
+                                                    routes[i].compid == target_component);
+            if (route_to_target_component && queued_on_chan[routes[i].channel]) {
+                forwarded_to_component = true;
+            }
         }
+    }
+
+    if (component_agnostic && !forwarded_to_component) {
+        // a parachute command for another component of our system is
+        // handled regardless of MAV_OPTIONS unless we sent it on to that
+        // component.  Note that it may still have been forwarded
+        // elsewhere, e.g. to every link if it is for all systems.
+        process_locally = true;
     }
 
     if (!match_component &&

--- a/libraries/GCS_MAVLink/MAVLink_routing.cpp
+++ b/libraries/GCS_MAVLink/MAVLink_routing.cpp
@@ -27,6 +27,7 @@
 #include "MAVLink_routing.h"
 
 #include <AP_ADSB/AP_ADSB.h>
+#include <AP_Logger/AP_Logger_config.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -49,18 +50,26 @@ MAVLink_routing::MAVLink_routing(void) : num_routes(0) {}
 
     1a) the message has no target_system field
 
-    1b) the message has a target_system of zero
+    1b) the message has a target_system of zero and has no
+        target_component field, a target_component of zero or one of
+        the flight controllers component IDs
 
     1c) the message has the flight controllers target system and has no
        target_component field
 
     1d) the message has the flight controllers target system and has
-       the flight controllers target_component 
+       one of the flight controllers component IDs as its
+       target_component.  As well as its own component ID the flight
+       controller answers to the IDs of components it sends messages
+       as (e.g. MAV_COMP_ID_LOG)
 
-    1e) the message has the flight controllers target system and the
-        flight controller has not seen any messages on any of its links
-        from a system that has the messages
-        target_system/target_component combination
+    1e) the MAV_OPTIONS bit ACCEPT_COMMANDS_FOR_OTHER_COMPONENTS is set
+        and the message has a target_system of zero, or has the flight
+        controllers target system and the flight controller has not
+        seen any messages on any of its links from a system that has
+        the messages target_system/target_component combination.  This
+        is the historical behaviour; by default a message addressed to
+        another component is not processed locally
 
   When a flight controller receives a message it should forward it
   onto another different link if any of these conditions hold for that
@@ -171,6 +180,33 @@ bool MAVLink_routing::check_and_forward(uint8_t framing_status,
     return forward(in_link, msg);
 }
 
+/*
+  return true if compid is one of our component IDs.  As well as the
+  autopilot's own component ID we answer to the IDs of components we
+  send messages as.
+
+  Note that a message addressed to our system and one of these
+  component IDs is taken to be for us alone, so it is not forwarded;
+  if something else on another link uses the same component ID (e.g. a
+  companion computer's own MAV_COMP_ID_LOG) then it will not see
+  messages addressed to that ID.  A message addressed to all systems
+  is still forwarded as usual.
+ */
+static bool compid_is_ours(int16_t compid)
+{
+    if (compid == mavlink_system.compid) {
+        return true;
+    }
+#if HAL_LOGGING_MAVLINK_ENABLED
+    // AP_Logger_MAVLink sends log blocks as MAV_COMP_ID_LOG, so the
+    // REMOTE_LOG_BLOCK_STATUS replies are addressed to that component
+    if (compid == MAV_COMP_ID_LOG) {
+        return true;
+    }
+#endif
+    return false;
+}
+
 bool MAVLink_routing::forward(GCS_MAVLINK &in_link,
                               const mavlink_message_t &msg)
 {
@@ -182,8 +218,8 @@ bool MAVLink_routing::forward(GCS_MAVLINK &in_link,
     bool broadcast_system = (target_system == 0 || target_system == -1);
     bool broadcast_component = (target_component == 0 || target_component == -1);
     bool match_system = broadcast_system || (target_system == mavlink_system.sysid);
-    bool match_component = match_system && (broadcast_component || 
-                                            (target_component == mavlink_system.compid));
+    bool match_component = match_system && (broadcast_component ||
+                                            compid_is_ours(target_component));
     bool process_locally = match_system && match_component;
 
     // don't ever forward data from a private channel
@@ -245,8 +281,14 @@ bool MAVLink_routing::forward(GCS_MAVLINK &in_link,
         }
     }
 
-    if ((!forwarded && match_system) ||
-        broadcast_system) {
+    if (!match_component &&
+        gcs().option_is_enabled(GCS::Option::ACCEPT_COMMANDS_FOR_OTHER_COMPONENTS) &&
+        ((!forwarded && match_system) || broadcast_system)) {
+        // the message is explicitly addressed to another component.  By
+        // default we do not act on it; ACCEPT_COMMANDS_FOR_OTHER_COMPONENTS
+        // restores the historical behaviour of handling it ourselves if
+        // it is for our system and we found nowhere to forward it to, or
+        // if it is for all systems (whether or not we forwarded it).
         process_locally = true;
     }
 

--- a/libraries/GCS_MAVLink/MAVLink_routing.h
+++ b/libraries/GCS_MAVLink/MAVLink_routing.h
@@ -52,6 +52,14 @@ public:
     bool find_by_mavtype_and_compid(uint8_t mavtype, uint8_t compid, uint8_t &sysid, mavlink_channel_t &channel) const;
 
 private:
+    // warn the user when we act on or discard a message addressed at a
+    // component which is not our own
+    void warn_about_message_for_other_component(const mavlink_message_t &msg,
+                                                bool process_locally,
+                                                int16_t target_component);
+    uint32_t last_acting_on_warning_ms;
+    uint32_t last_ignoring_warning_ms;
+
     // a simple linear routing table. We don't expect to have a lot of
     // routes, so a scalable structure isn't worthwhile yet.
     uint8_t num_routes;


### PR DESCRIPTION
### Summary

Stops acting on messages addressed to a component ID which is not ours.  MAV_OPTIONS bit 1 restores the old behaviour; parachute and flight-termination commands are acted upon regardless when nothing else will receive them.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

New autotests:

- Rover
  - `CommandForNonAutopilotComponent`: with the option bit set, a command for another component is acted on and not warned about.
  - `CommandForNonAutopilotComponentIgnored`: by default it is ignored, warned about, and the warning is rate limited.
  - `CommandForNonAutopilotComponentBroadcastSystem`: a command for all systems addressed to another component, with a route present on another link, is forwarded; it is acted on only with the option bit set.
  - `ParamSetForNonAutopilotComponent`: a `PARAM_SET` for another component is ignored and warned about.
  - `ComponentAgnosticCommandRouting`: parachute/termination commands, addressed to our system and to all systems, with no routes, with a route only to a different component, with a route only to a component with the addressed ID on another system, with a route to the addressed component, and from the link holding the only route to it (where any other command is ignored without a warning).
- Copter `ParachuteCommandForNonAutopilotComponent`: the chute deploys on a release sent to another component.
- Plane `MAV_CMD_DO_FLIGHTTERMINATION_for_other_component`: the flight terminates on a command sent to another component.

Existing tests adjusted: Plane `PreflightRebootComponent` sets the option bit so it still exercises the reboot handler's own guard.

`Rover.DataFlashOverMAVLink` passes again.  The routing, option-bit, safety-exception and rate-limit tests were each run against firmware without the corresponding fix and fail there.

@rmackay9 also confirmed in SITL that this resolves #34343 (see comment above).

### Description

The MAVLink routing spec used to say that a message addressed to our system and to a component we had never seen should be processed locally.  We've thought that insane for years, and @hamishwillee has since removed the rule from the spec ([mavlink-devguide#725](https://github.com/mavlink/mavlink-devguide/pull/725)).  This PR stops doing it.

#### What changes

- **Messages for another component are no longer acted on.**  A message addressed to our system (or to all systems) with a `target_component` which is neither ours nor 0 is not processed locally.  It is still forwarded exactly as before.  Messages with no `target_component`, or with 0, are unaffected.
- **`MAV_OPTIONS` bit 1 ("Act on MAVLink commands with any component id") restores the old behaviour.**  That includes messages addressed to all systems: master acted on those whatever component they named, even when it also forwarded them, and so does the option bit.
- **Parachute and flight termination are acted on regardless.**  `MAV_CMD_DO_PARACHUTE` and `MAV_CMD_DO_FLIGHTTERMINATION` addressed to another component are acted upon unless we actually sent the command on to that component.  Forwarding it somewhere else (e.g. a command for all systems going to a companion computer) does not count, nor does sending it to a component with the same ID on another system, nor a link whose transmit buffer it did not fit in.  This answers the concern about MAVLink-connected parachutes: if the parachute exists and we have seen it, it gets the command; if it does not appear to exist, we act.
  - The exception deliberately does not look at param1.  It exists because a command nobody else will receive should not be dropped, which is as true of `PARACHUTE_DISABLE` or a termination cancel (param1=0) as of a release or terminate.  A GCS which mis-addresses the release will mis-address the cancel too, so honouring only one half would leave an operator able to terminate a flight but not stand down.  On ordinary channels master already acted on all of these variants when they were sent to a component it had no route to, so nothing widens there.
  - It applies on private channels too, which is a change from master (which dropped them).  Nothing is forwarded from a private channel, so the addressed component can never receive the command there; that is the same "nobody else will get this" situation as having no route.
  - If the only route to the addressed component is on the link the command arrived on, we act on it as well: nothing is sent back out of the link it came in on, so we cannot tell whether the component will act on it.  The command is doubled rather than lost, and this is unchanged from master.
  - Gated by `AP_MAVLINK_COMMANDS_FOR_OTHER_COMPONENTS_ENABLED`; disabled on SkyViper-v2450.
- **`MAV_COMP_ID_LOG` is treated as one of our component IDs.**  `AP_Logger_MAVLink` sends log blocks as `MAV_COMP_ID_LOG`, and the GCS addresses its `REMOTE_LOG_BLOCK_STATUS` replies there; without this, DataFlash-over-MAVLink breaks.  A consequence is that a message addressed to our system and `MAV_COMP_ID_LOG` is not forwarded to some other component using that ID on another link.
- **Warnings.**  When we discard a message for another component, or act on a parachute/termination command for one, we send `MAV: ignoring cmd N for compid M` / `MAV: acting on cmd N for compid M` (or `msg N` for non-command messages) at WARNING severity.  This covers every message type, not just commands, so a mis-addressed `PARAM_SET`, mission item or FTP request is visible too, rather than showing up only as a timeout.
  - Rate limited to once every 10 seconds: a GCS may well send such messages continuously, and a low-bandwidth link must not be flooded.  "Ignoring" and "acting on" warnings are limited separately, so a stream of discarded messages cannot hide our acting on a parachute or termination command.  The warning is a pointer for the user, not a log of every message.
  - Not sent for acting on a message when `MAV_OPTIONS` bit 1 says to, nor for a message forwarded to the component it was addressed to, nor for discarding a message when the link it arrived on reaches the addressed component (e.g. a GCS and a camera sharing a companion computer's link to us).
  - We deliberately send nothing back to the sender of a discarded message: no `COMMAND_ACK`, no NACK.  Anything we sent would claim to come from us about a message which was never ours.

#### Things which may notice

- **GCS / companion software** sending commands to a component ID which does not exist (and which were silently being handled by the autopilot) will now see those commands ignored, with the warning above.  Set `MAV_OPTIONS` bit 1 if you cannot fix the sender.
- **Lua scripts** see messages after the routing decision (`mavlink:receive_chan()` is fed from `GCS_MAVLINK::raw_packetReceived()` after `routing.check_and_forward()`).  A script which impersonates its own component ID will no longer receive messages addressed to that ID by default.  None of the scripts in the tree do this; anyone who does will see the `MAV: ignoring ...` warning pointing at the problem, and can set `MAV_OPTIONS` bit 1 to restore the old behaviour.
- **AP_Periph** boards with MAVLink enabled behave just like the autopilot, and are slightly safer for it: `GCS_MAVLINK_Periph::handle_preflight_reboot()` has no component-ID check, so on master a reboot addressed to a component the Periph had never seen rebooted the Periph.  That no longer happens by default, but still does with `MAV_OPTIONS` bit 1 set.  AP_ExternalControl (fed only by DDS), the Periph ADSB bridge and DroneCAN serial tunnels do not go through MAVLink routing and are unaffected.
- The dev wiki's camera and gimbal MAVLink pages already document addressing commands to "Component ID of flight controller or just 0", and all their examples use `0 0`, so they need no change.

Created with claude and codex's help