### PR TITLE
Copter: replace division with multiplication in mode_flowhold

### DIFF
--- a/ArduCopter/mode_flowhold.cpp
+++ b/ArduCopter/mode_flowhold.cpp
@@ -338,8 +338,8 @@ void ModeFlowHold::run()
         Vector2f flow_angles;
 
         flowhold_flow_to_angle(flow_angles, (roll_in != 0) || (pitch_in != 0));
-        flow_angles.x = constrain_float(flow_angles.x, -angle_max_rad/2, angle_max_rad/2);
-        flow_angles.y = constrain_float(flow_angles.y, -angle_max_rad/2, angle_max_rad/2);
+        flow_angles.x = constrain_float(flow_angles.x, -angle_max_rad*0.5f, angle_max_rad*0.5f);
+        flow_angles.y = constrain_float(flow_angles.y, -angle_max_rad*0.5f, angle_max_rad*0.5f);
         bf_angles_rad += flow_angles;
     }
     bf_angles_rad.x = constrain_float(bf_angles_rad.x, -angle_max_rad, angle_max_rad);


### PR DESCRIPTION
### Summary

Replace floating-point division with multiplication by 0.5f in FlowHold mode target calculations.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Verified compilation and ensured it follows standard style guidelines.

### Description

This PR replaces `/ 2` with `* 0.5f` in `mode_flowhold.cpp` when calculating the constraints for `flow_angles`.

Using explicit float multiplication instead of division avoids generating floating-point division (FDIV) instructions, which are significantly more expensive on embedded FPUs. This change also aligns with ArduPilot's general coding style of prioritizing multiplication over division in high-frequency control loops.