### PR TITLE
.github: fix cache key to be unique per board

### DIFF
--- a/.github/workflows/test_size.yml
+++ b/.github/workflows/test_size.yml
@@ -172,7 +172,7 @@ jobs:
 
       - uses: ./.github/actions/setup-ccache
         with:
-          key-suffix: ${{ matrix.toolchain }}
+          key-suffix: ${{ matrix.toolchain }}-${{ matrix.config }}
       - name: Build ${{ env.BASE_REF }} ${{matrix.config}} ${{ matrix.toolchain }}
         env:
           CI_BUILD_TARGET: ${{matrix.config}}
@@ -370,7 +370,7 @@ jobs:
 
       - uses: ./.github/actions/save-ccache
         with:
-          key-suffix: ${{ matrix.toolchain }}
+          key-suffix: ${{ matrix.toolchain }}-${{ matrix.config }}
 
   global-summary:
     needs: build


### PR DESCRIPTION
### Summary

fix cache key for test_size build . the key should use the board name an not just the toolchain.
It will make unique cache per board. We are far from the limit now (<5gb) so we can do it safely.
it will also prevent to erase the cache each time a test_size job finish on master : 
<img width="1131" height="330" alt="image" src="https://github.com/user-attachments/assets/72ddd292-85c6-4f9d-abbd-3d78acc2d7a4" />
(see on https://github.com/ArduPilot/ardupilot/actions/runs/28346724077/job/83971496583 )

Other workflow don't present the same issue

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
