### PR TITLE
SITL: clarify synthetic clock parameter warning message and remove references

### DIFF
--- a/Tools/completion/bash/_ap_bin
+++ b/Tools/completion/bash/_ap_bin
@@ -23,7 +23,6 @@ _ap_bin()
     opts+=" --rate -r"
     opts+=" --console -C"
     opts+=" --instance -I"
-    opts+=" --synthetic-clock -S"
     opts+=" --home -O"
     opts+=" --model -M"
     opts+=" --fg -F"

--- a/Tools/completion/zsh/_ap_bin
+++ b/Tools/completion/zsh/_ap_bin
@@ -31,7 +31,6 @@ _ap_bin() {
     '--serial7[set device string for SERIAL7]:DEVICE:' \
     '--serial8[set device string for SERIAL8]:DEVICE:' \
     '--serial9[set device string for SERIAL9]:DEVICE:' \
-    '(-S --synthetic-clock)'{-S,--synthetic-clock}'[set synthetic clock mode]' \
     '--start-time[set simulation start time in UNIX timestamp]:TIMESTR:' \
     '--sysid[set MAV_SYSID]:ID:' \
     '--slave[set the number of JSON slaves]:number:' \

--- a/Tools/ros2/README.md
+++ b/Tools/ros2/README.md
@@ -208,7 +208,7 @@ ros2 run micro_ros_agent micro_ros_agent serial --baudrate 115200 --dev ./dev/tt
 ```
 
 ```bash
-arducopter --synthetic-clock --wipe --model quad --speedup 1 --slave 0 --instance 0 --serial1 uart:./dev/ttyROS1 --defaults $(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/copter.parm,$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/dds_serial.parm --sim-address 127.0.0.1
+arducopter --wipe --model quad --speedup 1 --slave 0 --instance 0 --serial1 uart:./dev/ttyROS1 --defaults $(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/copter.parm,$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/dds_serial.parm --sim-address 127.0.0.1
 ```
 
 ```bash

--- a/libraries/AP_HAL_SITL/SITL_cmdline.cpp
+++ b/libraries/AP_HAL_SITL/SITL_cmdline.cpp
@@ -323,7 +323,7 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
         {"rate",            true,   0, 'r'},
         {"console",         false,  0, 'C'},
         {"instance",        true,   0, 'I'},
-        {"synthetic-clock", false,  0, 'S'},
+        {"synthetic-clock", false,  0, 'S'}, // kept to warn that it's always enabled
         {"home",            true,   0, 'O'},
         {"model",           true,   0, 'M'},
         {"config",          true,   0, 'c'},
@@ -445,7 +445,7 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
         }
         break;
         case 'S':
-            printf("Ignoring stale command-line parameter '-S'");
+            printf("Ignoring obsolete command-line parameter '-S'/'--synthetic-clock'. Synthetic clock mode is now always enabled.\n");
             break;
         case 'O':
             home_str = gopt.optarg;

--- a/libraries/AP_HAL_SITL/SITL_cmdline.cpp
+++ b/libraries/AP_HAL_SITL/SITL_cmdline.cpp
@@ -88,7 +88,6 @@ void SITL_State::_usage(void)
            "\t--rate|-r RATE           set SITL framerate\n"
            "\t--console|-C             use console instead of TCP ports\n"
            "\t--instance|-I N          set instance of SITL (adds 10*instance to all port numbers)\n"
-           "\t--synthetic-clock|-S     set synthetic clock mode\n"
            "\t--home|-O HOME           set start location (lat,lng,alt,yaw) or location name\n"
            "\t--model|-M MODEL         set simulation model\n"
            "\t--config string          set additional simulation config string\n"


### PR DESCRIPTION
### Summary

Make the warning of the deprecated flag more clear and remove places where people might be tempted to specify it. The mode has always been turned on for a long time: https://github.com/ArduPilot/ardupilot/pull/29049

Does not touch ROS because there is a specific parameter object which may need its own deprecation process to avoid breaking ROS users.

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [X] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [X] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

As above.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
