### PR TITLE
Eliminate now-unnecessary code near SITL battery pin-setting

### DIFF
--- a/libraries/AP_HAL_SITL/SITL_Periph_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_Periph_State.cpp
@@ -134,8 +134,7 @@ void SITL_State::wait_clock(uint64_t wait_time_usec)
             struct sitl_input input {};
             sitl_model->update(input); // delays up to 1 millisecond
             sim_update();
-            constexpr float throttle = 0.0f;
-            update_voltage_current(throttle);
+            set_voltage_current_pins(sitl_model->get_battery_voltage(), sitl_model->get_battery_current());
         } else {
             usleep(1000);
         }

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -391,7 +391,7 @@ void SITL_State::_simulator_servos(struct sitl_input &input)
     }
     _sitl->throttle = throttle;
 
-    update_voltage_current(throttle);
+    set_voltage_current_pins(sitl_model->get_battery_voltage(), sitl_model->get_battery_current());
 }
 
 void SITL_State::init(int argc, char * const argv[])

--- a/libraries/AP_HAL_SITL/SITL_State_common.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State_common.cpp
@@ -473,32 +473,13 @@ void SITL_State_Common::sim_update(void)
 }
 
 /*
-  update voltage and current pins
+  set voltage and current pin values
  */
-void SITL_State_Common::update_voltage_current(float throttle)
+void SITL_State_Common::set_voltage_current_pins(float voltage, float current_amp)
 {
-    float voltage = 0;
-    float current = 0;
-    
-    if (_sitl != nullptr) {
-        if (_sitl->state.battery_voltage <= 0) {
-            if (_vehicle == ArduSub) {
-                voltage = sitl_model->get_battery_voltage();
-                current = sitl_model->get_battery_current();
-            } else {
-                voltage = sitl_model->get_battery_voltage();
-                current = sitl_model->get_battery_current();
-            }
-        } else {
-            // FDM provides voltage and current
-            voltage = _sitl->state.battery_voltage;
-            current = _sitl->state.battery_current;
-        }
-    }
-
     // assume 3DR power brick
     voltage_pin_voltage = (voltage / 10.1f);
-    current_pin_voltage = current/17.0f;
+    current_pin_voltage = current_amp / 17.0f;
     // fake battery2 as just a 25% gain on the first one
     voltage2_pin_voltage = voltage_pin_voltage * 0.25f;
     current2_pin_voltage = current_pin_voltage * 0.25f;

--- a/libraries/AP_HAL_SITL/SITL_State_common.h
+++ b/libraries/AP_HAL_SITL/SITL_State_common.h
@@ -228,7 +228,7 @@ protected:
 
     SITL::SIM *_sitl;
 
-    void update_voltage_current(float throttle);
+    void set_voltage_current_pins(float voltage, float current_amp);
 };
 
 #endif // CONFIG_HAL_BOARD == HAL_BOARD_SITL


### PR DESCRIPTION
### Summary

This is the final result of several previous preparatory PRs: Remove the now-unnecessary code. (Details below)
This is one of the final PRs for issue #10050 ! Hurray!
 
### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] Only simulation changes
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

The (silly-looking) code deleted by this PR was achieved intentionally via recent PRs:
- https://github.com/ArduPilot/ardupilot/pull/33463/changes#diff-cb54712a8aebcfc0532ab85828caee9ccff5af2ffe6248c0024b234cc9afadc4
- https://github.com/ArduPilot/ardupilot/pull/33461/changes#diff-cb54712a8aebcfc0532ab85828caee9ccff5af2ffe6248c0024b234cc9afadc4

The nullptr check is done by the calling function, so deleting it here is ok.

You can see visually there's no difference anymore between ArduSub and other vehicles.

The only spot `_sitl->state.battery_XXX` members get set is in `SITL::Aircraft::fill_fdm` where we see it is (now) set from these same members of `SITL::Aircraft`, so the if-case distinguishing these does nothing.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
