### PR TITLE
AP_OpticalFlow: add FLOW_HF_RATEF to correct HereFlow output rate

### DIFF
--- a/libraries/AP_OpticalFlow/AP_OpticalFlow.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow.cpp
@@ -105,6 +105,14 @@ const AP_Param::GroupInfo AP_OpticalFlow::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("_OPTIONS", 7,  AP_OpticalFlow, _options,   0),
 
+    // @Param: _HF_RATEF
+    // @DisplayName: HereFlow output rate correction factor
+    // @Description: Correction applied to the rate of a HereFlow/DroneCAN flow node whose reported integration_interval is wrong, so it reports flow and its own gyro at the wrong rate. This scales flow rate and body rate together (so the gyro compensation stays valid), unlike FLOW_FXSCALER/FYSCALER which only scale flow. Leave at 1.0 unless the flow_cal_check sensor-rate slope (flow node gyro vs IMU gyro) is not ~1.0; then set this to 1/slope. Only affects FLOW_TYPE=6 (DroneCAN).
+    // @Range: 0.25 4.0
+    // @Increment: 0.01
+    // @User: Advanced
+    AP_GROUPINFO("_HF_RATEF", 8,  AP_OpticalFlow, _hereflow_rate_scale, 1.0f),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow.h
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow.h
@@ -146,6 +146,7 @@ private:
     AP_Int8  _address;              // address on the bus (allows selecting between 8 possible I2C addresses for px4flow)
     AP_Float  _height_override;              // height of the sensor above the ground. Only used in rover
     AP_Int16 _options;              // options parameter
+    AP_Float _hereflow_rate_scale;  // HereFlow output-rate correction (flow and gyro), 1.0 = none
 
     // method called by backend to update frontend state:
     void update_state(const OpticalFlow_state &state);

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_Backend.h
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_Backend.h
@@ -57,6 +57,13 @@ protected:
     // get the flow scaling parameters
     Vector2f _flowScaler(void) const { return Vector2f(frontend._flowScalerX, frontend._flowScalerY); }
 
+    // output-rate correction for HereFlow nodes that report a wrong integration_interval
+    float _hereflowRateScale(void) const
+    {
+        const float s = frontend._hereflow_rate_scale;
+        return is_positive(s) ? s : 1.0f;
+    }
+
     // get the yaw angle in radians
     float _yawAngleRad(void) const { return cd_to_rad(float(frontend._yawAngle_cd)); }
 

--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_HereFlow.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_HereFlow.cpp
@@ -73,7 +73,10 @@ void AP_OpticalFlow_HereFlow::_push_state(void)
     //setup scaling based on parameters
     float flowScaleFactorX = 1.0f + 0.001f * flowScaler.x;
     float flowScaleFactorY = 1.0f + 0.001f * flowScaler.y;
-    float integralToRate = 1.0f / integral_time;
+    // FLOW_HF_RATEF corrects a node that reports integration_interval at the wrong
+    // rate; applied here it scales flow and gyro together so the EKF's gyro
+    // compensation stays valid (FLOW_*SCALER cannot, it scales flow only).
+    float integralToRate = _hereflowRateScale() / integral_time;
     //Convert to Raw Flow measurement to Flow Rate measurement
     state.flowRate = Vector2f{
         flow_integral.x * flowScaleFactorX,


### PR DESCRIPTION
## Summary

A HereFlow / DroneCAN optical-flow node can report at the wrong rate when the `integration_interval` it sends is wrong, under-scaling both the flow rate and the body (gyro) rate it reports by the same factor. `FLOW_FXSCALER`/`FYSCALER` cannot correct this - they scale only the flow rate, not the body rate used for gyro compensation, so they would inject spurious flow during rotation. `FLOW_HF_RATEF` scales the HereFlow output rate so flow and gyro are corrected together.

## Testing

- [x] Checked by a human programmer
- [x] Tested on hardware
- [x] Logs available on request

## Description

The HereFlow backend forms both outputs as `integral * (1 / integration_interval)`. A node that reports `integration_interval` about 2x too large (observed on an Holybro H-Flow) therefore reports flow and its own gyro at about half rate. The EKF then derives about half the true optical-flow velocity and under-brakes in position-controlled modes.

This is invisible to the onboard FlowCal, which fits flow against the sensor's own gyro - wrong by the same factor - and so reports "no better scalar". It cannot be fixed with `FLOW_FXSCALER`/`FYSCALER` either: those scale `flowRate` but not `bodyRate`, so correcting flow alone leaves the gyro compensation wrong and injects spurious flow on every rotation.

`FLOW_HF_RATEF` (default 1.0, a no-op for correctly behaving nodes) multiplies `integralToRate` in the HereFlow backend, so flow rate and body rate are scaled together and the gyro compensation stays valid. Set it to 1 / (measured rate error), where the error is found by regressing the node's reported body rate against the flight-controller IMU gyro during rotation.

Before / after on an ARK Flow, `FLOW_HF_RATEF` 1.0 -> 1.92: the node's reported gyro rate goes from ~0.5x the flight-controller IMU to ~1:1 (plot below), and the derived optical-flow velocity matches GPS.

<img width="1210" height="572" alt="hflow_before_after" src="https://github.com/user-attachments/assets/777fadd8-9f09-475d-9bc5-4517de451ea9" />


