### PR TITLE
AP_AHRS: cache EKF filter faults in backend Estimates

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -1512,9 +1512,7 @@ AP_AHRS::EKFType AP_AHRS::_active_EKF_type(void) const
             return fallback_active_EKF_type();
         }
         if (always_use_EKF()) {
-            uint16_t ekf2_faults;
-            ekf2.EKF2.getFilterFaults(ekf2_faults);
-            if (ekf2_faults == 0) {
+            if (ekf2_estimates.filter_faults == 0) {
                 ret = EKFType::TWO;
             }
         } else if (ekf2_estimates.healthy) {
@@ -1531,9 +1529,7 @@ AP_AHRS::EKFType AP_AHRS::_active_EKF_type(void) const
             return fallback_active_EKF_type();
         }
         if (always_use_EKF()) {
-            uint16_t ekf3_faults;
-            ekf3.EKF3.getFilterFaults(ekf3_faults);
-            if (ekf3_faults == 0) {
+            if (ekf3_estimates.filter_faults == 0) {
                 ret = EKFType::THREE;
             }
         } else if (ekf3_estimates.healthy) {

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -68,6 +68,11 @@ public:
         // true if the AHRS has completed initialisation
         bool initialised;
 
+        // filter fault status bitmask (see NavFilterFaultBit); non-zero
+        // if the backend is reporting one or more filter faults.
+        // Backends with no concept of filter faults leave this zero.
+        uint16_t filter_faults;
+
         // inertial sensor information
         uint8_t primary_gyro;
 

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF2.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF2.cpp
@@ -181,6 +181,8 @@ void AP_AHRS_NavEKF2::get_results(AP_AHRS_Backend::Estimates &results)
     EKF2.getFilterStatus(results.filter_status);
     results.filter_status_valid = true;
 
+    EKF2.getFilterFaults(results.filter_faults);
+
     // provides the innovations normalised between 0 and 1:
     Vector2f offset;
     results.variances_valid = EKF2.getVariances(results.velVar, results.posVar, results.hgtVar, results.magVar, results.tasVar, offset);

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
@@ -181,6 +181,8 @@ void AP_AHRS_NavEKF3::get_results(AP_AHRS_Backend::Estimates &results)
     EKF3.getFilterStatus(results.filter_status);
     results.filter_status_valid = true;
 
+    EKF3.getFilterFaults(results.filter_faults);
+
     // provides the innovations normalised between 0 and 1:
     Vector2f offset;
     results.variances_valid = EKF3.getVariances(results.velVar, results.posVar, results.hgtVar, results.magVar, results.tasVar, offset);


### PR DESCRIPTION
### Summary

Stop calling EKF methods to determine filter faults, instead look at a new member in the estimates structure

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                 *                                                   
Durandal                            8               0      *           -8      88                56     0      -24
Hitec-Airspeed           *                                 *                                                   
KakuteH7-bdshot                     -16             -8     *           -16     0                 40     -8     -144
MatekF405                           48              8      *           16      8                 80     -24    0
Pixhawk1-1M-bdshot                  16              8                  -152    -24               16     80     -8
SITL_x86_64_linux_gnu               -56             -64                -56     -56               -56    -56    -56
YJUAV_A6SE                          80              16     *           -16     -8                32     8      32
f103-QiotekPeriph        *                                 *                                                   
f303-MatekGPS            *                                 *                                                   
f303-Universal           *                                 *                                                   
iomcu                                                                                *                         
revo-mini                           -16             0      *           -8      -16               -192   -16    0
skyviper-v2450                                                         8                                       
speedybeef4                         0               8      *           16      -16               -48    16     -56
```

### Description

Move the getFilterFaults() calls into the EKF2/EKF3 get_results() methods, storing the result in Estimates::filter_faults, and consult that cached mask in _active_EKF_type() rather than reaching into the EKF backends. No functional change: the mask is refreshed in get_results() immediately before _active_EKF_type() runs, and the not-started cases remain guarded by the existing ekfN.started checks.

This is just moving a point if difference between the backends out of AP_AHRS - we should never be looking at the EKF type when determining how to treat the filter, just looking at the estimates each is returning.

Since no other backend ever sets any bits in this mask, the code which is currently specific to EKF2 and EKF3 can simply be generalised to run on other backends (in an iteration across an ordered list of backends, for example....)

None of our existing non-EKF estimators would really use the bits in this at the moment - it is rather specific to the EKFs.  It *may* be better to replace the mask with a `bool faulty;` instead and leave the use of the enumeration up to the EKFs.
