### PR TITLE
board_types: reserve IDs 110-119 for Syro, add SYRO_V6X

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -65,6 +65,9 @@ Reserved "GUMSTIX [BL] FMU v6"         54
 Reserved "ARK CAN FLOW"                80
 Reserved "NXP ucans32k146"             34
 
+# IDs 110-119 reserved for Syro
+TARGET_HW_SYRO_V6X                     110
+
 # values from external vendors
 EXT_HW_RADIOLINK_MINI_PIX               3
 


### PR DESCRIPTION
### Summary

Reserve ID for Syro V6X

### Classification & Testing (check all that apply and add your own)

- [v] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

