### PR TITLE
AP_Bootloader: Add Nyxtronics board NYX405V1 with ID 1330

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -367,6 +367,9 @@ AP_HW_CBU_H753-SOM                   1302
 
 AP_HW_KHA_ETH                        1315
 
+# IDs 1330-1339 reserved for Nyxtronics
+AP_HW_NYXTRONICS_NYX405V1            1330
+
 AP_HW_FlysparkF4                     1361
 
 # IDs 1362-1369 reserved for SparkNavi


### PR DESCRIPTION
### Summary
Added Nyxtronics board NYX405V1 with ID 1330
Reserved 1330-1339 IDs field for future use

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change


Updated only Tools/AP_Bootloader/board_types.txt file
