### PR TITLE
Remove dead stores

### DIFF
--- a/libraries/AP_CSVReader/tests/test_csvreader.cpp
+++ b/libraries/AP_CSVReader/tests/test_csvreader.cpp
@@ -136,6 +136,124 @@ TEST(AP_CSVReader, missinglastcr)
     EXPECT_STREQ((char*)term, "1");
 }
 
+// A Saleae async-serial capture row looks like:
+//     Time [s],Value,Parity Error,Framing Error
+//     0.000010,0xZZ,,
+// AP_HAL_SITL's read_from_async_csv() feeds such rows through AP_CSVReader
+// and then decodes the "Value" term's two hex digits (term[2],term[3]) with
+// hex_twochars_to_uint8().  This test pushes a row whose Value has an invalid
+// hex character through the parser and confirms where the error is (and is
+// not) caught: AP_CSVReader splits the row cleanly -- it does no hex
+// validation -- and it is the subsequent hex decode that rejects the byte.
+TEST(AP_CSVReader, saleae_value_invalid_hex)
+{
+    static const char *row =
+        "0.000010,0xZZ,,\r\n"
+        ;
+
+    uint8_t term[64];
+    AP_CSVReader csvreader{term, ARRAY_SIZE(term), ','};
+
+    uint8_t value_term[64] = {};
+    uint8_t termcount = 0;
+    for (uint8_t i=0; i<strlen(row); i++) {
+        switch (csvreader.feed(row[i])) {
+        case AP_CSVReader::RetCode::ERROR:
+            // the parser must NOT flag an error: "0xZZ" is a perfectly valid
+            // CSV term, it is just not valid hex
+            FAIL() << "unexpected ERROR from parser at offset " << (int)i;
+            break;
+        case AP_CSVReader::RetCode::OK:
+            continue;
+        case AP_CSVReader::RetCode::TERM_DONE:
+        case AP_CSVReader::RetCode::VECTOR_DONE:
+            if (termcount == 1) {  // the "Value" column
+                memcpy(value_term, term, sizeof(value_term));
+            }
+            termcount++;
+            continue;
+        }
+    }
+
+    // four terms: Time, Value, Parity Error, Framing Error
+    EXPECT_EQ(termcount, 4);
+    // the parser handed us the Value term verbatim, bad hex and all
+    EXPECT_STREQ((char*)value_term, "0xZZ");
+
+    // ... and the hex decode (as performed by read_from_async_csv) rejects it
+    uint8_t decoded;
+    EXPECT_FALSE(hex_twochars_to_uint8((const char*)&value_term[2], decoded));
+}
+
+// Companion to the above: a well-formed Value term decodes to the right byte,
+// confirming the decode the SITL reader relies on works end-to-end.
+TEST(AP_CSVReader, saleae_value_valid_hex)
+{
+    static const char *row =
+        "0.000010,0x55,,\r\n"
+        ;
+
+    uint8_t term[64];
+    AP_CSVReader csvreader{term, ARRAY_SIZE(term), ','};
+
+    uint8_t value_term[64] = {};
+    uint8_t termcount = 0;
+    for (uint8_t i=0; i<strlen(row); i++) {
+        switch (csvreader.feed(row[i])) {
+        case AP_CSVReader::RetCode::ERROR:
+            FAIL() << "unexpected ERROR from parser at offset " << (int)i;
+            break;
+        case AP_CSVReader::RetCode::OK:
+            continue;
+        case AP_CSVReader::RetCode::TERM_DONE:
+        case AP_CSVReader::RetCode::VECTOR_DONE:
+            if (termcount == 1) {
+                memcpy(value_term, term, sizeof(value_term));
+            }
+            termcount++;
+            continue;
+        }
+    }
+
+    EXPECT_EQ(termcount, 4);
+    EXPECT_STREQ((char*)value_term, "0x55");
+
+    uint8_t decoded;
+    EXPECT_TRUE(hex_twochars_to_uint8((const char*)&value_term[2], decoded));
+    EXPECT_EQ(decoded, 0x55u);
+}
+
+// A term that does not fit in the caller-supplied buffer (term_len-1 chars,
+// reserving one byte for the null terminator) must return ERROR rather than
+// overrun.
+TEST(AP_CSVReader, term_overflow_returns_error)
+{
+    // term_len 4 => room for 3 characters plus a null terminator
+    uint8_t term[4];
+    AP_CSVReader csvreader{term, ARRAY_SIZE(term), ','};
+
+    // first three characters are accepted
+    EXPECT_EQ(csvreader.feed('A'), AP_CSVReader::RetCode::OK);
+    EXPECT_EQ(csvreader.feed('B'), AP_CSVReader::RetCode::OK);
+    EXPECT_EQ(csvreader.feed('C'), AP_CSVReader::RetCode::OK);
+    // the fourth would overrun the buffer
+    EXPECT_EQ(csvreader.feed('D'), AP_CSVReader::RetCode::ERROR);
+}
+
+// A quoted term that is followed by non-separator, non-newline data is
+// malformed and must return ERROR.
+TEST(AP_CSVReader, malformed_quoted_term_returns_error)
+{
+    uint8_t term[16];
+    AP_CSVReader csvreader{term, ARRAY_SIZE(term), ','};
+
+    EXPECT_EQ(csvreader.feed('"'), AP_CSVReader::RetCode::OK);  // open quote
+    EXPECT_EQ(csvreader.feed('A'), AP_CSVReader::RetCode::OK);  // contents
+    EXPECT_EQ(csvreader.feed('"'), AP_CSVReader::RetCode::OK);  // close quote
+    // stray character after the closing quote is not allowed
+    EXPECT_EQ(csvreader.feed('X'), AP_CSVReader::RetCode::ERROR);
+}
+
 AP_GTEST_MAIN()
 
 

--- a/libraries/AP_HAL_SITL/UARTDriver.cpp
+++ b/libraries/AP_HAL_SITL/UARTDriver.cpp
@@ -821,9 +821,9 @@ uint16_t UARTDriver::read_from_async_csv(uint8_t *buffer, uint16_t space)
                         break;
                     }
                     if (!hex_twochars_to_uint8((const char*)&logic_async_csv.term[2], logic_async_csv.loaded_data.b)) {
-                        // invalid character
-                        retcode = AP_CSVReader::RetCode::ERROR;
-                        return 0;
+                        // invalid character; panic as we do for other
+                        // malformed-CSV cases rather than silently stopping
+                        AP_HAL::panic("Malformed CSV?");
                     }
                     break;
                 case 2:  // error

--- a/libraries/AP_InertialSensor/AP_InertialSensor_ADIS16607.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_ADIS16607.cpp
@@ -392,9 +392,9 @@ void AP_InertialSensor_ADIS16607::read_sensor_fifo(void)
         } else if (ch == ADIS16607_FIFO_CHANNEL_MAX_INDEX) {
             need_sync = false;
         } else {
-            // Read to end of FIFO block
+            // Read to end of FIFO block (data discarded; the read advances the FIFO)
             while (fifo_word_num != 0) {
-                val = read_reg16(REG_FIFO_DATA);
+                UNUSED_RESULT(read_reg16(REG_FIFO_DATA));
                 ch = read_reg16(REG_FIFO_CH_INDEX);
                 fifo_word_num--;
                 if (ch == ADIS16607_FIFO_CHANNEL_MAX_INDEX) {

--- a/libraries/AP_Mount/AP_Mount_Viewpro.cpp
+++ b/libraries/AP_Mount/AP_Mount_Viewpro.cpp
@@ -475,7 +475,6 @@ void AP_Mount_Viewpro::send_target_angles(const MountAngleTarget &angle_rad)
 {
     const float pitch_rad = angle_rad.pitch;
     const float yaw_rad = angle_rad.yaw;
-    bool yaw_is_ef = angle_rad.yaw_is_ef;
 
     // gimbal does not support lock in angle control mode
     if (!set_lock(false)) {
@@ -483,14 +482,13 @@ void AP_Mount_Viewpro::send_target_angles(const MountAngleTarget &angle_rad)
     }
 
     // convert yaw angle to body-frame
-    float yaw_bf_rad = yaw_is_ef ? wrap_PI(yaw_rad - AP::ahrs().get_yaw_rad()) : yaw_rad;
+    float yaw_bf_rad = angle_rad.yaw_is_ef ? wrap_PI(yaw_rad - AP::ahrs().get_yaw_rad()) : yaw_rad;
 
     // enforce body-frame yaw angle limits.  If beyond limits always use body-frame control
     const float yaw_bf_min = radians(_params.yaw_angle_min);
     const float yaw_bf_max = radians(_params.yaw_angle_max);
     if (yaw_bf_rad < yaw_bf_min || yaw_bf_rad > yaw_bf_max) {
         yaw_bf_rad = constrain_float(yaw_bf_rad, yaw_bf_min, yaw_bf_max);
-        yaw_is_ef = false;
     }
 
     // scale pitch and yaw to values gimbal understands

--- a/libraries/SITL/SIM_BalanceBot.cpp
+++ b/libraries/SITL/SIM_BalanceBot.cpp
@@ -119,10 +119,9 @@ void BalanceBot::update(const struct sitl_input &input)
     // accel in body frame due to motor
     accel_body = Vector3f(accel_vf_x*cos(theta), 0, -accel_vf_x*sin(theta));
 
-    // update theta and angular velocity
+    // update angular velocity (theta is re-derived from the attitude each
+    // step via the DCM below, so it is not integrated here)
     ang_vel += angular_accel_bf_y * delta_time;
-    theta += ang_vel * delta_time;
-    theta = fmod(theta, radians(360));
 
     gyro = Vector3f(0, ang_vel, radians(yaw_rate));
 


### PR DESCRIPTION
### Summary

Removes dead stores of local variables to move towards clang-scan-build cleanliness

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Removes dead stores detected by clang-scan-build
