### PR TITLE
SITL::SimRover uses SITL::Battery internal battery model

### DIFF
--- a/libraries/SITL/SIM_Rover.cpp
+++ b/libraries/SITL/SIM_Rover.cpp
@@ -56,6 +56,7 @@ SimRover::SimRover(const char *frame_str) :
                   default_battery_resistance_ohm,
                   sitl->batt_voltage,
                   ambient_outside_temperature_degC());
+    battery_voltage = battery.get_voltage();
 }
 
 /*

--- a/libraries/SITL/SIM_Rover.cpp
+++ b/libraries/SITL/SIM_Rover.cpp
@@ -287,6 +287,7 @@ void SimRover::update_battery()
     const uint64_t now_us = AP_HAL::micros64();
     battery.consume_energy(battery_current, now_us);
     battery_voltage = battery.get_voltage();
+    battery_temperature_degC = battery.get_temperature_degC();
 }
 
 } // namespace SITL

--- a/libraries/SITL/SIM_Rover.cpp
+++ b/libraries/SITL/SIM_Rover.cpp
@@ -172,10 +172,11 @@ void SimRover::update_ackermann_or_skid(const struct sitl_input &input, float de
 
             // vectored thrust conversion
             if (vectored_thrust) {
+                const float thrust = throttle;
                 const float steering_angle_rad = radians(steering * vectored_angle_max);
-                steering = sinf(steering_angle_rad) * throttle;
-                throttle *= cosf(steering_angle_rad);
-                battery_current = 20.0f * fabsf(throttle);
+                steering = sinf(steering_angle_rad) * thrust;
+                throttle = cosf(steering_angle_rad) * thrust;
+                battery_current = 20.0f * fabsf(thrust);
             }
         }
     } else {

--- a/libraries/SITL/SIM_Rover.cpp
+++ b/libraries/SITL/SIM_Rover.cpp
@@ -220,11 +220,13 @@ void SimRover::update_omni3(const struct sitl_input &input, float delta_time)
     // use forward kinematics to calculate body frame velocity
     Vector3f wheel_ang_vel;
     battery_current = 0.0f;
-    for (uint8_t i=0; i<3; i++) {
-        wheel_ang_vel[i] = input.servos[i] ? normalise_servo_input(input.servos[i]) : 0;
-        battery_current += 10.0f * fabsf(wheel_ang_vel[i]);
-    };
-    wheel_ang_vel *= omni3_wheel_max_ang_vel;
+    if (!battery_is_empty()) {
+        for (uint8_t i=0; i<3; i++) {
+            wheel_ang_vel[i] = input.servos[i] ? normalise_servo_input(input.servos[i]) : 0;
+            battery_current += 10.0f * fabsf(wheel_ang_vel[i]);
+        };
+        wheel_ang_vel *= omni3_wheel_max_ang_vel;
+    }
 
     // derivation of forward kinematics for an Omni3Mecanum rover
     // A. Gfrerrer. "Geometry and kinematics of the Mecanum wheel",

--- a/libraries/SITL/SIM_Rover.cpp
+++ b/libraries/SITL/SIM_Rover.cpp
@@ -50,6 +50,12 @@ SimRover::SimRover(const char *frame_str) :
     }
 
     lock_step_scheduled = true;
+
+    constexpr float default_battery_resistance_ohm = 0.01f;
+    battery.setup(sitl->batt_capacity_ah,
+                  default_battery_resistance_ohm,
+                  sitl->batt_voltage,
+                  ambient_outside_temperature_degC());
 }
 
 /*
@@ -145,26 +151,34 @@ void SimRover::update(const struct sitl_input &input)
  */
 void SimRover::update_ackermann_or_skid(const struct sitl_input &input, float delta_time)
 {
-    float steering, throttle;
+    float steering = 0.0f;
+    float throttle = 0.0f;
 
-    // if in skid steering mode the steering and throttle values are used for motor1 and motor2
-    if (skid_steering) {
-        const float motor1 = input.servos[0] ? normalise_servo_input(input.servos[0]) : 0;
-        const float motor2 = input.servos[2] ? normalise_servo_input(input.servos[2]) : 0;
-        steering = motor1 - motor2;
-        throttle = 0.5*(motor1 + motor2);
-    } else {
-        // steering here should really be "old steering" as no-pulses
-        // should yield no servo movement
-        steering = input.servos[0] ? normalise_servo_input(input.servos[0]) : 0;
-        throttle = input.servos[2] ? normalise_servo_input(input.servos[2]) : 0;
+    if (!battery_is_empty()) {
+        // if in skid steering mode the steering and throttle values are used for motor1 and motor2
+        if (skid_steering) {
+            const float motor1 = input.servos[0] ? normalise_servo_input(input.servos[0]) : 0;
+            const float motor2 = input.servos[2] ? normalise_servo_input(input.servos[2]) : 0;
+            steering = motor1 - motor2;
+            throttle = 0.5*(motor1 + motor2);
+            battery_current = 10.0f * (fabsf(motor1) + fabsf(motor2));
+        } else {
+            // steering here should really be "old steering" as no-pulses
+            // should yield no servo movement
+            steering = input.servos[0] ? normalise_servo_input(input.servos[0]) : 0;
+            throttle = input.servos[2] ? normalise_servo_input(input.servos[2]) : 0;
+            battery_current = 20.0f * fabsf(throttle) + 1.0f * fabsf(steering);
 
-        // vectored thrust conversion
-        if (vectored_thrust) {
-            const float steering_angle_rad = radians(steering * vectored_angle_max);
-            steering = sinf(steering_angle_rad) * throttle;
-            throttle *= cosf(steering_angle_rad);
+            // vectored thrust conversion
+            if (vectored_thrust) {
+                const float steering_angle_rad = radians(steering * vectored_angle_max);
+                steering = sinf(steering_angle_rad) * throttle;
+                throttle *= cosf(steering_angle_rad);
+                battery_current = 20.0f * fabsf(throttle);
+            }
         }
+    } else {
+        battery_current = 0.0f;
     }
 
     // speed in m/s in body frame
@@ -204,8 +218,10 @@ void SimRover::update_omni3(const struct sitl_input &input, float delta_time)
 
     // use forward kinematics to calculate body frame velocity
     Vector3f wheel_ang_vel;
+    battery_current = 0.0f;
     for (uint8_t i=0; i<3; i++) {
         wheel_ang_vel[i] = input.servos[i] ? normalise_servo_input(input.servos[i]) : 0;
+        battery_current += 10.0f * wheel_ang_vel[i];
     };
     wheel_ang_vel *= omni3_wheel_max_ang_vel;
 
@@ -259,6 +275,14 @@ void SimRover::update_omni3(const struct sitl_input &input, float delta_time)
 
     // accel in body frame due to motors (excluding gravity)
     accel_body = Vector3f(accel_x, accel_y, 0);
+}
+
+void SimRover::update_battery()
+{
+    battery.maybe_reset(sitl->batt_voltage, sitl->batt_capacity_ah);
+    const uint64_t now_us = AP_HAL::micros64();
+    battery.consume_energy(battery_current, now_us);
+    battery_voltage = battery.get_voltage();
 }
 
 } // namespace SITL

--- a/libraries/SITL/SIM_Rover.cpp
+++ b/libraries/SITL/SIM_Rover.cpp
@@ -28,6 +28,13 @@ namespace SITL {
 SimRover::SimRover(const char *frame_str) :
     Aircraft(frame_str)
 {
+    constexpr float default_battery_resistance_ohm = 0.01f;
+    battery.setup(sitl->batt_capacity_ah,
+                  default_battery_resistance_ohm,
+                  sitl->batt_voltage,
+                  ambient_outside_temperature_degC());
+    battery_voltage = battery.get_voltage();
+
     skid_steering = strstr(frame_str, "skid") != nullptr;
 
     if (skid_steering) {
@@ -50,13 +57,6 @@ SimRover::SimRover(const char *frame_str) :
     }
 
     lock_step_scheduled = true;
-
-    constexpr float default_battery_resistance_ohm = 0.01f;
-    battery.setup(sitl->batt_capacity_ah,
-                  default_battery_resistance_ohm,
-                  sitl->batt_voltage,
-                  ambient_outside_temperature_degC());
-    battery_voltage = battery.get_voltage();
 }
 
 /*

--- a/libraries/SITL/SIM_Rover.cpp
+++ b/libraries/SITL/SIM_Rover.cpp
@@ -221,7 +221,7 @@ void SimRover::update_omni3(const struct sitl_input &input, float delta_time)
     battery_current = 0.0f;
     for (uint8_t i=0; i<3; i++) {
         wheel_ang_vel[i] = input.servos[i] ? normalise_servo_input(input.servos[i]) : 0;
-        battery_current += 10.0f * wheel_ang_vel[i];
+        battery_current += 10.0f * fabsf(wheel_ang_vel[i]);
     };
     wheel_ang_vel *= omni3_wheel_max_ang_vel;
 

--- a/libraries/SITL/SIM_Rover.h
+++ b/libraries/SITL/SIM_Rover.h
@@ -63,6 +63,9 @@ private:
     float turn_circle(float steering) const;
     float calc_yaw_rate(float steering, float speed);
     float calc_lat_accel(float steering_angle, float speed);
+
+    void update_battery() override;
+    bool battery_is_empty() { return battery_voltage < 0.5f; };
 };
 
 } // namespace SITL


### PR DESCRIPTION
### Summary

Simulated rover uses the internal SITL::Battery. This means it responds to SIM_BATT_VOLTAGE and SIM_BATT_CAP_AH parameters as-documented.

This mostly accomplishes https://github.com/ArduPilot/ardupilot/issues/10050 for Rover.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

In SITL, I manipulated SIM_BATT_CAP_AH and SIM_BATT_VOLTAGE parameters and observed them having the documented & expected effects. (Including losing thrust and coming to a stop when battery capacity is exhausted.)

### Description

The battery consumption model proposed is extremely simple, happy to improve it slightly or OK to land as-is and let a future PR do that.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
