### PR TITLE
autotest: print beacon position delta as float, not truncated %u

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -10198,7 +10198,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             new_pos = self.get_global_position_int()
             pos_delta = self.get_distance_int(old_pos, new_pos)
             max_delta = 1
-            self.progress("delta=%u want <= %u" % (pos_delta, max_delta))
+            self.progress(f"delta={pos_delta:.2f} want <= {max_delta}")
             if pos_delta <= max_delta:
                 break
 


### PR DESCRIPTION
### Summary

Adjusts output to add more precision

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

BeaconPosition() (also exercised by the Replay Beacon bit) waits for the EKF position to settle within max_delta=1 m of the pre-switch GPS fix and logs the distance with "delta=%u".  pos_delta is a float in metres, so %u truncated it: a genuine 1.55 m miss printed as "delta=1", which reads as though it satisfied "want <= 1" yet the test still timed out -- actively misleading when diagnosing the beacon-convergence flake.  Print %.2f.

Discovered as part of chasing this outlier down:

<img width="1690" height="676" alt="image" src="https://github.com/user-attachments/assets/903b414c-85a5-430c-bc62-f225cf9b6b5b" />
