### PR TITLE
Plane: disable setting home inflight

### DIFF
--- a/ArduPlane/Plane.cpp
+++ b/ArduPlane/Plane.cpp
@@ -481,7 +481,7 @@ void Plane::update_GPS_10Hz(void)
             // We countdown N number of good GPS fixes
             // so that the altitude is more accurate
             // -------------------------------------
-            if (current_loc.lat == 0 && current_loc.lng == 0) {
+            if ((current_loc.lat == 0 && current_loc.lng == 0) || is_flying()) {
                 ground_start_count = 5;
 
             } else if (!hal.util->was_watchdog_reset()) {

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -4903,6 +4903,49 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         if ex is not None:
             raise ex
 
+    def HomeNotSetMidAir(self):
+        '''home must not be set to the current position when GPS first locks while flying'''
+        # boot with GPS disabled: with no fix the FC has no home and the GPS-fix countdown stays pending
+        self.context_push()
+        self.set_parameters({"SIM_GPS1_ENABLE": 0})     # no GPS fix at boot
+        self.reboot_sitl()
+        launch = self.sitl_start_location()             # known launch point (degrees)
+
+        # take off in FBWA without GPS (force-arm bypasses the GPS arming checks)
+        self.change_mode("FBWA")
+        self.arm_vehicle(force=True)
+        self.set_rc(4, 1700)        # rudder to counteract prop torque
+        self.set_rc(2, 1200)        # a little up elevator
+        self.set_rc(3, 1300)        # start rolling
+        self.wait_airspeed(6, 100, timeout=30)
+        self.set_rc_from_map({3: 2000, 2: 1300, 4: 1500})   # full throttle, climb out
+        self.wait_airspeed(15, 100, timeout=40)             # airspeed alone makes is_flying() true
+        self.delay_sim_time(15, reason="climb and fly away from launch with no GPS")
+
+        # GPS locks mid-air: the fix must defer the home set while is_flying()
+        self.set_parameter("SIM_GPS1_ENABLE", 1)
+        self.delay_sim_time(5, reason="let the GPS-fix countdown elapse in the air")
+
+        # the fix defers the home set while flying, so the FC should still have no home...
+        try:
+            home = self.poll_home_position(timeout=15)
+        except NotAchievedException:
+            home = None
+        if home is None:
+            self.progress("home correctly not set while flying")
+        else:
+            # ...and any home that is reported must be the launch point, never the mid-air position
+            home_loc = mavutil.location(home.latitude * 1e-7, home.longitude * 1e-7, 0, 0)
+            dist = self.get_distance(home_loc, launch)
+            self.progress("home is %.1fm from launch" % dist)
+            if dist > 50:
+                raise NotAchievedException("home was set to the mid-air position (%.0fm from launch)" % dist)
+
+        # cleanup: disarm, restore parameters and reboot to a clean state
+        self.disarm_vehicle(force=True)
+        self.context_pop()
+        self.reboot_sitl()
+
     def AUTOTUNE(self):
         '''Test AutoTune mode'''
         self.run_autotune()
@@ -8349,6 +8392,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.MAV_CMD_NAV_LOITER_TO_ALT,
             self.DeepStall,
             self.WatchdogHome,
+            self.HomeNotSetMidAir,
             self.LargeMissions,
             self.Soaring,
             self.Terrain,


### PR DESCRIPTION
### Summary

Bug: when we takeoff in plane with no gps nad get it mid air the home point sets in that location.
This causes both a bad and unwanted home point + height change which propegates into global_position_int and other height sources.

### Classification & Testing (check all that apply and add your own)

- [ X ] Checked by a human programmer
- [    ] Non-functional change
- [    ]  No-binary change
- [    ] Infrastructure change (e.g. unit tests, helper scripts)
- [ X ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ X ] Tested manually, description below (e.g. SITL)
- [    ] Tested on hardware
- [    ] Logs attached
- [    ] Logs available on request

### Description

1: added to an exiting if gate another condition to block the one-shot home set mid-air
2: added test

 AI assistance: the autotest and this PR description were prepared with AI
 assistance (Claude Code); the author has reviewed the change and is responsible for it.