### PR TITLE
SITL::QuadPlane uses Plane's update_battery() function

### DIFF
--- a/libraries/SITL/SIM_QuadPlane.cpp
+++ b/libraries/SITL/SIM_QuadPlane.cpp
@@ -132,6 +132,7 @@ void QuadPlane::update(const struct sitl_input &input)
 
     motor_mask |= ((1U<<frame->num_motors)-1U) << frame->motor_offset;
     frame->calculate_forces(*this, input, quad_rot_accel, quad_accel_body, rpm, false);
+    update_battery(input);
 
     // rotate frames for copter tailsitters
     if (copter_tailsitter) {
@@ -139,24 +140,6 @@ void QuadPlane::update(const struct sitl_input &input)
         quad_accel_body.rotate(ROTATION_PITCH_270);
     }
 
-    battery.maybe_reset(sitl->batt_voltage, sitl->batt_capacity_ah, sitl->batt_resistance);
-    battery_voltage = battery.get_voltage();
-    battery_current = frame->get_current_amp();
-    battery_temperature_degC = battery.get_temperature_degC();
-
-    const uint64_t now_us = AP_HAL::micros64();
-    battery.consume_energy(battery_current, now_us);
-
-    float throttle;
-    if (reverse_thrust) {
-        throttle = filtered_servo_angle(input, 2);
-    } else {
-        throttle = filtered_servo_range(input, 2);
-    }
-    // assume 20A at full fwd throttle
-    throttle = fabsf(throttle);
-    battery_current += 20 * throttle;
-    
     rot_accel += quad_rot_accel;
     accel_body += quad_accel_body;
 
@@ -169,4 +152,25 @@ void QuadPlane::update(const struct sitl_input &input)
 
     // update magnetic field
     update_mag_field_bf();
+}
+
+void QuadPlane::update_battery(const struct sitl_input &input)
+{
+    battery.maybe_reset(sitl->batt_voltage, sitl->batt_capacity_ah, sitl->batt_resistance);
+    battery_voltage = battery.get_voltage();
+    battery_temperature_degC = battery.get_temperature_degC();
+
+    battery_current = frame->get_current_amp();
+
+    float throttle;
+    if (reverse_thrust) {
+        throttle = filtered_servo_angle(input, 2);
+    } else {
+        throttle = filtered_servo_range(input, 2);
+    }
+    // assume 20A at full fwd throttle
+    throttle = fabsf(throttle);
+    battery_current += 20 * throttle;
+
+    battery.consume_energy(battery_current, AP_HAL::micros64());
 }

--- a/libraries/SITL/SIM_QuadPlane.h
+++ b/libraries/SITL/SIM_QuadPlane.h
@@ -45,6 +45,7 @@ public:
 
 private:
     Frame *frame;
+    void update_battery(const struct sitl_input &input) override;
 };
 
 } // namespace SITL


### PR DESCRIPTION
### Summary

QuadPlane was already using SITL::Battery before #33528 landed (which upgrades Plane to use it), so this just refactors QuadPlane to follow the structure its parent (now) uses.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Although QuadPlane does not seem to emit BATTERY_STATUS mavlink info, setting the voltage & capacity very low while in hovering flight causes QuadPlane to fall to the ground.

### Description

(Github makes the diff look more complicated than it actually is.)

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
