### PR TITLE
Correct matrix used for wind estimation in DCM

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -14722,7 +14722,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         '''test land detector with significant AHRS trim'''
         self.context_push()
         self.set_parameters({
-            "SIM_ACC_TRIM_X": 0.12,
+            "SIM_BRD_TRIM_X": 0.12,
             "AHRS_TRIM_X": 0.12,
         })
         self.reboot_sitl()

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -3213,6 +3213,84 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             )
         self.fly_home_land_and_disarm()
 
+    def WindEstimatesTrim(self):
+        '''DCM wind estimate must be unchanged by a board mounting offset that
+        is corrected by AHRS_TRIM, i.e. it must use the trimmed (vehicle)
+        fuselage axis, not the raw IMU/board axis.
+
+        In straight-and-level flight the wind triangle's airspeed-fed branch
+        projects the measured airspeed along the fuselage axis, so a pitched
+        board axis injects a vertical wind of ~airspeed*sin(tilt).  We fly
+        straight and level on DCM and compare the steady vertical wind
+        estimate with no mount offset against the estimate with an 8-degree
+        offset (SIM_BRD_TRIM, a rigid board mounting tilt of both the accel
+        and gyro) corrected by AHRS_TRIM.  The trim must not change it.
+
+        We compare the two rather than assert ~zero because the wind triangle
+        ignores angle-of-attack, so there is always a small AoA-induced
+        vertical wind present in both cases; only the *difference* isolates
+        the trim error.
+        '''
+        def avg_wind(duration=15):
+            # average horizontal speed and vertical speed_z of the WIND message
+            spd = []
+            spd_z = []
+            tstart = self.get_sim_time()
+            while self.get_sim_time() - tstart < duration:
+                m = self.assert_receive_message('WIND', timeout=5)
+                spd.append(m.speed)
+                spd_z.append(m.speed_z)
+            return sum(spd) / len(spd), sum(spd_z) / len(spd_z)
+
+        self.set_parameters({
+            "SIM_WIND_SPD": 5,
+            "SIM_WIND_DIR": 45,
+            "SIM_WIND_DIR_Z": 0,    # purely horizontal truth wind
+        })
+        self.reboot_sitl()
+        # arm and take off with the default estimator (AHRS_EKF_TYPE=0 has no
+        # EKF, so arming readiness would time out); switch to DCM in flight:
+        self.wait_ready_to_arm()
+        self.takeoff(70)  # default wind sim wind is a sqrt function up to 60m
+        self.set_parameter("AHRS_EKF_TYPE", 0)  # use DCM
+        # straight and level so the airspeed-fed straight-flight branch runs:
+        self.change_mode('CRUISE')
+        self.delay_sim_time(40, reason="settle into straight level flight and let the DCM wind estimate converge")
+        baseline_spd, baseline_z = avg_wind()
+
+        # introduce an 8-degree rigid board pitch mounting offset (accel and
+        # gyro rotated together) and correct it with AHRS_TRIM, exactly as a
+        # tilted real mount would be handled.  Applied together, the AHRS
+        # attitude output is unchanged, so the vehicle keeps flying level:
+        trim_rad = math.radians(8)
+        self.set_parameters({
+            "SIM_BRD_TRIM_Y": trim_rad,
+            "AHRS_TRIM_Y": trim_rad,
+        })
+        self.delay_sim_time(40, reason="let the attitude and wind estimate resettle after introducing the mount offset")
+        trimmed_spd, trimmed_z = avg_wind()
+
+        # The board mount offset (corrected by trim) must not move the wind
+        # estimate.  The dominant error is vertical: the straight-flight
+        # branch projects airspeed along the fuselage axis, so the raw
+        # (pitched) board axis shifts speed_z by ~airspeed*sin(8deg).  The
+        # horizontal must also be invariant (it was only corrupted when the
+        # simulated compass was not rotated with the board, leaving a yaw
+        # error; SIM_BRD_TRIM now rotates the compass too).
+        self.progress("WIND.speed_z:   baseline=%.2f trimmed=%.2f (d=%.2f)" %
+                      (baseline_z, trimmed_z, trimmed_z - baseline_z))
+        self.progress("WIND.speed(hz): baseline=%.2f trimmed=%.2f (d=%.2f)" %
+                      (baseline_spd, trimmed_spd, trimmed_spd - baseline_spd))
+        if abs(trimmed_z - baseline_z) > 1.0:
+            raise NotAchievedException(
+                "AHRS trim changed the vertical wind estimate: speed_z baseline=%.2f trimmed=%.2f" %
+                (baseline_z, trimmed_z))
+        if abs(trimmed_spd - baseline_spd) > 1.0:
+            raise NotAchievedException(
+                "AHRS trim changed the horizontal wind estimate: speed baseline=%.2f trimmed=%.2f" %
+                (baseline_spd, trimmed_spd))
+        self.fly_home_land_and_disarm()
+
     def WindMessageSpeed(self):
         '''Test that WIND.speed is horizontal (ground-plane) speed only'''
         # SIM_WIND_DIR_Z is an elevation angle (degrees from horizontal).
@@ -8331,6 +8409,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.MANUAL_CONTROL,
             self.RunMissionScript,
             self.WindEstimates,
+            self.WindEstimatesTrim,
             self.WindMessageSpeed,
             self.AltResetBadGPS,
             self.AirspeedCal,

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -13474,7 +13474,7 @@ switch value'''
                          ("INS_ACC2OFFS", "SIM_ACC2_BIAS", pre_aofs[1], aofs[1]),
                          ("INS_ACCSCAL", "SIM_ACC1_SCAL", pre_ascale[0], ascale[0]),
                          ("INS_ACC2SCAL", "SIM_ACC2_SCAL", pre_ascale[1], ascale[1]),
-                         ("AHRS_TRIM", "SIM_ACC_TRIM", pre_atrim, atrim)]
+                         ("AHRS_TRIM", "SIM_BRD_TRIM", pre_atrim, atrim)]
             axes = ['X', 'Y', 'Z']
 
             # form the pre-calibration params
@@ -13550,8 +13550,8 @@ switch value'''
             "SIM_ACC2_BIAS_Z": 2.3,
             "AHRS_TRIM_X": 0.05,
             "AHRS_TRIM_Y": -0.03,
-            "SIM_ACC_TRIM_X": -0.04,
-            "SIM_ACC_TRIM_Y": 0.05,
+            "SIM_BRD_TRIM_X": -0.04,
+            "SIM_BRD_TRIM_Y": 0.05,
         })
         expected_parms = {
             "AHRS_TRIM_X": -0.04,
@@ -13663,8 +13663,8 @@ switch value'''
                     self.set_parameters({
                         'AHRS_TRIM_X': math.radians(r),
                         'AHRS_TRIM_Y': math.radians(p),
-                        "SIM_ACC_TRIM_X": math.radians(r),
-                        "SIM_ACC_TRIM_Y": math.radians(p),
+                        "SIM_BRD_TRIM_X": math.radians(r),
+                        "SIM_BRD_TRIM_Y": math.radians(p),
                     })
                     self.reboot_sitl()
                     self.ahrstrim_attitude_correctness_test_attitude(11)
@@ -13683,8 +13683,8 @@ switch value'''
                     self.set_parameters({
                         'AHRS_TRIM_X': math.radians(r),
                         'AHRS_TRIM_Y': math.radians(p),
-                        "SIM_ACC_TRIM_X": math.radians(r),
-                        "SIM_ACC_TRIM_Y": math.radians(p),
+                        "SIM_BRD_TRIM_X": math.radians(r),
+                        "SIM_BRD_TRIM_Y": math.radians(p),
                     })
                     self.reboot_sitl()
                     self.ahrstrim_attitude_correctness_test_attitude(ahrs_type)

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -1084,7 +1084,10 @@ void AP_AHRS_DCM::estimate_wind(void)
     // this is based on the wind speed estimation code from MatrixPilot by
     // Bill Premerlani. Adaption for ArduPilot by Jon Challinger
     // See http://gentlenav.googlecode.com/files/WindEstimation.pdf
-    const Vector3f fuselageDirection = _dcm_matrix.colx();
+    // use the trim-corrected (vehicle body) forward axis, not the raw board
+    // axis _dcm_matrix.colx(): a non-zero AHRS_TRIM otherwise feeds the wind
+    // triangle the sensor-board direction rather than the fuselage direction.
+    const Vector3f fuselageDirection = _body_dcm_matrix.colx();
     const Vector3f fuselageDirectionDiff = fuselageDirection - _last_fuse;
 
     // scrap our data and start over if we're taking too long to get a direction change
@@ -1133,7 +1136,7 @@ void AP_AHRS_DCM::estimate_wind(void)
 #if AP_AIRSPEED_ENABLED
     if (now - _last_wind_time > 2000 && airspeed_sensor_enabled()) {
         // when flying straight use airspeed to get wind estimate if available
-        const Vector3f airspeed = _dcm_matrix.colx() * AP::airspeed()->get_airspeed();
+        const Vector3f airspeed = fuselageDirection * AP::airspeed()->get_airspeed();
         const Vector3f wind = velocity - (airspeed * get_EAS2TAS());
         _wind = _wind * 0.92f + wind * 0.08f;
     }

--- a/libraries/AP_Compass/AP_Compass_SITL.cpp
+++ b/libraries/AP_Compass/AP_Compass_SITL.cpp
@@ -125,6 +125,14 @@ void AP_Compass_SITL::_timer()
         // rotate compass
         f.rotate_inverse((enum Rotation)_sitl->mag_orient[sitl_instance].get());
         f.rotate(get_board_orientation());
+        // SIM_BRD_TRIM: rigid board mounting offset (same rotation applied to
+        // the accels and gyros), keeping the compass consistent with the IMU
+        const Vector3f &board_trim = _sitl->board_trim.get();
+        if (!board_trim.is_zero()) {
+            Matrix3f trim_rotation;
+            trim_rotation.from_euler(board_trim.x, board_trim.y, board_trim.z);
+            f = trim_rotation.transposed() * f;
+        }
         // scale the compass to simulate sensor scale factor errors
         f *= _sitl->mag_scaling[sitl_instance];
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
@@ -81,10 +81,13 @@ void AP_InertialSensor_SITL::generate_accel()
                                   sitl->state.yAccel,
                                   sitl->state.zAccel);
 
-        const Vector3f &accel_trim = sitl->accel_trim.get();
-        if (!accel_trim.is_zero()) {
+        // SIM_BRD_TRIM: simulate a rigid board mounting offset by rotating
+        // the sensor frame.  Applied to both accel (here) and gyro so the two
+        // stay consistent, as a real tilted mount would.
+        const Vector3f &board_trim = sitl->board_trim.get();
+        if (!board_trim.is_zero()) {
             Matrix3f trim_rotation;
-            trim_rotation.from_euler(accel_trim.x, accel_trim.y, 0);
+            trim_rotation.from_euler(board_trim.x, board_trim.y, board_trim.z);
             accel = trim_rotation.transposed() * accel;
         }
 
@@ -276,6 +279,14 @@ void AP_InertialSensor_SITL::generate_gyro()
         }
 
         Vector3f gyro {p, q, r};
+
+        // SIM_BRD_TRIM: rigid board mounting offset, same rotation as accel:
+        const Vector3f &board_trim = sitl->board_trim.get();
+        if (!board_trim.is_zero()) {
+            Matrix3f trim_rotation;
+            trim_rotation.from_euler(board_trim.x, board_trim.y, board_trim.z);
+            gyro = trim_rotation.transposed() * gyro;
+        }
 
 #if HAL_INS_TEMPERATURE_CAL_ENABLE
         sitl->imu_tcal[gyro_instance].sitl_apply_gyro(get_temperature(), gyro);

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -1119,12 +1119,12 @@ const AP_Param::GroupInfo SIM::var_ins[] = {
     // @Vector3Parameter: 1
     AP_GROUPINFO("ACC3_SCAL",    24, SIM, accel_scale[2], 0),
 #endif
-    // @Param: ACC_TRIM
-    // @DisplayName: Accelerometer trim
-    // @Description: Trim applied to simulated accelerometer
+    // @Param: BRD_TRIM
+    // @DisplayName: Board mounting trim
+    // @Description: Rigid board mounting offset (roll, pitch, yaw in radians) applied as a rotation to the simulated accelerometers, gyros and compasses, as a tilted autopilot mounting would be. Intended to be cancelled by AHRS_TRIM.
     // @User: Advanced
     // @Vector3Parameter: 1
-    AP_GROUPINFO("ACC_TRIM",     25, SIM, accel_trim, 0),
+    AP_GROUPINFO("BRD_TRIM",     25, SIM, board_trim, 0),
 
 #if APM_BUILD_TYPE(APM_BUILD_Rover)
     // @Param{Rover}: SAIL_TYPE

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -610,7 +610,7 @@ public:
     AP_Float accel_noise[INS_MAX_INSTANCES]; // in m/s/s
     AP_Vector3f accel_bias[INS_MAX_INSTANCES]; // in m/s/s
     AP_Vector3f accel_scale[INS_MAX_INSTANCES]; // in m/s/s
-    AP_Vector3f accel_trim;
+    AP_Vector3f board_trim;  // rigid board mounting offset (rad), rotates accel+gyro+compass
     AP_Float accel_fail[INS_MAX_INSTANCES];  // accelerometer failure value
     // gyro and accel fail masks
     AP_Int8 gyro_fail_mask;


### PR DESCRIPTION
### Summary

Change DCM to use fuselage-frame rather than autopilot-frame for calculating wind

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<img width="2004" height="1378" alt="image" src="https://github.com/user-attachments/assets/acf69e3b-b08a-4f35-87c5-be8ffb23748f" />

<img width="2004" height="1378" alt="image" src="https://github.com/user-attachments/assets/8e72f17e-1bdc-494e-af5d-ef2e14a68586" />

New autotest fails before / passes afterwards.  Essentially, "AHRS trim when properly accounted for should not affect wind speed at all"

### Description

DCM currently uses a matrix which has not been adjusted for the autopilot trim (so it works in autopilot body frame rather than the way the fuselage is actually pointed)

Also fixes up a bit of simulation stuff.... simulated board trim now affects more than just the accels - the compass and gyro data also get rotated.  It made a difference!
