### PR TITLE
autotest: build Replay tool with the vehicle's configure options

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -12934,10 +12934,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
     def Replay(self):
         '''test replay correctness'''
         self.progress("Building Replay")
-        # configure for the sitl board explicitly: another test (e.g. a
-        # CAN/periph test) may have left the shared build directory
-        # configured for a different board, which would fail this build:
-        util.build_SITL('tool/Replay', board='sitl', clean=False, configure=True)
+        self.build_replay()
         self.set_parameters({
             "LOG_DARM_RATEMAX": 0,
             "LOG_FILE_RATEMAX": 0,

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -3252,10 +3252,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
     def Replay(self):
         '''test replay correctness'''
         self.progress("Building Replay")
-        # configure for the sitl board explicitly: another test (e.g. a
-        # CAN/periph test) may have left the shared build directory
-        # configured for a different board, which would fail this build:
-        util.build_SITL('tool/Replay', board='sitl', clean=False, configure=True)
+        self.build_replay()
         self.set_parameters({
             "LOG_DARM_RATEMAX": 0,
             "LOG_FILE_RATEMAX": 0,

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -14929,6 +14929,25 @@ switch value'''
         # heading seemingly indefinitely.
         self.reboot_sitl()
 
+    def build_replay(self):
+        '''build the Replay tool with the same configuration as the vehicle
+        binary under test.
+
+        The Replay tool runs the EKF over the logged inputs and the test
+        requires its output to match the live solution bit-for-bit, so the
+        tool must be compiled identically to the vehicle.  Any compile-time
+        difference (num_aux_imus, ekf_single, postype_single, debug, ...)
+        changes the EKF result and makes replay diverge from the live log.
+
+        configure=True is forced because a preceding test (e.g. a CAN/periph
+        test) may have left the shared build directory configured for a
+        different board; we reconfigure for the sitl board but keep the
+        vehicle's configure options.'''
+        build_opts = copy.copy(self.build_opts)
+        build_opts["clean"] = False
+        build_opts["configure"] = True
+        util.build_SITL('tool/Replay', board='sitl', **build_opts)
+
     def run_replay(self, filepath):
         '''runs replay in filepath, returns filepath to Replay logfile'''
         util.run_cmd(


### PR DESCRIPTION
### Summary

Correct Plane Replay test 

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

The Replay test requires the Replay tool's EKF output to match the live solution bit-for-bit.  Commit 390016f6b4 made the Replay subtest rebuild tool/Replay with "board='sitl', configure=True" to recover from a preceding test leaving the build dir configured for another board.  That reconfigure also discarded the vehicle's configure options -- notably --num-aux-imus, which Plane CI builds with (build_ci.sh) -- so tool/Replay was compiled with a different INS_MAX_INSTANCES than the flying binary. The EKF's IMU-instance-sized arrays then differ between the live run and replay, so the replayed solution no longer matched the log and test.Plane.Replay failed (XKF*/XKY* mismatches).

Build tool/Replay with the same build_opts as the vehicle under test (still forcing configure=True for the board-safety reason above) so the tool matches the vehicle for num_aux_imus and any other compile-time option (ekf_single, postype_single, debug, ...).
