### PR TITLE
AP_NavEKF3: make the optical-flow nav gain detune height configurable (EK3_FLOW_GAIN_H)

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -650,6 +650,15 @@ const AP_Param::GroupInfo NavEKF3::var_info[] = {
 
     // 59 was GSF_DELAY which was never released in a stable version
 
+    // @Param: FLOW_GAIN_H
+    // @DisplayName: Optical flow nav gain full-scale height
+    // @Description: Height in metres below which the optical-flow navigation velocity gain handed to the position controller is left at full scale. Above this height the gain reduces as this value divided by the height above ground, to compensate for optical-flow velocity noise that grows with height. Larger values reduce the detune so position hold stays more responsive at height but with more risk of a flow-driven oscillation; smaller values detune more aggressively. Only takes effect while navigating on optical flow (relative aiding). Takes effect immediately, so it can be tuned in flight.
+    // @Range: 4 40
+    // @Increment: 1
+    // @Units: m
+    // @User: Advanced
+    AP_GROUPINFO("FLOW_GAIN_H", 59, NavEKF3, _flowNavGainHgt, 4.0f),
+
     // @Param: GSF_RST_MAX
     // @DisplayName: Maximum number of resets to the EKF-GSF yaw estimate allowed
     // @Description: Sets the maximum number of times the EKF3 will be allowed to reset its yaw to the estimate from the EKF-GSF yaw estimator. No resets will be allowed unless the use of the EKF-GSF yaw estimate is enabled via the EK3_GSF_USE_MASK parameter.

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -434,6 +434,7 @@ private:
     AP_Int8  _flowDelay_ms;         // effective average delay of optical flow measurements rel to IMU (msec)
     AP_Int16  _rngInnovGate;        // Percentage number of standard deviations applied to range finder innovation consistency check
     AP_Float _maxFlowRate;          // Maximum flow rate magnitude that will be accepted by the filter
+    AP_Float _flowNavGainHgt;       // height (m) below which the optical-flow nav velocity gain is full scale; above it the gain handed to the controller falls as _flowNavGainHgt/height
     AP_Float _rngNoise;             // Range finder noise : m
     AP_Int8 _gpsCheck;              // Bitmask controlling which preflight GPS checks are bypassed
     AP_Int8 _imuMask;               // Bitmask of IMUs to instantiate EKF3 for

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
@@ -408,8 +408,10 @@ void NavEKF3_core::getEkfControlLimits(float &ekfGndSpdLimit, float &ekfNavVelGa
     if (PV_AidingMode == AID_RELATIVE && relyingOnFlowData) {
         // allow 1.0 rad/sec margin for angular motion
         ekfGndSpdLimit = MAX((frontend->_maxFlowRate - 1.0f), 0.0f) * MAX((terrainState - stateStruct.position[2]), rngOnGnd);
-        // use standard gains up to 5.0 metres height and reduce above that
-        ekfNavVelGainScaler = 4.0f / MAX((terrainState - stateStruct.position[2]),4.0f);
+        // use full nav gains up to _flowNavGainHgt metres and reduce above that as
+        // _flowNavGainHgt/height to limit optical-flow velocity noise that grows with height
+        const ftype gainHgt = MAX(frontend->_flowNavGainHgt.get(), 1.0f);
+        ekfNavVelGainScaler = gainHgt / MAX((terrainState - stateStruct.position[2]), gainHgt);
     } else {
         ekfGndSpdLimit = 400.0f; //return 80% of max filter speed
         ekfNavVelGainScaler = 1.0f;


### PR DESCRIPTION
## Summary

Make the height that scales the optical-flow navigation velocity gain configurable (`EK3_FLOW_GAIN_H`) so the detune can be matched to the airframe and operating altitude instead of a fixed constant.

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [x] Tested in SITL
- [x] Tested on hardware
- [x] Logs available on request

## Description

When navigating on optical flow, `getEkfControlLimits()` reduces the position controller navigation velocity gain as `4 / max(HAGL, 4)`: full gain below 4 m, then `4/HAGL` above. The `1/HAGL` shape is sound - it cancels the height-scaling of optical-flow velocity noise, keeping the noise-driven lean roughly constant with height - but the constant 4 is hard-coded and conservative. At height the detune is heavy (about 9% of full authority at 45 m), which can leave too little authority to hold position against wind. On a flight at ~40 m the default lets the vehicle drift away while a larger value holds:

<img width="935" height="550" alt="drift_vs_hold" src="https://github.com/user-attachments/assets/05f0f943-ee70-4112-9e24-a406ea7ff7ff" />

`EK3_FLOW_GAIN_H` replaces the hard-coded 4 (default 4, so no behaviour change). The scaler becomes `EK3_FLOW_GAIN_H / max(HAGL, EK3_FLOW_GAIN_H)`. Raising it softens the detune so position hold stays more responsive at height; lowering it detunes harder. The value is read every control cycle so it can be swept in flight.

A floor on the scaler was considered instead and rejected: a floor breaks the `1/HAGL` shape at the top, leaving the gain above the oscillation threshold at high altitude, which is exactly where the detune is needed. Scaling the constant keeps the correct altitude schedule.

There are two bounds. Too low and the controller cannot hold position (drift, as above); too high and the flow-driven limit cycle returns. A practical starting point is `EK3_FLOW_GAIN_H ~= 0.25 * (max height above ground)`, e.g. 12 for ~45 m, scaled up for higher flights.

This is most useful alongside the aiding-mode fix (https://github.com/ArduPilot/ardupilot/pull/33568) that lets a GPS-then-flow vehicle reach `AID_RELATIVE`, since the scaler only applies in that mode; on a vehicle that boots flow-only it takes effect on its own. The evidence flights above carried that aiding-mode fix.
