### PR TITLE
Name the EKF fault bits via a structure in AP_NavEKF_common.h

### DIFF
--- a/libraries/AP_NavEKF/AP_Nav_Common.h
+++ b/libraries/AP_NavEKF/AP_Nav_Common.h
@@ -72,6 +72,20 @@ union nav_filter_status {
 
 static_assert(sizeof(uint32_t) == sizeof(nav_filter_status), "nav_filter_status must be uint32_t");
 
+// enumeration corresponding to the bits within the filter-faults
+// bitmask returned by the EKF getFilterFaults() methods.  NavEKF2 and
+// NavEKF3 both populate this mask with identical meanings.
+enum class NavFilterFaultBit {
+    BAD_QUATERNION   =   1, // 0 - quaternion attitude estimate is NaN
+    BAD_VELOCITY     =   2, // 1 - velocity estimate is NaN
+    BAD_XMAG         =   4, // 2 - X magnetometer measurement is bad
+    BAD_YMAG         =   8, // 3 - Y magnetometer measurement is bad
+    BAD_ZMAG         =  16, // 4 - Z magnetometer measurement is bad
+    BAD_AIRSPEED     =  32, // 5 - airspeed measurement is bad
+    BAD_SIDESLIP     =  64, // 6 - synthetic sideslip measurement is bad
+    NOT_INITIALISED  = 128, // 7 - filter states have not been initialised
+};
+
 union nav_gps_status {
     struct {
         bool bad_sAcc           : 1; // 0 - true if reported gps speed accuracy is insufficient to start using GPS

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -450,14 +450,14 @@ return the filter fault status as a bitmasked integer
 */
 void  NavEKF2_core::getFilterFaults(uint16_t &faults) const
 {
-    faults = (stateStruct.quat.is_nan()<<0 |
-              stateStruct.velocity.is_nan()<<1 |
-              faultStatus.bad_xmag<<2 |
-              faultStatus.bad_ymag<<3 |
-              faultStatus.bad_zmag<<4 |
-              faultStatus.bad_airspeed<<5 |
-              faultStatus.bad_sideslip<<6 |
-              !statesInitialised<<7);
+    faults = (stateStruct.quat.is_nan()     * uint16_t(NavFilterFaultBit::BAD_QUATERNION) |
+              stateStruct.velocity.is_nan() * uint16_t(NavFilterFaultBit::BAD_VELOCITY) |
+              faultStatus.bad_xmag          * uint16_t(NavFilterFaultBit::BAD_XMAG) |
+              faultStatus.bad_ymag          * uint16_t(NavFilterFaultBit::BAD_YMAG) |
+              faultStatus.bad_zmag          * uint16_t(NavFilterFaultBit::BAD_ZMAG) |
+              faultStatus.bad_airspeed      * uint16_t(NavFilterFaultBit::BAD_AIRSPEED) |
+              faultStatus.bad_sideslip      * uint16_t(NavFilterFaultBit::BAD_SIDESLIP) |
+              !statesInitialised            * uint16_t(NavFilterFaultBit::NOT_INITIALISED));
 }
 
 /*

--- a/libraries/AP_NavEKF2/LogStructure.h
+++ b/libraries/AP_NavEKF2/LogStructure.h
@@ -179,6 +179,7 @@ struct PACKED log_NKF3 {
 // @Field: OFN: Most recent position reset (North component)
 // @Field: OFE: Most recent position reset (East component)
 // @Field: FS: Filter fault status
+// @FieldBitmaskEnum: FS: NavFilterFaultBit
 // @Field: TS: Filter timeout status bitmask (0:position measurement, 1:velocity measurement, 2:height measurement, 3:magnetometer measurement, 4:airspeed measurement)
 // @Field: SS: Filter solution status
 // @FieldBitmaskEnum: SS: NavFilterStatusBit

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
@@ -594,14 +594,14 @@ return the filter fault status as a bitmasked integer
 */
 void  NavEKF3_core::getFilterFaults(uint16_t &faults) const
 {
-    faults = (stateStruct.quat.is_nan()<<0 |
-              stateStruct.velocity.is_nan()<<1 |
-              faultStatus.bad_xmag<<2 |
-              faultStatus.bad_ymag<<3 |
-              faultStatus.bad_zmag<<4 |
-              faultStatus.bad_airspeed<<5 |
-              faultStatus.bad_sideslip<<6 |
-              !statesInitialised<<7);
+    faults = (stateStruct.quat.is_nan()     * uint16_t(NavFilterFaultBit::BAD_QUATERNION) |
+              stateStruct.velocity.is_nan() * uint16_t(NavFilterFaultBit::BAD_VELOCITY) |
+              faultStatus.bad_xmag          * uint16_t(NavFilterFaultBit::BAD_XMAG) |
+              faultStatus.bad_ymag          * uint16_t(NavFilterFaultBit::BAD_YMAG) |
+              faultStatus.bad_zmag          * uint16_t(NavFilterFaultBit::BAD_ZMAG) |
+              faultStatus.bad_airspeed      * uint16_t(NavFilterFaultBit::BAD_AIRSPEED) |
+              faultStatus.bad_sideslip      * uint16_t(NavFilterFaultBit::BAD_SIDESLIP) |
+              !statesInitialised            * uint16_t(NavFilterFaultBit::NOT_INITIALISED));
 }
 
 // Return the navigation filter status message

--- a/libraries/AP_NavEKF3/LogStructure.h
+++ b/libraries/AP_NavEKF3/LogStructure.h
@@ -187,6 +187,7 @@ struct PACKED log_XKF3 {
 // @Field: OFN: Most recent position reset (North component)
 // @Field: OFE: Most recent position reset (East component)
 // @Field: FS: Filter fault status
+// @FieldBitmaskEnum: FS: NavFilterFaultBit
 // @Field: TS: Filter timeout status bitmask (0:position measurement, 1:velocity measurement, 2:height measurement, 3:magnetometer measurement, 4:airspeed measurement, 5:drag measurement)
 // @Field: SS: Filter solution status
 // @FieldBitmaskEnum: SS: NavFilterStatusBit


### PR DESCRIPTION
### Summary

Gives these bits names and uses them within the code and within the logger metadata

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                 *
Durandal                            *               *      *           *       *                 *      *      *
Hitec-Airspeed           *                                 *
KakuteH7-bdshot                     *               *      *           *       *                 *      *      *
MatekF405                           *               *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot                  *               *                  *       *                 *      *      *
SITL_x86_64_linux_gnu               0               0                  0       0                 0      0      0
YJUAV_A6SE                          *               *      *           *       *                 *      *      *
f103-QiotekPeriph        *                                 *
f303-MatekGPS            *                                 *
f303-Universal           *                                 *
iomcu                                                                                *
revo-mini                           *               *      *           *       *                 *      *      *
skyviper-v2450                                                         *
speedybeef4                         *               *      *           *       *                 *      *      *
```

The SITL changes are because there are extra debug symbols associated with the new enumeration.  That's possibly something to look at fixing in `size_compare_branches.py`

### Description

Not clear whether we really *should* be exposing these outside the EKFs - perhaps the information should only be reflected in the return values for various getters.  Only user is the active-backend determination stuff, and that could probably be achieved by looking at various fields in the estimates structure.  We could also perhaps be more nuanced in our backend selection by looking at this information (e.g. "do we need position right now?")

But this is a no-compiler-output change (or near-enough) and (a) removes flat numeric constants from the code (b) ties the EKFs together so they don't diverge on this faults structure and (c) adds to the logger metadata to make log analysis a tiny bit easier.
