### PR TITLE
Tidy reporting of secondary estimates via logging and MAVLink

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -1927,9 +1927,9 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             })
             self.reboot_sitl()
             self.delay_sim_time(5, reason="allow DCM to settle")
-            # the secondary estimator has no valid estimate, so no AHRS2
-            # message is sent:
-            self.assert_not_receive_message('AHRS2', timeout=5)
+            # the secondary estimate is now reported even though it has no
+            # valid location; AHRS2 is sent regardless of estimate validity:
+            self.assert_receive_message('AHRS2', timeout=5)
         finally:
             self.context_pop()
             self.reboot_sitl()

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -11,6 +11,7 @@ import os
 import signal
 import time
 
+from pymavlink import mavextra
 from pymavlink import mavutil
 from pymavlink import quaternion
 from pymavlink.rotmat import Vector3
@@ -1882,7 +1883,56 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         if self.get_distance_int(gpi, ahrs2) > 10:
             raise NotAchievedException("Secondary location looks bad")
 
+        # secondary altitude should be close to the primary altitude
+        # (AHRS2.altitude is MSL in metres, GLOBAL_POSITION_INT.alt is
+        # MSL in mm):
+        if abs(ahrs2.altitude - gpi.alt * 1.0e-3) > 10:
+            raise NotAchievedException(
+                "Secondary altitude looks bad (want=%f got=%f)" %
+                (gpi.alt * 1.0e-3, ahrs2.altitude))
+
+        # secondary yaw should match the simulated yaw; check_attitudes_match
+        # only checks AHRS2 roll and pitch:
+        simstate = self.assert_receive_message('SIMSTATE', verbose=1)
+        want = math.degrees(simstate.yaw)
+        got = math.degrees(ahrs2.yaw)
+        if abs(mavextra.angle_diff(want, got)) > 15:
+            raise NotAchievedException(
+                "Secondary yaw looks bad (want=%f got=%f)" % (want, got))
+
         self.check_attitudes_match()
+
+    def AHRS2Logging(self):
+        '''check the secondary AHRS estimate is logged to the AHR2 message'''
+        self.wait_ready_to_arm()
+        self.takeoff(alt=100, mode='TAKEOFF')
+        self.change_mode('LOITER')
+        # loiter long enough to sweep the yaw through a full circle so the
+        # secondary yaw and position are meaningfully exercised:
+        self.delay_sim_time(60, reason="sweep yaw through a circle")
+        self.fly_home_land_and_disarm()
+        self.assert_AHR2_log_matches_primary()
+
+    def AHRS2NoSecondaryEstimate(self):
+        '''check AHRS2 mavlink reporting when the secondary estimator has no
+        valid estimate.  Disabling the EKFs leaves DCM as the active
+        estimator and the configured-but-unstarted EKF3 as the secondary;
+        that secondary has no valid attitude or location.'''
+        self.context_push()
+        try:
+            self.set_parameters({
+                "EK2_ENABLE": 0,
+                "EK3_ENABLE": 0,
+                "AHRS_EKF_TYPE": 3,
+            })
+            self.reboot_sitl()
+            self.delay_sim_time(5, reason="allow DCM to settle")
+            # the secondary estimator has no valid estimate, so no AHRS2
+            # message is sent:
+            self.assert_not_receive_message('AHRS2', timeout=5)
+        finally:
+            self.context_pop()
+            self.reboot_sitl()
 
     def MainFlight(self):
         '''Lots of things in one flight'''
@@ -8398,6 +8448,8 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.RCDisableAirspeedUse,
             self.AHRS_ORIENTATION,
             self.AHRSTrim,
+            self.AHRS2Logging,
+            self.AHRS2NoSecondaryEstimate,
             self.LandingDrift,
             self.TakeoffAuto1,
             self.TakeoffAuto2,

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -15084,6 +15084,78 @@ switch value'''
             raise NotAchievedException("quat pitch differs from attitude pitch; want=%f got=%f" %
                                        (want, got))
 
+    def assert_AHR2_log_matches_primary(self):
+        '''check the AHR2 dataflash message (the secondary AHRS estimate) is
+        present in the current onboard log, that it tracks the primary
+        estimate (ATT/POS) and that its logged quaternion is consistent
+        with its logged eulers.  AHR2 and ATT are co-logged at the same
+        rate so the most-recently-seen ATT/POS is a valid comparison.'''
+        dfreader = self.dfreader_for_current_onboard_log()
+        att = None
+        pos = None
+        checked_attitude = 0
+        checked_position = 0
+        while True:
+            m = dfreader.recv_match(type=['ATT', 'POS', 'AHR2'])
+            if m is None:
+                break
+            m_type = m.get_type()
+            if m_type == 'ATT':
+                att = m
+                continue
+            if m_type == 'POS':
+                pos = m
+                continue
+
+            # m_type == 'AHR2'; compare the secondary attitude against
+            # the primary (ATT):
+            if att is not None:
+                for (field, secondary, primary) in [
+                        ('roll', m.Roll, att.Roll),
+                        ('pitch', m.Pitch, att.Pitch),
+                        ('yaw', m.Yaw, att.Yaw),
+                ]:
+                    if abs(mavextra.angle_diff(secondary, primary)) > 15:
+                        raise NotAchievedException(
+                            "AHR2.%s (%f) does not match ATT.%s (%f)" %
+                            (field, secondary, field, primary))
+                checked_attitude += 1
+
+            # the logging reads estimates->quaternion directly, so check
+            # the logged quaternion is normalised and consistent with the
+            # logged eulers:
+            qmag = math.sqrt(m.Q1**2 + m.Q2**2 + m.Q3**2 + m.Q4**2)
+            if abs(qmag - 1) > 0.02:
+                raise NotAchievedException(
+                    "AHR2 quaternion not normalised (mag=%f)" % qmag)
+            euler = quaternion.Quaternion([m.Q1, m.Q2, m.Q3, m.Q4]).euler
+            for (field, from_euler, from_log) in [
+                    ('roll', math.degrees(euler[0]), m.Roll),
+                    ('pitch', math.degrees(euler[1]), m.Pitch),
+                    ('yaw', math.degrees(euler[2]), m.Yaw),
+            ]:
+                if abs(mavextra.angle_diff(from_euler, from_log)) > 10:
+                    raise NotAchievedException(
+                        "AHR2 quaternion %s (%f) inconsistent with euler (%f)" %
+                        (field, from_euler, from_log))
+
+            # the secondary position should be close to the primary (POS):
+            if pos is not None and m.Lat != 0 and m.Lng != 0:
+                secondary_loc = mavutil.location(m.Lat, m.Lng, 0, 0)
+                primary_loc = mavutil.location(pos.Lat, pos.Lng, 0, 0)
+                dist = self.get_distance(primary_loc, secondary_loc)
+                if dist > 50:
+                    raise NotAchievedException(
+                        "AHR2 position %fm from primary (POS)" % dist)
+                checked_position += 1
+
+        if checked_attitude == 0:
+            raise NotAchievedException("Found no AHR2 messages to check attitude")
+        if checked_position == 0:
+            raise NotAchievedException("Found no AHR2 messages to check position")
+        self.progress("Checked AHR2 log (attitude=%u position=%u)" %
+                      (checked_attitude, checked_position))
+
     def MultipleGPS(self):
         '''check ArduPilot behaviour across multiple GPS units'''
         self.assert_message_rate_hz('GPS2_RAW', 0)

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -252,6 +252,7 @@ AP_AHRS::AP_AHRS(uint8_t flags) :
     // sure it is set early:
     update_configured_ekf_type();
     update_active_EKF_type();
+    update_secondary_backend_pointers();
 
 #if APM_BUILD_COPTER_OR_HELI || APM_BUILD_TYPE(APM_BUILD_ArduSub)
     // Copter and Sub force the use of EKF
@@ -322,6 +323,17 @@ void AP_AHRS::update_active_EKF_type()
     INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
 }
 
+// update the pointer to the estimates containing the secondary backend's data
+void AP_AHRS::update_secondary_backend_pointers()
+{
+    EKFType secondary_type;
+    if (!_get_secondary_EKF_type(secondary_type)) {
+        secondary_estimates = nullptr;
+        return;
+    }
+    secondary_estimates = estimates_for_type(secondary_type);
+}
+
 // init sets up INS board orientation
 void AP_AHRS::init()
 {
@@ -356,6 +368,7 @@ void AP_AHRS::init()
     // we may have updated ekf_type()'s results, so set the backend again:
     update_configured_ekf_type();
     update_active_EKF_type();
+    update_secondary_backend_pointers();
 
 #if AP_CUSTOMROTATIONS_ENABLED
     // convert to new custom rotation
@@ -474,15 +487,12 @@ void AP_AHRS::update_state(void)
     update_trig();
 
     state.quat_ok = active_estimates->get_quaternion(state.quat);
-    state.secondary_attitude_ok = _get_secondary_attitude(state.secondary_attitude);
-    state.secondary_quat_ok = _get_secondary_quaternion(state.secondary_quat);
     state.location_ok = _get_location(state.location);
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     if (state.location_ok && !state.location.initialised()) {
         AP_HAL::panic("uninitialised location returned by _get_location");
     }
 #endif  // CONFIG_HAL_BOARD == HAL_BOARD_SITL
-    state.secondary_pos_ok = _get_secondary_position(state.secondary_pos);
     state.ground_speed_vec = active_estimates->velocity_NE;
     state.ground_speed = state.ground_speed_vec.length();
     state.corrected_dv_valid = _getCorrectedDeltaVelocityNED(state.corrected_dv, state.corrected_dv_dt);
@@ -604,6 +614,7 @@ void AP_AHRS::update(bool skip_ins_update)
 
     update_configured_ekf_type();
     update_active_EKF_type();
+    update_secondary_backend_pointers();
 
     // update blinking lights, buzzer etc bsaed on active EKF type:
     update_notify_from_filter_status(active_estimates->filter_status);
@@ -981,15 +992,6 @@ bool AP_AHRS::use_compass(void)
     return active_backend->use_compass();
 }
 
-const AP_AHRS_Backend::Estimates *AP_AHRS::get_secondary_estimates() const
-{
-    EKFType secondary_ekf_type;
-    if (!_get_secondary_EKF_type(secondary_ekf_type)) {
-        return nullptr;
-    }
-    return estimates_for_type(secondary_ekf_type);
-}
-
 AP_AHRS_Backend::Estimates *AP_AHRS::estimates_for_type(EKFType type)
 {
     switch (type) {
@@ -1019,80 +1021,6 @@ AP_AHRS_Backend::Estimates *AP_AHRS::estimates_for_type(EKFType type)
 #endif
     }
     return nullptr;
-}
-
-// return secondary attitude solution if available, as eulers in radians
-bool AP_AHRS::_get_secondary_attitude(Vector3f &eulers) const
-{
-    const auto *estimates = get_secondary_estimates();
-    if (estimates == nullptr) {
-        return false;
-    }
-    eulers[0] = estimates->roll_rad;
-    eulers[1] = estimates->pitch_rad;
-    eulers[2] = estimates->yaw_rad;
-    return estimates->attitude_valid;
-}
-
-// return secondary attitude solution if available, as quaternion
-bool AP_AHRS::_get_secondary_quaternion(Quaternion &quat) const
-{
-    const auto *estimates = get_secondary_estimates();
-    if (estimates == nullptr) {
-        return false;
-    }
-    return estimates->get_quaternion(quat);
-}
-
-// return secondary position solution if available
-bool AP_AHRS::_get_secondary_position(Location &loc) const
-{
-    EKFType secondary_ekf_type;
-    if (!_get_secondary_EKF_type(secondary_ekf_type)) {
-        return false;
-    }
-
-    switch (secondary_ekf_type) {
-
-#if AP_AHRS_DCM_ENABLED
-    case EKFType::DCM:
-        // return DCM position
-        loc = dcm_estimates.location;
-        // FIXME: we intentionally do not return whether location is
-        // actually valid here so we continue to send mavlink messages
-        // and log data:
-        return true;
-#endif
-
-#if HAL_NAVEKF2_AVAILABLE
-    case EKFType::TWO:
-        // EKF2 is secondary
-        ekf2_estimates.get_location(loc);
-        return ekf2.started;
-#endif
-
-#if HAL_NAVEKF3_AVAILABLE
-    case EKFType::THREE:
-        // EKF3 is secondary
-        ekf3_estimates.get_location(loc);
-        return ekf3.started;
-#endif
-
-#if AP_AHRS_SIM_ENABLED
-    case EKFType::SIM:
-        // SITL is secondary (should never happen)
-        return false;
-#endif
-
-#if AP_AHRS_EXTERNAL_ENABLED
-    case EKFType::EXTERNAL:
-        // External is secondary
-        return external_estimates.get_location(loc);
-#endif
-    }
-
-    // since there is no default case above, this is unreachable
-    return false;
 }
 
 // set the EKF's origin location in 10e7 degrees.  This should only

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -212,22 +212,9 @@ public:
     // return the quaternion defining the rotation from NED to XYZ (body) axes
     bool get_quaternion(Quaternion &quat) const WARN_IF_UNUSED;
 
-    // return secondary attitude solution if available, as eulers in radians
-    bool get_secondary_attitude(Vector3f &eulers) const {
-        eulers = state.secondary_attitude;
-        return state.secondary_attitude_ok;
-    }
-
-    // return secondary attitude solution if available, as quaternion
-    bool get_secondary_quaternion(Quaternion &quat) const {
-        quat = state.secondary_quat;
-        return state.secondary_quat_ok;
-    }
-
-    // return secondary position solution if available
-    bool get_secondary_position(Location &loc) const {
-        loc = state.secondary_pos;
-        return state.secondary_pos_ok;
+    // return secondary estimates; note that this may return nullptr!
+    const AP_AHRS_Backend::Estimates *get_secondary_estimates() const {
+        return secondary_estimates;
     }
 
     // EKF has a better ground speed vector estimate
@@ -948,17 +935,14 @@ private:
     // if we have an estimate
     bool _airspeed_EAS(float &airspeed_ret, AirspeedEstimateType &status) const;
 
-    // return secondary attitude solution if available, as eulers in radians
-    bool _get_secondary_attitude(Vector3f &eulers) const;
-
-    // return secondary attitude solution if available, as quaternion
-    bool _get_secondary_quaternion(Quaternion &quat) const;
-
     // set state.configured_ekf_type and the pointer to the configured backend
     void update_configured_ekf_type();
 
     // set state.active_EKF_type and the pointer to the active backend
     void update_active_EKF_type();
+
+    // update secondary backend pointers:
+    void update_secondary_backend_pointers();
 
     // get active EKF type
     EKFType _active_EKF_type(void) const;
@@ -973,9 +957,6 @@ private:
     // return estimate of true airspeed vector in body frame in m/s
     // returns false if estimate is unavailable
     bool _airspeed_TAS(Vector3f &vec) const;
-
-    // return secondary position solution if available
-    bool _get_secondary_position(Location &loc) const;
 
     // Retrieves the corrected NED delta velocity in use by the inertial navigation
     bool _getCorrectedDeltaVelocityNED(Vector3f& ret, float& dt) const WARN_IF_UNUSED;
@@ -1036,14 +1017,8 @@ private:
         Quaternion quat;
         bool quat_ok;
         uint16_t attitude_reset_count;
-        Vector3f secondary_attitude;
-        bool secondary_attitude_ok;
-        Quaternion secondary_quat;
-        bool secondary_quat_ok;
         Location location;
         bool location_ok;
-        Location secondary_pos;
-        bool secondary_pos_ok;
         Vector2f ground_speed_vec;
         float ground_speed;
         bool corrected_dv_valid;
@@ -1150,9 +1125,15 @@ private:
     AP_AHRS_Backend *active_backend;
     AP_AHRS_Backend::Estimates *active_estimates;
 
-    const AP_AHRS_Backend::Estimates *get_secondary_estimates() const;
-
     uint16_t last_active_estimates_attitude_reset_count;
+
+    // secondary estimates - used for reporting purposes.  If the
+    // primary backend fails this is the backend/result pair likely to
+    // be used by the vehicle.  In the case that the primary *has*
+    // failed this *continues* to be the same estimates.  For now.
+    // Note that these pointers *must* be nullptr-checked before use!
+    // AP_AHRS_Backend *secondary_backend;
+    AP_AHRS_Backend::Estimates *secondary_estimates;
 };
 
 namespace AP {

--- a/libraries/AP_AHRS/AP_AHRS_Logging.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_Logging.cpp
@@ -12,12 +12,19 @@
 // Write an AHRS2 packet
 void AP_AHRS::Write_AHRS2() const
 {
-    Vector3f euler;
-    Location loc;
-    Quaternion quat;
-    if (!get_secondary_attitude(euler) || !get_secondary_position(loc) || !get_secondary_quaternion(quat)) {
+    const auto *estimates = secondary_estimates;
+    if (estimates == nullptr) {
         return;
     }
+
+    // valid attitude required before logging (FIXME)
+    if (!estimates->attitude_valid) {
+        return;
+    }
+
+    const Location &loc = estimates->location;
+    const auto &quat = estimates->quaternion;
+
     float alt;
     if (!loc.initialised() || !loc.get_alt_m(Location::AltFrame::ABSOLUTE, alt)) {
         alt = AP_Logger::quiet_nanf();
@@ -25,9 +32,9 @@ void AP_AHRS::Write_AHRS2() const
     const struct log_AHRS pkt{
         LOG_PACKET_HEADER_INIT(LOG_AHR2_MSG),
         time_us : AP_HAL::micros64(),
-        roll  : (int16_t)(degrees(euler.x)*100),
-        pitch : (int16_t)(degrees(euler.y)*100),
-        yaw   : (uint16_t)(wrap_360_cd(degrees(euler.z)*100)),
+        roll  : (int16_t)(degrees(estimates->roll_rad)*100),
+        pitch : (int16_t)(degrees(estimates->pitch_rad)*100),
+        yaw   : (uint16_t)(wrap_360_cd(degrees(estimates->yaw_rad)*100)),
         alt   : alt,
         lat   : loc.lat,
         lng   : loc.lng,

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -616,20 +616,20 @@ void GCS_MAVLINK::send_proximity()
 // report AHRS2 state
 void GCS_MAVLINK::send_ahrs2()
 {
-    const AP_AHRS &ahrs = AP::ahrs();
-    Vector3f euler;
-    Location loc {};
-    // we want one or both of these, use | to avoid short-circuiting:
-    if (uint8_t(ahrs.get_secondary_attitude(euler)) |
-        uint8_t(ahrs.get_secondary_position(loc))) {
+    const auto *estimates = AP::ahrs().get_secondary_estimates();
+    if (estimates == nullptr) {
+        return;
+    }
+
+    const Location &loc = estimates->location;
+
         mavlink_msg_ahrs2_send(chan,
-                               euler.x,
-                               euler.y,
-                               euler.z,
+                               estimates->roll_rad,
+                               estimates->pitch_rad,
+                               estimates->yaw_rad,
                                loc.alt*1.0e-2f,
                                loc.lat,
                                loc.lng);
-    }
 }
 #endif  // AP_AHRS_ENABLED
 


### PR DESCRIPTION
### Summary

Creates and uses a secondary_backend_estimates pointer to point to results rather than using individual methods

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Now includes an autotest showing behaviour is preserved - except where it isn't (top patch shows that)

```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                 *                                                   
Durandal                            -264            -256   *           -272    -176              -328   -272   -376
Hitec-Airspeed           *                                 *                                                   
KakuteH7-bdshot                     -280            -280   *           -272    -272              -128   -280   -264
MatekF405                           -288            -240   *           -216    -192              -232   -200   -272
Pixhawk1-1M-bdshot                  -248            -288               -416    -280              -288   -144   -320
SITL_x86_64_linux_gnu               -4152           -4152              -56     -56               -56    -56    -4144
YJUAV_A6SE                          -296            -272   *           -312    -296              -480   -296   -368
f103-QiotekPeriph        *                                 *                                                   
f303-MatekGPS            *                                 *                                                   
f303-Universal           *                                 *                                                   
iomcu                                                                                *                         
revo-mini                           -280            -272   *           -256    -272              -208   -272   -272
skyviper-v2450                                                         -272                                    
speedybeef4                         -272            -256   *           -240    -280              712    -248   -256
```

### Description

Calculates and stores the secondary backend pointer once per lop, uses it to retrieve data when needed.

The calculation will disappear in a future PR where we just parameterise the secondary....

*note*:  small change in behaviour.  DCM is usually secondary, so usually getting the secondary location would return true.  I've removed the check for validity in the callers rather than lying in the AHRS, but it does mean we will log/send values from all of the backends regardless of whether they have a location.


... also note that it's a bit rude to be accessing the members directly in the GCS method.  I'm thinking of moving that method into the AHRS to make it a little less spicy.
