### PR TITLE
SITL::Submarine uses internal SITL::Battery

### DIFF
--- a/libraries/SITL/SIM_Submarine.cpp
+++ b/libraries/SITL/SIM_Submarine.cpp
@@ -63,6 +63,12 @@ Submarine::Submarine(const char *frame_str) :
         n_thrusters = 8;
     }
     lock_step_scheduled = true;
+
+    constexpr float default_battery_resistance_ohm = 0.033;
+    battery.setup(sitl->batt_capacity_ah,
+                  default_battery_resistance_ohm,
+                  sitl->batt_voltage,
+                  ambient_outside_temperature_degC());
 }
 
 float Submarine::perpendicular_distance_to_rangefinder_surface() const
@@ -85,7 +91,7 @@ void Submarine::calculate_forces(const struct sitl_input &input, Vector3f &rot_a
         float output = 0;
         // if valid pwm and not in the esc deadzone
         // TODO: extract deadzone from parameters/vehicle code
-        if (pwm < 2000 && pwm > 1000 && (pwm < 1475 || pwm > 1525)) {
+        if (!battery_is_empty() && pwm < 2000 && pwm > 1000 && (pwm < 1475 || pwm > 1525)) {
             output = (pwm - 1500) / 400.0; // range -1~1
         }
 
@@ -120,21 +126,19 @@ void Submarine::calculate_forces(const struct sitl_input &input, Vector3f &rot_a
     add_shove_forces(rot_accel, body_accel);
 }
 
-// Note: Sub does not comply with SIM_BATT_CAP_AH, instead it always
-// uses an unlimited-capacity battery model.
 void Submarine::update_battery(const struct sitl_input &input)
 {
-    battery_voltage = sitl->batt_voltage;
+    battery.maybe_reset(sitl->batt_voltage, sitl->batt_capacity_ah);
     battery_current = 0.0f;
-    // Model battery usage via linear voltage-sag and current draw for every actuator
-    constexpr float voltage_sag_scaler_volts = 0.5f;
     constexpr float current_draw_scaler_amps = 15.0f;
     for (uint8_t i=0; i<6; i++) {
         const float pwm = input.servos[i];
         const float fraction = fabsf(pwm - 1500) / 500.0f;
-        battery_voltage -= fraction * voltage_sag_scaler_volts;
         battery_current += fraction * current_draw_scaler_amps;
     }
+    battery.consume_energy(battery_current, AP_HAL::micros64());
+    battery_voltage = battery.get_voltage();
+    battery_temperature_degC = battery.get_temperature_degC();
 }
 
 /**

--- a/libraries/SITL/SIM_Submarine.h
+++ b/libraries/SITL/SIM_Submarine.h
@@ -111,6 +111,7 @@ protected:
     // Sub needs the sitl_input, should never use the parent's input-free version.
     // (Using it would be using the wrong battery model, but it would silently work.)
     void update_battery() override { INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control); };
+    bool battery_is_empty() { return battery_voltage < 0.5f; };
 
     Frame *frame;
     Thruster* thrusters;


### PR DESCRIPTION
### Summary

SITL::Submarine uses the internal SITL::Battery. This means it responds to SIM_BATT_VOLTAGE and SIM_BATT_CAP_AH parameters as-documented.

This mostly accomplishes https://github.com/ArduPilot/ardupilot/issues/10050 for Sub.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

In SITL, I manipulated SIM_BATT_CAP_AH and SIM_BATT_VOLTAGE parameters and observed them having the documented & expected effects. (Including losing thrust when battery capacity is exhausted.)

### Description

This adds realism & conformance with the user-facing documentation for SITL::Submarine.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
