### PR TITLE
autotest: fix flaky FRSkyMAVlite by using sim time for SPort polling

### DIFF
--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -14305,7 +14305,8 @@ switch value'''
         self.customise_SITL_commandline([
             "--serial5=tcp:%u" % port # serial5 spews to localhost port
         ])
-        frsky = FRSkyPassThrough(("127.0.0.1", port))
+        frsky = FRSkyPassThrough(("127.0.0.1", port),
+                                 get_time=self.get_sim_time_cached)
         frsky.connect()
 
         sport_to_mavlite = SPortToMAVlite()


### PR DESCRIPTION
### Summary

Fixes flake on FRSkyMAVlite by using sim time rather than wall-clock time for the timeouts

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

FRSkyMAVlite drove its FRSkyPassThrough with the default get_time=time.time (wall clock), unlike the sibling FrSky telemetry tests which already pass get_time=self.get_sim_time_cached.

The SPort exchange is a poll/response handshake: the test sends a poll and will not send the next one until it receives a response frame, re-polling only after get_time() advances 5s (see check_poll()).  With wall-clock timing that re-poll is 5s of wall time, but read_message_via_mavlite() times out after 30*speedup/10 *sim* seconds, which is a near-constant ~3s of wall time at any speedup.  So if a single response frame is lost or delayed - far more likely at high speedup where the wall-paced test and the sim-paced autopilot serial link drift - the handshake stalls and the test can never re-poll to recover before timing out ("Did not get parameter via mavlite").

Drive the poll timing off sim time like the other FrSky tests so the 5s re-poll scales with speedup and recovers the handshake.  Reproduced reliably at --speedup=40 (6/6 failures); with this change 6/6 pass.
