### PR TITLE
AP_Param: publish actual loaded defaults count, not the pre-count

### DIFF
--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -2458,7 +2458,7 @@ bool AP_Param::load_defaults_file(const char *filename, bool last_pass)
     }
     free(mutable_filename);
 
-    num_param_overrides = num_defaults;
+    num_param_overrides = idx;
 
 #if AP_PARAM_DEFAULTS_ENABLED
     purge_defaults_list_overrides();
@@ -2592,7 +2592,7 @@ void AP_Param::load_param_defaults(const volatile char *ptr, int32_t length, boo
             vp->set_float(value, var_type);
         }
     }
-    num_param_overrides = num_defaults;
+    num_param_overrides = idx;
 
 #if AP_PARAM_DEFAULTS_ENABLED
     purge_defaults_list_overrides();


### PR DESCRIPTION
### Summary

Publish the actual number of loaded parameter defaults instead of the pre-load count, so consumers do not scan stale override slots.

### Classification & Testing

- [x] Checked by a human programmer

Compile-checked on SITL. The change is small and reasoned directly from the load path; no automated test, as exercising it needs defaults-loading scaffolding plus access to the private override count.

### Description

`load_defaults_file()` and `load_param_defaults()` count the defaults entries first and size `param_overrides[]` to that count (`num_defaults`). During the load an entry whose parameter does not exist is skipped, so the number actually inserted (`idx`) can be below `num_defaults`. Both functions then set `num_param_overrides = num_defaults`, leaving the trailing override slots holding stale `object_ptr` values.

Consumers scan `param_overrides[]` up to `num_param_overrides`: default lookup, the read-only check, and `purge_defaults_list_overrides()`. The last is the sharp edge - it compares each defaults-list entry against `param_overrides[i].object_ptr`, so a stale slot can match a live parameter and wrongly purge it from the defaults list.

Set `num_param_overrides = idx` so only the slots that were really filled are scanned. `param_overrides_len` still holds the allocation size, so buffer accounting is unchanged.