### PR TITLE
AP_AHRS: correct get_quaternion comment to body-to-NED rotation

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -2726,7 +2726,7 @@ bool AP_AHRS::airspeed_vector_TAS(Vector3f &vec) const
     return state.airspeed_TAS_vec_ok;
 }
 
-// return the quaternion defining the rotation from NED to XYZ (body) axes
+// return the quaternion defining the rotation from XYZ (body) to NED axes
 bool AP_AHRS::get_quaternion(Quaternion &quat) const
 {
     quat = state.quat;

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -209,7 +209,7 @@ public:
     // true if compass is being used
     bool use_compass();
 
-    // return the quaternion defining the rotation from NED to XYZ (body) axes
+    // return the quaternion defining the rotation from XYZ (body) to NED axes
     bool get_quaternion(Quaternion &quat) const WARN_IF_UNUSED;
 
     // return secondary attitude solution if available, as eulers in radians


### PR DESCRIPTION
The quaternion is built from the body-to-NED DCM (the same matrix returned by get_rotation_body_to_ned()), so it defines the rotation from XYZ (body) to NED axes, not the reverse as previously documented.

Fixes #17662

### Summary

<!-- Put a one or two line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [ ] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
