### PR TITLE
ArduPlane: Fix QLOITER fly away for bicopters

### DIFF
--- a/ArduPlane/tiltrotor.cpp
+++ b/ArduPlane/tiltrotor.cpp
@@ -323,12 +323,17 @@ void Tiltrotor::continuous_update(void)
         // the way forward
         slew(get_forward_flight_tilt());
     } else {
-        // until we have completed the transition we limit the tilt to
-        // Q_TILT_MAX. Anything above 50% throttle gets
-        // Q_TILT_MAX. Below 50% throttle we decrease linearly. This
-        // relies heavily on Q_VFWD_GAIN being set appropriately.
-       float settilt = constrain_float((SRV_Channels::get_output_scaled(SRV_Channel::k_throttle)-MAX(plane.aparm.throttle_min.get(),0)) * 0.02, 0, 1);
-       slew(MIN(settilt * max_angle_deg * (1/90.0), get_forward_flight_tilt())); 
+        if (type == TILT_TYPE_BICOPTER) {
+            // Bypass thrust vectoring for a bicopter
+            slew(0);
+        } else {
+            // until we have completed the transition we limit the tilt to
+            // Q_TILT_MAX. Anything above 50% throttle gets
+            // Q_TILT_MAX. Below 50% throttle we decrease linearly. This
+            // relies heavily on Q_VFWD_GAIN being set appropriately.
+            float settilt = constrain_float((SRV_Channels::get_output_scaled(SRV_Channel::k_throttle)-MAX(plane.aparm.throttle_min.get(),0)) * 0.02, 0, 1);
+            slew(MIN(settilt * max_angle_deg * (1/90.0), get_forward_flight_tilt()));
+        }
     }
 }
 


### PR DESCRIPTION
### Summary

Fixes a fly-away when entering QLOITER mode with a tiltrotor configuration that doesn't include a fwd thrust motor such as a Bi-Copter. Without this fix the Bi-Copter tilts forwards and continues to accelerate forwards.

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [X] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Created a Bi-Copter configuration in Gazebo and flew with SITL. Entering and Exiting QLOITER mode.

### Description

With the original code, when a Bi-Copter configured vehicle enters QLOITER, the affected section of code applies the formula for adding forward tilt to the tilt-pods as if it was trying to fly on a fixed-wing. For a Bi-Copter, that causes a fly-away.
This change adds a conditional check so that vehicles configured as a Bi-Copter do not attempt to use forward tilt.
 Following this change, if a bi-copter wants to fly on a fixed wing it will need to complete a full transition to fixed wing flight (assuming it has wings to fly with.)
