### PR TITLE
AP_Logger: retry blocks when doing replay logging rather than dying

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem.h
+++ b/libraries/AP_Filesystem/AP_Filesystem.h
@@ -151,6 +151,15 @@ public:
     // get_singleton for scripting
     static AP_Filesystem *get_singleton(void);
 
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    // SITL-only: permit filesystem operations from the main thread while
+    // armed for the duration of a deliberate write (the AP_Logger
+    // replay-block drain).  See AP_Filesystem_Backend::file_op_allowed().
+    void set_file_op_allowed_main_thread(bool allowed) {
+        AP_Filesystem_Backend::set_file_op_allowed_main_thread(allowed);
+    }
+#endif  // CONFIG_HAL_BOARD == HAL_BOARD_SITL
+
 private:
     struct Backend {
         const char *prefix;

--- a/libraries/AP_Filesystem/AP_Filesystem_backend.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_backend.cpp
@@ -69,11 +69,22 @@ void AP_Filesystem_Backend::unload_file(FileData *fd)
 }
 
 // return true if file operations are allowed
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+bool AP_Filesystem_Backend::_file_op_allowed_main_thread;
+#endif  // CONFIG_HAL_BOARD == HAL_BOARD_SITL
+
 bool AP_Filesystem_Backend::file_op_allowed(void) const
 {
     if (!hal.util->get_soft_armed() || !hal.scheduler->in_main_thread()) {
         return true;
     }
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    // the AP_Logger replay-block drain deliberately writes from the main
+    // thread while armed; it sets this around its write
+    if (_file_op_allowed_main_thread) {
+        return true;
+    }
+#endif  // CONFIG_HAL_BOARD == HAL_BOARD_SITL
     return false;
 }
 

--- a/libraries/AP_Filesystem/AP_Filesystem_backend.h
+++ b/libraries/AP_Filesystem/AP_Filesystem_backend.h
@@ -100,9 +100,23 @@ public:
     // unload data from load_file()
     virtual void unload_file(FileData *fd);
 
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    // SITL-only: filesystem operations from the main thread while armed
+    // are normally an internal error (they would stall the flight loop).
+    // The AP_Logger replay-block drain deliberately writes from the main
+    // thread; it sets this around its brief write to permit it.
+    static void set_file_op_allowed_main_thread(bool allowed) {
+        _file_op_allowed_main_thread = allowed;
+    }
+#endif  // CONFIG_HAL_BOARD == HAL_BOARD_SITL
+
 protected:
     // return true if file operations are allowed
     bool file_op_allowed(void) const;
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    static bool _file_op_allowed_main_thread;
+#endif  // CONFIG_HAL_BOARD == HAL_BOARD_SITL
 };
 
 

--- a/libraries/AP_Logger/AP_Logger.cpp
+++ b/libraries/AP_Logger/AP_Logger.cpp
@@ -1470,7 +1470,12 @@ void AP_Logger::io_thread(void)
 
         last_run_us = AP_HAL::micros();
 
-        FOR_EACH_BACKEND(io_timer());
+        {
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+            WITH_SEMAPHORE(io_timer_backend_calls_sem);
+#endif  // CONFIG_HAL_BOARD == HAL_BOARD_SITL
+            FOR_EACH_BACKEND(io_timer());
+        }
 
         if (now - last_stack_us > 100000U) {
             last_stack_us = now;

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -522,6 +522,13 @@ private:
     void io_thread();
     bool check_crash_dump_save(void);
 
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    // serialises the IO thread's io_timer() pass against a backend
+    // draining its own buffer (the SITL replay-block retry path) so the
+    // two never consume the write buffer concurrently
+    HAL_Semaphore io_timer_backend_calls_sem;
+#endif  // CONFIG_HAL_BOARD == HAL_BOARD_SITL
+
 #if HAL_LOGGER_FILE_CONTENTS_ENABLED
     // support for logging file content
     struct file_list {

--- a/libraries/AP_Logger/AP_Logger_Backend.cpp
+++ b/libraries/AP_Logger/AP_Logger_Backend.cpp
@@ -14,6 +14,7 @@
 #include <Filter/Filter.h>
 #include "AP_Logger.h"
 #include <AP_IOMCU/AP_IOMCU.h>
+#include <AP_Filesystem/AP_Filesystem.h>
 
 #if HAL_LOGGER_FENCE_ENABLED
     #include <AC_Fence/AC_Fence.h>
@@ -464,6 +465,38 @@ bool AP_Logger_Backend::WritePrioritisedBlock(const void *pBuffer, uint16_t size
     if (!ensure_format_emitted(pBuffer, size)) {
         return false;
     }
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    // When generating replay logs while disarmed under SITL we must not
+    // drop blocks or the resulting log will not replay correctly.  A
+    // failed write here means the buffer has filled faster than the IO
+    // thread can drain it to disk; flush the buffer ourselves to make
+    // space and retry rather than dropping the block.  We hold
+    // io_timer_backend_calls_sem across the flush so we don't race the
+    // IO thread's io_timer() calls, and (since we are on the main thread
+    // and may be armed) we briefly permit main-thread filesystem I/O
+    // around the write.  Give up after 30 seconds of wall-clock time in
+    // case something is wrong.
+    if (_front.log_replay() && _front.log_while_disarmed()) {
+        const uint64_t start_us = hal.util->get_hw_rtc();
+        const uint32_t dropped_before = _dropped;
+        while (!_WritePrioritisedBlock(pBuffer, size, is_critical)) {
+            if (hal.util->get_hw_rtc() - start_us > 30U * 1000U * 1000U) {
+                AP_HAL::panic("Failed to log replay block");
+            }
+            WITH_SEMAPHORE(_front.io_timer_backend_calls_sem);
+            AP::FS().set_file_op_allowed_main_thread(true);
+            flush(false);  // drain to the OS, but don't force a slow fsync
+            AP::FS().set_file_op_allowed_main_thread(false);
+        }
+        // a failed attempt above will have incremented the dropped
+        // counter, but we did not actually lose the block - we drained
+        // and wrote it - so restore the counter to avoid the log being
+        // reported as having dropped blocks.
+        _dropped = dropped_before;
+        return true;
+    }
+#endif  // CONFIG_HAL_BOARD == HAL_BOARD_SITL
 
     return _WritePrioritisedBlock(pBuffer, size, is_critical);
 }

--- a/libraries/AP_Logger/AP_Logger_Backend.h
+++ b/libraries/AP_Logger/AP_Logger_Backend.h
@@ -104,8 +104,10 @@ public:
     void Fill_Format_Units(const struct LogStructure *s, struct log_Format_Units &pkt);
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL || CONFIG_HAL_BOARD == HAL_BOARD_LINUX
-    // currently only AP_Logger_File support this:
-    virtual void flush(void) { }
+    // currently only AP_Logger_File support this.  do_fsync may be set
+    // false to drain the buffer to the OS without forcing a disk sync
+    // (the sync can block the calling thread for a long time under load).
+    virtual void flush(bool do_fsync=true) { }
 #endif
 
      // for Logger_MAVlink

--- a/libraries/AP_Logger/AP_Logger_File.cpp
+++ b/libraries/AP_Logger/AP_Logger_File.cpp
@@ -879,17 +879,20 @@ bool AP_Logger_File::write_lastlog_file(uint16_t log_num)
 }
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL || CONFIG_HAL_BOARD == HAL_BOARD_LINUX
-void AP_Logger_File::flush(void)
-#if APM_BUILD_TYPE(APM_BUILD_Replay) || APM_BUILD_TYPE(APM_BUILD_UNKNOWN)
+void AP_Logger_File::flush(bool do_fsync)
+#if APM_BUILD_TYPE(APM_BUILD_Replay) || APM_BUILD_TYPE(APM_BUILD_UNKNOWN) || CONFIG_HAL_BOARD == HAL_BOARD_SITL
 {
     uint32_t tnow = AP_HAL::millis();
     while (_write_fd != -1 && _initialised && !recent_open_error() && _writebuf.available()) {
         // convince the IO timer that it really is OK to write out
         // less than _writebuf_chunk bytes:
-        if (tnow > 2001) { // avoid resetting _last_write_time to 0
-            _last_write_time = tnow - 2001;
-        }
+        _last_write_time = tnow - 2001;
         io_timer();
+    }
+    if (!do_fsync) {
+        // caller just wants the buffer drained to the OS, not a
+        // (potentially slow) forced disk sync
+        return;
     }
     if (write_fd_semaphore.take(1)) {
         if (_write_fd != -1) {
@@ -903,9 +906,10 @@ void AP_Logger_File::flush(void)
 #else
 {
     // flush is for replay and examples only
+    (void)do_fsync;
 }
-#endif // APM_BUILD_TYPE(APM_BUILD_Replay) || APM_BUILD_TYPE(APM_BUILD_UNKNOWN)
-#endif
+#endif // APM_BUILD_TYPE(APM_BUILD_Replay) || APM_BUILD_TYPE(APM_BUILD_UNKNOWN) || CONFIG_HAL_BOARD == HAL_BOARD_SITL
+#endif // CONFIG_HAL_BOARD == HAL_BOARD_SITL || CONFIG_HAL_BOARD == HAL_BOARD_LINUX
 
 void AP_Logger_File::io_timer(void)
 {

--- a/libraries/AP_Logger/AP_Logger_File.h
+++ b/libraries/AP_Logger/AP_Logger_File.h
@@ -57,7 +57,7 @@ public:
     uint16_t find_oldest_log() override;
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL || CONFIG_HAL_BOARD == HAL_BOARD_LINUX
-    void flush(void) override;
+    void flush(bool do_fsync=true) override;
 #endif
     void periodic_1Hz() override;
     void periodic_fullrate() override;


### PR DESCRIPTION
### Summary

SITL-only change avoids CI flake where the IO thread doesn't work fast enough to get data from the buffer to disk

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

No compiler output on CubeOrange Copter

Test branches show the fix:
  - replay-torture (reproducer, expect ❌ 0 / 10): https://github.com/peterbarker/ardupilot/actions/runs/28077382449
  - replay-torture-fix (torture + fix, expect ✅ 10 / 10): https://github.com/peterbarker/ardupilot/actions/runs/28077384456

### Description

retry each backend until it gets it right!

Integer-wrap-protection was just crap, removed it.  Arithmetic elsewhere checked.


