### PR TITLE
Copter: refactor pilot takeoff altitude constraint logic

### DIFF
--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -318,8 +318,10 @@
 //////////////////////////////////////////////////////////////////////////////
 // Takeoff
 //
+#define PILOT_TKO_ALT_M_MIN 0.0f  // the minimum altitude above home that pilot initiated takeoff will climb to before switching to normal altitude control.
+#define PILOT_TKO_ALT_M_MAX 10.0f  // the maximum altitude above home that pilot initiated takeoff will climb to before switching to normal altitude control.
 #ifndef PILOT_TKO_ALT_M_DEFAULT
- # define PILOT_TKO_ALT_M_DEFAULT 0     // default final alt above home for pilot initiated takeoff
+ # define PILOT_TKO_ALT_M_DEFAULT PILOT_TKO_ALT_M_MIN     // default final alt above home for pilot initiated takeoff
 #endif
 
 

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -1134,3 +1134,13 @@ Location Mode::get_stopping_point() const
     copter.pos_control->get_stopping_point_D_m(stopping_point_ned_m.z);
     return Location::from_ekf_offset_NED_m(stopping_point_ned_m, Location::AltFrame::ABOVE_ORIGIN);
 }
+
+/**
+ * Returns the pilot’s takeoff altitude in meters, constrained to the range [PILOT_TKO_ALT_M_MIN, PILOT_TKO_ALT_M_MAX].
+ * 
+ * @return The constrained takeoff altitude in meters.
+ */
+float Mode::get_constrained_takeoff_alt() const
+{
+    return constrain_float(g2.pilot_takeoff_alt_m, PILOT_TKO_ALT_M_MIN, PILOT_TKO_ALT_M_MAX);
+}

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -222,6 +222,9 @@ protected:
     // Return stopping point as a location with above origin alt frame
     Location get_stopping_point() const;
 
+    // Return stopping point as a location with above origin alt frame, but with the altitude constrained to be within the range of PILOT_TKO_ALT_M_MIN and PILOT_TKO_ALT_M_MAX
+    float get_constrained_takeoff_alt() const;
+
     // functions to control normal landing.  pause_descent is true if vehicle should not descend
     void land_run_horizontal_control();
     void land_run_vertical_control(bool pause_descent = false);

--- a/ArduCopter/mode_althold.cpp
+++ b/ArduCopter/mode_althold.cpp
@@ -65,7 +65,7 @@ void ModeAltHold::run()
     case AltHoldModeState::Takeoff:
         // initiate take-off
         if (!takeoff.running()) {
-            takeoff.start_m(constrain_float(g2.pilot_takeoff_alt_m, 0.0, 10.0));
+            takeoff.start_m(get_constrained_takeoff_alt());
         }
 
         // get avoidance adjusted climb rate

--- a/ArduCopter/mode_flowhold.cpp
+++ b/ArduCopter/mode_flowhold.cpp
@@ -284,7 +284,7 @@ void ModeFlowHold::run()
 
         // initiate take-off
         if (!takeoff.running()) {
-            takeoff.start_m(constrain_float(g2.pilot_takeoff_alt_m, 0.0, 10.0));
+            takeoff.start_m(get_constrained_takeoff_alt());
         }
 
         // get avoidance adjusted climb rate

--- a/ArduCopter/mode_loiter.cpp
+++ b/ArduCopter/mode_loiter.cpp
@@ -132,7 +132,7 @@ void ModeLoiter::run()
     case AltHoldModeState::Takeoff:
         // initiate take-off
         if (!takeoff.running()) {
-            takeoff.start_m(constrain_float(g2.pilot_takeoff_alt_m, 0.0, 10.0));
+            takeoff.start_m(get_constrained_takeoff_alt());
         }
 
         // get avoidance adjusted climb rate

--- a/ArduCopter/mode_poshold.cpp
+++ b/ArduCopter/mode_poshold.cpp
@@ -181,7 +181,7 @@ void ModePosHold::run()
     case AltHoldModeState::Takeoff:
         // initiate take-off
         if (!takeoff.running()) {
-            takeoff.start_m(constrain_float(g2.pilot_takeoff_alt_m, 0.0f, 10.0f));
+            takeoff.start_m(get_constrained_takeoff_alt());
         }
 
         // avoidance-adjusted climb

--- a/ArduCopter/mode_sport.cpp
+++ b/ArduCopter/mode_sport.cpp
@@ -90,7 +90,7 @@ void ModeSport::run()
     case AltHoldModeState::Takeoff:
         // initiate take-off
         if (!takeoff.running()) {
-            takeoff.start_m(constrain_float(g2.pilot_takeoff_alt_m, 0.0, 10.0));
+            takeoff.start_m(get_constrained_takeoff_alt());
         }
 
         // get avoidance adjusted climb rate

--- a/ArduCopter/mode_zigzag.cpp
+++ b/ArduCopter/mode_zigzag.cpp
@@ -325,7 +325,7 @@ void ModeZigZag::manual_control()
     case AltHoldModeState::Takeoff:
         // initiate take-off
         if (!takeoff.running()) {
-            takeoff.start_m(constrain_float(g2.pilot_takeoff_alt_m, 0.0, 10.0));
+            takeoff.start_m(get_constrained_takeoff_alt());
         }
 
         // get avoidance adjusted climb rate


### PR DESCRIPTION
### Summary

Centralize pilot takeoff altitude constraint logic by introducing `Mode::get_constrained_takeoff_alt()` to eliminate code duplication across multiple flight modes.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Tested via SITL to ensure that pilot-initiated takeoff behavior in AltHold, Loiter, and PosHold modes remains unchanged and correctly adheres to the defined altitude constraints.

### Description

This PR refactors the pilot takeoff altitude validation logic to improve code maintainability and eliminate redundancy.

1. **Centralized Constants:**
   Defined `PILOT_TKO_ALT_M_MIN` and `PILOT_TKO_ALT_M_MAX` macros to centralize the allowable altitude boundaries.

2. **Added Helper Function:**
   Introduced `Mode::get_constrained_takeoff_alt()` in the base `Mode` class. This function safely constrains `g2.pilot_takeoff_alt_m` using the centralized macros.

3. **Code Cleanup:**
   Replaced duplicated `constrain_float(...)` implementations in various flight mode files (such as `mode_althold.cpp`, `mode_loiter.cpp`, `mode_poshold.cpp`, etc.) with a clean, single-line call:
   `takeoff.start_m(get_constrained_takeoff_alt());`
