### PR TITLE
Copter: Fix CPU-based spoolup check being gated by ESC telem

### DIFF
--- a/ArduCopter/takeoff_check.cpp
+++ b/ArduCopter/takeoff_check.cpp
@@ -7,13 +7,14 @@
 // detects if the vehicle should be allowed to takeoff or not and sets the motors.blocked flag
 void Copter::takeoff_check()
 {
-#if HAL_WITH_ESC_TELEM && FRAME_CONFIG != HELI_FRAME
     // if motors have become unblocked return immediately
     // this ensures the motors can only be blocked immediately after arming
     uint32_t now_ms = AP_HAL::millis();
     if (!motors->get_spoolup_block()) {
         takeoff_check_warning_ms = now_ms;
+#if HAL_WITH_ESC_TELEM && FRAME_CONFIG != HELI_FRAME
         takeoff_check_state.warning_ms = now_ms;
+#endif
         return;
     }
 
@@ -25,8 +26,13 @@ void Copter::takeoff_check()
         return;
     }
 
+    // Default to true so it doesn't block takeoff if telemetry is missing
+    bool motor_check_passed = true;
+
+#if HAL_WITH_ESC_TELEM && FRAME_CONFIG != HELI_FRAME
     // Run the common motor checks (called early so it can clear its warning timer when disarmed)
-    const bool motor_check_passed = motors_takeoff_check(g2.takeoff_rpm_min, g2.takeoff_rpm_max);
+    motor_check_passed = motors_takeoff_check(g2.takeoff_rpm_min, g2.takeoff_rpm_max);
+#endif
 
     // Check system load
     float avg_load, peak_load;
@@ -51,5 +57,4 @@ void Copter::takeoff_check()
             gcs().send_text(MAV_SEVERITY_CRITICAL, "%s CPU overload (%4.1f%%)", prefix_str, avg_load);
         }
     }
-#endif
 }


### PR DESCRIPTION
### Summary
This PR fixes a bug where the CPU-based spoolup check was completely bypassed on vehicles without ESC telemetry due to an overly broad preprocessor macro.
<!-- Put a one or two line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->
Compiled successfully locally for SITL (`./waf configure --board sitl` and `./waf copter`).
### Description

<!-- Describe the PR's content here -->
Fixes #33399

In `Copter::takeoff_check()`, the `#if HAL_WITH_ESC_TELEM` compiler guard was previously wrapped around the entire function's logic. This inadvertently prevented the CPU system load checks from running on vehicles that did not have ESC telemetry enabled. 

This PR tightens the scope of the `#if HAL_WITH_ESC_TELEM` guards to only wrap the specific ESC warning states and the `motors_takeoff_check`. The `motor_check_passed` boolean is now initialized to `true` by default so vehicles without telemetry don't fail the pre-arm check, and the CPU load check is freed to run universally for all frames.
<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
