### PR TITLE
Fix flaking QLoiterRecovery autotest

### DIFF
--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -2364,7 +2364,6 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
 
     def QLoiterRecovery(self):
         '''test QLOITER recovery from bad attitude'''
-        self.context_push()
         self.install_example_script_context("sim_arming_pos.lua")
         self.install_terrain_handlers_context()
 
@@ -2375,6 +2374,9 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             "LOG_DISARMED": 1,
             "Q_LAND_FINAL_SPD" : 2,
             "HOME_RESET_ALT" : -1,
+            # disable simulated battery voltage sag so the repeated max-thrust
+            # recoveries are not slowed by it
+            "SIM_BATT_RES_OHM" : 0,
         })
 
         self.reboot_sitl(check_position=True)
@@ -2453,11 +2455,9 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.arm_vehicle(force=True)
         self.change_mode("QLAND")
         self.wait_disarmed(timeout=300) # give quadplane a long time to land
-        self.context_pop()
 
     def CruiseRecovery(self):
         '''test QAssist recovery in CRUISE mode from bad attitude'''
-        self.context_push()
         self.install_example_script_context("sim_arming_pos.lua")
         self.install_terrain_handlers_context()
 
@@ -2468,6 +2468,9 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             "LOG_DISARMED": 1,
             "Q_LAND_FINAL_SPD" : 2,
             "HOME_RESET_ALT" : -1,
+            # disable simulated battery voltage sag so the repeated max-thrust
+            # recoveries are not slowed by it
+            "SIM_BATT_RES_OHM" : 0,
         })
 
         self.reboot_sitl(check_position=True)
@@ -2558,7 +2561,6 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.arm_vehicle(force=True)
         self.change_mode("QLAND")
         self.wait_disarmed(timeout=300) # give quadplane a long time to land
-        self.context_pop()
 
     def FastInvertedRecovery(self):
         '''test recovery from inverted flight is fast'''

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -2456,6 +2456,66 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.change_mode("QLAND")
         self.wait_disarmed(timeout=300) # give quadplane a long time to land
 
+    def SimBatteryResistance(self):
+        '''check SIM_BATT_RES_OHM controls simulated battery voltage sag under load'''
+        self.set_parameters({
+            # an analog monitor reports the simulated (sagged) battery voltage
+            "BATT_MONITOR": 4,  # 4 is analog volt+curr
+            # unlimited capacity pins the resting voltage at SIM_BATT_VOLTAGE, so
+            # any drop in the reported voltage is purely sag (current * resistance)
+            "SIM_BATT_CAP_AH": 0,
+            "SIM_BATT_VOLTAGE": 12.6,
+            # keep battery failsafes out of the way while we deliberately sag the pack
+            "BATT_LOW_VOLT": 0,
+            "BATT_CRT_VOLT": 0,
+            "BATT_FS_LOW_ACT": 0,
+            "BATT_FS_CRT_ACT": 0,
+        })
+        self.reboot_sitl()  # BATT_MONITOR change requires a reboot
+
+        # put the motors under a steady hover load
+        self.takeoff(20, mode="QHOVER")
+
+        def hover_voltage():
+            # let the 10Hz sim voltage filter settle, then average a few samples
+            self.delay_sim_time(2)
+            samples = 10
+            total = 0
+            for _ in range(samples):
+                m = self.assert_receive_message('BATTERY_STATUS', timeout=5)
+                total += m.voltages[0] * 0.001  # mV -> V
+            return total / samples
+
+        # with sag disabled the pack should read close to its resting voltage
+        self.set_parameter("SIM_BATT_RES_OHM", 0)
+        v_no_sag = hover_voltage()
+        self.progress(f"hover voltage, sag disabled: {v_no_sag}V")
+        if abs(v_no_sag - 12.6) > 0.2:
+            raise NotAchievedException(
+                "Expected ~resting voltage with sag disabled, got {v_no_sag}V")
+
+        # introducing resistance should sag the voltage under the same load
+        hover_voltage_ohms = 0.05
+        self.set_parameter("SIM_BATT_RES_OHM", hover_voltage_ohms)
+        v_sag = hover_voltage()
+        self.progress("hover voltage, {hover_voltage_ohms}ohm: {v_sag}V")
+        if v_sag > v_no_sag - 0.3:
+            raise NotAchievedException(
+                "Expected voltage sag with resistance, got {v_sag}V (no-sag {v_no_sag}V)")
+
+        # more resistance should sag the voltage further still
+        hover_voltage_more_ohms = 0.1
+        self.set_parameter("SIM_BATT_RES_OHM", hover_voltage_more_ohms)
+        v_more_sag = hover_voltage()
+        self.progress("hover voltage, {hover_voltage_more_ohms}ohm: {v_more_sag}V")
+        if v_more_sag > v_sag - 0.2:
+            raise NotAchievedException(
+                "Expected more sag at higher resistance, got {v_more_sag}V ({hover_voltage_more_ohms}ohm {v_sag}V)")
+
+        # restore full thrust before landing so the RTL is not handicapped
+        self.set_parameter("SIM_BATT_RES_OHM", 0)
+        self.do_RTL()
+
     def CruiseRecovery(self):
         '''test QAssist recovery in CRUISE mode from bad attitude'''
         self.install_example_script_context("sim_arming_pos.lua")
@@ -3299,6 +3359,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             self.DoRepositionTerrain,
             self.DoRepositionTerrain2,
             self.QLoiterRecovery,
+            self.SimBatteryResistance,
             self.FastInvertedRecovery,
             self.CruiseRecovery,
             self.RudderArmedTakeoffRequiresNeutralThrottle,

--- a/libraries/SITL/SIM_Battery.cpp
+++ b/libraries/SITL/SIM_Battery.cpp
@@ -138,8 +138,13 @@ void Battery::setup(float _capacity_Ah, float _resistance_ohm, float _max_voltag
     remaining_Ah = compute_remaining_Ah(voltage_set);
 }
 
-void Battery::maybe_reset(float desired_voltage, float desired_capacity_Ah)
+// A negative value for desired_resistance means "no change".
+void Battery::maybe_reset(float desired_voltage, float desired_capacity_Ah, float desired_resistance_ohm)
 {
+    if (!is_negative(desired_resistance_ohm)) {
+        resistance_ohm = desired_resistance_ohm;
+    }
+
     const bool reset_not_needed = (is_equal(voltage_set, desired_voltage)
                                    && is_equal(capacity_Ah, desired_capacity_Ah));
     if (reset_not_needed) {

--- a/libraries/SITL/SIM_Battery.h
+++ b/libraries/SITL/SIM_Battery.h
@@ -28,7 +28,9 @@ public:
     void setup(float _capacity_Ah, float _resistance_ohm, float _max_voltage, float _ambient_temperature_degC);
 
     // Resets the battery state if the configuration (e.g. from SIM_BATT_* parameters) has changed.
-    void maybe_reset(float desired_voltage, float desired_capacity_Ah);
+    // Changing desired_resistance_ohm does not cause a state reset.
+    // A negative desired_resistance value means to leave the existing resistance unchanged.
+    void maybe_reset(float desired_voltage, float desired_capacity_Ah, float desired_resistance_ohm = -1.0f);
 
     // Call this periodically to "step" the battery forward in time
     void consume_energy(float attempted_current_amp, uint64_t now_us);

--- a/libraries/SITL/SIM_Multicopter.cpp
+++ b/libraries/SITL/SIM_Multicopter.cpp
@@ -87,7 +87,7 @@ void MultiCopter::update(const struct sitl_input &input)
 }
 
 void MultiCopter::update_battery() {
-    battery.maybe_reset(sitl->batt_voltage, sitl->batt_capacity_ah);
+    battery.maybe_reset(sitl->batt_voltage, sitl->batt_capacity_ah, sitl->batt_resistance);
     battery_voltage = battery.get_voltage();
     battery_current = frame->get_current_amp();
     battery_temperature_degC = battery.get_temperature_degC();

--- a/libraries/SITL/SIM_QuadPlane.cpp
+++ b/libraries/SITL/SIM_QuadPlane.cpp
@@ -139,7 +139,7 @@ void QuadPlane::update(const struct sitl_input &input)
         quad_accel_body.rotate(ROTATION_PITCH_270);
     }
 
-    battery.maybe_reset(sitl->batt_voltage, sitl->batt_capacity_ah);
+    battery.maybe_reset(sitl->batt_voltage, sitl->batt_capacity_ah, sitl->batt_resistance);
     battery_voltage = battery.get_voltage();
     battery_current = frame->get_current_amp();
     battery_temperature_degC = battery.get_temperature_degC();

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -129,6 +129,7 @@ const AP_Param::GroupInfo SIM::var_info[] = {
     // @Description: Simulated battery internal resistance, used to model voltage sag under load (sag = current * resistance) and temperature growth. A negative value implies "use previous resistance", which is the default in order that a model-provided resistance is the default behavior. Set to 0 to disable voltage sag and temperature growth entirely.
     // @Units: Ohm
     // @User: Advanced
+    // @RebootRequired: True
     AP_GROUPINFO("BATT_RES_OHM",  21, SIM,  batt_resistance,  -1),
     // 23 was SONAR_GLITCH
     // 24 was SONAR_RND

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -124,6 +124,12 @@ const AP_Param::GroupInfo SIM::var_info[] = {
     // @Units: Ah
     // @User: Advanced
     AP_GROUPINFO("BATT_CAP_AH",   20, SIM,  batt_capacity_ah,  0),
+    // @Param: BATT_RES_OHM
+    // @DisplayName: Simulated battery internal resistance
+    // @Description: Simulated battery internal resistance, used to model voltage sag under load (sag = current * resistance) and temperature growth. A negative value implies "use previous resistance", which is the default in order that a model-provided resistance is the default behavior. Set to 0 to disable voltage sag and temperature growth entirely.
+    // @Units: Ohm
+    // @User: Advanced
+    AP_GROUPINFO("BATT_RES_OHM",  21, SIM,  batt_resistance,  -1),
     // 23 was SONAR_GLITCH
     // 24 was SONAR_RND
     // @Param: RC_FAIL

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -229,6 +229,7 @@ public:
 
     AP_Float batt_voltage; // battery voltage base
     AP_Float batt_capacity_ah; // battery capacity in Ah
+    AP_Float batt_resistance; // battery internal resistance override in ohms; <0 uses the vehicle model's value
     AP_Int8  rc_fail;     // fail RC input
     AP_Int8  rc_chancount; // channel count
     AP_Int8  float_exception; // enable floating point exception checks

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -229,7 +229,7 @@ public:
 
     AP_Float batt_voltage; // battery voltage base
     AP_Float batt_capacity_ah; // battery capacity in Ah
-    AP_Float batt_resistance; // battery internal resistance override in ohms; <0 uses the vehicle model's value
+    AP_Float batt_resistance; // battery internal resistance override in ohms
     AP_Int8  rc_fail;     // fail RC input
     AP_Int8  rc_chancount; // channel count
     AP_Int8  float_exception; // enable floating point exception checks

--- a/libraries/SITL/tests/test_battery.cpp
+++ b/libraries/SITL/tests/test_battery.cpp
@@ -18,6 +18,10 @@ constexpr float large_capacity_Ah = 8.0f;
 constexpr float low_resistance_ohm = 0.005f;
 constexpr float high_resistance_ohm = 0.04f;
 
+// A negative resistance passed to maybe_reset() means "leave the
+// existing resistance unchanged".  This is also the default
+constexpr float keep_resistance = -1.0f;
+
 // This can be any value, in operation it would come from AP_HAL::micros64().
 constexpr uint64_t initial_us = 0;
 
@@ -329,6 +333,46 @@ TEST_F(BatteryTest, Resetting)
         }
         // (Don't add further tests here, batteries no longer match their names.)
     }
+}
+
+TEST_F(BatteryTest, ResistanceOverride)
+{
+    // Unlimited capacity keeps the resting voltage pinned at max, so any drop in
+    // the observed voltage is purely sag (current * resistance).
+    SITL::Battery battery;
+    // The initial resistance is arbitrary, as this test will vary it as-needed.
+    battery.setup(0.0f, high_resistance_ohm, max_voltage, ambient_temperature_degC);
+
+    constexpr float current_amp = 25.0f;
+    constexpr float dt_sec = 0.01f;
+    constexpr float settle_sec = 5.0f;  // many time-constants of the 10Hz voltage filter
+    uint64_t now_us = initial_us;
+
+    // Apply the requested resistance, then drive a constant current long enough for
+    // the voltage filter to settle, and return the resulting sagged voltage.
+    auto sagged_voltage = [&](float resistance_ohm) -> float {
+        battery.maybe_reset(max_voltage, battery.get_capacity(), resistance_ohm);
+        for (float t = 0.0f; t < settle_sec; t += dt_sec) {
+            now_us += static_cast<uint64_t>(dt_sec * 1e6);
+            battery.consume_energy(current_amp, now_us);
+        }
+        return battery.get_voltage();
+    };
+
+    // Zero resistance disables sag entirely.
+    EXPECT_FLOAT_EQ(sagged_voltage(0.0f), max_voltage);
+
+    // A negative resistance leaves the previous resistance (still zero) in place.
+    EXPECT_FLOAT_EQ(sagged_voltage(keep_resistance), max_voltage);
+
+    // A positive resistance sags the voltage by current * resistance...
+    const float low_sag = sagged_voltage(low_resistance_ohm);
+    EXPECT_NEAR(low_sag, max_voltage - current_amp * low_resistance_ohm, 1e-3f);
+
+    // ...and a higher resistance sags more.
+    const float high_sag = sagged_voltage(high_resistance_ohm);
+    EXPECT_LT(high_sag, low_sag);
+    EXPECT_NEAR(high_sag, max_voltage - current_amp * high_resistance_ohm, 1e-3f);
 }
 
 AP_GTEST_MAIN()


### PR DESCRIPTION
### Summary

Stops this newly-flaking test from flaking by disabling newly-introduced voltage-sag capabilities for the specific test

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Adds a parameter which allows the resistance specified in the model json to be overridden by parameter.
