### PR TITLE
AP_Mount: fix gimbal-manager-set-attitude NaN check

### DIFF
--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -466,7 +466,7 @@ void AP_Mount::handle_gimbal_manager_set_attitude(const mavlink_message_t &msg)
     const Vector3f att_rate_degs {
         packet.angular_velocity_x,
         packet.angular_velocity_y,
-        packet.angular_velocity_y
+        packet.angular_velocity_z
     };
 
     // ensure that we are only demanded to a specific attitude or to


### PR DESCRIPTION
### Summary

This fixes a typo in the AP_Mount library's handler for the gimbal-manager-set-attitude message ([see mavlink message description here](https://mavlink.io/en/messages/common.html#GIMBAL_MANAGER_SET_ATTITUDE))

From inspection this is only used to check if any of the angular velocity fields are NaNs which allows the caller to specify if rate control is used.  The bug would only appear if the caller set angular velocity x and y to valid numbers and z to NaN.  In this case the bug would allow a NaN to get into the mount's target yaw rate.

I have not actually tested the change but surely it's valid and safe.

While investigating I found we have not documented the use of this command on the wiki.  [See new issue here](https://github.com/ArduPilot/ardupilot_wiki/issues/7817).

This was first noticed by @lthall

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

