### PR TITLE
Add generic test for inverted-Heli flying

### DIFF
--- a/Tools/autotest/helicopter.py
+++ b/Tools/autotest/helicopter.py
@@ -278,24 +278,28 @@ class AutoTestHelicopter(AutoTestCopter):
         # shaping cannot recover cleanly
         self.ModeFlip(do_pitch_flip=False)
 
-    def HeliQuadInvertedFlight(self):
-        '''fly inverted on collective-pitch quad frame'''
-        self.customise_SITL_commandline(
-            [],
-            defaults_filepath=self.model_defaults_filepath('heli-quad'),
-            model="heli-quad:@ROMFS/models/heliquad.json",
-            wipe=True,
-        )
+    def fly_inverted_flight(self, collective_servos=None, yaw_tolerance=20):
+        '''engage inverted flight from a hover in ALT_HOLD and verify that the
+        vehicle stays inverted and holds altitude, then recover.  Assumes the
+        frame has already been set up and the vehicle is disarmed.  If
+        collective_servos is given those servo channels must reach negative
+        blade pitch (PWM below mid) while inverted.  yaw_tolerance is the
+        allowed heading drift in degrees, or None to not check heading (a
+        single tail rotor re-trims when inverted and drifts slowly).'''
         rc_option_inverted = 43
         self.set_parameter("RC10_OPTION", rc_option_inverted)
         self.set_rc(10, 1000)
+        # clear any interlock/throttle override left over from a previous
+        # frame's attempt, so the vehicle can pass its arming checks
+        self.zero_throttle()
+        self.set_rc(8, 1000)
         self.takeoff(30, mode='ALT_HOLD')
 
         self.progress("Engaging inverted flight")
         self.set_rc(10, 2000)
         tstart = self.get_sim_time()
         while True:
-            if self.get_sim_time_cached() - tstart > 10:
+            if self.get_sim_time_cached() - tstart > 15:
                 raise NotAchievedException("Did not roll inverted")
             m = self.assert_receive_message('ATTITUDE')
             if abs(math.degrees(m.roll)) > 150:
@@ -312,23 +316,113 @@ class AutoTestHelicopter(AutoTestCopter):
             roll_deg = math.degrees(m.roll)
             if abs(roll_deg) < 150:
                 raise NotAchievedException(f"Did not stay inverted (roll {roll_deg:.1f})")
-            yaw_err = (math.degrees(m.yaw) - hold_yaw_deg + 180) % 360 - 180
-            if abs(yaw_err) > 20:
-                raise NotAchievedException(f"Did not hold heading while inverted (err {yaw_err:.1f}deg)")
+            if yaw_tolerance is not None:
+                yaw_err = (math.degrees(m.yaw) - hold_yaw_deg + 180) % 360 - 180
+                if abs(yaw_err) > yaw_tolerance:
+                    raise NotAchievedException(f"Did not hold heading while inverted (err {yaw_err:.1f}deg)")
             alt = self.get_altitude(relative=True)
             if abs(alt - hold_alt) > 5:
                 raise NotAchievedException(f"Lost altitude while inverted ({alt:.1f}m vs {hold_alt:.1f}m)")
-            servo = self.assert_receive_message('SERVO_OUTPUT_RAW')
-            for n in 1, 2, 3, 4:
-                max_collective = max(max_collective, getattr(servo, f"servo{n}_raw"))
-        if max_collective >= 1500:
+            if collective_servos is not None:
+                servo = self.assert_receive_message('SERVO_OUTPUT_RAW')
+                for n in collective_servos:
+                    max_collective = max(max_collective, getattr(servo, f"servo{n}_raw"))
+        if collective_servos is not None and max_collective >= 1500:
             raise NotAchievedException("Rotor not at negative collective while inverted (max %u)" % max_collective)
-        self.progress("Inverted flight held altitude and heading, max collective PWM %u" % max_collective)
+        self.progress("Inverted flight held altitude and heading")
 
         self.progress("Disengaging inverted flight")
         self.set_rc(10, 1000)
         self.wait_attitude(desroll=0, despitch=0, tolerance=10, timeout=15)
+
+    def HeliQuadInvertedFlight(self):
+        '''fly inverted on collective-pitch quad frame'''
+        self.customise_SITL_commandline(
+            [],
+            defaults_filepath=self.model_defaults_filepath('heli-quad'),
+            model="heli-quad:@ROMFS/models/heliquad.json",
+            wipe=True,
+        )
+        # the four collective servos must swing to negative blade pitch
+        self.fly_inverted_flight(collective_servos=(1, 2, 3, 4))
         self.do_RTL()
+
+    def InvertedFlight(self):
+        '''attempt inverted flight on each heli frame and check the set that
+        succeeds matches expectations'''
+        # parameters that let the traditional heli frames push the collective
+        # negative far enough to hold inverted flight; set for this test only.
+        # IM_STB_COL_* only affect STABILIZE collective; the maneuver flies in
+        # ALT_HOLD so they are belt-and-braces.
+        inverted_params = {
+            "H_COL_MIN": 1260,
+            "H_COL_ANG_MIN": -12,
+            "IM_STB_COL_1": 40,
+            "IM_STB_COL_2": 70,
+            "IM_STB_COL_3": 80,
+        }
+        # frames expected to sustain inverted flight.  Any frame that flies
+        # inverted but is not listed here, or any listed frame that fails to,
+        # fails the test - so the list is kept honest as frames are added or
+        # the model/controllers change.  heli-quad has its own dedicated test.
+        expect_inverted = {
+            'heli',
+            'heli-dual',
+            'heli-gas',
+            'heli-ddvptail',
+            'heli-ddfptail',
+            'heli-blade360',
+        }
+        vinfo = vehicleinfo.VehicleInfo()
+        frames = vinfo.options[self.vehicleinfo_key()]["frames"]
+        flew_inverted = set()
+        results = {}
+        for frame in sorted(frames.keys()):
+            if frame == 'heli-quad':
+                continue
+            self.start_subtest("Inverted flight: frame (%s)" % frame)
+            frame_bits = frames[frame]
+            model = frame_bits.get("model", frame)
+            defaults = self.model_defaults_filepath(frame)
+            if not isinstance(defaults, list):
+                defaults = [defaults]
+            self.customise_SITL_commandline(
+                [],
+                defaults_filepath=defaults,
+                model=model,
+                wipe=True,
+            )
+            self.set_parameters(inverted_params)
+            try:
+                # don't check heading: a tail rotor re-trims when
+                # inverted and the heading drifts slowly, which is
+                # orthogonal to whether the frame can sustain inverted
+                # flight (holding altitude inverted needs negative
+                # collective, which is the thing under test)
+                self.fly_inverted_flight(yaw_tolerance=None)
+                flew_inverted.add(frame)
+                results[frame] = "inverted OK"
+                self.progress("Inverted flight achieved on %s" % frame)
+            except (NotAchievedException, AutoTestTimeoutException) as e:
+                results[frame] = "not achieved: %s" % str(e)
+                self.progress("Inverted flight not achieved on %s: %s" % (frame, str(e)))
+
+        # a successful frame leaves the vehicle hovering; disarm it so the
+        # harness does not see it still armed at the end of the test
+        self.zero_throttle()
+        self.set_rc(8, 1000)
+        if self.armed():
+            self.disarm_vehicle(force=True)
+
+        self.progress("Inverted flight results: %s" % str(results))
+        unexpected_pass = flew_inverted - expect_inverted
+        unexpected_fail = expect_inverted - flew_inverted
+        if unexpected_pass:
+            raise NotAchievedException(
+                "Frames flew inverted but were not expected to: %s" % str(sorted(unexpected_pass)))
+        if unexpected_fail:
+            raise NotAchievedException(
+                "Frames expected to fly inverted but did not: %s" % str(sorted(unexpected_fail)))
 
     def hover(self):
         self.progress("Setting hover collective")
@@ -1328,6 +1422,7 @@ class AutoTestHelicopter(AutoTestCopter):
             self.HeliQuad,
             self.HeliQuadFlip,
             self.HeliQuadInvertedFlight,
+            self.InvertedFlight,
             self.MountFailsafeAction,
             self.StickArmingRequiresZeroThrottle,
         ])

--- a/Tools/autotest/helicopter.py
+++ b/Tools/autotest/helicopter.py
@@ -347,8 +347,8 @@ class AutoTestHelicopter(AutoTestCopter):
         self.fly_inverted_flight(collective_servos=(1, 2, 3, 4))
         self.do_RTL()
 
-    def InvertedFlight(self):
-        '''attempt inverted flight on each heli frame and check the set that
+    def HeliSingleInvertedFlight(self):
+        '''attempt inverted flight on heli single frame and check the set that
         succeeds matches expectations'''
         # parameters that let the traditional heli frames push the collective
         # negative far enough to hold inverted flight; set for this test only.
@@ -357,72 +357,21 @@ class AutoTestHelicopter(AutoTestCopter):
         inverted_params = {
             "H_COL_MIN": 1260,
             "H_COL_ANG_MIN": -12,
+            "ATC_RATE_R_MAX": 120,
+            "ATC_RATE_P_MAX": 120,
             "IM_STB_COL_1": 40,
             "IM_STB_COL_2": 70,
             "IM_STB_COL_3": 80,
         }
-        # frames expected to sustain inverted flight.  Any frame that flies
-        # inverted but is not listed here, or any listed frame that fails to,
-        # fails the test - so the list is kept honest as frames are added or
-        # the model/controllers change.  heli-quad has its own dedicated test.
-        expect_inverted = {
-            'heli',
-            'heli-dual',
-            'heli-gas',
-            'heli-ddvptail',
-            'heli-ddfptail',
-            'heli-blade360',
-        }
-        vinfo = vehicleinfo.VehicleInfo()
-        frames = vinfo.options[self.vehicleinfo_key()]["frames"]
-        flew_inverted = set()
-        results = {}
-        for frame in sorted(frames.keys()):
-            if frame == 'heli-quad':
-                continue
-            self.start_subtest("Inverted flight: frame (%s)" % frame)
-            frame_bits = frames[frame]
-            model = frame_bits.get("model", frame)
-            defaults = self.model_defaults_filepath(frame)
-            if not isinstance(defaults, list):
-                defaults = [defaults]
-            self.customise_SITL_commandline(
-                [],
-                defaults_filepath=defaults,
-                model=model,
-                wipe=True,
-            )
-            self.set_parameters(inverted_params)
-            try:
-                # don't check heading: a tail rotor re-trims when
-                # inverted and the heading drifts slowly, which is
-                # orthogonal to whether the frame can sustain inverted
-                # flight (holding altitude inverted needs negative
-                # collective, which is the thing under test)
-                self.fly_inverted_flight(yaw_tolerance=None)
-                flew_inverted.add(frame)
-                results[frame] = "inverted OK"
-                self.progress("Inverted flight achieved on %s" % frame)
-            except (NotAchievedException, AutoTestTimeoutException) as e:
-                results[frame] = "not achieved: %s" % str(e)
-                self.progress("Inverted flight not achieved on %s: %s" % (frame, str(e)))
-
-        # a successful frame leaves the vehicle hovering; disarm it so the
-        # harness does not see it still armed at the end of the test
-        self.zero_throttle()
-        self.set_rc(8, 1000)
-        if self.armed():
-            self.disarm_vehicle(force=True)
-
-        self.progress("Inverted flight results: %s" % str(results))
-        unexpected_pass = flew_inverted - expect_inverted
-        unexpected_fail = expect_inverted - flew_inverted
-        if unexpected_pass:
-            raise NotAchievedException(
-                "Frames flew inverted but were not expected to: %s" % str(sorted(unexpected_pass)))
-        if unexpected_fail:
-            raise NotAchievedException(
-                "Frames expected to fly inverted but did not: %s" % str(sorted(unexpected_fail)))
+        self.customise_SITL_commandline(
+            [],
+            defaults_filepath=self.model_defaults_filepath('heli'),
+            model="heli",
+            wipe=True,
+        )
+        self.set_parameters(inverted_params)
+        self.fly_inverted_flight(yaw_tolerance=30)
+        self.do_RTL()
 
     def hover(self):
         self.progress("Setting hover collective")
@@ -1422,7 +1371,7 @@ class AutoTestHelicopter(AutoTestCopter):
             self.HeliQuad,
             self.HeliQuadFlip,
             self.HeliQuadInvertedFlight,
-            self.InvertedFlight,
+            self.HeliSingleInvertedFlight,
             self.MountFailsafeAction,
             self.StickArmingRequiresZeroThrottle,
         ])


### PR DESCRIPTION
### Summary

Iterates the Heli frames, trying to fly each inverted

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request


### Description

Follow-up I promised in https://github.com/ArduPilot/ardupilot/pull/33521 (and currently has patches from that PR in here).  ~~It's actually only a single patch on top!~~ I rebased

Iterates the Heli frames and changes the tuning a little to allow for inverted flight


```
  Per-frame inverted-flight performance

  ┌───────────────┬───────────┬──────────────────┬──────────────────┬────────────────────┬───────────────────────────┐
  │     frame     │ inverted? │ alt drop (tuned) │ headroom (tuned) │ alt drop (default) │          result           │
  ├───────────────┼───────────┼──────────────────┼──────────────────┼────────────────────┼───────────────────────────┤
  │ heli          │ yes       │ 0.0 m            │ 140 µs (0% sat)  │ 6.1 m              │ tuned PASS / default FAIL │
  ├───────────────┼───────────┼──────────────────┼──────────────────┼────────────────────┼───────────────────────────┤
  │ heli-blade360 │ yes       │ 0.1 m            │ 115 µs (0%)      │ 6.2 m              │ PASS / FAIL               │
  ├───────────────┼───────────┼──────────────────┼──────────────────┼────────────────────┼───────────────────────────┤
  │ heli-ddfptail │ yes       │ 0.1 m            │ 140 µs (0%)      │ 6.2 m              │ PASS / FAIL               │
  ├───────────────┼───────────┼──────────────────┼──────────────────┼────────────────────┼───────────────────────────┤
  │ heli-ddvptail │ yes       │ 0.0 m            │ 140 µs (0%)      │ 6.7 m              │ PASS / FAIL               │
  ├───────────────┼───────────┼──────────────────┼──────────────────┼────────────────────┼───────────────────────────┤
  │ heli-dual     │ yes       │ 1.2 m            │ 106 µs (0%)      │ 6.4 m              │ PASS / FAIL               │
  ├───────────────┼───────────┼──────────────────┼──────────────────┼────────────────────┼───────────────────────────┤
  │ heli-gas      │ yes       │ 0.1 m            │ 105 µs (0%)      │ 22.9 m             │ PASS / FAIL               │
  └───────────────┴───────────┴──────────────────┴──────────────────┴────────────────────┴───────────────────────────┘

  The story: every frame rolls inverted fine in both configs — attitude control isn't the limiter. What separates pass from fail is collective authority. With the test's tuned range
  (−12°/H_COL_MIN 1260), all six settle into steady inverted hover with ~105–140 µs of collective headroom to spare and 0% saturation, holding altitude within ~1 m. With the default range
  (−2°/1460), the collective pins at its floor (100% saturated) — it physically can't make enough negative thrust — and altitude collapses 6–7 m (heli-gas worst at 23 m; its throttle
  governor behaves differently, only 33% saturated but still loses the most). So the maneuver is gated by negative-collective range, not the controllers, and all six frames are comfortably
  capable once given the range — none is marginal.
```

<img width="1350" height="1404" alt="image" src="https://github.com/user-attachments/assets/285db002-6442-47c3-81f5-03d7230d5bf8" />

<img width="1350" height="1404" alt="image" src="https://github.com/user-attachments/assets/7ab903e3-0476-40f7-b689-e972079928f7" />

<img width="1600" height="500" alt="image" src="https://github.com/user-attachments/assets/d2751e7e-417e-45c1-b68c-5291fd7212a0" />

<img width="1140" height="1425" alt="image" src="https://github.com/user-attachments/assets/540f04ac-1a77-42de-bd59-61fcb3031ba0" />


```
  ┌───────────────┬───────────────────────────┬────────────────────┬────────────┐
  │     frame     │ peak yaw drift (inverted) │ yaw actuator range │ saturated? │
  ├───────────────┼───────────────────────────┼────────────────────┼────────────┤
  │ heli          │ 40°                       │ 1542–1846          │ no         │
  ├───────────────┼───────────────────────────┼────────────────────┼────────────┤
  │ heli-blade360 │ 42°                       │ 1255–1430          │ no         │
  ├───────────────┼───────────────────────────┼────────────────────┼────────────┤
  │ heli-ddfptail │ 28°                       │ 1284–1969          │ no         │
  ├───────────────┼───────────────────────────┼────────────────────┼────────────┤
  │ heli-ddvptail │ 40°                       │ 1541–1833          │ no         │
  ├───────────────┼───────────────────────────┼────────────────────┼────────────┤
  │ heli-dual     │ 179°                      │ 1410–1776          │ no         │
  ├───────────────┼───────────────────────────┼────────────────────┼────────────┤
  │ heli-gas      │ 43°                       │ 1604–1675          │ no         │
  └───────────────┴───────────────────────────┴────────────────────┴────────────┘

  The yaw story (and the justification for not gating the generic test on heading):
  - Every frame's heading drifts while inverted — typically ~30–45°, because a tail rotor's yaw torque direction effectively reverses relative to the airframe when upside down, so the
  controller is fighting a re-trimmed plant. The drift is bounded and slow, not a spin-out — the yaw actuator works steadily and never saturates (stays off the 1000/2000 stops on all
  frames), so yaw control is retained, just with a standing heading offset.
  - heli-dual is the outlier: ~179° — it essentially yaws around while inverted. A tandem/dual-swash heli has fundamentally different yaw authority (differential collective, no tail rotor),
  and inverted it loses heading completely even though it holds altitude fine (1.2 m drop, passes the test). This is exactly why heading is excluded — heli-dual would otherwise fail on an
  axis orthogonal to "can it sustain inverted flight."
```


