### PR TITLE
Create and use attitude reset counter in place of primary core index

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -312,7 +312,8 @@ private:
 
     // system time in milliseconds of last recorded yaw reset from ekf
     uint32_t ekfYawReset_ms;
-    int8_t ekf_primary_core;
+    // old value of counter which increments when our attitude estimate is reset
+    uint16_t attitude_reset_count;
 
     // vibration check
     struct {

--- a/ArduCopter/ekf_check.cpp
+++ b/ArduCopter/ekf_check.cpp
@@ -257,11 +257,10 @@ void Copter::check_ekf_reset()
     }
 
     // check for change in primary EKF, reset attitude target and log.  AC_PosControl handles position target adjustment
-    if ((ahrs.get_primary_core_index() != ekf_primary_core) && (ahrs.get_primary_core_index() != -1)) {
+    const auto new_reset_count = ahrs.get_last_attitude_reset_count();
+    if (new_reset_count != attitude_reset_count) {
         attitude_control->inertial_frame_reset();
-        ekf_primary_core = ahrs.get_primary_core_index();
-        LOGGER_WRITE_ERROR(LogErrorSubsystem::EKF_PRIMARY, LogErrorCode(ekf_primary_core));
-        gcs().send_text(MAV_SEVERITY_WARNING, "EKF primary changed:%d", (unsigned)ekf_primary_core);
+        attitude_reset_count = new_reset_count;
     }
 }
 

--- a/Blimp/Blimp.h
+++ b/Blimp/Blimp.h
@@ -117,7 +117,6 @@ private:
 
     // system time in milliseconds of last recorded yaw reset from ekf
     uint32_t ekfYawReset_ms;
-    int8_t ekf_primary_core;
 
     // vibration check
     struct {

--- a/Blimp/ekf_check.cpp
+++ b/Blimp/ekf_check.cpp
@@ -184,13 +184,6 @@ void Blimp::check_ekf_reset()
         ekfYawReset_ms = new_ekfYawReset_ms;
         LOGGER_WRITE_EVENT(LogEvent::EKF_YAW_RESET);
     }
-
-    // check for change in primary EKF, reset attitude target and log.  AC_PosControl handles position target adjustment
-    if ((ahrs.get_primary_core_index() != ekf_primary_core) && (ahrs.get_primary_core_index() != -1)) {
-        ekf_primary_core = ahrs.get_primary_core_index();
-        LOGGER_WRITE_ERROR(LogErrorSubsystem::EKF_PRIMARY, LogErrorCode(ekf_primary_core));
-        gcs().send_text(MAV_SEVERITY_WARNING, "EKF primary changed:%d", (unsigned)ekf_primary_core);
-    }
 }
 
 // check for high vibrations affecting altitude control

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -4769,7 +4769,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         def statustext_hook(mav, message):
             if message.get_type() != 'STATUSTEXT':
                 return
-            if message.text.startswith("EKF primary changed:"):
+            if message.text.startswith("EKF3 primary changed:"):
                 try:
                     lane = int(message.text.strip().split(":")[-1])
                     self.lane_switches.append(lane)
@@ -4808,7 +4808,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         # Wait for automatic lane switch to occur
         self.wait_statustext(
-            text="EKF primary changed:1",
+            text="EKF3 primary changed:1",
             timeout=30,
             check_context=True
         )

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -453,7 +453,6 @@ void AP_AHRS::update_state(void)
 
     state.primary_accel = active_estimates->primary_accel;
 
-    state.primary_core = _get_primary_core_index();
     state.EAS2TAS = AP_AHRS_Backend::get_EAS2TAS();
     state.airspeed_EAS_ok = _airspeed_EAS(state.airspeed_EAS, state.airspeed_estimate_type);
     state.airspeed_TAS_ok = _airspeed_TAS(state.airspeed_TAS);
@@ -609,13 +608,24 @@ void AP_AHRS::update(bool skip_ins_update)
     // update blinking lights, buzzer etc bsaed on active EKF type:
     update_notify_from_filter_status(active_estimates->filter_status);
 
-#if HAL_GCS_ENABLED
+    bool attitude_was_reset = false;
     if (state.active_EKF_type != last_active_ekf_type) {
         last_active_ekf_type = state.active_EKF_type;
-        const char *shortname = active_backend->shortname();
-        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AHRS: %s active", shortname);
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AHRS: %s active", active_backend->shortname());
+        last_active_estimates_attitude_reset_count = active_estimates->attitude_reset_count;
+        attitude_was_reset = true;
+    } else {
+        // estimator has not changed - but perhaps the estimator's
+        // output might have reset:
+        if (active_estimates->attitude_reset_count != last_active_estimates_attitude_reset_count) {
+            last_active_estimates_attitude_reset_count = active_estimates->attitude_reset_count;
+            attitude_was_reset = true;
+        }
     }
-#endif // HAL_GCS_ENABLED
+    if (attitude_was_reset) {
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "AHRS attitude reset");
+        state.attitude_reset_count++;
+    }
 
     // update published state, including copying state from the active backend:
     update_state();
@@ -2252,42 +2262,6 @@ uint8_t AP_AHRS::get_active_airspeed_index() const
 
     return 0;
 #endif // AP_AIRSPEED_ENABLED
-}
-
-// return the index of the primary core or -1 if no primary core selected
-int8_t AP_AHRS::_get_primary_core_index() const
-{
-    switch (active_EKF_type()) {
-#if AP_AHRS_DCM_ENABLED
-    case EKFType::DCM:
-        // we have only one core
-        return 0;
-#endif
-#if AP_AHRS_SIM_ENABLED
-    case EKFType::SIM:
-        // we have only one core
-        return 0;
-#endif
-#if AP_AHRS_EXTERNAL_ENABLED
-    case EKFType::EXTERNAL:
-        // we have only one core
-        return 0;
-#endif
-
-#if HAL_NAVEKF2_AVAILABLE
-    case EKFType::TWO:
-        return ekf2.EKF2.getPrimaryCoreIndex();
-#endif
-
-#if HAL_NAVEKF3_AVAILABLE
-    case EKFType::THREE:
-        return ekf3.EKF3.getPrimaryCoreIndex();
-#endif
-    }
-
-    // we should never get here
-    INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
-    return -1;
 }
 
 #if AP_AHRS_EKF_RESET_ENABLED

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -623,7 +623,6 @@ void AP_AHRS::update(bool skip_ins_update)
         }
     }
     if (attitude_was_reset) {
-        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "AHRS attitude reset");
         state.attitude_reset_count++;
     }
 

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -405,6 +405,11 @@ public:
         return active_backend->getLastPosDownReset(posDelta);
     }
 
+    // returns a counter which is incremented each time the estimator's output resets
+    uint16_t get_last_attitude_reset_count() const {
+        return state.attitude_reset_count;
+    }
+
     // Resets the baro so that it reads zero at the current height
     // Resets the EKF height to zero
     // Adjusts the EKf origin height so that the EKF height + origin height is the same as before
@@ -475,9 +480,6 @@ public:
     // to use, i.e, the one being used by the primary lane. A lane switch could have happened due to an 
     // airspeed sensor fault, which makes this even more necessary
     uint8_t get_active_airspeed_index() const;
-
-    // return the index of the primary core or -1 if no primary core selected
-    int8_t get_primary_core_index() const { return state.primary_core; }
 
     // get the index of the current primary accelerometer sensor
     uint8_t get_primary_accel_index(void) const { return state.primary_accel; }
@@ -991,9 +993,6 @@ private:
     // get secondary EKF type.  returns false if no secondary (i.e. only using DCM)
     bool _get_secondary_EKF_type(EKFType &secondary_ekf_type) const;
 
-    // return the index of the primary core or -1 if no primary core selected
-    int8_t _get_primary_core_index() const;
-
     // get current location estimate
     bool _get_location(Location &loc) const;
 
@@ -1021,7 +1020,6 @@ private:
         EKFType configured_ekf_type;  // vetted parameter-configured EKFType
         uint8_t primary_gyro;
         uint8_t primary_accel;
-        uint8_t primary_core;
         Vector3f gyro_estimate;
         Matrix3f dcm_matrix;
         Vector3f gyro_drift;
@@ -1037,6 +1035,7 @@ private:
         bool airspeed_TAS_vec_ok;
         Quaternion quat;
         bool quat_ok;
+        uint16_t attitude_reset_count;
         Vector3f secondary_attitude;
         bool secondary_attitude_ok;
         Quaternion secondary_quat;
@@ -1152,6 +1151,8 @@ private:
     AP_AHRS_Backend::Estimates *active_estimates;
 
     const AP_AHRS_Backend::Estimates *get_secondary_estimates() const;
+
+    uint16_t last_active_estimates_attitude_reset_count;
 };
 
 namespace AP {

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -84,6 +84,7 @@ public:
         float yaw_rad;
         Matrix3f dcm_matrix;
         Quaternion quaternion;
+        uint16_t attitude_reset_count;  // counter incremented each time a sudden shift happens in attitude
 
         // backends must always return the result in the vehicle body
         // frame.  A backend using the autopilot sensors will need to

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF2.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF2.cpp
@@ -6,6 +6,7 @@
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Logger/AP_Logger.h>
+#include <GCS_MAVLink/GCS.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -50,6 +51,16 @@ void AP_AHRS_NavEKF2::update()
         return;
     }
     EKF2.UpdateFilter();
+
+    // check the current primary core; if it has changed then assume
+    // our attitude is reset:
+    const int8_t primary_core = EKF2.getPrimaryCoreIndex();
+    if (old_primary_core != primary_core) {
+        old_primary_core = primary_core;
+        attitude_reset_count++;
+        LOGGER_WRITE_ERROR(LogErrorSubsystem::EKF_PRIMARY, LogErrorCode(primary_core));
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "EKF2 primary changed:%d", (unsigned)primary_core);
+    }
 }
 
 void AP_AHRS_NavEKF2::get_results(AP_AHRS_Backend::Estimates &results)
@@ -100,6 +111,8 @@ void AP_AHRS_NavEKF2::get_results(AP_AHRS_Backend::Estimates &results)
     results.quaternion.rotate(-AP::ahrs().get_trim());
 
     results.attitude_valid = started;
+
+    results.attitude_reset_count = attitude_reset_count;
 
     /*
      * acceleration estimates

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF2.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF2.h
@@ -99,6 +99,10 @@ public:
     bool start();
     bool started;
     uint32_t start_time_ms;  // timer used to delay starting the filter
+
+    // a counter which is incremented each time the primary core changes:
+    uint16_t attitude_reset_count;
+    int8_t old_primary_core;
 };
 
 #endif  // AP_AHRS_NAVEKF2_ENABLED

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
@@ -6,6 +6,7 @@
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Logger/AP_Logger.h>
+#include <GCS_MAVLink/GCS.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -49,6 +50,16 @@ void AP_AHRS_NavEKF3::update()
         return;
     }
     EKF3.UpdateFilter();
+
+    // check the current primary core; if it has changed then assume
+    // our attitude is reset:
+    const int8_t primary_core = EKF3.getPrimaryCoreIndex();
+    if (old_primary_core != primary_core) {
+        old_primary_core = primary_core;
+        attitude_reset_count++;
+        LOGGER_WRITE_ERROR(LogErrorSubsystem::EKF_PRIMARY, LogErrorCode(primary_core));
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "EKF3 primary changed:%d", (unsigned)primary_core);
+    }
 }
 
 void AP_AHRS_NavEKF3::get_results(AP_AHRS_Backend::Estimates &results)
@@ -99,6 +110,8 @@ void AP_AHRS_NavEKF3::get_results(AP_AHRS_Backend::Estimates &results)
     results.quaternion.rotate(-AP::ahrs().get_trim());
 
     results.attitude_valid = started;
+
+    results.attitude_reset_count = attitude_reset_count;
 
     /*
      * acceleration estimates

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF3.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF3.h
@@ -98,6 +98,10 @@ public:
     bool start();
     bool started;
     uint32_t start_time_ms;  // timer used to delay starting the filter
+
+    // a counter which is incremented each time the primary core changes:
+    uint16_t attitude_reset_count;
+    int8_t old_primary_core;
 };
 
 #endif  // AP_AHRS_NAVEKF3_ENABLED


### PR DESCRIPTION
### Summary

Switches detection of attitude reset from being "which primary core are we running" to "has the reset count changed?"

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board,copter,plane
CubeOrange,16,152
```

### Description

Copter was using primary core index as an indicating of whether you'd just undergone an attitude reset.

This was problematic in that if you changed estimators the it was reasonably likely the attitude would be reset but you wouldn't detect it.

We will now say the attitude has reset if we change cores *or* estimators*.

All vehicles now get this code, so we will log events for ekf-primary-changed in the EKF backends and send text on all vehicles.

I think we might be able to do better here - DCM does have a reset function, for example, and if an EKF ever resets itself that should also count as an attitude reset.

We should get vehicles using this.  Since AC_AttitudeControl just goes and gets AHRS data itself now-adays it could just look at this counter itself rather than going through Copter!

