### PR TITLE
Move instantiation of beacon library up to AP_Vehicle

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -172,9 +172,6 @@ const AP_Scheduler::Task Copter::scheduler_tasks[] = {
 #if HAL_PROXIMITY_ENABLED
     SCHED_TASK_CLASS(AP_Proximity,         &copter.g2.proximity,        update,         200, 200,  36),
 #endif
-#if AP_BEACON_ENABLED
-    SCHED_TASK_CLASS(AP_Beacon,            &copter.g2.beacon,           update,         400,  50,  39),
-#endif
     SCHED_TASK(update_altitude,       10,    100,  42),
     SCHED_TASK(run_nav_updates,       50,    100,  45),
     SCHED_TASK(update_throttle_hover,100,     90,  48),
@@ -704,8 +701,8 @@ void Copter::ten_hz_logging_loop()
         g2.proximity.log();  // Write proximity sensor distances
 #endif
 #if AP_BEACON_ENABLED
-        g2.beacon.log();
-#endif
+        beacon.log();
+#endif  // AP_BEACON_ENABLED
     }
 #if AP_WINCH_ENABLED
     if (should_log(MASK_LOG_ANY)) {

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -99,11 +99,6 @@
 #include "AP_ExternalControl_Copter.h"
 #endif
 
-#include <AP_Beacon/AP_Beacon_config.h>
-#if AP_BEACON_ENABLED
- #include <AP_Beacon/AP_Beacon.h>
-#endif
-
 #if AP_AVOIDANCE_ENABLED
  #include <AC_Avoidance/AC_Avoid.h>
 #endif

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1,5 +1,6 @@
 #include "Copter.h"
 
+#include <AP_Beacon/AP_Beacon.h>
 #include <AP_Gripper/AP_Gripper.h>
 #include <AP_InertialSensor/AP_InertialSensor_rate_config.h>
 
@@ -648,11 +649,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("DEV_OPTIONS", 7, ParametersG2, dev_options, 0),
 
-#if AP_BEACON_ENABLED
-    // @Group: BCN
-    // @Path: ../libraries/AP_Beacon/AP_Beacon.cpp
-    AP_SUBGROUPINFO(beacon, "BCN", 14, ParametersG2, AP_Beacon),
-#endif
+    // 14 was AP_Beacon
 
 #if HAL_PROXIMITY_ENABLED
     // @Group: PRX
@@ -1204,9 +1201,6 @@ ParametersG2::ParametersG2(void) :
 #if AP_TEMPCALIBRATION_ENABLED
     , temp_calibration()
 #endif
-#if AP_BEACON_ENABLED
-    , beacon()
-#endif
 #if HAL_PROXIMITY_ENABLED
     , proximity()
 #endif
@@ -1289,6 +1283,10 @@ void Copter::load_parameters(void)
     // PARAMETER_CONVERSION - Added: Feb-2024 for Copter-4.6
         { &gripper, gripper.var_info, 13 },
 #endif
+#if AP_BEACON_ENABLED
+    // PARAMETER_CONVERSION - Added: Jun-2026 for Copter-4.8
+        { &beacon, beacon.var_info, 14 },
+#endif  // AP_BEACON_ENABLED
     };
 
     AP_Param::convert_g2_objects(&g2, g2_conversions, ARRAY_SIZE(g2_conversions));

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -551,11 +551,6 @@ public:
     AP_TempCalibration temp_calibration;
 #endif
 
-#if AP_BEACON_ENABLED
-    // beacon (non-GPS positioning) library
-    AP_Beacon beacon;
-#endif
-
 #if HAL_PROXIMITY_ENABLED
     // proximity (aka object avoidance) library
     AP_Proximity proximity;

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -147,11 +147,6 @@ void Copter::init_ardupilot()
     g2.proximity.init();
 #endif
 
-#if AP_BEACON_ENABLED
-    // init beacons used for non-gps position estimation
-    g2.beacon.init();
-#endif
-
 #if MODE_AUTO_ENABLED
     // initialise mission library
     mode_auto.mission.init();

--- a/Rover/Parameters.cpp
+++ b/Rover/Parameters.cpp
@@ -1,5 +1,6 @@
 #include "Rover.h"
 
+#include <AP_Beacon/AP_Beacon.h>
 #include <AP_Gripper/AP_Gripper.h>
 
 /*
@@ -364,11 +365,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     AP_SUBGROUPINFO(afs, "AFS_", 5, ParametersG2, AP_AdvancedFailsafe),
 #endif
 
-#if AP_BEACON_ENABLED
-    // @Group: BCN
-    // @Path: ../libraries/AP_Beacon/AP_Beacon.cpp
-    AP_SUBGROUPINFO(beacon, "BCN", 6, ParametersG2, AP_Beacon),
-#endif
+    // 6 was AP_Beacon
 
     // 7 was used by AP_VisualOdometry
 
@@ -672,9 +669,6 @@ ParametersG2::ParametersG2(void)
 #if AP_ROVER_ADVANCED_FAILSAFE_ENABLED
     afs(),
 #endif
-#if AP_BEACON_ENABLED
-    beacon(),
-#endif
     wheel_rate_control(wheel_encoder),
     motors(wheel_rate_control),
     attitude_control(),
@@ -844,6 +838,10 @@ void Rover::load_parameters(void)
     // PARAMETER_CONVERSION - Added: Feb-2024 for Copter-4.6
         { &gripper, gripper.var_info, 39 },
 #endif
+#if AP_BEACON_ENABLED
+    // PARAMETER_CONVERSION - Added: Jun-2026 for Rover-4.8
+        { &beacon, beacon.var_info, 6 },
+#endif  // AP_BEACON_ENABLED
     };
 
     AP_Param::convert_g2_objects(&g2, g2_conversions, ARRAY_SIZE(g2_conversions));

--- a/Rover/Parameters.h
+++ b/Rover/Parameters.h
@@ -6,7 +6,6 @@
 #include <AC_Avoidance/AC_Avoid.h>
 #include "AC_Sprayer/AC_Sprayer.h"
 #include <AP_AIS/AP_AIS.h>
-#include <AP_Beacon/AP_Beacon.h>
 #include <AP_Follow/AP_Follow.h>
 #include <AP_Proximity/AP_Proximity.h>
 #include "AP_Rally.h"
@@ -291,10 +290,6 @@ public:
 #if AP_ROVER_ADVANCED_FAILSAFE_ENABLED
     // advanced failsafe library
     AP_AdvancedFailsafe_Rover afs;
-#endif
-
-#if AP_BEACON_ENABLED
-    AP_Beacon beacon;
 #endif
 
     // wheel encoders

--- a/Rover/Rover.cpp
+++ b/Rover/Rover.cpp
@@ -80,9 +80,6 @@ const AP_Scheduler::Task Rover::scheduler_tasks[] = {
     SCHED_TASK(set_servos,            400,    200,  15),
     SCHED_TASK_CLASS(AP_GPS,              &rover.gps,              update,         50,  300,  18),
     SCHED_TASK_CLASS(AP_Baro,             &rover.barometer,        update,         10,  200,  21),
-#if AP_BEACON_ENABLED
-    SCHED_TASK_CLASS(AP_Beacon,           &rover.g2.beacon,        update,         50,  200,  24),
-#endif
 #if HAL_PROXIMITY_ENABLED
     SCHED_TASK_CLASS(AP_Proximity,        &rover.g2.proximity,     update,         200,  200,  27),
 #endif
@@ -380,8 +377,8 @@ void Rover::update_logging1(void)
     if (should_log(MASK_LOG_THR)) {
         Log_Write_Throttle();
 #if AP_BEACON_ENABLED
-        g2.beacon.log();
-#endif
+        beacon.log();
+#endif  // AP_BEACON_ENABLED
     }
 
     if (should_log(MASK_LOG_NTUN)) {

--- a/Rover/system.cpp
+++ b/Rover/system.cpp
@@ -48,11 +48,6 @@ void Rover::init_ardupilot()
     g2.proximity.init();
 #endif
 
-#if AP_BEACON_ENABLED
-    // init beacons used for non-gps position estimation
-    g2.beacon.init();
-#endif
-
     // and baro for EKF
     barometer.set_log_baro_bit(MASK_LOG_IMU);
     barometer.calibrate();

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -10159,45 +10159,22 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             if m.lat != 0 or m.lon != 0:
                 return m
 
-    def BeaconPosition(self):
-        '''Fly Beacon Position'''
-        self.reboot_sitl()
-
-        self.wait_ready_to_arm(require_absolute=True)
-
-        old_pos = self.get_global_position_int()
-        print("old_pos=%s" % str(old_pos))
-
-        self.set_parameters({
-            "BCN_TYPE": 10,
-            "BCN_LATITUDE": SITL_START_LOCATION.lat,
-            "BCN_LONGITUDE": SITL_START_LOCATION.lng,
-            "BCN_ALT": SITL_START_LOCATION.alt,
-            "BCN_ORIENT_YAW": 0,
-            "AVOID_ENABLE": 4,
-            "GPS1_TYPE": 0,
-            "EK3_ENABLE": 1,
-            "EK3_SRC1_POSXY": 4, # Beacon
-            "EK3_SRC1_POSZ": 1,  # Baro
-            "EK3_SRC1_VELXY": 0, # None
-            "EK3_SRC1_VELZ": 0,  # None
-            "EK2_ENABLE": 0,
-            "AHRS_EKF_TYPE": 3,
-        })
-        self.reboot_sitl()
-
-        # require_absolute=True infers a GPS is present
+    def fly_beacon_position(self, old_pos):
+        '''fly a beacon-position check against the currently-configured
+        beacon backend; old_pos is a (GPS-derived) GLOBAL_POSITION_INT
+        captured before the GPS was disabled'''
+        # require_absolute=False as we have disabled the GPS:
         self.wait_ready_to_arm(require_absolute=False)
 
         tstart = self.get_sim_time()
-        timeout = 20
+        timeout = 30
         while True:
             if self.get_sim_time_cached() - tstart > timeout:
                 raise NotAchievedException("Did not get new position like old position")
             self.progress("Fetching location")
             new_pos = self.get_global_position_int()
             pos_delta = self.get_distance_int(old_pos, new_pos)
-            max_delta = 1
+            max_delta = 2
             self.progress("delta=%u want <= %u" % (pos_delta, max_delta))
             if pos_delta <= max_delta:
                 break
@@ -10221,6 +10198,52 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.assert_current_onboard_log_contains_message("BCN")
 
         self.disarm_vehicle(force=True)
+
+    def BeaconPosition(self):
+        '''Fly Beacon Position over each beacon backend type'''
+        self.reboot_sitl()
+
+        self.wait_ready_to_arm(require_absolute=True)
+
+        old_pos = self.get_global_position_int()
+        print("old_pos=%s" % str(old_pos))
+
+        # configuration common to all beacon backends:
+        self.set_parameters({
+            "BCN_LATITUDE": SITL_START_LOCATION.lat,
+            "BCN_LONGITUDE": SITL_START_LOCATION.lng,
+            "BCN_ALT": SITL_START_LOCATION.alt,
+            "BCN_ORIENT_YAW": 0,
+            "AVOID_ENABLE": 4,
+            "GPS1_TYPE": 0,
+            "EK3_ENABLE": 1,
+            "EK3_SRC1_POSXY": 4, # Beacon
+            "EK3_SRC1_POSZ": 1,  # Baro
+            "EK3_SRC1_VELXY": 0, # None
+            "EK3_SRC1_VELZ": 0,  # None
+            "EK2_ENABLE": 0,
+            "AHRS_EKF_TYPE": 3,
+        })
+
+        # iterate over the beacon backends; each entry is the backend
+        # name, the parameters which select it, and any extra SITL
+        # command-line needed to attach a simulated device:
+        backends = [
+            ("SITL", {
+                "BCN_TYPE": 10,  # SITL
+            }, None),
+            ("NoopLoop", {
+                "BCN_TYPE": 3,           # NoopLoop
+                "SERIAL5_PROTOCOL": 13,  # Beacon
+            }, ["--serial5=sim:nooploop"]),
+        ]
+        for (name, params, customisations) in backends:
+            self.start_subtest("Beacon backend: %s" % name)
+            if customisations is not None:
+                self.customise_SITL_commandline(customisations)
+            self.set_parameters(params)
+            self.reboot_sitl()
+            self.fly_beacon_position(old_pos)
 
     def AC_Avoidance_Beacon(self):
         '''Test beacon avoidance slide behaviour'''

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -6334,6 +6334,59 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
 
         self.progress("All done")
 
+    def BeaconPosition(self):
+        '''drive in MANUAL using only a (simulated) beacon for position'''
+        self.set_parameters({
+            "BCN_TYPE": 10,    # SITL
+            "BCN_LATITUDE": SITL_START_LOCATION.lat,
+            "BCN_LONGITUDE": SITL_START_LOCATION.lng,
+            "BCN_ALT": SITL_START_LOCATION.alt,
+            "BCN_ORIENT_YAW": 0,
+            "GPS1_TYPE": 0,    # no GPS
+            "EK3_ENABLE": 1,
+            "EK3_SRC1_POSXY": 4,  # Beacon
+            "EK3_SRC1_VELXY": 0,  # None
+            "EK3_SRC1_POSZ": 1,   # Baro
+            "EK3_SRC1_VELZ": 0,   # None
+            "EK3_SRC1_YAW": 1,    # Compass
+            "EK2_ENABLE": 0,
+            "AHRS_EKF_TYPE": 3,
+        })
+        self.reboot_sitl()
+
+        # becoming armable with the GPS disabled proves the EKF is deriving a
+        # usable position purely from the beacon library, which the vehicle
+        # initialises and updates via AP_Vehicle:
+        # (require_absolute=False as we have deliberately disabled the GPS)
+        self.wait_ready_to_arm(require_absolute=False)
+
+        # use get_mav_location() (GLOBAL_POSITION_INT, the EKF/beacon-fused
+        # position) rather than self.mav.location(), which blocks waiting for a
+        # GPS 3D fix that never arrives with the GPS disabled:
+        start_loc = self.get_mav_location()
+        self.progress("Beacon-derived start location: %s" % str(start_loc))
+
+        # arm and drive forward in MANUAL, confirming we can travel a known
+        # distance using only the beacon for position.  Throughout the drive,
+        # validate that the EKF's reported position (GLOBAL_POSITION_INT) stays
+        # close to the true simulator position (SIMSTATE):
+        self.context_push()
+        self.install_message_hook_context(
+            vehicle_test_suite.TestSuite.ValidateGlobalPositionIntAgainstSimState(
+                self, max_allowed_divergence=5))
+        self.change_mode('MANUAL')
+        self.arm_vehicle()
+        self.set_rc(3, 2000)   # full throttle forward
+        self.wait_distance(10, accuracy=2, timeout=60)
+        self.set_rc(3, 1500)   # stop
+        # hold station and confirm the beacon-derived position stays locked to
+        # the true position (GLOBAL_POSITION_INT vs SIMSTATE) while stationary:
+        self.delay_sim_time(30, reason="stationary beacon position tracking")
+        self.disarm_vehicle()
+        self.context_pop()
+
+        self.assert_current_onboard_log_contains_message("BCN")
+
     def PrivateChannel(self):
         '''test the serial option bit specifying a mavlink channel as private'''
         global mav2
@@ -7514,6 +7567,7 @@ return update()
             self.MAV_CMD_NAV_RETURN_TO_LAUNCH,
             self.StickMixingAuto,
             self.AutoDock,
+            self.BeaconPosition,
             self.PrivateChannel,
             self.GCSFailsafe,
             self.RoverInitialMode,

--- a/libraries/AP_HAL_SITL/SITL_State_common.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State_common.cpp
@@ -121,6 +121,14 @@ SITL::SerialDevice *SITL_State_Common::create_serial_sim(const char *name, const
         }
         frsky_d = NEW_NOTHROW SITL::Frsky_D();
         return frsky_d;
+#if AP_SIM_NOOPLOOP_ENABLED
+    } else if (streq(name, "nooploop")) {
+        if (nooploop != nullptr) {
+            AP_HAL::panic("Only one nooploop at a time");
+        }
+        nooploop = NEW_NOTHROW SITL::Beacon_NoopLoop();
+        return nooploop;
+#endif  // AP_SIM_NOOPLOOP_ENABLED
     // } else if (streq(name, "frsky-SPort")) {
     //     if (frsky_sport != nullptr) {
     //         AP_HAL::panic("Only one frsky_sport at a time");
@@ -369,6 +377,11 @@ void SITL_State_Common::sim_update(void)
     for (uint8_t i=0; i<num_serial_rangefinders; i++) {
         serial_rangefinders[i]->update(sitl_model->rangefinder_range());
     }
+#if AP_SIM_NOOPLOOP_ENABLED
+    if (nooploop != nullptr) {
+        nooploop->update();
+    }
+#endif  // AP_SIM_NOOPLOOP_ENABLED
     if (efi_ms != nullptr) {
         efi_ms->update(*sitl_model);
     }

--- a/libraries/AP_HAL_SITL/SITL_State_common.h
+++ b/libraries/AP_HAL_SITL/SITL_State_common.h
@@ -23,6 +23,8 @@
 
 #include <SITL/SIM_SerialRangeFinder.h>
 
+#include <SITL/SIM_Beacon_NoopLoop.h>
+
 #include <SITL/SIM_Siyi_ZT30.h>
 #include <SITL/SIM_Topotek.h>
 #include <SITL/SIM_Viewpro.h>
@@ -117,6 +119,11 @@ public:
 
     SITL::SerialRangeFinder *serial_rangefinders[16];
     uint8_t num_serial_rangefinders;
+
+#if AP_SIM_NOOPLOOP_ENABLED
+    // simulated NoopLoop beacon system:
+    SITL::Beacon_NoopLoop *nooploop;
+#endif  // AP_SIM_NOOPLOOP_ENABLED
 
     // simulated Frsky devices
     SITL::Frsky_D *frsky_d;

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -292,6 +292,12 @@ const AP_Param::GroupInfo AP_Vehicle::var_info[] = {
     AP_SUBGROUPINFO(rpm_sensor, "RPM", 32, AP_Vehicle, AP_RPM),
 #endif
 
+#if AP_BEACON_ENABLED
+    // @Group: BCN
+    // @Path: ../AP_Beacon/AP_Beacon.cpp
+    AP_SUBGROUPINFO(beacon, "BCN", 33, AP_Vehicle, AP_Beacon),
+#endif  // AP_BEACON_ENABLED
+
     AP_GROUPEND
 };
 
@@ -427,6 +433,11 @@ void AP_Vehicle::setup()
 #if AP_GRIPPER_ENABLED
     AP::gripper().init();
 #endif
+
+    // init beacons used for non-gps position estimation
+#if AP_BEACON_ENABLED
+    beacon.init();
+#endif  // AP_BEACON_ENABLED
 
     // init_ardupilot is where the vehicle does most of its initialisation.
     init_ardupilot();
@@ -621,6 +632,9 @@ const AP_Scheduler::Task AP_Vehicle::scheduler_tasks[] = {
 #if HAL_GYROFFT_ENABLED
     FAST_TASK_CLASS(AP_GyroFFT,    &vehicle.gyro_fft,       sample_gyros),
 #endif
+#if AP_BEACON_ENABLED
+    SCHED_TASK_CLASS(AP_Beacon,    &vehicle.beacon,         update,                  400, 200, 24),
+#endif  // AP_BEACON_ENABLED
 #if AP_AIRSPEED_ENABLED
     SCHED_TASK_CLASS(AP_Airspeed,  &vehicle.airspeed,       update,                   10, 100, 41),    // NOTE: the priority number here should be right before Plane's calc_airspeed_errors
 #endif

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -81,6 +81,11 @@
 #include <AP_Gripper/AP_Gripper.h>
 #endif
 
+#include <AP_Beacon/AP_Beacon_config.h>
+#if AP_BEACON_ENABLED
+#include <AP_Beacon/AP_Beacon.h>
+#endif  // AP_BEACON_ENABLED
+
 #include <AP_RPM/AP_RPM_config.h>
 #if AP_RPM_ENABLED
 #include <AP_RPM/AP_RPM.h>
@@ -375,6 +380,11 @@ protected:
 #if AP_GRIPPER_ENABLED
     AP_Gripper gripper;
 #endif
+
+#if AP_BEACON_ENABLED
+    // beacon (non-GPS positioning) library
+    AP_Beacon beacon;
+#endif  // AP_BEACON_ENABLED
 
 #if AP_IBUS_TELEM_ENABLED
     AP_IBus_Telem ibus_telem;

--- a/libraries/SITL/SIM_Beacon_NoopLoop.cpp
+++ b/libraries/SITL/SIM_Beacon_NoopLoop.cpp
@@ -1,0 +1,146 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  Simulator for the NoopLoop (LinkTrack) UWB beacon system
+*/
+
+#include "SIM_Beacon_NoopLoop.h"
+
+#if AP_SIM_NOOPLOOP_ENABLED
+
+#include <AP_HAL/AP_HAL.h>
+
+using namespace SITL;
+
+// NODE_FRAME2 layout (tag position + anchor ranges); offsets and
+// scalings must match AP_Beacon/AP_Beacon_Nooploop.cpp:
+#define NOOPLOOP_HEADER                     0x55
+#define NOOPLOOP_FUNCTION_MARK_NODE_FRAME2  0x04
+#define NOOPLOOP_NF2_SYSTIME                6    // 4 bytes, system time (ms)
+#define NOOPLOOP_NF2_PRECISION_X            10   // 1 byte each x,y,z, m*100
+#define NOOPLOOP_NF2_POSX                   13   // 3 bytes, ENU x (East) m*1000
+#define NOOPLOOP_NF2_POSY                   16   // 3 bytes, ENU y (North) m*1000
+#define NOOPLOOP_NF2_POSZ                   19   // 3 bytes, ENU z (Up) m*1000
+#define NOOPLOOP_NF2_VALID_NODES            118  // 1 byte, number of node blocks
+#define NOOPLOOP_NF2_NODE_BLOCK             119  // start of first node block
+#define NOOPLOOP_NF2_NODE_BLOCK_LEN         13   // bytes per node block
+
+// SETTING_FRAME0 layout (anchor positions):
+#define NOOPLOOP_HEADER2                       0x54
+#define NOOPLOOP_FUNCTION_MARK_SETTING_FRAME0  0x00
+#define NOOPLOOP_SF0_SZ                        128  // total frame length
+#define NOOPLOOP_SF0_A0                        37   // offset of first anchor
+#define NOOPLOOP_SF0_ANCHOR_LEN                9    // 3 x 3-byte position
+
+// anchors arranged in a rectangle around the beacon origin (NED metres):
+Vector3f Beacon_NoopLoop::anchor_position(uint8_t i) const
+{
+    switch (i) {
+    case 0: return Vector3f{ 25,  25, 0};  // NE
+    case 1: return Vector3f{-25,  25, 0};  // SE
+    case 2: return Vector3f{-25, -25, 0};  // SW
+    case 3: return Vector3f{ 25, -25, 0};  // NW
+    }
+    return Vector3f{};
+}
+
+void Beacon_NoopLoop::put_int24_le(uint8_t *buf, int32_t value_mm)
+{
+    buf[0] = value_mm & 0xff;
+    buf[1] = (value_mm >> 8) & 0xff;
+    buf[2] = (value_mm >> 16) & 0xff;
+}
+
+void Beacon_NoopLoop::send_data(const Vector3f &pos_ned)
+{
+    // the driver discards NODE_FRAME2 frames until it has the anchor
+    // positions, so (re)send those each cycle ahead of the position:
+    send_setting_frame0();
+    send_node_frame2(pos_ned);
+}
+
+void Beacon_NoopLoop::send_setting_frame0()
+{
+    uint8_t buf[NOOPLOOP_SF0_SZ] {};
+
+    buf[0] = NOOPLOOP_HEADER2;
+    buf[1] = NOOPLOOP_FUNCTION_MARK_SETTING_FRAME0;
+
+    for (uint8_t i=0; i<num_anchors; i++) {
+        const Vector3f pos = anchor_position(i);
+        uint8_t *p = &buf[NOOPLOOP_SF0_A0 + i*NOOPLOOP_SF0_ANCHOR_LEN];
+        // anchor position is carried as ENU millimetres:
+        put_int24_le(&p[0], int32_t(pos.y * 1000));   // East
+        put_int24_le(&p[3], int32_t(pos.x * 1000));   // North
+        put_int24_le(&p[6], int32_t(-pos.z * 1000));  // Up
+    }
+
+    // the checksum is the modulo-256 sum of all preceding bytes:
+    uint8_t crc = 0;
+    for (uint16_t i=0; i<NOOPLOOP_SF0_SZ-1; i++) {
+        crc += buf[i];
+    }
+    buf[NOOPLOOP_SF0_SZ-1] = crc;
+
+    write_to_autopilot((const char*)buf, sizeof(buf));
+}
+
+void Beacon_NoopLoop::send_node_frame2(const Vector3f &pos_ned)
+{
+    const uint16_t frame_len = NOOPLOOP_NF2_NODE_BLOCK + num_anchors*NOOPLOOP_NF2_NODE_BLOCK_LEN + 1;
+    uint8_t buf[NOOPLOOP_NF2_NODE_BLOCK + num_anchors*NOOPLOOP_NF2_NODE_BLOCK_LEN + 1] {};
+
+    buf[0] = NOOPLOOP_HEADER;
+    buf[1] = NOOPLOOP_FUNCTION_MARK_NODE_FRAME2;
+    buf[2] = frame_len & 0xff;
+    buf[3] = (frame_len >> 8) & 0xff;
+
+    // system time (ms):
+    const uint32_t now_ms = AP_HAL::millis();
+    buf[NOOPLOOP_NF2_SYSTIME+0] = now_ms & 0xff;
+    buf[NOOPLOOP_NF2_SYSTIME+1] = (now_ms >> 8) & 0xff;
+    buf[NOOPLOOP_NF2_SYSTIME+2] = (now_ms >> 16) & 0xff;
+    buf[NOOPLOOP_NF2_SYSTIME+3] = (now_ms >> 24) & 0xff;
+
+    // position precision in each axis (m*100); report 0.1m:
+    buf[NOOPLOOP_NF2_PRECISION_X+0] = 10;
+    buf[NOOPLOOP_NF2_PRECISION_X+1] = 10;
+    buf[NOOPLOOP_NF2_PRECISION_X+2] = 10;
+
+    // tag (vehicle) position, ENU millimetres:
+    put_int24_le(&buf[NOOPLOOP_NF2_POSX], int32_t(pos_ned.y * 1000));   // East
+    put_int24_le(&buf[NOOPLOOP_NF2_POSY], int32_t(pos_ned.x * 1000));   // North
+    put_int24_le(&buf[NOOPLOOP_NF2_POSZ], int32_t(-pos_ned.z * 1000));  // Up
+
+    // distance from the tag to each anchor:
+    buf[NOOPLOOP_NF2_VALID_NODES] = num_anchors;
+    for (uint8_t i=0; i<num_anchors; i++) {
+        uint8_t *block = &buf[NOOPLOOP_NF2_NODE_BLOCK + i*NOOPLOOP_NF2_NODE_BLOCK_LEN];
+        const float dist = (pos_ned - anchor_position(i)).length();
+        block[1] = i;                                  // node id
+        put_int24_le(&block[2], int32_t(dist * 1000)); // distance (mm)
+    }
+
+    // the checksum is the modulo-256 sum of all preceding bytes:
+    uint8_t crc = 0;
+    for (uint16_t i=0; i<frame_len-1U; i++) {
+        crc += buf[i];
+    }
+    buf[frame_len-1] = crc;
+
+    write_to_autopilot((const char*)buf, frame_len);
+}
+
+#endif  // AP_SIM_NOOPLOOP_ENABLED

--- a/libraries/SITL/SIM_Beacon_NoopLoop.h
+++ b/libraries/SITL/SIM_Beacon_NoopLoop.h
@@ -1,0 +1,69 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  Simulator for the NoopLoop (LinkTrack) UWB beacon system
+
+  Driver: AP_Beacon/AP_Beacon_Nooploop.cpp
+
+  Use:
+
+./Tools/autotest/sim_vehicle.py -v ArduCopter -A "--serial5=sim:nooploop" --map --console
+
+param set SERIAL5_PROTOCOL 13  # beacon
+param set BCN_TYPE 3           # nooploop
+param set GPS1_TYPE 0
+param set AHRS_EKF_TYPE 3
+param set EK3_SRC1_POSXY 4     # beacon
+param set BCN_LATITUDE -35.363262
+param set BCN_LONGITUDE 149.165237
+param set BCN_ALT 584.0
+reboot
+*/
+
+#pragma once
+
+#include "SIM_SerialBeacon.h"
+
+#if AP_SIM_NOOPLOOP_ENABLED
+
+namespace SITL {
+
+class Beacon_NoopLoop : public SerialBeacon {
+public:
+
+    using SerialBeacon::SerialBeacon;
+
+protected:
+
+    void send_data(const Vector3f &pos_ned) override;
+
+private:
+
+    static constexpr uint8_t num_anchors = 4;
+
+    // position of anchor i, in NED metres relative to the beacon origin:
+    Vector3f anchor_position(uint8_t i) const;
+
+    // build and emit the two frames the driver consumes:
+    void send_setting_frame0();                    // anchor positions
+    void send_node_frame2(const Vector3f &pos_ned); // tag position + ranges
+
+    // store value (millimetres) as a signed 24-bit little-endian integer:
+    static void put_int24_le(uint8_t *buf, int32_t value_mm);
+};
+
+}
+
+#endif  // AP_SIM_NOOPLOOP_ENABLED

--- a/libraries/SITL/SIM_SerialBeacon.cpp
+++ b/libraries/SITL/SIM_SerialBeacon.cpp
@@ -1,0 +1,61 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  Base class for serially-attached simulated positioning beacons
+*/
+
+#include "SIM_SerialBeacon.h"
+
+#if AP_SIM_NOOPLOOP_ENABLED
+
+#include <AP_HAL/AP_HAL.h>
+#include <SITL/SITL.h>
+
+using namespace SITL;
+
+void SerialBeacon::update()
+{
+    if (!init_sitl_pointer()) {
+        return;
+    }
+
+    // send data out at the beacon's reading rate:
+    const uint32_t now_ms = AP_HAL::millis();
+    if (now_ms - last_sent_ms < reading_interval_ms()) {
+        return;
+    }
+    last_sent_ms = now_ms;
+
+    // the beacon system origin is the same as the vehicle/EKF origin:
+    const Location &origin = _sitl->state.home;
+    if (!origin.initialised()) {
+        return;
+    }
+
+    // truth location of the simulated vehicle:
+    const Location veh_loc {
+        int32_t(_sitl->state.latitude * 1.0e7),
+        int32_t(_sitl->state.longitude * 1.0e7),
+        int32_t(_sitl->state.altitude * 1.0e2),
+        Location::AltFrame::ABSOLUTE
+    };
+
+    // vehicle position in NED metres relative to the beacon origin:
+    const Vector3f pos_ned = origin.get_distance_NED(veh_loc);
+
+    send_data(pos_ned);
+}
+
+#endif  // AP_SIM_NOOPLOOP_ENABLED

--- a/libraries/SITL/SIM_SerialBeacon.h
+++ b/libraries/SITL/SIM_SerialBeacon.h
@@ -1,0 +1,55 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  Base class for serially-attached simulated positioning beacons
+*/
+
+#pragma once
+
+#include "SIM_config.h"
+
+#if AP_SIM_NOOPLOOP_ENABLED  // currently the only serial beacon
+
+#include "SIM_SerialDevice.h"
+
+#include <AP_Math/AP_Math.h>
+
+namespace SITL {
+
+class SerialBeacon : public SerialDevice {
+public:
+
+    SerialBeacon() {}
+
+    // update; works out the vehicle's position relative to the beacon
+    // origin and sends beacon data to the autopilot:
+    void update();
+
+protected:
+
+    // send beacon data describing the supplied vehicle position (in NED
+    // metres relative to the beacon origin); implemented per beacon type:
+    virtual void send_data(const Vector3f &pos_ned) = 0;
+
+    virtual uint16_t reading_interval_ms() const { return 200; } // 5Hz default
+
+private:
+
+    uint32_t last_sent_ms;
+};
+
+}
+
+#endif  // AP_SIM_NOOPLOOP_ENABLED

--- a/libraries/SITL/SIM_config.h
+++ b/libraries/SITL/SIM_config.h
@@ -13,6 +13,10 @@
 #define AP_SIM_AIS_ENABLED (CONFIG_HAL_BOARD == HAL_BOARD_SITL)
 #endif  // AP_SIM_AIS_ENABLED
 
+#ifndef AP_SIM_NOOPLOOP_ENABLED
+#define AP_SIM_NOOPLOOP_ENABLED (CONFIG_HAL_BOARD == HAL_BOARD_SITL)
+#endif  // AP_SIM_NOOPLOOP_ENABLED
+
 /*
  * Simulated proximity sensor configuration:
  */


### PR DESCRIPTION
### Summary

Removes instantiation in Copter and Plane, put it in AP_Vehicle

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Parameter upgrade was tested using `test_param_upgrade.py`
[param_upgrade_pr.log](https://github.com/user-attachments/files/29453228/param_upgrade_pr.log)

Beacon required >2048kB of flash:
```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                 *                                                   
Durandal                            *               *      *           *       *                 *      *      *
Hitec-Airspeed           *                                 *                                                   
KakuteH7-bdshot                     *               *      *           *       *                 *      *      *
MatekF405                           *               *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot                  *               *                  *       *                 *      *      *
SITL_x86_64_linux_gnu               15328           11232              4600    4600              15288  4632   11192
YJUAV_A6SE                          4912            4792   *           92      172               4744   172    4816
f103-QiotekPeriph        *                                 *                                                   
f303-MatekGPS            *                                 *                                                   
f303-Universal           *                                 *                                                   
iomcu                                                                                *                         
revo-mini                           *               *      *           *       *                 *      *      *
skyviper-v2450                                                         *                                       
speedybeef4                         *               *      *           *       *                 *      *      *
```

### Description

Moves the beacon object ownership up.

Adds a nooploop simulator I made many years back for additional testing

Additional regression tests added to improve coverage.
