### PR TITLE
AP_NavEKF3: fall back to relative aiding when optical flow replaces lost GPS

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -3739,6 +3739,60 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 raise NotAchievedException("Alt should be limited by EKF optical flow limits")
         self.reboot_sitl(force=True)
 
+    def OpticalFlowGPSLossAiding(self):
+        '''EKF falls back to relative aiding when flow replaces lost GPS in flight'''
+        # A vehicle that takes off on GPS is in AID_ABSOLUTE.  When it switches to
+        # a flow-only source set it loses GPS position but keeps aiding on optical
+        # flow, and must fall back to AID_RELATIVE - otherwise it stays stuck in
+        # AID_ABSOLUTE and the optical-flow control limits never apply.  XKF4.AID
+        # exposes the mode (0:absolute, 1:none, 2:relative).
+        self.set_parameters({
+            "SIM_FLOW_ENABLE": 1,
+            "FLOW_TYPE": 10,
+            "SIM_TERRAIN": 0,
+            "EK3_SRC2_POSXY": 0,   # none
+            "EK3_SRC2_VELXY": 5,   # optical flow
+            "EK3_SRC2_POSZ": 1,    # baro
+            "EK3_SRC2_VELZ": 0,    # none
+            "EK3_SRC2_YAW": 1,     # compass
+            "RC8_OPTION": 90,      # EKF source selector
+        })
+        self.set_analog_rangefinder_parameters()
+        self.set_rc(8, 1000)       # source set 1 (GPS)
+        self.reboot_sitl()
+
+        self.takeoff(8, mode='LOITER')   # AID_ABSOLUTE on GPS
+
+        self.progress("switching to optical-flow source set")
+        self.set_rc(8, 1500)
+
+        # GPS position times out, then the filter must fall back to AID_RELATIVE
+        self.delay_sim_time(15)
+
+        # switch back to GPS and return
+        self.set_rc(8, 1000)
+        self.delay_sim_time(2)
+        self.do_RTL()
+
+        # confirm the EKF was AID_ABSOLUTE on GPS and fell back to AID_RELATIVE
+        # on flow.  without the fallback AID never reaches 2.
+        dfreader = self.dfreader_for_current_onboard_log()
+        saw_absolute = False
+        saw_relative = False
+        while True:
+            m = dfreader.recv_match(type='XKF4')
+            if m is None:
+                break
+            if m.AID == 0:
+                saw_absolute = True
+            elif m.AID == 2:
+                saw_relative = True
+        if not saw_absolute:
+            raise NotAchievedException("expected AID_ABSOLUTE while navigating on GPS")
+        if not saw_relative:
+            raise NotAchievedException(
+                "EKF did not fall back to AID_RELATIVE after GPS-to-flow switch")
+
     def LoiterNoCompassYaw(self):
         '''Loiter indoors with optical flow and no GPS, compass not an EK3 yaw source'''
         # Indoor case: position from optical flow + rangefinder, no GPS. The
@@ -14335,6 +14389,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
              self.OpticalFlow,
              self.OpticalFlowLocation,
              self.OpticalFlowLimits,
+             self.OpticalFlowGPSLossAiding,
              self.LoiterNoCompassYaw,
              self.LoiterNoCompassYawGPS,
              self.OpticalFlowCalibration,

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -399,6 +399,14 @@ void NavEKF3_core::setAidingMode()
                 velTimeout = !optFlowUsed && !gpsVelUsed && !bodyOdmUsed;
                 gpsIsInUse = false;
 
+                // If no absolute position source remains but optical flow (or body
+                // odometry) is still aiding, drop to relative aiding. Without this the
+                // filter stays in AID_ABSOLUTE while dead-reckoning on flow, so the
+                // flow-relative control limits in getEkfControlLimits never engage.
+                if (!readyToUseGPS() && !readyToUseRangeBeacon() && !readyToUseExtNav() &&
+                    (optFlowUsed || bodyOdmUsed)) {
+                    PV_AidingMode = AID_RELATIVE;
+                }
             }
             break;
         }

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp
@@ -177,7 +177,8 @@ void NavEKF3_core::Log_Write_XKF4(uint64_t time_us) const
         timeouts : timeoutStatus,
         solution : solutionStatus.value,
         gps : gpsCheckStatus.value,
-        primary : frontend->getPrimaryCoreIndex()
+        primary : frontend->getPrimaryCoreIndex(),
+        aiding_mode : (uint8_t)PV_AidingMode
     };
     AP::logger().WriteBlock(&pkt4, sizeof(pkt4));
 }

--- a/libraries/AP_NavEKF3/LogStructure.h
+++ b/libraries/AP_NavEKF3/LogStructure.h
@@ -192,6 +192,7 @@ struct PACKED log_XKF3 {
 // @FieldBitmaskEnum: SS: NavFilterStatusBit
 // @Field: GPS: Filter GPS status
 // @Field: PI: Primary core index
+// @Field: AID: Position and velocity aiding mode (0:absolute, 1:none, 2:relative)
 struct PACKED log_XKF4 {
     LOG_PACKET_HEADER;
     uint64_t time_us;
@@ -209,6 +210,7 @@ struct PACKED log_XKF4 {
     uint32_t solution;
     uint16_t gps;
     int8_t primary;
+    uint8_t aiding_mode;
 };
 
 
@@ -462,7 +464,7 @@ struct PACKED log_XKV {
     { LOG_XKF3_MSG, sizeof(log_XKF3), \
       "XKF3","QBcccccchhhccff","TimeUS,C,IVN,IVE,IVD,IPN,IPE,IPD,IMX,IMY,IMZ,IYAW,IVT,RErr,ErSc", "s#nnnmmmGGGd?--", "F-BBBBBBCCCBB00" , true }, \
     { LOG_XKF4_MSG, sizeof(log_XKF4), \
-      "XKF4","QBcccccfffHBIHb","TimeUS,C,SV,SP,SH,SM,SVT,errRP,OFN,OFE,FS,TS,SS,GPS,PI", "s#------mm-----", "F-------??-----" , true }, \
+      "XKF4","QBcccccfffHBIHbB","TimeUS,C,SV,SP,SH,SM,SVT,errRP,OFN,OFE,FS,TS,SS,GPS,PI,AID", "s#------mm------", "F-------??------" , true }, \
     { LOG_XKF5_MSG, sizeof(log_XKF5), \
       "XKF5","QBBhhhcccCCffff","TimeUS,C,NI,FIX,FIY,AFI,HAGL,TOfs,RI,rng,Herr,eAng,eVel,ePos,BOf", "s#----m???mrnmm", "F-----BBBBB0000" , true }, \
     { LOG_XKFA_MSG, sizeof(log_XKFA), \


### PR DESCRIPTION
## Summary

Fall back to relative aiding when a vehicle that was using GPS keeps navigating on optical flow after losing absolute position, so the optical-flow control limits actually take effect.

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [x] Tested in SITL
- [x] Tested on hardware
- [x] Logs available on request
- [x] Autotest included

## Description

`getEkfControlLimits()` returns an optical-flow ground-speed limit and a navigation velocity gain scaler (`4/HAGL`) that the position controller applies to reduce its gain with height, compensating for optical-flow velocity noise that grows with height. Both are gated on `PV_AidingMode == AID_RELATIVE`.

`setAidingMode()` has no `AID_ABSOLUTE -> AID_RELATIVE` transition. A vehicle that boots on GPS enters `AID_ABSOLUTE`; if it then switches to an optical-flow source set (POSXY None) it loses GPS position fusion but keeps dead-reckoning on flow, and stays in `AID_ABSOLUTE` - the only exit from that state is `AID_NONE`, which requires flow fusion to stop as well. So for the whole flow flight `getEkfControlLimits()` returns the no-limit defaults (scaler 1.0) and the position controller runs at full gain on flow.

This was found by logging the scaler that `getEkfControlLimits()` hands the controller. On a real GPS-then-flow Loiter flight it sits at 1.0 for the entire flow portion regardless of height; replaying the same log with the fix shows it engaging:

<img width="935" height="550" alt="scaler_before_after" src="https://github.com/user-attachments/assets/c332d8db-48e1-444e-8042-e02527ff3861" />

Full controller gain on optical flow at height drives a position-controller limit cycle (here at ~50 m, ~0.5 Hz, around +/-20 deg of roll):

<img width="935" height="462" alt="limit_cycle" src="https://github.com/user-attachments/assets/d644408d-728e-42e2-836f-6bdfafa8d836" />

The fix: when position aiding is lost and no absolute source remains but optical flow or body odometry is still aiding, transition to `AID_RELATIVE`. It reuses the existing `posAidLossCritical` timeout so it does not switch on a transient GPS glitch. A GPS, external nav or beacon source that is still delivering measurements (within 2 s, a 3D fix for GPS) counts as remaining even while its positions are rejected, so a sustained glitch is recovered in place as before rather than bouncing through relative aiding with a velocity reset; a source that stops delivering does fall back. A vehicle fusing drag or airspeed does not fall back: relative aiding drops to no aiding once flow is 5 s stale, which would end its drag dead reckoning, so it stays in `AID_ABSOLUTE` as on master and does not get the flow control limits.

The states are not reset on this edge. The generic mode-change reset zeroes the horizontal velocity and moves the position to the last `AID_NONE` datum, which is right when relative aiding starts from nothing but throws away a good flow solution here. In SITL, moving at 5.4 m/s through the fall back, that reset stepped the estimate 21 m and 5.9 m/s; without it the step is the vehicle's own motion between samples. Replaying a SITL flight through the fall back, velocity and position are then bit-identical to master's for the whole flow segment, differing only when GPS returns (0.10 m/s, 0.02 m) - the edge changes the aiding mode and what hangs off it, not the flow solution. The position timeout that the skipped reset would have cleared is cleared on the edge instead, so a short flow dropout in relative aiding does not report the horizontal velocity as lost.

Validated by replaying a real flow flight: the aiding mode goes `AID_ABSOLUTE -> AID_RELATIVE` on the flow segments and the gain scaler engages (`1.0 -> 4/HAGL`, about 0.09 at 45 m). Later flights with the fix confirm the scaler engaging in flight.

`OpticalFlowGPSLossAiding` flies about 100 m out on GPS, switches to a flow source set and keeps moving through the fall back, checking that `XKF4.AID` reaches relative aiding and that the estimated position and velocity do not step across the transition. `OpticalFlowFallbackKeepsAbsolute` checks the two cases that must not fall back: GPS fixes rejected by a stepped glitch while flow velocity is fused, and flow stopping while drag dead reckoning.

### It also enables the optical-flow height limit

`getHeightControlLimit()` gates on the same `AID_RELATIVE`, so this fallback also switches on the EKF height limit (`0.7 x RNGFND_MAX - 1`, less the terrain offset) for a GPS-booted vehicle that loses GPS. Its only consumer is `AC_Avoid::adjust_velocity_z()`. A hovering vehicle is unaffected, because that function returns early on a zero climb demand, but with a climb demand above the limit avoidance used to back the vehicle down - measured at 18 m of descent under full up stick. That backup is a pre-existing defect that already reached vehicles booting without GPS; this PR only widens who can reach it. #34380 addresses it, and on rmackay9's proposal on #33585 is being reworked into removing the height limit altogether, pending agreement there on the default above the range finder range.
