### PR TITLE
SITL::Submarine battery temperature

### DIFF
--- a/libraries/SITL/SIM_Submarine.cpp
+++ b/libraries/SITL/SIM_Submarine.cpp
@@ -135,6 +135,8 @@ void Submarine::update_battery(const struct sitl_input &input)
         battery_voltage -= fraction * voltage_sag_scaler_volts;
         battery_current += fraction * current_draw_scaler_amps;
     }
+    // Some reasonable constant battery temperature for underwater operations
+    battery_temperature_degC = 8.0;
 }
 
 /**


### PR DESCRIPTION
### Summary

Specify 8 deg C as a reasonable constant battery temperature for SITL::Submarine.

This is chained behind #33461 .

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
