### PR TITLE
AP_AHRS: remove backend get_relative_position_*_origin methods

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -1223,60 +1223,6 @@ bool AP_AHRS::get_vert_pos_rate_D(float &velocity) const
     return active_estimates->get_vert_pos_rate_D(velocity);
 }
 
-/*
-  return a relative NED position from the origin in meters
-*/
-bool AP_AHRS::get_relative_position_NED_origin(Vector3p &vec) const
-{
-    switch (active_EKF_type()) {
-#if AP_AHRS_DCM_ENABLED
-    case EKFType::DCM:
-        return dcm.get_relative_position_NED_origin(vec);
-#endif
-#if HAL_NAVEKF2_AVAILABLE
-    case EKFType::TWO: {
-        Vector2p posNE;
-        postype_t posD;
-        if (ekf2.EKF2.getPosNE(posNE) && ekf2.EKF2.getPosD(posD)) {
-            // position is valid
-            vec.x = posNE.x;
-            vec.y = posNE.y;
-            vec.z = posD;
-            return true;
-        }
-        return false;
-    }
-#endif
-
-#if HAL_NAVEKF3_AVAILABLE
-    case EKFType::THREE: {
-            Vector2p posNE;
-            postype_t posD;
-            if (ekf3.EKF3.getPosNE(posNE) && ekf3.EKF3.getPosD(posD)) {
-                // position is valid
-                vec.x = posNE.x;
-                vec.y = posNE.y;
-                vec.z = posD;
-                return true;
-            }
-            return false;
-        }
-#endif
-
-#if AP_AHRS_SIM_ENABLED
-    case EKFType::SIM:
-        return sim.get_relative_position_NED_origin(vec);
-#endif
-#if AP_AHRS_EXTERNAL_ENABLED
-    case EKFType::EXTERNAL: {
-        return external.get_relative_position_NED_origin(vec);
-    }
-#endif
-    }
-    // since there is no default case above, this is unreachable
-    return false;
-}
-
 bool AP_AHRS::get_relative_position_NED_origin_float(Vector3f &vec) const
 {
     Vector3p tmp_posNED;
@@ -1299,44 +1245,6 @@ bool AP_AHRS::get_relative_position_NED_home(Vector3f &vec) const
     }
     vec = _home.get_distance_NED(loc);
     return true;
-}
-
-/*
-  return a relative position estimate from the origin in meters
-*/
-bool AP_AHRS::get_relative_position_NE_origin(Vector2p &posNE) const
-{
-    switch (active_EKF_type()) {
-#if AP_AHRS_DCM_ENABLED
-    case EKFType::DCM:
-        return dcm.get_relative_position_NE_origin(posNE);
-#endif
-#if HAL_NAVEKF2_AVAILABLE
-    case EKFType::TWO: {
-        bool position_is_valid = ekf2.EKF2.getPosNE(posNE);
-        return position_is_valid;
-    }
-#endif
-
-#if HAL_NAVEKF3_AVAILABLE
-    case EKFType::THREE: {
-        bool position_is_valid = ekf3.EKF3.getPosNE(posNE);
-        return position_is_valid;
-    }
-#endif
-
-#if AP_AHRS_SIM_ENABLED
-    case EKFType::SIM: {
-        return sim.get_relative_position_NE_origin(posNE);
-    }
-#endif
-#if AP_AHRS_EXTERNAL_ENABLED
-    case EKFType::EXTERNAL:
-        return external.get_relative_position_NE_origin(posNE);
-#endif
-    }
-    // since there is no default case above, this is unreachable
-    return false;
 }
 
 bool AP_AHRS::get_relative_position_NE_origin_float(Vector2f &posNE) const
@@ -1362,46 +1270,6 @@ bool AP_AHRS::get_relative_position_NE_home(Vector2f &posNE) const
 
     posNE = _home.get_distance_NE(loc);
     return true;
-}
-
-// write a relative ground position estimate to the origin in meters, North/East order
-
-
-/*
-  return a relative ground position from the origin in meters, down
-*/
-bool AP_AHRS::get_relative_position_D_origin(postype_t &posD) const
-{
-    switch (active_EKF_type()) {
-#if AP_AHRS_DCM_ENABLED
-    case EKFType::DCM:
-        return dcm.get_relative_position_D_origin(posD);
-#endif
-#if HAL_NAVEKF2_AVAILABLE
-    case EKFType::TWO: {
-        bool position_is_valid = ekf2.EKF2.getPosD(posD);
-        return position_is_valid;
-    }
-#endif
-
-#if HAL_NAVEKF3_AVAILABLE
-    case EKFType::THREE: {
-        bool position_is_valid = ekf3.EKF3.getPosD(posD);
-        return position_is_valid;
-    }
-#endif
-
-#if AP_AHRS_SIM_ENABLED
-    case EKFType::SIM:
-        return sim.get_relative_position_D_origin(posD);
-#endif
-#if AP_AHRS_EXTERNAL_ENABLED
-    case EKFType::EXTERNAL:
-        return external.get_relative_position_D_origin(posD);
-#endif
-    }
-    // since there is no default case above, this is unreachable
-    return false;
 }
 
 bool AP_AHRS::get_relative_position_D_origin_float(float &posD) const
@@ -1445,6 +1313,7 @@ void AP_AHRS::get_relative_position_D_home(float &posD) const
     posD = originD - ((originLLH.alt - _home.alt) * 0.01f);
     return;
 }
+
 /*
   canonicalise _ekf_type, forcing it to be 0, 2 or 3
   type 1 has been deprecated

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -279,22 +279,36 @@ public:
     // order. Must only be called if have_inertial_nav() is true
     bool get_velocity_NED(Vector3f &vec) const WARN_IF_UNUSED;
 
-    // return the relative position NED from either home or origin
+    // return the relative position NED from home
     // return true if the estimate is valid
     bool get_relative_position_NED_home(Vector3f &vec) const WARN_IF_UNUSED;
-    bool get_relative_position_NED_origin(Vector3p &vec) const WARN_IF_UNUSED;
+    bool get_relative_position_NE_home(Vector2f &posNE) const WARN_IF_UNUSED;
+    void get_relative_position_D_home(float &posD) const;
+
+    // return the relative position NED from origin
+    // return true if the estimate is valid
+    bool get_relative_position_NED_origin(Vector3p &vec) const WARN_IF_UNUSED {
+        vec.xy() = active_estimates->position_NE;
+        vec.z = active_estimates->position_D;
+        return (active_estimates->position_NE_valid && active_estimates->position_D_valid);
+    }
     bool get_relative_position_NED_origin_float(Vector3f &vec) const WARN_IF_UNUSED;
 
     // return the relative position NE from home or origin
     // return true if the estimate is valid
-    bool get_relative_position_NE_home(Vector2f &posNE) const WARN_IF_UNUSED;
-    bool get_relative_position_NE_origin(Vector2p &posNE) const WARN_IF_UNUSED;
+    bool get_relative_position_NE_origin(Vector2p &posNE) const WARN_IF_UNUSED {
+        posNE = active_estimates->position_NE;
+        return active_estimates->position_NE_valid;
+    }
     bool get_relative_position_NE_origin_float(Vector2f &posNE) const WARN_IF_UNUSED;
 
     // return the relative position down from home or origin
     // baro will be used for the _home relative one if the EKF isn't
-    void get_relative_position_D_home(float &posD) const;
-    bool get_relative_position_D_origin(postype_t &posD) const WARN_IF_UNUSED;
+    bool get_relative_position_D_origin(postype_t &posD) const WARN_IF_UNUSED {
+        posD = active_estimates->position_D;
+        return active_estimates->position_D_valid;
+    }
+
     bool get_relative_position_D_origin_float(float &posD) const WARN_IF_UNUSED;
 
     // return location corresponding to vector relative to the

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -149,6 +149,12 @@ public:
          */
         bool provides_common_origin;
 
+        // origin-relative position:
+        Vector2p position_NE;
+        bool position_NE_valid;  // true if position_NE is valid
+        postype_t position_D;
+        bool position_D_valid;   // true if position_D is valid
+
         bool get_hagl(float &height) const WARN_IF_UNUSED {
             height = hagl;
             return hagl_valid;
@@ -285,25 +291,6 @@ public:
         return false;
     }
     virtual bool get_origin(Location &ret) const = 0;
-
-    // return a position relative to origin in meters, North/East/Down
-    // order. This will only be accurate if have_inertial_nav() is
-    // true
-    virtual bool get_relative_position_NED_origin(Vector3p &vec) const WARN_IF_UNUSED {
-        return false;
-    }
-
-    // return a position relative to origin in meters, North/East
-    // order. Return true if estimate is valid
-    virtual bool get_relative_position_NE_origin(Vector2p &vecNE) const WARN_IF_UNUSED {
-        return false;
-    }
-
-    // return a Down position relative to origin in meters
-    // Return true if estimate is valid
-    virtual bool get_relative_position_D_origin(postype_t &posD) const WARN_IF_UNUSED {
-        return false;
-    }
 
     // return true if we will use compass for yaw
     virtual bool use_compass(void) = 0;

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -204,6 +204,20 @@ void AP_AHRS_DCM::get_results(AP_AHRS_Backend::Estimates &results)
     // origin-relative functions
     // results.provides_common_origin = false;
 
+    // origin-relative position:
+    {
+        // DCM calculates in global co-ordinates and here converts
+        // back to relative-to-origin by subtracting the current
+        // location from the origin:
+        Location origin;
+        if (get_origin(origin) && results.location_valid) {
+            const Vector3p posNED = origin.get_distance_NED_postype(results.location);
+            results.position_NE = posNED.xy();
+            results.position_NE_valid = true;
+            results.position_D = posNED.z;
+            results.position_D_valid = true;
+        }
+    }
     // hagl is not supplied:
     // results.hagl_valid = false;
     // results.hagl = 0;
@@ -1362,40 +1376,6 @@ bool AP_AHRS_DCM::get_origin(Location &ret) const
         ret = AP::ahrs().get_home();
     }
     return !ret.is_zero();
-}
-
-bool AP_AHRS_DCM::get_relative_position_NED_origin(Vector3p &posNED) const
-{
-    Location origin;
-    if (!AP_AHRS_DCM::get_origin(origin)) {
-        return false;
-    }
-    Location loc;
-    if (!AP_AHRS_DCM::get_location(loc)) {
-        return false;
-    }
-    posNED = origin.get_distance_NED_postype(loc);
-    return true;
-}
-
-bool AP_AHRS_DCM::get_relative_position_NE_origin(Vector2p &posNE) const
-{
-    Vector3p posNED;
-    if (!AP_AHRS_DCM::get_relative_position_NED_origin(posNED)) {
-        return false;
-    }
-    posNE = posNED.xy();
-    return true;
-}
-
-bool AP_AHRS_DCM::get_relative_position_D_origin(postype_t &posD) const
-{
-    Vector3p posNED;
-    if (!AP_AHRS_DCM::get_relative_position_NED_origin(posNED)) {
-        return false;
-    }
-    posD = posNED.z;
-    return true;
 }
 
 // return true if DCM has a yaw source available

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -96,9 +96,6 @@ public:
 
     // relative-origin functions for fallback in AP_InertialNav
     bool get_origin(Location &ret) const override;
-    bool get_relative_position_NED_origin(Vector3p &vec) const override;
-    bool get_relative_position_NE_origin(Vector2p &posNE) const override;
-    bool get_relative_position_D_origin(postype_t &posD) const override;
 
     // return true if DCM has a yaw source
     bool yaw_source_available(void) const;

--- a/libraries/AP_AHRS/AP_AHRS_External.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_External.cpp
@@ -70,6 +70,17 @@ void AP_AHRS_External::get_results(AP_AHRS_Backend::Estimates &results)
     // origin-relative functions
     results.provides_common_origin = true;
 
+    // origin-relative position:
+    Location orgn;
+    if (extahrs.get_origin(orgn) &&
+        results.location_valid) {
+        const Vector3p posNED = orgn.get_distance_NED_postype(results.location);
+        results.position_NE = posNED.xy();
+        results.position_NE_valid = true;
+        results.position_D = posNED.z;
+        results.position_D_valid = true;
+    }
+
     // hagl is not supplied:
     // results.hagl_valid = false;
     // results.hagl = 0;
@@ -121,46 +132,6 @@ void AP_AHRS_External::get_results(AP_AHRS_Backend::Estimates &results)
 
     results.terrain_alt_variance = 0;
     results.terrain_alt_variance_valid = true;
-}
-
-bool AP_AHRS_External::get_relative_position_NED_origin(Vector3p &vec) const
-{
-    auto &extahrs = AP::externalAHRS();
-    Location loc, orgn;
-    if (extahrs.get_origin(orgn) &&
-        extahrs.get_location(loc)) {
-        const Vector2f diff2d = orgn.get_distance_NE(loc);
-        vec = Vector3p(diff2d.x, diff2d.y,
-                       -(loc.alt - orgn.alt)*0.01);
-        return true;
-    }
-    return false;
-}
-
-bool AP_AHRS_External::get_relative_position_NE_origin(Vector2p &posNE) const
-{
-    auto &extahrs = AP::externalAHRS();
-
-    Location loc, orgn;
-    if (!extahrs.get_location(loc) ||
-        !extahrs.get_origin(orgn)) {
-        return false;
-    }
-    posNE = orgn.get_distance_NE_postype(loc);
-    return true;
-}
-
-bool AP_AHRS_External::get_relative_position_D_origin(postype_t &posD) const
-{
-    auto &extahrs = AP::externalAHRS();
-
-    Location orgn, loc;
-    if (!extahrs.get_origin(orgn) ||
-        !extahrs.get_location(loc)) {
-        return false;
-    }
-    posD = -(loc.alt - orgn.alt)*0.01;
-    return true;
 }
 
 bool AP_AHRS_External::pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const

--- a/libraries/AP_AHRS/AP_AHRS_External.h
+++ b/libraries/AP_AHRS/AP_AHRS_External.h
@@ -63,9 +63,6 @@ public:
     // AHRS backend to be shared with the external AHRS
     bool set_origin(const Location &loc) override;
     bool get_origin(Location &ret) const override;
-    bool get_relative_position_NED_origin(Vector3p &vec) const override;
-    bool get_relative_position_NE_origin(Vector2p &posNE) const override;
-    bool get_relative_position_D_origin(postype_t &posD) const override;
 
     void get_control_limits(float &ekfGndSpdLimit, float &controlScaleXY) const override;
 };

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF2.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF2.cpp
@@ -142,6 +142,10 @@ void AP_AHRS_NavEKF2::get_results(AP_AHRS_Backend::Estimates &results)
     // origin-relative functions
     results.provides_common_origin = true;
 
+    // origin-relative position:
+    results.position_NE_valid = EKF2.getPosNE(results.position_NE);
+    results.position_D_valid = EKF2.getPosD(results.position_D);
+
     results.hagl_valid = EKF2.getHAGL(results.hagl);
 
     /*

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
@@ -142,6 +142,10 @@ void AP_AHRS_NavEKF3::get_results(AP_AHRS_Backend::Estimates &results)
     // origin-relative functions
     results.provides_common_origin = true;
 
+    // origin-relative position:
+    results.position_NE_valid = EKF3.getPosNE(results.position_NE);
+    results.position_D_valid = EKF3.getPosD(results.position_D);
+
     results.hagl_valid = EKF3.getHAGL(results.hagl);
 
     /*

--- a/libraries/AP_AHRS/AP_AHRS_SIM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_SIM.cpp
@@ -35,53 +35,6 @@ bool AP_AHRS_SIM::airspeed_EAS(uint8_t index, float &airspeed_ret) const
     return airspeed_EAS(airspeed_ret);
 }
 
-bool AP_AHRS_SIM::get_relative_position_NED_origin(Vector3p &vec) const
-{
-    if (_sitl == nullptr) {
-        return false;
-    }
-
-    Location loc, orgn;
-    if (!get_location(loc) ||
-        !get_origin(orgn)) {
-        return false;
-    }
-
-    const Vector2p diff2d = orgn.get_distance_NE_postype(loc);
-    const struct SITL::sitl_fdm &fdm = _sitl->state;
-    vec = Vector3p(diff2d.x, diff2d.y,
-                   -(fdm.altitude - orgn.alt*0.01f));
-
-    return true;
-}
-
-bool AP_AHRS_SIM::get_relative_position_NE_origin(Vector2p &posNE) const
-{
-    Location loc, orgn;
-    if (!get_location(loc) ||
-        !get_origin(orgn)) {
-        return false;
-    }
-    posNE = orgn.get_distance_NE_postype(loc);
-
-    return true;
-}
-
-bool AP_AHRS_SIM::get_relative_position_D_origin(postype_t &posD) const
-{
-    if (_sitl == nullptr) {
-        return false;
-    }
-    const struct SITL::sitl_fdm &fdm = _sitl->state;
-    Location orgn;
-    if (!get_origin(orgn)) {
-        return false;
-    }
-    posD = -(fdm.altitude - orgn.alt*0.01f);
-
-    return true;
-}
-
 bool AP_AHRS_SIM::get_filter_status(nav_filter_status &status) const
 {
     memset(&status, 0, sizeof(status));
@@ -193,6 +146,20 @@ void AP_AHRS_SIM::get_results(AP_AHRS_Backend::Estimates &results)
 
     // origin-relative functions
     // results.provides_common_origin = false;
+
+    // origin-relative position:
+    {
+        Location orgn;
+        if (get_origin(orgn)) {
+            results.position_D = -(fdm.altitude - orgn.alt*0.01f);
+            results.position_D_valid = true;
+
+            if (results.location_valid) {
+                results.position_NE = orgn.get_distance_NE_postype(results.location);
+                results.position_NE_valid = true;
+            }
+        }
+    }
 
     results.hagl_valid = true;
     results.hagl = _sitl->state.altitude - AP::ahrs().get_home().alt*0.01f;

--- a/libraries/AP_AHRS/AP_AHRS_SIM.h
+++ b/libraries/AP_AHRS/AP_AHRS_SIM.h
@@ -78,9 +78,6 @@ public:
 
     // relative-origin functions for fallback in AP_InertialNav
     bool get_origin(Location &ret) const override;
-    bool get_relative_position_NED_origin(Vector3p &vec) const override;
-    bool get_relative_position_NE_origin(Vector2p &posNE) const override;
-    bool get_relative_position_D_origin(postype_t &posD) const override;
 
     void get_control_limits(float &ekfGndSpdLimit, float &controlScaleXY) const override;
     bool get_innovations(Vector3f &velInnov, Vector3f &posInnov, Vector3f &magInnov, float &tasInnov, float &yawInnov) const override;


### PR DESCRIPTION
### Summary

Moves location-relative data into the estimates structure, removes infrastructure to directly retrieve from backends

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

the data goes into the estimates structure and is evaluated once on each call to update().  That means it is the same for the entire main loop run, which is nice.

ExternalAHRS got a free upgrade to `postype` on its relative-from-origin locations.
