### PR TITLE
Blimp: Add autotest for Blimp's motor frame and auto mode plus some fixes

### DIFF
--- a/Blimp/mode_auto.cpp
+++ b/Blimp/mode_auto.cpp
@@ -56,8 +56,6 @@ void ModeAuto::run()
 
     yaw_forward();
     blimp.loiter->run(target_pos, target_yaw, Vector4b{false,false,false,false});
-    gcs().send_named_float("TarX", target_pos.x);
-    gcs().send_named_float("TarY", target_pos.y);
 }
 
 Location ModeAuto::loc_from_cmd(const AP_Mission::Mission_Command& cmd, const Location& default_loc) const
@@ -168,7 +166,6 @@ void ModeAuto::do_nav_wp(const AP_Mission::Mission_Command& cmd)
         mission_started = true;
     }
 
-
     AP_Mission::Mission_Command next_cmd;
     if (!mission.get_next_nav_cmd(cmd.index+1, next_cmd)) {
         fast_wp = false;
@@ -192,7 +189,7 @@ bool ModeAuto::verify_nav_wp(const AP_Mission::Mission_Command& cmd)
 
     if (blimp.loiter->target_within(g.wp_radius*0.5)) {
         s_finished = scurve_this_leg.advance_target_along_track(scurve_prev_leg, scurve_next_leg, g.wp_radius, g.wp_accel, fast_wp, dt, scurve_this_leg_origin, target_vel, target_accel);
-        target_pos = Vector3f{(float)scurve_this_leg_origin.x,(float)scurve_this_leg_origin.y, (float)scurve_this_leg_origin.z};;
+        target_pos = Vector3f{(float)scurve_this_leg_origin.x,(float)scurve_this_leg_origin.y, (float)scurve_this_leg_origin.z};
         scurve_this_leg_origin = origin;
     }
 

--- a/Tools/autotest/blimp.py
+++ b/Tools/autotest/blimp.py
@@ -169,6 +169,76 @@ class AutoTestBlimp(TestSuite):
 
         self.disarm_vehicle()
 
+    def FlyManualFourMotor(self):
+        '''test manual mode on the four-motor blimp frame'''
+        self.customise_SITL_commandline(
+            [],
+            model='blimp-motor',
+            defaults_filepath=self.model_defaults_filepath('blimp-motor'),
+        )
+
+        speed_accuracy = 0.1
+        heading_accuracy = 10
+
+        self.change_mode('MANUAL')
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+
+        def stop_blimp():
+            self.progress("Stopping.")
+            self.set_rc(1, 1500)
+            self.set_rc(2, 1500)
+            self.set_rc(3, 1500)
+            self.set_rc(4, 1500)
+            self.wait_speed_vector(Vector3(0, 0, 0), accuracy=speed_accuracy, timeout=20)
+            self.wait_yaw_speed(0, 0.2, 10)
+
+        def stop_blimp_wait_heading():
+            stop_blimp()
+            self.wait_heading(0, accuracy=heading_accuracy, timeout=2)
+
+        self.progress("Moving forward.")
+        self.set_rc(2, 2000)
+        self.wait_speed_vector(Vector3(1.6, 0, 0), accuracy=speed_accuracy, timeout=10)
+        stop_blimp_wait_heading()
+
+        self.progress("Moving right.")
+        self.set_rc(1, 2000)
+        self.wait_speed_vector(Vector3(0, 1.1, 0), accuracy=speed_accuracy, timeout=10)
+        stop_blimp_wait_heading()
+
+        self.progress("Moving backward.")
+        self.set_rc(2, 1000)
+        self.wait_speed_vector(Vector3(-1.6, 0, 0), accuracy=speed_accuracy, timeout=10)
+        stop_blimp_wait_heading()
+
+        self.progress("Moving left.")
+        self.set_rc(1, 1000)
+        self.wait_speed_vector(Vector3(0, -1.1, 0), accuracy=speed_accuracy, timeout=10)
+        stop_blimp_wait_heading()
+
+        self.progress("Moving up.")
+        self.set_rc(3, 2000)
+        self.wait_speed_vector(Vector3(0, 0, -1.1), accuracy=speed_accuracy, timeout=15)
+        stop_blimp_wait_heading()
+
+        self.progress("Moving down.")
+        self.set_rc(3, 1000)
+        self.wait_speed_vector(Vector3(0, 0, 1.1), accuracy=speed_accuracy, timeout=15)
+        stop_blimp_wait_heading()
+
+        self.progress("Yawing right.")
+        self.set_rc(4, 2000)
+        self.wait_yaw_speed(1.0, accuracy=speed_accuracy, timeout=10)
+        stop_blimp()
+
+        self.progress("Yawing left.")
+        self.set_rc(4, 1000)
+        self.wait_yaw_speed(-1.0, accuracy=speed_accuracy, timeout=10)
+        stop_blimp()
+
+        self.disarm_vehicle()
+
     def FlyLoiter(self):
         '''test loiter mode'''
 
@@ -237,6 +307,46 @@ class AutoTestBlimp(TestSuite):
 
         self.disarm_vehicle()
 
+    def FlyAuto(self):
+        '''test AUTO mode with a small mission '''
+        self.customise_SITL_commandline(
+            [],
+            model='blimp-motor',
+            defaults_filepath=self.model_defaults_filepath('blimp-motor'),
+        )
+
+        alt = 1  # metres above home (corner/default)
+        alt_high = 1.5
+        alt_low = 0.5
+        size = 5  # metres square
+
+        self.progress("Uploading simple relhome mission.")
+
+        # build a simple relative-to-home mission using helper
+        # items are tuples: (MAV_CMD, metres_north, metres_east, alt, [opts])
+        self.upload_simple_relhome_mission([
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 0,      0,      alt),
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, size/2, -1,     alt_high),
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, size,   0,      alt),
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, size-1, size/2, alt_low),
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, size,   size,   alt),
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, size/2, size-1, alt_high),
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 0,      size,   alt),
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 0,      0,      alt),
+        ])
+
+        # ensure we start from first waypoint
+        self.set_current_waypoint(0, check_afterwards=False)
+
+        # switch to AUTO and arm
+        self.change_mode('AUTO')
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+
+        self.wait_statustext("Mission Complete", timeout=100)
+        # always disarm at end of test
+        self.disarm_vehicle()
+
     def UTMGlobalPosition(self):
         '''test UTM_GLOBAL_POSITION message sending'''
         self.wait_ready_to_arm()
@@ -257,11 +367,12 @@ class AutoTestBlimp(TestSuite):
 
     def tests(self):
         '''return list of all tests'''
-        # ret = super(AutoTestBlimp, self).tests()
         ret = []
         ret.extend([
             self.FlyManualFinned,
+            self.FlyManualFourMotor,
             self.FlyLoiter,
+            self.FlyAuto,
             self.PREFLIGHT_Pressure,
             self.UTMGlobalPosition,
         ])


### PR DESCRIPTION
- Adds a manual test for the four motor frame
- Adds a very simple auto mode test
- Some small fixes in the blimp code (removing missed named_float calls and fixing a typo).
- Update pymavlink module with the new modes.

I realised I had forgotten to add the new modes to pymavlink in the last PR, so they're in this one. Can't quite remember how that process works again - do I make PRs for the mavlink and pymavlink branches in their respective repos too?

All tested in SITL/autotest.