### PR TITLE
SITL: fixes for flakey QuadPlane ShipLanding

### DIFF
--- a/libraries/SITL/SIM_Ship.cpp
+++ b/libraries/SITL/SIM_Ship.cpp
@@ -202,6 +202,13 @@ void ShipSim::send_report(void)
         return;
     }
 
+    // Drain and discard anything the vehicle sends us:
+    {
+        uint8_t discard[1024];
+        while (mav_socket.recv(discard, sizeof(discard), 0) > 0) {
+        }
+    }
+
     uint32_t now = AP_HAL::millis();
 
     const uint8_t component_id = MAV_COMP_ID_USER10;


### PR DESCRIPTION
### Summary

drains mavlink connection to ship which was apparently interfering in the data link between vehicle and ship.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

(5/5 on gcc-13, was 0/5)

i.e.e running this test on my laptop almost always failed, now it passes.

### Description

SIM_Ship connects to the vehicle's SERIAL link as a TCP client and only ever sends its position; it never reads the socket.  The vehicle streams MAVLink telemetry back on that link, so with nothing draining it the connection backs up: the ship's receive window closes and the vehicle's send queue grows without bound (observed growing past 370KB via `ss`).

At high SIM_SPEEDUP (e.g. the ShipLanding test's SIM_SPEEDUP=10) the vehicle produces that telemetry ~10x faster, saturating the link and intermittently starving reception of the ship's GLOBAL_POSITION_INT.  AP_Follow then hits its 3s position-timeout, the plane_ship_landing.lua applet reports "Lost beacon", and the ship landing fails to reach the target altitude. This made test.QuadPlane.ShipLanding fail (flaky; ~always under gcc-13, intermittently under gcc-11 - purely a timing sensitivity, not the cause).

Drain and discard any received data each report cycle so the connection cannot back up.  test.QuadPlane.ShipLanding now passes 5/5 under gcc-13 (was 0/5).
