### PR TITLE
AP_Airspeed: simplify observation Jacobian calculation in airspeed calibration

### DIFF
--- a/libraries/AP_Airspeed/Airspeed_Calibration.cpp
+++ b/libraries/AP_Airspeed/Airspeed_Calibration.cpp
@@ -68,8 +68,8 @@ float Airspeed_Calibration::update(float airspeed, const Vector3f &vg, int16_t m
 
     // observation Jacobian
     Vector3f H_TAS(
-        -(state.z*SH2*(2*vg.x - 2*state.x))/2,
-        -(state.z*SH2*(2*vg.y - 2*state.y))/2,
+        -(state.z*SH2*(vg.x - state.x)),
+        -(state.z*SH2*(vg.y - state.y)),
         1/SH2);
 
     // Calculate the fusion innovation covariance assuming a TAS measurement


### PR DESCRIPTION
### Summary

Simplify observation Jacobian calculation in airspeed calibration by removing redundant operations.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Verified mathematical simplification and compilation.

### Description

This PR simplifies the observation Jacobian (H_TAS) calculation in `Airspeed_Calibration.cpp`. 

The original expression `(2 * vg.x - 2 * state.x) / 2` has been mathematically reduced to `(vg.x - state.x)`. This eliminates redundant multiplication and division operations entirely, improving both code readability and execution efficiency in the calibration loop.
