### PR TITLE
waf: check standard /opt for compiler before using PATH

### DIFF
--- a/Tools/ardupilotwaf/chibios.py
+++ b/Tools/ardupilotwaf/chibios.py
@@ -535,8 +535,7 @@ def setup_optimization(env):
 
 def configure(cfg):
     cfg.find_program('make', var='MAKE')
-    #cfg.objcopy = cfg.find_program('%s-%s'%(cfg.env.TOOLCHAIN,'objcopy'), var='OBJCOPY', mandatory=True)
-    cfg.find_program('arm-none-eabi-objcopy', var='OBJCOPY')
+    cfg.find_program('%s-objcopy' % cfg.env.TOOLCHAIN, var='OBJCOPY')
     env = cfg.env
     bldnode = cfg.bldnode.make_node(cfg.variant)
     def srcpath(path):

--- a/Tools/ardupilotwaf/toolchain.py
+++ b/Tools/ardupilotwaf/toolchain.py
@@ -21,6 +21,7 @@ from waflib.Tools import clang, clangxx, gcc, gxx
 from waflib.Tools import c_config
 from waflib import Logs
 
+import glob
 import os
 import re
 import sys
@@ -130,6 +131,41 @@ def _set_pkgconfig_crosscompilation_wrapper(cfg):
 
     cfg.validate_cfg = new_validate_cfg
 
+# Directories where ArduPilot's own setup scripts (Tools/environment_install/
+# install-prereqs-*.sh) install the cross toolchains, keyed by toolchain triple.
+ARDUPILOT_TOOLCHAIN_DIRS = {
+    'arm-none-eabi': ['/opt/gcc-arm-none-eabi-10-2020-q4-major/bin'],
+}
+
+def _prefer_installed_toolchain(cfg):
+    """Bias program lookup toward ArduPilot's own installed toolchain.
+
+    Prepends the first matching install dir to the PATH that waf's find_program
+    consults (cfg.environ), so gcc/g++/ar/nm/objcopy/size all resolve to the
+    same toolchain, with a normal PATH fallback when it is not installed there.
+    This lets the build find its supported compiler even when a *different*
+    arm-none-eabi-gcc is the system default on PATH (e.g. for another project),
+    so ArduPilot need not prepend its toolchain to the global PATH.
+
+    A user-supplied --toolchain (which sets TOOLCHAIN to an explicit value rather
+    than a plain triple) takes precedence and is left untouched.
+    """
+    dirs = list(ARDUPILOT_TOOLCHAIN_DIRS.get(cfg.env.TOOLCHAIN, []))
+    if cfg.env.TOOLCHAIN == 'arm-none-eabi':
+        # accept any versioned install too, preferring the highest version
+        dirs += sorted(glob.glob('/opt/gcc-arm-none-eabi-*/bin'), reverse=True)
+    for d in dirs:
+        if not os.path.exists(os.path.join(d, '%s-gcc' % cfg.env.TOOLCHAIN)):
+            continue
+        # copy os.environ the first time so we never mutate the real process env
+        if getattr(cfg, 'environ', os.environ) is os.environ:
+            cfg.environ = dict(os.environ)
+        path = cfg.environ.get('PATH', '')
+        if d not in path.split(os.pathsep):
+            cfg.environ['PATH'] = d + os.pathsep + path
+        cfg.msg('Using toolchain dir', d)
+        return
+
 def configure(cfg):
     _filter_supported_c_compilers('gcc', 'clang')
     _filter_supported_cxx_compilers('g++', 'clang++')
@@ -142,6 +178,8 @@ def configure(cfg):
         cfg.load('compiler_cxx compiler_c gccdeps')
 
         return
+
+    _prefer_installed_toolchain(cfg)
 
     _set_pkgconfig_crosscompilation_wrapper(cfg)
     if sys.platform.startswith("cygwin"):

--- a/Tools/environment_install/install-prereqs-arch.sh
+++ b/Tools/environment_install/install-prereqs-arch.sh
@@ -117,12 +117,20 @@ if [ ! -d $OPT/$ARM_ROOT ]; then
 fi
 
 exportline="export PATH=$OPT/$ARM_ROOT/bin:\$PATH";
-if ! grep -Fxq "$exportline" ~/.bashrc ; then
-    if maybe_prompt_user "Add $OPT/$ARM_ROOT/bin to your PATH [N/y]?" ; then
+# The build discovers this toolchain automatically (see the install-dir lookup in
+# Tools/ardupilotwaf/toolchain.py), it is opt-in and NOT added by default -- and,
+# unlike the rest of the installer, it is deliberately not auto-confirmed by -y.
+if grep -Fxq "$exportline" ~/.bashrc 2>/dev/null; then
+    : # already present in ~/.bashrc
+elif $ASSUME_YES; then
+    echo "Not adding $OPT/$ARM_ROOT/bin to PATH (opt-in; the build finds it automatically)."
+else
+    read -p "Add $OPT/$ARM_ROOT/bin to your PATH? Optional, the build finds it without this [y/N] "
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
         echo "$exportline" >> ~/.bashrc
         . "$HOME/.bashrc"
     else
-        echo "Skipping adding $OPT/$ARM_ROOT/bin to PATH."
+        echo "Not adding $OPT/$ARM_ROOT/bin to PATH (the build finds it automatically)."
     fi
 fi
 

--- a/Tools/environment_install/install-prereqs-mac.sh
+++ b/Tools/environment_install/install-prereqs-mac.sh
@@ -187,15 +187,23 @@ SCRIPT_DIR=$(dirname $(grealpath ${BASH_SOURCE[0]}))
 ARDUPILOT_ROOT=$(grealpath "$SCRIPT_DIR/../../")
 
 if [[ $DO_AP_STM_ENV -eq 1 ]]; then
-exportline="export PATH=$OPT/$ARM_ROOT/bin:\$PATH";
-grep -Fxq "$exportline" ~/$SHELL_LOGIN 2>/dev/null || {
-    if maybe_prompt_user "Add $OPT/$ARM_ROOT/bin to your PATH [N/y]?" ; then
-        echo $exportline >> ~/$SHELL_LOGIN
-        eval $exportline
+    # The build discovers this toolchain automatically (see the install-dir lookup in
+    # Tools/ardupilotwaf/toolchain.py), it is opt-in and NOT added by default -- and,
+    # unlike the rest of the installer, it is deliberately not auto-confirmed by -y.
+    exportline="export PATH=$OPT/$ARM_ROOT/bin:\$PATH";
+    if grep -Fxq "$exportline" ~/$SHELL_LOGIN 2>/dev/null; then
+        : # already present in ~/$SHELL_LOGIN
+    elif $ASSUME_YES; then
+        echo "Not adding $OPT/$ARM_ROOT/bin to PATH (opt-in; the build finds it automatically)."
     else
-        echo "Skipping adding $OPT/$ARM_ROOT/bin to PATH."
+        read -p "Add $OPT/$ARM_ROOT/bin to your PATH? Optional, the build finds it without this [y/N] "
+        if [[ $REPLY =~ ^[Yy]$ ]]; then
+            echo "$exportline" >> ~/$SHELL_LOGIN
+            eval "$exportline"
+        else
+            echo "Not adding $OPT/$ARM_ROOT/bin to PATH (the build finds it automatically)."
+        fi
     fi
-}
 fi
 
 exportline2="export PATH=$ARDUPILOT_ROOT/$ARDUPILOT_TOOLS:\$PATH";

--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -553,15 +553,23 @@ fi
 heading "Adding ArduPilot Tools to environment"
 
 if [[ $DO_AP_STM_ENV -eq 1 ]]; then
-exportline="export PATH=$OPT/$ARM_ROOT/bin:\$PATH";
-grep -Fxq "$exportline" ~/$SHELL_LOGIN 2>/dev/null || {
-    if maybe_prompt_user "Add $OPT/$ARM_ROOT/bin to your PATH [N/y]?" ; then
-        echo "$exportline" >> ~/$SHELL_LOGIN
-        eval "$exportline"
+    # The build discovers this toolchain automatically (see the install-dir lookup in
+    # Tools/ardupilotwaf/toolchain.py), it is opt-in and NOT added by default -- and,
+    # unlike the rest of the installer, it is deliberately not auto-confirmed by -y.
+    exportline="export PATH=$OPT/$ARM_ROOT/bin:\$PATH";
+    if grep -Fxq "$exportline" ~/$SHELL_LOGIN 2>/dev/null; then
+        : # already present in ~/$SHELL_LOGIN
+    elif $ASSUME_YES; then
+        echo "Not adding $OPT/$ARM_ROOT/bin to PATH (opt-in; the build finds it automatically)."
     else
-        echo "Skipping adding $OPT/$ARM_ROOT/bin to PATH."
+        read -p "Add $OPT/$ARM_ROOT/bin to your PATH? Optional, the build finds it without this [y/N] "
+        if [[ $REPLY =~ ^[Yy]$ ]]; then
+            echo "$exportline" >> ~/$SHELL_LOGIN
+            eval "$exportline"
+        else
+            echo "Not adding $OPT/$ARM_ROOT/bin to PATH (the build finds it automatically)."
+        fi
     fi
-}
 fi
 
 exportline2="export PATH=\"$ARDUPILOT_ROOT/$ARDUPILOT_TOOLS:\"\$PATH";


### PR DESCRIPTION
## Summary
ArduPilot's STM32/ChibiOS build now locates its own arm-none-eabi toolchain at configure time, and the prereqs installers no longer add that toolchain to the global PATH by default. This lets one machine build ArduPilot alongside another arm-none-eabi project (e.g. PX4) without the two toolchains fighting over PATH.

## Problem
install-prereqs installs the supported toolchain (gcc-arm-none-eabi-10-2020-q4-major) to /opt and offers to prepend it to PATH via the login profile — but the prompt is auto-confirmed by -y, so scripted/CI installs add it unconditionally, and the build then relies on that bare arm-none-eabi-gcc being first on PATH. On a machine that also builds another arm-none-eabi project — e.g. PX4, whose documented compiler is the distro gcc-arm-none-eabi — whichever toolchain wins PATH silently overrides the other. The build also cannot find its toolchain without that global PATH edit, and chibios.py looked up objcopy by a hardcoded arm-none-eabi-objcopy rather than the configured TOOLCHAIN, so even an explicit --toolchain= could not fully pin it.

## Solution
- waf discovers ArduPilot's installed toolchain dir at configure and prefers it, with a normal PATH fallback when it is installed elsewhere; an explicit --toolchain still takes precedence.
- objcopy is now located via the configured TOOLCHAIN prefix, like every other tool.
- adding the toolchain to PATH (install-prereqs ubuntu/mac/arch) is now opt-in and off by default, and is no longer auto-confirmed by -y, since the build finds it without PATH.
