### PR TITLE
Fix broken COMPASS_DISBLMSΚ for hwdef-ed compasses

### DIFF
--- a/libraries/AP_HAL/hwdef/scripts/hwdef.py
+++ b/libraries/AP_HAL/hwdef/scripts/hwdef.py
@@ -545,8 +545,11 @@ class HWDef:
             args.append(str(compass.rotation))
 
             f.write(
-                '#define HAL_MAG_PROBE%u %s {add_backend(DRIVER_%s, AP_Compass_%s::%s(%s));RETURN_IF_NO_SPACE;}\n'
-                % (n, wrapper, driver, driver, probe, ','.join(args)))
+                '''#define HAL_MAG_PROBE%u %s \\
+                    if (_driver_enabled(DRIVER_%s)) { \\
+                        {add_backend(DRIVER_%s, AP_Compass_%s::%s(%s));RETURN_IF_NO_SPACE;} \\
+                    }\n'''
+                % (n, wrapper, driver, driver, driver, probe, ','.join(args)))
             f.write(f"#undef AP_COMPASS_{driver}_ENABLED\n#define AP_COMPASS_{driver}_ENABLED 1\n")
         if len(devlist) > 0:
             f.write('#define HAL_MAG_PROBE_LIST %s\n\n' % ';'.join(devlist))


### PR DESCRIPTION
### Summary

https://github.com/ArduPilot/ardupilot/pull/31591 broke COMPASS_DISBLMSK for compasses defined in the hwdef.

This PR fixes it.

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [X] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [X] Tested manually, description below (e.g. SITL)
- [X] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

I compared before/after behaviour in a CubeOrangePlus.

### Description

The issue lied with a MACRO change from pasting inline code to defining a function.
The inline code would check for `_driver_enabled()` and exit early, but the method would evaluate and instantiate the driver at call-time.

### Alternatives

For the hwdef-ed compasses the `_driver_enabled()` will run twice, once out of the `add_backend()` and once inside it. But the internal check can't be simply removed because `COMPASS_DISBLMSK` covers non-hwdef-ed compass drivers.
An alternative would be to modify all related MACROS which define `add_backend()`.