### PR TITLE
AP_HAL_ChibiOS: add delay before flash erase to ensure USB initialization

### DIFF
--- a/libraries/AP_HAL_ChibiOS/Storage.cpp
+++ b/libraries/AP_HAL_ChibiOS/Storage.cpp
@@ -420,6 +420,9 @@ bool Storage::_flash_erase_sector(uint8_t sector)
 #endif
     // erasing a page can take long enough that USB may not initialise properly if it happens
     // while the host is connecting. Only do a flash erase if we have been up for more than 4s
+    while (AP_HAL::millis() < 4000) {
+        hal.scheduler->delay(100);
+    }
     for (uint8_t i=0; i<STORAGE_FLASH_RETRIES; i++) {
         // a sector erase stops the whole MCU so set up a long expected delay
         EXPECT_DELAY_MS(1000);


### PR DESCRIPTION
### Summary

This PR adds a delay before flash erase to address an issue where a device fails to re-enumerate over USB after a full parameter reset, which requires a physical reconnection otherwise.

This is an issue that is already documented in the code, but the suggested fix was seemingly not implemented.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Ran Unit Tests and autotest (copter only) locally on this branch before submitting.
Also tested on hardware (see logs below).

### Description

I encountered the issue described in the comment within `Storage::_flash_erase_sector` after doing a full parameter reset and noticed that the suggested fix from that comment had never been implemented.
A search using `git blame` shows that the comment was added in 2019, but I wasn't able to find any changes or reverts related to this issue.

Regardless, I have implemented and tested the suggested action on my device. With this change, the device correclty re-enumerate over USB after a full parameter reset. Without it, the device must be physically disconnected and reconnected to enumerate correctly.

However I am not certain this is the right change to make. I am used to triggering full parameter resets on other flight controllers during our manufacturing process, but the AEDROX is the only device I have seen failing with this behavior.
For what it's worth, the AEDROX board used for testing is rev1.1 and the firmware was compiled from https://github.com/ArduPilot/ardupilot/pull/33393. The change in this PR was rebased against this other PR.

Was there a reason for not implementing this suggested change? And/or is there another mechanism elsewhere in the codebase that was intended to address this?

Here is a dmesg log of what I was observing before the change:

```log
<Initial connection via USB>
[24770.670067] usb 3-12: new full-speed USB device number 88 using xhci_hcd
[24770.806974] usb 3-12: New USB device found, idVendor=1209, idProduct=5741, bcdDevice= 2.00
[24770.806979] usb 3-12: New USB device strings: Mfr=1, Product=2, SerialNumber=3
[24770.806980] usb 3-12: Product: AEDROXH7
[24770.806981] usb 3-12: Manufacturer: ArduPilot
[24770.806982] usb 3-12: SerialNumber: 270027001651343434353737
[24770.809095] cdc_acm 3-12:1.0: ttyACM1: USB ACM device
<Connect to the device via USB with mavproxy, change some of the default parameter values, then set FORMAT_VERSION to 0 to trigger a full parameter reset upon reboot. Then reboot>
<Device disconnects, but the device descriptor can not be read ever again. The board does show correct led patterns, though>
[25625.687388] usb 3-12: USB disconnect, device number 88
[25626.034730] usb 3-12: new full-speed USB device number 89 using xhci_hcd
[25641.458560] usb 3-12: device descriptor read/64, error -110
[25657.074322] usb 3-12: device descriptor read/64, error -110
[25657.298289] usb 3-12: new full-speed USB device number 90 using xhci_hcd
[25672.690107] usb 3-12: device descriptor read/64, error -110
[25688.305889] usb 3-12: device descriptor read/64, error -110
[25688.409928] usb usb3-port12: attempt power cycle
[25688.801948] usb 3-12: new full-speed USB device number 91 using xhci_hcd
[25693.817839] xhci_hcd 0000:00:14.0: Timeout while waiting for setup device command
[25699.193800] xhci_hcd 0000:00:14.0: Timeout while waiting for setup device command
[25699.397798] usb 3-12: device not accepting address 91, error -62
[25699.397881] usb 3-12: WARN: invalid context state for evaluate context command.
[25699.517710] usb 3-12: new full-speed USB device number 92 using xhci_hcd
[25704.569681] xhci_hcd 0000:00:14.0: Timeout while waiting for setup device command
[25709.945609] xhci_hcd 0000:00:14.0: Timeout while waiting for setup device command
[25710.149602] usb 3-12: device not accepting address 92, error -62
[25710.149686] usb 3-12: WARN: invalid context state for evaluate context command.
[25710.149790] usb usb3-port12: unable to enumerate USB device
```

With the change:

```log
<Initial connection via USB>
[26179.914479] usb 3-12: new full-speed USB device number 97 using xhci_hcd
[26180.059393] usb 3-12: New USB device found, idVendor=1209, idProduct=5741, bcdDevice= 2.00
[26180.059400] usb 3-12: New USB device strings: Mfr=1, Product=2, SerialNumber=3
[26180.059401] usb 3-12: Product: AEDROXH7
[26180.059403] usb 3-12: Manufacturer: ArduPilot
[26180.059404] usb 3-12: SerialNumber: 270027001651343434353737
[26180.061800] cdc_acm 3-12:1.0: ttyACM1: USB ACM device
<Connect to the device via USB with mavproxy, change some of the default parameter values, then set FORMAT_VERSION to 0 to trigger a full parameter reset upon reboot. Then reboot>
[27486.463505] usb 3-12: USB disconnect, device number 97
[27486.819317] usb 3-12: new full-speed USB device number 98 using xhci_hcd
[27486.960481] usb 3-12: New USB device found, idVendor=1209, idProduct=5741, bcdDevice= 2.00
[27486.960486] usb 3-12: New USB device strings: Mfr=1, Product=2, SerialNumber=3
[27486.960487] usb 3-12: Product: AEDROXH7
[27486.960488] usb 3-12: Manufacturer: ArduPilot
[27486.960489] usb 3-12: SerialNumber: 270027001651343434353737
[27486.962778] cdc_acm 3-12:1.0: ttyACM0: USB ACM device
<Mavproxy automatically reconnects to the device>
```