### PR TITLE
Copter: fix PosHold pilot override mix

### DIFF
--- a/ArduCopter/mode_poshold.cpp
+++ b/ArduCopter/mode_poshold.cpp
@@ -314,7 +314,7 @@ void ModePosHold::run()
             controller_to_pilot_roll_mix = (float)(now_ms - controller_to_pilot_start_time_roll_ms) / (float)POSHOLD_CONTROLLER_TO_PILOT_MIX_TIME_MS;
 
             // mix final loiter lean angle and pilot desired lean angles
-            roll_rad = mix_controls(controller_to_pilot_roll_mix, controller_final_roll_rad, pilot_roll_rad + wind_comp_roll_rad);
+            roll_rad = mix_controls(controller_to_pilot_roll_mix, pilot_roll_rad + wind_comp_roll_rad, controller_final_roll_rad);
             break;
     }
 
@@ -407,7 +407,7 @@ void ModePosHold::run()
             controller_to_pilot_pitch_mix = (float)(now_ms - controller_to_pilot_start_time_pitch_ms) / (float)POSHOLD_CONTROLLER_TO_PILOT_MIX_TIME_MS;
 
             // mix final loiter lean angle and pilot desired lean angles
-            pitch_rad = mix_controls(controller_to_pilot_pitch_mix, controller_final_pitch_rad, pilot_pitch_rad + wind_comp_pitch_rad);
+            pitch_rad = mix_controls(controller_to_pilot_pitch_mix, pilot_pitch_rad + wind_comp_pitch_rad, controller_final_pitch_rad);
             break;
     }
 

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -9471,6 +9471,75 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.context_pop()
 
+    def PosHoldDesiredAttitudeMonotonic(self):
+        '''check PosHold desired attitude does not reverse during a sustained stick input
+        '''
+
+        '''
+        Reproduces https://github.com/ArduPilot/ardupilot/issues/33588 : starting from
+        a settled PosHold/LOITER hold, a single sustained roll or pitch stick input
+        produces a non-monotonic, two-stage desired-attitude response - the desired
+        attitude moves in the commanded direction, briefly reverses back towards its
+        previous value, then resumes towards the commanded attitude.  Copter-4.6.3
+        produces a single smooth response.  The desired attitude here should rise
+        essentially monotonically while the stick is held.
+        '''
+        # the size of desired-attitude reversal (deg) we are prepared to tolerate.
+        # a correct (monotonic) response stays well under this; the regression
+        # produces a reversal of roughly 8deg.
+        max_allowed_reversal_deg = 3.0
+
+        self.set_message_rate_hz('ATTITUDE_TARGET', 50)
+        self.takeoff(15, mode='GUIDED')
+        self.set_rc(3, 1500)
+        self.change_mode('POSHOLD')
+
+        for (name, channel, axis) in [("roll", 1, 0), ("pitch", 2, 1)]:
+            # let PosHold brake and settle into a stationary LOITER hold so the
+            # desired attitude starts near zero before the step input.  The
+            # PILOT_OVERRIDE->BRAKE->LOITER transition is time-driven and not
+            # observable over MAVLink, so settle on a fixed delay and then confirm
+            # the vehicle has actually come to rest:
+            self.progress(f"Settling into LOITER hold before {name} step")
+            self.delay_sim_time(8, reason="braking to a stationary LOITER hold before step input")
+            self.wait_groundspeed(0, 0.5, minimum_duration=2, timeout=30)
+
+            # sample the desired attitude continuously, applying a sustained
+            # full-deflection step part way through so we capture the response
+            # from before the step until well after it has settled:
+            tstart = self.get_sim_time()
+            samples = []
+            applied = False
+            while self.get_sim_time_cached() - tstart < 3.0:
+                m = self.assert_receive_message('ATTITUDE_TARGET')
+                t = self.get_sim_time_cached() - tstart
+                q = quaternion.Quaternion([m.q[0], m.q[1], m.q[2], m.q[3]])
+                samples.append(math.degrees(q.euler[axis]))
+                if not applied and t > 0.5:
+                    self.progress("Applying sustained %s input" % name)
+                    self.set_rc(channel, 1900)
+                    applied = True
+            self.set_rc(channel, 1500)
+
+            # the response is commanded positive; find the worst reversal (a fall
+            # back towards zero after the desired attitude has begun to rise):
+            peak = 0.0
+            max_reversal = 0.0
+            for desired in samples:
+                if desired > peak:
+                    peak = desired
+                elif peak > 5 and (peak - desired) > max_reversal:
+                    max_reversal = peak - desired
+            self.progress("%s: desired-attitude peak=%.1fdeg reversal=%.1fdeg" %
+                          (name, peak, max_reversal))
+            if max_reversal > max_allowed_reversal_deg:
+                raise NotAchievedException(
+                    "PosHold %s desired attitude reversed by %.1fdeg (>%.1f) during "
+                    "sustained input (issue #33588)" %
+                    (name, max_reversal, max_allowed_reversal_deg))
+
+        self.do_RTL()
+
     def initial_mode(self):
         return "STABILIZE"
 
@@ -14481,6 +14550,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
              self.MANUAL_CONTROL,
              self.ModeZigZag,
              self.PosHoldTakeOff,
+             self.PosHoldDesiredAttitudeMonotonic,
              self.ModeFollow,
              self.ModeFollow_with_FOLLOW_TARGET,
              self.RangeFinderDrivers,


### PR DESCRIPTION
### Summary

Fix the PosHold `CONTROLLER_TO_PILOT_OVERRIDE` mix direction for roll and pitch.

Current master can produce a non-monotonic two-stage desired response under a sustained roll or pitch stick input in PosHold. 
This patch restores the intended blend from the retained controller output to the pilot lean angle target plus wind compensation. 

Related issue: https://github.com/ArduPilot/ardupilot/issues/33588

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [x] Logs attached
- [x] Logs available on request

Manual SITL validation:

- The controller-to-pilot mixing logic was updated with reference to the Copter-4.6.3 implementation.
- The patched branch was tested in SITL using the same PosHold stick-response procedure described in #33588.
- After the change, the intermediate desired-rate reversal and two-stage attitude response are no longer present.
- The resulting response is consistent with the smooth behavior observed on Copter-4.6.3.

Before the fix, the same sustained RC1 step input produces a two-stage desired response in PosHold: the desired rate briefly reverses, causing ATT.DesRoll to rise, partially return, and then rise again.
<img width="600" alt="PosHold_two-stage_desired_response" src="https://github.com/user-attachments/assets/f6f4244c-3b4e-49bc-bba3-52996ed910a1" />

After the fix, a sustained RC1 step input produces a single smooth desired response in PosHold, with no intermediate reversal or two-stage attitude rise.
<img width="600" alt="fixed_behavior_Roll" src="https://github.com/user-attachments/assets/20d797ae-8245-4bdf-864b-c566fd0d564a" />
<img width="600" alt="fixed_behavior_pitch" src="https://github.com/user-attachments/assets/f45ebba7-2117-4b0e-9c92-eea1d928bab4" />

- SITL log:
  [`poshold-pilot-mix_PosHold_fixed-stick-response.bin`](https://drive.google.com/file/d/1Q308CpTa8FoR7L8awOIrynhwXJ4uYYeD/view?usp=sharing)

### Description
`mix_controls()` uses a ratio of `1` for `first_control` and `0` for `second_control`. 
In `CONTROLLER_TO_PILOT_OVERRIDE`, these inputs are the retained controller output and the pilot lean angle target plus wind compensation.

The existing ratio increases from `0` to `1`, incorrectly increasing the controller contribution during a transition intended to hand control to the pilot. 
When the transition completes, PosHold switches directly to full pilot override, producing the non-monotonic response described in #33588.

This patch changes the roll and pitch controller weights to decrease from `1` to `0` during the override blend, restoring the controller-to-pilot transition behavior used in Copter-4.6.3.

AI-assisted: AI tools supported the analysis and implementation. The human author reviewed the change and performed the reported SITL testing.
