### PR TITLE
Fix Copter circle mode entry when RC input present

### DIFF
--- a/ArduCopter/mode_circle.cpp
+++ b/ArduCopter/mode_circle.cpp
@@ -81,16 +81,16 @@ void ModeCircle::run()
                 speed_changing = false;
             } else {
                 const float rate_degs = copter.circle_nav->get_rate_degs();           // circle controller's rate target, which begins as the circle_rate parameter
-                const float rate_current_degs = copter.circle_nav->get_rate_current(); // current adjusted rate target, which is probably different from _rate_degs
+                const float rate_target_degs = copter.circle_nav->get_rate_target_degs(); // current adjusted rate target, which is probably different from _rate_degs
                 const float rate_pilot_change_degs = (roll_stick_norm * G_Dt);        // rate of change from 0 to 1 degrees per second
-                float rate_new_degs = rate_current_degs;                              // new rate target
+                float rate_new_degs = rate_target_degs;                               // new rate target
                 if (is_positive(rate_degs)) {
                     // currently moving clockwise, constrain 0 to 90
-                    rate_new_degs = constrain_float(rate_current_degs + rate_pilot_change_degs, 0, 90);
+                    rate_new_degs = constrain_float(rate_target_degs + rate_pilot_change_degs, 0, 90);
 
                 } else if (is_negative(rate_degs)) {
                     // currently moving counterclockwise, constrain -90 to 0
-                    rate_new_degs = constrain_float(rate_current_degs + rate_pilot_change_degs, -90, 0);
+                    rate_new_degs = constrain_float(rate_target_degs + rate_pilot_change_degs, -90, 0);
 
                 } else if (is_zero(rate_degs) && !speed_changing) {
                     // Stopped, pilot has released the roll stick, and pilot now wants to begin moving with the roll stick

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -814,6 +814,57 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             )
         self.do_RTL()
 
+    def CircleManualControlEntryLeft(self):
+        '''Circle orbits at the configured rate when entered holding roll stick left'''
+        # CIRCLE_OPTIONS defaults to 1 (manual control enabled); the pilot
+        # roll stick trims the orbit rate.  Holding the stick against the
+        # CIRCLE_RATE sign on entry used to pin the rate at zero so the
+        # vehicle never orbited at all.  The orbit must still reach the
+        # configured rate, and the pilot can then trim it down to a stop.
+        self.set_parameters({
+            "CIRCLE_RADIUS_M": 10,
+            "CIRCLE_RATE": 20,  # +ve, clockwise
+        })
+        expected_groundspeed = math.pi * 2 * 10 * (20 / 360.0)  # ~3.49m/s
+        self.takeoff(10, mode='LOITER')
+        self.hover()  # circle mode uses throttle input
+        self.set_rc(1, 1400)  # held left, against the CIRCLE_RATE sign
+        self.change_mode('CIRCLE')
+        self.wait_groundspeed(
+            expected_groundspeed - 0.5,
+            expected_groundspeed + 0.5,
+            minimum_duration=5,
+            timeout=30,
+        )
+        # the pilot can still trim the orbit rate down to a stop:
+        self.set_rc(1, 1100)
+        self.wait_groundspeed(0, 0.5, minimum_duration=2, timeout=60)
+        self.set_rc(1, 1500)
+        self.do_RTL()
+
+    def CircleManualControlEntryRight(self):
+        '''Circle orbits at the configured rate when entered holding roll stick right'''
+        # Holding the roll stick with the CIRCLE_RATE sign on entry used to
+        # leave the rate crawling up from zero instead of starting at the
+        # configured rate.  The orbit must reach the configured rate.
+        self.set_parameters({
+            "CIRCLE_RADIUS_M": 10,
+            "CIRCLE_RATE": 20,  # +ve, clockwise
+        })
+        expected_groundspeed = math.pi * 2 * 10 * (20 / 360.0)  # ~3.49m/s
+        self.takeoff(10, mode='LOITER')
+        self.hover()  # circle mode uses throttle input
+        self.set_rc(1, 1600)  # held right, with the CIRCLE_RATE sign
+        self.change_mode('CIRCLE')
+        self.wait_groundspeed(
+            expected_groundspeed - 0.5,
+            expected_groundspeed + 0.5,
+            minimum_duration=5,
+            timeout=30,
+        )
+        self.set_rc(1, 1500)
+        self.do_RTL()
+
     # test copter-circle-speed lua script:
     def LuaCopterCircleSpeed(self):
         '''test the consistent-ground-speed-circling works'''
@@ -18674,6 +18725,8 @@ return update, 1000
             self.MountSolo,
             self.MountSiyiZT30,
             self.CircleSpeed,
+            self.CircleManualControlEntryLeft,
+            self.CircleManualControlEntryRight,
             self.LuaCopterCircleSpeed,
             self.TakeoffWithLocation,
             self.MountTopotek,

--- a/libraries/AC_WPNav/AC_Circle.h
+++ b/libraries/AC_WPNav/AC_Circle.h
@@ -72,6 +72,12 @@ public:
     // May be lower than the configured maximum due to ramp constraints.
     float get_rate_current() const { return degrees(_angular_vel_rads); }
 
+    // Returns the commanded turn-rate target in degrees per second.
+    // This is the rate the controller ramps towards (set by the RATE
+    // parameter or set_rate_degs()), unlike the instantaneous ramped
+    // velocity returned by get_rate_current().
+    float get_rate_target_degs() const { return degrees(_rotation_rate_max_rads); }
+
     // Sets the target circle rate in degrees per second.
     // Positive values result in clockwise rotation; negative for counter-clockwise.
     void set_rate_degs(float rate_degs);

--- a/libraries/AC_WPNav/AC_Circle.h
+++ b/libraries/AC_WPNav/AC_Circle.h
@@ -68,14 +68,9 @@ public:
     // Returns the configured circle turn rate in degrees per second from the RATE parameter.
     float get_rate_degs() const { return _rate_parm_degs; }
 
-    // Returns the current angular velocity in degrees per second.
-    // May be lower than the configured maximum due to ramp constraints.
-    float get_rate_current() const { return degrees(_angular_vel_rads); }
-
     // Returns the commanded turn-rate target in degrees per second.
     // This is the rate the controller ramps towards (set by the RATE
-    // parameter or set_rate_degs()), unlike the instantaneous ramped
-    // velocity returned by get_rate_current().
+    // parameter or set_rate_degs()).
     float get_rate_target_degs() const { return degrees(_rotation_rate_max_rads); }
 
     // Sets the target circle rate in degrees per second.


### PR DESCRIPTION
### Summary

If there's a bit of roll present then the vehicle doesn't start circling....

### Classification & Testing (check all that apply and add your own)

- [ ] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

@tridge , @MichelleRos and I stumbled on this while I was demoing a feature.

### Description

Still working this one out in my head.  The test is pretty convincing, 'though.

Here's what Claude says:

```
● The introducing commit is 809b170015 Copter: Circle mode pilot control of rate
  & radius — the feature commit itself. Only two commits ever touched this
  logic: that one and today's fix. Let me confirm the bug was present from the
  start in that commit.
.
.
  So: a latent defect in the original 2020 feature, exposed whenever Circle is
  entered with the roll stick already deflected (the default CIRCLE_OPTIONS=1
  enables the manual control path).
```

```
● No, that is not expected behaviour — it's a real bug, and I've fixed it.
  Here's the full picture.

  What's happening

  CIRCLE_OPTIONS defaults to 1 (MANUAL_CONTROL), so the pilot's roll stick
  adjusts the orbit rate in Circle mode. RC1 at 1400 is left of centre,
  feeding a negative roll_stick_norm into that rate-adjust logic
  (ArduCopter/mode_circle.cpp).

  The defect: the adjustment integrated onto get_rate_current(), which
  returns the instantaneous ramping angular velocity (_angular_vel_rads),
  not the rate target (_rotation_rate_max_rads). On entry the actual
  velocity is 0 and ramping toward CIRCLE_RATE (20°/s). With the stick
  held left and the parameter positive, the code clamps rate_new to [0,
  90], so each loop computes 0 - delta → 0, writes that back as the
  target, and the ramp never builds. The orbit never starts — and because
  the target itself was overwritten to 0, centring the stick afterward
  leaves it at 0 forever (exactly your second observation). The variable's
  own comment ("current adjusted rate target") shows the intent was
  always the target, not the ramped velocity.

  The fix

  Integrate onto the commanded rate target instead of the ramped velocity.
  I added AC_Circle::get_rate_target_degs() (returns
  degrees(_rotation_rate_max_rads)) and used it in mode_circle.cpp. Now:
  - Enter Circle holding left stick → orbit starts at ~`CIRCLE_RATE`
  immediately; a sustained hold only slowly trims the rate down (the
  intended manual-control behaviour).
  - Centre the stick → rate holds steady. In steady state
  _angular_vel_rads ≈ _rotation_rate_max_rads, so established orbits are
  unchanged.
```
