### PR TITLE
AP_HAL: increase maximum allowed notch count to make way for quintuple notches

### DIFF
--- a/libraries/AP_HAL/AP_HAL_Boards.h
+++ b/libraries/AP_HAL/AP_HAL_Boards.h
@@ -333,16 +333,16 @@
 #if defined(STM32H7) || CONFIG_HAL_BOARD == HAL_BOARD_SITL || CONFIG_HAL_BOARD == HAL_BOARD_LINUX
 // Enough for a double-notch per motor on an octa using three IMUs and one harmonics
 // plus one static notch with one double-notch harmonics
-#define HAL_HNF_MAX_FILTERS 54
+#define HAL_HNF_MAX_FILTERS 78
 #elif defined(STM32F7)
 // Enough for a notch per motor on an octa using three IMUs and one harmonics
 // plus one static notch with one harmonics
-#define HAL_HNF_MAX_FILTERS 27
+#define HAL_HNF_MAX_FILTERS 39
 #else
 // Enough for a notch per motor on an octa quad using two IMUs and one harmonic
 // plus one static notch with one harmonic
 // Or triple-notch per motor on one IMU with one harmonic
-#define HAL_HNF_MAX_FILTERS 24
+#define HAL_HNF_MAX_FILTERS 30
 #endif
 #endif // HAL_HNF_MAX_FILTERS
 


### PR DESCRIPTION
Quintuple harmonic notches (Options bit 6) multiply the per-source filter count by five, which can exceed HAL_HNF_MAX_FILTERS on multi-IMU setups and trip the "Too many notches" config error at boot. Raise the cap to give headroom: 54 to 78 on H7/SITL/Linux, 27 to 39 on F7, 24 to 30 elsewhere. The existing per-class comments describe a representative minimum configuration the cap covers, so they remain accurate after the increase.