### PR TITLE
Plane: Guided attitude rate control

### DIFF
--- a/ArduPlane/GCS_MAVLink_Plane.cpp
+++ b/ArduPlane/GCS_MAVLink_Plane.cpp
@@ -1041,6 +1041,8 @@ void GCS_MAVLINK_Plane::handle_set_attitude_target(const mavlink_message_t &msg)
 
         uint8_t attitude_mask = att_target.type_mask & 0b10000111; // q plus rpy
 
+        plane.guided_state.last_forced_rpy_rates_ms = 0; // by default, disabe rate control
+
         uint32_t now = AP_HAL::millis();
         if ((attitude_mask & 0b10000001) ||    // partial, including roll
                 (attitude_mask == 0b10000000)) { // all angles
@@ -1071,6 +1073,26 @@ void GCS_MAVLINK_Plane::handle_set_attitude_target(const mavlink_message_t &msg)
             // Update timer for external throttle
             plane.guided_state.last_forced_throttle_ms = now;
         }
+
+        // Note: Historically, attitude_mask used BODY_ROLL/PITCH/YAW_RATE_IGNORE to indicate which axes to ignore when handling attitude (not just rates).
+        // For attitude rate control, and to avoid conflicts with existing behavior, ATTITUDE_IGNORE must be set, and we require that all 3 axes need to be enable.
+
+        if (attitude_mask & 0b10000000) { // we use attitude control
+            return;
+        }
+
+        if ((attitude_mask & 0b00000001) && (attitude_mask & 0b00000010) && (attitude_mask & 0b00000100)) {
+            plane.guided_state.forced_rpy_rates_cd.x = degrees(att_target.body_roll_rate) * 100;
+            plane.guided_state.forced_rpy_rates_cd.y = degrees(att_target.body_pitch_rate) * 100;
+            plane.guided_state.forced_rpy_rates_cd.z = degrees(att_target.body_yaw_rate) * 100;
+            
+            // Enable and update timer for rate control
+            plane.guided_state.last_forced_rpy_rates_ms = now;
+
+            // Disable attitude control
+            plane.guided_state.last_forced_rpy_ms  = {0, 0, 0};
+        }
+
     }
 
 void GCS_MAVLINK_Plane::handle_set_position_target_local_ned(const mavlink_message_t &msg)

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -577,6 +577,10 @@ private:
         // last time we heard from the external controller
         Vector3l last_forced_rpy_ms;
 
+        // roll pitch yaw rates commandes from external controller in centidegrees
+        Vector3l forced_rpy_rates_cd;
+        int32_t last_forced_rpy_rates_ms;
+
         // throttle  commanded from external controller in percent
         float forced_throttle;
         uint32_t last_forced_throttle_ms;

--- a/ArduPlane/mode.cpp
+++ b/ArduPlane/mode.cpp
@@ -53,6 +53,7 @@ bool Mode::enter()
 
     // reset external attitude guidance
     plane.guided_state.last_forced_rpy_ms.zero();
+    plane.guided_state.last_forced_rpy_rates_ms = 0;
     plane.guided_state.last_forced_throttle_ms = 0;
 
 #if AP_PLANE_OFFBOARD_GUIDED_SLEW_ENABLED

--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -362,6 +362,8 @@ public:
     // methods that affect movement of the vehicle in this mode
     void update() override;
 
+    void run() override;
+
     void navigate() override;
 
     virtual bool is_guided_mode() const override { return true; }

--- a/ArduPlane/mode_guided.cpp
+++ b/ArduPlane/mode_guided.cpp
@@ -36,6 +36,33 @@ void ModeGuided::update()
     }
 #endif
 
+    // Throttle output
+    if (plane.guided_throttle_passthru) {
+        // manual passthrough of throttle in fence breach
+        SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, plane.get_throttle_input(true));
+
+    }  else if (plane.aparm.throttle_cruise > 1 &&
+            plane.guided_state.last_forced_throttle_ms > 0 &&
+            millis() - plane.guided_state.last_forced_throttle_ms < plane.g2.guided_timeout*1000.0f) {
+        // Received an external msg that guides throttle within g2.guided_timeout?
+        SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, plane.guided_state.forced_throttle);
+
+    } else {
+        // TECS control
+        plane.calc_throttle();
+
+    }
+
+    if (plane.guided_state.last_forced_rpy_rates_ms > 0 &&
+            millis() - plane.guided_state.last_forced_rpy_rates_ms < plane.g2.guided_timeout*1000.0f) {
+        
+        plane.nav_roll_cd = plane.ahrs.roll_sensor;
+        plane.nav_pitch_cd = plane.ahrs.pitch_sensor;
+        plane.update_load_factor();
+        return;
+    }
+
+
     // Received an external msg that guides roll within g2.guided_timeout?
     if (plane.guided_state.last_forced_rpy_ms.x > 0 &&
             millis() - plane.guided_state.last_forced_rpy_ms.x < plane.g2.guided_timeout*1000.0f) {
@@ -82,22 +109,7 @@ void ModeGuided::update()
         plane.calc_nav_pitch();
     }
 
-    // Throttle output
-    if (plane.guided_throttle_passthru) {
-        // manual passthrough of throttle in fence breach
-        SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, plane.get_throttle_input(true));
 
-    }  else if (plane.aparm.throttle_cruise > 1 &&
-            plane.guided_state.last_forced_throttle_ms > 0 &&
-            millis() - plane.guided_state.last_forced_throttle_ms < plane.g2.guided_timeout*1000.0f) {
-        // Received an external msg that guides throttle within g2.guided_timeout?
-        SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, plane.guided_state.forced_throttle);
-
-    } else {
-        // TECS control
-        plane.calc_throttle();
-
-    }
 
 }
 
@@ -198,5 +210,23 @@ void ModeGuided::update_target_altitude()
 #endif // AP_PLANE_OFFBOARD_GUIDED_SLEW_ENABLED
         {
         Mode::update_target_altitude();
+    }
+}
+
+void ModeGuided::run() {
+    if (plane.guided_state.last_forced_rpy_rates_ms > 0 &&
+            millis() - plane.guided_state.last_forced_rpy_rates_ms < plane.g2.guided_timeout*1000.0f) {
+        
+        const float speed_scaler = plane.get_speed_scaler();
+        float roll_out = plane.rollController.get_rate_out(plane.guided_state.forced_rpy_rates_cd.x / 100.0f, speed_scaler);
+        float pitch_out = plane.pitchController.get_rate_out(plane.guided_state.forced_rpy_rates_cd.y / 100.0f, speed_scaler);
+        float yaw_out = plane.yawController.get_rate_out(plane.guided_state.forced_rpy_rates_cd.z / 100.0f, speed_scaler, true);
+
+        SRV_Channels::set_output_scaled(SRV_Channel::k_aileron, roll_out);
+        SRV_Channels::set_output_scaled(SRV_Channel::k_elevator, pitch_out);
+        SRV_Channels::set_output_scaled(SRV_Channel::k_rudder, yaw_out);
+
+    } else {
+        Mode::run();
     }
 }

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -6513,6 +6513,102 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.delay_sim_time(5, reason="terrain altitude to stabilise before landing")
         self.fly_home_land_and_disarm()
 
+    def MAV_CMD_GUIDED_ATTITUDE_RATE(self, tolerance=0.5):
+        """Test setting of attitude rate target in guided mode."""
+        self.takeoff(1000, timeout=120)
+        self.change_mode("GUIDED")
+
+        # Test rate control with type_mask ignoring attitude angles
+        # type_mask bits: bit 0=roll_rate, bit 1=pitch_rate, bit 2=yaw_rate, bit 6=throttle, bit 7=attitude
+        # Set bit 7 to ignore attitude, clear bits 0-2 to use rates
+        steps = [
+            {"name": "barrel", "roll_r": 1, "pitch_r": 0, "yaw_r": 0, "thr": 0.5, "time": 10.0, "mask": 0b10000000},
+            {"name": "stable", "roll_r": 0, "pitch_r": 0,  "yaw_r": 0, "thr": 0.5, "time": 5.0, "mask": 0b10000000},
+            {"name": "gfactor", "roll_r": 0, "pitch_r": 0.5, "yaw_r": 0, "thr": 0.5, "time": 3.0, "mask": 0b10000000},
+            {"name": "i-loop", "roll_r": 0., "pitch_r": -1, "yaw_r": 0, "thr": 0.7, "time": 25.0, "mask": 0b10000000},
+            {"name": "b-loop", "roll_r": 1., "pitch_r": 1,  "yaw_r": 0, "thr": 0.9, "time": 15.0, "mask": 0b10000000},
+        ]
+
+        state_wait = "wait"
+        state_hold = "hold"
+        try:
+            for step in steps:
+                state = state_wait
+                state_start = self.get_sim_time_cached()
+                while True:
+                    m = self.mav.recv_match(type='ATTITUDE',
+                                            blocking=True,
+                                            timeout=0.1)
+                    now = self.get_sim_time_cached()
+
+                    time_boot_millis = 0
+                    target_system = 1
+                    target_component = 1
+                    # type_mask: ignore attitude (bit 7), use rates (bits 0-2 cleared)
+                    type_mask = step["mask"]
+
+                    # Identity quaternion since we're ignoring attitude
+                    q = quaternion.Quaternion([1, 0, 0, 0])
+
+                    self.mav.mav.set_attitude_target_send(
+                        time_boot_millis,
+                        target_system,
+                        target_component,
+                        type_mask,
+                        q,
+                        step["roll_r"],   # rad/s
+                        step["pitch_r"],  # rad/s
+                        step["yaw_r"],    # rad/s
+                        step["thr"]
+                    )
+
+                    # Calculate rate error from ATTITUDE message gyro fields
+                    roll_rate_error = abs(m.rollspeed - step["roll_r"])
+                    pitch_rate_error = abs(m.pitchspeed - step["pitch_r"])
+
+                    self.progress("%s(%s) - %f: Roll rate=%f -> %f (error %f), Pitch rate=%f -> %f (error %f)" % (
+                        step["name"],
+                        state,
+                        now - state_start,
+                        m.rollspeed,
+                        step["roll_r"],
+                        roll_rate_error,
+                        m.pitchspeed,
+                        step["pitch_r"],
+                        pitch_rate_error
+                    ))
+
+                    if state == state_wait:
+                        # Reduced tolerance for initial trigger
+                        if roll_rate_error < tolerance and pitch_rate_error < tolerance:
+                            state = state_hold
+                            state_start = now
+
+                        # Allow 5 seconds to reach target rate
+                        if (now - state_start) > 5:
+                            raise NotAchievedException(step["name"] + ": Failed to achieve target rate")
+
+                    elif state == state_hold:
+                        # Give 1 second to stabilize
+                        if (now - state_start) > 1 and ((roll_rate_error > tolerance) or (pitch_rate_error > tolerance)):
+                            raise NotAchievedException(step["name"] + ": Failed to hold target rate")
+
+                        # Hold for 3 seconds
+                        if (now - state_start) > step["time"]:
+                            self.progress("%s Done" % (step["name"]))
+                            break
+
+        except Exception as e:
+            self.change_mode('FBWA')
+            self.set_rc(3, 1700)
+            raise e
+
+        # back to FBWA
+        self.change_mode('FBWA')
+        self.set_rc(3, 1700)
+        self.wait_level_flight()
+        self.fly_home_land_and_disarm(timeout=180)
+
     def _MAV_CMD_PREFLIGHT_CALIBRATION(self, command):
         self.context_push()
         self.start_subtest("Denied when armed")
@@ -8343,6 +8439,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.ExternalPositionEstimate,
             self.SagetechMXS,
             self.MAV_CMD_GUIDED_CHANGE_ALTITUDE,
+            self.MAV_CMD_GUIDED_ATTITUDE_RATE,
             self.MAV_CMD_PREFLIGHT_CALIBRATION,
             self.MAV_CMD_DO_INVERTED_FLIGHT,
             self.MAV_CMD_DO_AUTOTUNE_ENABLE,


### PR DESCRIPTION
### Summary

Add support for attitude rate control in ArduPlane "GUIDED" mode, using the MAVLink  **SET_ATTITUDE_TARGET** message.


### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [X] Automated test(s) verify changes (e.g. unit test, autotest)
- [X] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [X] Logs attached
- [ ] Logs available on request

### Description

In **GUIDED** mode, when receiving a **SET_ATTITUDE_TARGET** message with the attitude fields ignored via `type_mask` and the body roll/pitch/yaw rate fields enabled, ArduPlane directly commands the roll, pitch, and yaw controllers to track the requested body-rate targets.

Thrust handling remains unchanged and follows the behavior of other **GUIDED** submodes: it can be controlled either through the message's thrust field or through TECS.

Note: when using rate control, roll and pitch limits are not enforced. This allows an onboard computer to perform fully automated aerobatic maneuvers.

### Test
Tested in SITL using MAVLink **SET_ATTITUDE_TARGET** messages. Verified that **GUIDED** mode correctly accepts and applies roll, pitch, and yaw rate targets.

Added an autotest for this feature that performs barrel rolls and inverted loops.

Below are some logs screenshot from the autotest run:

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/4d67f4c0-5216-4f0b-99bf-876d1115589f" />
<img width="1324" height="651" alt="image" src="https://github.com/user-attachments/assets/93e621e6-c2f8-4bc1-85d1-0c362c15e8ca" />
<img width="1646" height="982" alt="image" src="https://github.com/user-attachments/assets/8dda3d16-f97d-48e9-a369-b3fb92a25c78" />


The visible pitch-rate oscillations during looping are due to the pitch controller's tracking accuracy while performing the maneuver.

