### PR TITLE
SITL::MultiCopter overrides parent's update_battery()

### DIFF
--- a/libraries/SITL/SIM_Multicopter.cpp
+++ b/libraries/SITL/SIM_Multicopter.cpp
@@ -74,14 +74,7 @@ void MultiCopter::update(const struct sitl_input &input)
         accel_body.zero();
     }
 
-    battery.maybe_reset(sitl->batt_voltage, sitl->batt_capacity_ah);
-    battery_voltage = battery.get_voltage();
-    battery_current = frame->get_current_amp();
-    battery_temperature_degC = battery.get_temperature_degC();
-
-    const uint64_t now_us = AP_HAL::micros64();
-    battery.consume_energy(battery_current, now_us);
-
+    update_battery();
     update_dynamics(rot_accel);
     update_external_payload(input);
 
@@ -93,3 +86,12 @@ void MultiCopter::update(const struct sitl_input &input)
     update_mag_field_bf();
 }
 
+void MultiCopter::update_battery() {
+    battery.maybe_reset(sitl->batt_voltage, sitl->batt_capacity_ah);
+    battery_voltage = battery.get_voltage();
+    battery_current = frame->get_current_amp();
+    battery_temperature_degC = battery.get_temperature_degC();
+
+    const uint64_t now_us = AP_HAL::micros64();
+    battery.consume_energy(battery_current, now_us);
+}

--- a/libraries/SITL/SIM_Multicopter.h
+++ b/libraries/SITL/SIM_Multicopter.h
@@ -47,6 +47,7 @@ protected:
     // calculate rotational and linear accelerations
     void calculate_forces(const struct sitl_input &input, Vector3f &rot_accel, Vector3f &body_accel);
     Frame *frame;
+    void update_battery() override;
 };
 
 }


### PR DESCRIPTION
### Summary

A simple PR, only moves a few lines into a function.
This is the natural refactor now that #33463 has landed: MultiCopter should use the same code structure as its parent.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

For such a simple code-reorganization, it can be visually checked as correct.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
