### PR TITLE
Tools/ros2: fix colcon exec issues more thoroughly

### DIFF
--- a/Tools/ros2/ardupilot_sitl/src/ardupilot_sitl/launch.py
+++ b/Tools/ros2/ardupilot_sitl/src/ardupilot_sitl/launch.py
@@ -58,6 +58,7 @@ class VirtualPortsLaunch:
         action = ExecuteProcess(
             cmd=[
                 [
+                    "exec ",  # take place of shell so socat gets signals
                     "socat ",
                     "-d -d ",
                     f"pty,raw,echo=0,link={tty0} ",
@@ -302,6 +303,7 @@ class MAVProxyLaunch:
         print(f"map:              {map}")
 
         cmd = [
+            "exec ",  # take place of shell so mavproxy (though not its subprocesses!) get signals
             f"{command} ",
             f"--out {out} ",
             "--out ",


### PR DESCRIPTION
### Summary

Un-regress colcon regressions by completing the attempted fix.

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [X] Infrastructure change (e.g. unit tests, helper scripts)
- [X] Automated test(s) verify changes (e.g. unit test, autotest)
- [X] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Ran 10 times without a failure on my fork. Previously most tries would fail.

### Description
The launch scripts use shell mode to launch all components of the test, excluding for whatever reason the micro ROS agent, which means the command is executed as `/bin/sh -c <command>`.

This causes the shutdown signals to go to the shell process, which dies and leaves the actual component orphaned as `sh` does not do job control. Therefore each test leaves a copy of the components running. Future tests then end up talking to past components and the tests hang up and die.

A previous PR (#33324) recognized and fixed this problem on the SITL binary, but it just made the overall failures worse as the past mavproxy and socat would then be more likely to reconnect to future instances.

Fix by making mavproxy and socat also exec so that there is only ever one process for them. mavproxy does technically launch subprocesses which may be left hanging but they should be killed by mavproxy itself on a clean shutdown.

Future work will disable shell mode so there is no need for the extra step, and arguments are better handled. This could also set up a session/process group for mavproxy, assuming it is supported by the ROS framework, to reduce the chances of its children giving problems.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
