### PR TITLE
Move control limits into estimates structure

### DIFF
--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -709,8 +709,10 @@ void AC_PosControl::NE_update_controller()
     }
     _last_update_ne_ticks = AP::scheduler().ticks32();
 
-    float ahrsGndSpdLimit, ahrsControlScaleXY;
-    AP::ahrs().getControlLimits(ahrsGndSpdLimit, ahrsControlScaleXY);
+    // the estimator might require scaling down of control
+    // (e.g. because of sensors being used to arrive at attitude
+    // estimate):
+    const float ahrsControlScaleXY = AP::ahrs().get_control_gain_scaler_XY();
 
     // Update lateral position, velocity, and acceleration offsets using path shaping
     NE_update_offsets();
@@ -1100,7 +1102,7 @@ void AC_PosControl::D_update_controller()
 
     // P controller: convert position error to velocity target
     _vel_target_ned_ms.z = _p_pos_d_m.update_all(_pos_target_ned_m.z, _pos_estimate_ned_m.z);
-    _vel_target_ned_ms.z *= AP::ahrs().getControlScaleZ();
+    _vel_target_ned_ms.z *= AP::ahrs().get_control_gain_scaler_Z();
 
     _pos_desired_ned_m.z = _pos_target_ned_m.z - (_pos_offset_ned_m.z + _pos_terrain_d_m);
 
@@ -1111,7 +1113,7 @@ void AC_PosControl::D_update_controller()
 
     // PID controller: convert velocity error to acceleration
     _accel_target_ned_mss.z = _pid_vel_d_m.update_all(_vel_target_ned_ms.z, _vel_estimate_ned_ms.z, _dt_s, _motors.limit.throttle_lower, _motors.limit.throttle_upper);
-    _accel_target_ned_mss.z *= AP::ahrs().getControlScaleZ();
+    _accel_target_ned_mss.z *= AP::ahrs().get_control_gain_scaler_Z();
 
     // add feed forward component
     _accel_target_ned_mss.z += _accel_desired_ned_mss.z + _accel_offset_ned_mss.z + _accel_terrain_d_mss;

--- a/libraries/AC_WPNav/AC_Loiter.cpp
+++ b/libraries/AC_WPNav/AC_Loiter.cpp
@@ -319,9 +319,9 @@ bool AC_Loiter::loiter_option_is_set(LoiterOption option) const {
 // - Resulting velocity and acceleration are sent to the position controller.
 void AC_Loiter::calc_desired_velocity(bool avoidance_on)
 {
-    float ekfGndSpdLimit_ms, ahrsControlScaleXY;
-    // Query EKF-imposed horizontal ground speed limit (e.g. for optical flow)
-    AP::ahrs().getControlLimits(ekfGndSpdLimit_ms, ahrsControlScaleXY);
+    // the estimator might impose limits on maximum velocity (e.g. due
+    // to the sensors being used to supply its estimated velocity):
+    const float ekfGndSpdLimit_ms = AP::ahrs().get_control_ground_speed_limit_ms();
 
     const float dt_s = _pos_control.get_dt_s();
 

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -2025,41 +2025,6 @@ void AP_AHRS::load_watchdog_home()
     }
 }
 
-// get_hgt_ctrl_limit - get maximum height to be observed by the control loops in metres and a validity flag
-// this is used to limit height during optical flow navigation
-// it will return false when no limiting is required
-bool AP_AHRS::get_hgt_ctrl_limit(float& limit) const
-{
-    switch (active_EKF_type()) {
-#if AP_AHRS_DCM_ENABLED
-    case EKFType::DCM:
-        // We are not using an EKF so no limiting applies
-        return false;
-#endif
-
-#if HAL_NAVEKF2_AVAILABLE
-    case EKFType::TWO:
-        return ekf2.EKF2.getHeightControlLimit(limit);
-#endif
-
-#if HAL_NAVEKF3_AVAILABLE
-    case EKFType::THREE:
-        return ekf3.EKF3.getHeightControlLimit(limit);
-#endif
-
-#if AP_AHRS_SIM_ENABLED
-    case EKFType::SIM:
-        return false;
-#endif
-#if AP_AHRS_EXTERNAL_ENABLED
-    case EKFType::EXTERNAL:
-        return false;
-#endif
-    }
-
-    return false;
-}
-
 // Set to true if the terrain underneath is stable enough to be used as a height reference
 // this is not related to terrain following
 void AP_AHRS::set_terrain_hgt_stable(bool stable)

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -1698,21 +1698,6 @@ void AP_AHRS::writeTerrainAMSL(float alt_amsl_m)
 #endif
 }
 
-/*
-  get gain factor for Z controllers
- */
-float AP_AHRS::getControlScaleZ(void) const
-{
-#if AP_AHRS_DCM_ENABLED
-    if (active_EKF_type() == EKFType::DCM) {
-        // when flying on DCM lower gains by 4x to cope with the high
-        // lag
-        return 0.25;
-    }
-#endif
-    return 1;
-}
-
 // get compass offset estimates
 // true if offsets are valid
 bool AP_AHRS::getMagOffsets(uint8_t mag_idx, Vector3f &magOffsets) const

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -396,7 +396,10 @@ public:
     // get_hgt_ctrl_limit - get maximum height to be observed by the control loops in meters and a validity flag
     // this is used to limit height during optical flow navigation
     // it will return invalid when no limiting is required
-    bool get_hgt_ctrl_limit(float &limit) const;
+    bool get_hgt_ctrl_limit(float &limit) const {
+        limit = active_estimates->control_height_limit_m;
+        return active_estimates->control_height_limit_valid;
+    }
 
     // Set to true if the terrain underneath is stable enough to be used as a height reference
     // this is not related to terrain following

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -330,12 +330,11 @@ public:
     // Write terrain (derived from SRTM) altitude in meters above sea level
     void writeTerrainAMSL(float alt_amsl_m);
 
-    // get speed limit
-    void getControlLimits(float &ekfGndSpdLimit, float &controlScaleXY) const {
-        active_backend->get_control_limits(ekfGndSpdLimit, controlScaleXY);
-    }
-
-    float getControlScaleZ(void) const;
+    // get speed limit imposed by the estimator
+    float get_control_ground_speed_limit_ms() const { return active_estimates->control_ground_speed_limit_ms; }
+    // get scaler used to limit response due to poor AHRS estimates
+    float get_control_gain_scaler_XY() const { return active_estimates->control_gain_scaler_XY; }
+    float get_control_gain_scaler_Z() const { return active_estimates->control_gain_scaler_Z; }
 
     // is the AHRS subsystem healthy?
     bool healthy() const;

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -234,6 +234,11 @@ public:
         float control_gain_scaler_XY;
         float control_gain_scaler_Z;
 
+        // hgt_ctrl_limit - get maximum height to be observed by the control loops in metres and a validity flag
+        // this is used to limit height during optical flow navigation
+        float control_height_limit_m;
+        bool control_height_limit_valid; // false when no limiting is required
+
     private:
         bool hagl_valid;
         float hagl;

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -226,6 +226,14 @@ public:
         float terrain_alt_variance;
         bool terrain_alt_variance_valid;
 
+        // impositions on control placed on it by the estimator.  So,
+        // for example, if Optical flow is in play then perhaps we
+        // can't travel as fast:
+        float control_ground_speed_limit_ms;
+        // or we want to scale down the control magnitudes:
+        float control_gain_scaler_XY;
+        float control_gain_scaler_Z;
+
     private:
         bool hagl_valid;
         float hagl;
@@ -315,8 +323,6 @@ public:
     virtual bool get_innovations(Vector3f &velInnov, Vector3f &posInnov, Vector3f &magInnov, float &tasInnov, float &yawInnov) const {
         return false;
     }
-
-    virtual void get_control_limits(float &ekfGndSpdLimit, float &controlScaleXY) const = 0;
 };
 
 // Converts an upstream "something changed" key (an EKF reset

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -153,6 +153,9 @@ AP_AHRS_DCM::update()
 #endif // HAL_LOGGING_ENABLED
 }
 
+// note that contrary to most code we leave commented code in here as
+// an exhaustive list of all of the data that *can* be returned in the
+// Estimates:
 void AP_AHRS_DCM::get_results(AP_AHRS_Backend::Estimates &results)
 {
     const auto now_ms = AP_HAL::millis();

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -269,6 +269,9 @@ void AP_AHRS_DCM::get_results(AP_AHRS_Backend::Estimates &results)
     results.control_ground_speed_limit_ms = 50.0;
     results.control_gain_scaler_XY = 0.5;
     results.control_gain_scaler_Z = 0.25;
+    // control height is never limited:
+    // results.control_height_limit_valid = false;
+    // results.control_height_limit_m = 0;
 }
 
 /*

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -264,6 +264,11 @@ void AP_AHRS_DCM::get_results(AP_AHRS_Backend::Estimates &results)
     // results.variances_valid = false;
 
     // terrain_alt_variance_valid = false;
+
+    // lower gains in VTOL controllers when flying on DCM
+    results.control_ground_speed_limit_ms = 50.0;
+    results.control_gain_scaler_XY = 0.5;
+    results.control_gain_scaler_Z = 0.25;
 }
 
 /*
@@ -1382,13 +1387,6 @@ bool AP_AHRS_DCM::get_origin(Location &ret) const
 bool AP_AHRS_DCM::yaw_source_available(void) const
 {
     return AP::compass().use_for_yaw();
-}
-
-void AP_AHRS_DCM::get_control_limits(float &ekfGndSpdLimit, float &ekfNavVelGainScaler) const
-{
-    // lower gains in VTOL controllers when flying on DCM
-    ekfGndSpdLimit = 50.0;
-    ekfNavVelGainScaler = 0.5;
 }
 
 #endif  // AP_AHRS_DCM_ENABLED

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -100,8 +100,6 @@ public:
     // return true if DCM has a yaw source
     bool yaw_source_available(void) const;
 
-    void get_control_limits(float &ekfGndSpdLimit, float &controlScaleXY) const override;
-
 private:
 
     // Get a derivative of the vertical position in m/s which is kinematically consistent with the vertical position is required by some control loops.

--- a/libraries/AP_AHRS/AP_AHRS_External.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_External.cpp
@@ -25,6 +25,11 @@ void AP_AHRS_External::get_results(AP_AHRS_Backend::Estimates &results)
     results.primary_accel = _ins.get_first_usable_accel();
 #endif  // AP_INERTIALSENSOR_ENABLED
 
+    // no limit on gains, large vel limit
+    results.control_ground_speed_limit_ms = 400.0;
+    results.control_gain_scaler_XY = 1;
+    results.control_gain_scaler_Z = 1;
+
     if (!extahrs.get_quaternion(results.quaternion)) {
         results.attitude_valid = false;
         return;
@@ -147,13 +152,6 @@ bool AP_AHRS_External::get_origin(Location &ret) const
 bool AP_AHRS_External::set_origin(const Location &loc)
 {
     return AP::externalAHRS().set_origin(loc);
-}
-
-void AP_AHRS_External::get_control_limits(float &ekfGndSpdLimit, float &ekfNavVelGainScaler) const
-{
-    // no limit on gains, large vel limit
-    ekfGndSpdLimit = 400.0;
-    ekfNavVelGainScaler = 1;
 }
 
 #endif

--- a/libraries/AP_AHRS/AP_AHRS_External.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_External.cpp
@@ -30,6 +30,10 @@ void AP_AHRS_External::get_results(AP_AHRS_Backend::Estimates &results)
     results.control_gain_scaler_XY = 1;
     results.control_gain_scaler_Z = 1;
 
+    // control height is never limited:
+    // results.control_height_limit_valid = false;
+    // results.control_height_limit_m = 0;
+
     if (!extahrs.get_quaternion(results.quaternion)) {
         results.attitude_valid = false;
         return;

--- a/libraries/AP_AHRS/AP_AHRS_External.h
+++ b/libraries/AP_AHRS/AP_AHRS_External.h
@@ -63,8 +63,6 @@ public:
     // AHRS backend to be shared with the external AHRS
     bool set_origin(const Location &loc) override;
     bool get_origin(Location &ret) const override;
-
-    void get_control_limits(float &ekfGndSpdLimit, float &controlScaleXY) const override;
 };
 
 #endif

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF2.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF2.cpp
@@ -217,6 +217,8 @@ void AP_AHRS_NavEKF2::get_results(AP_AHRS_Backend::Estimates &results)
 
     EKF2.getEkfControlLimits(results.control_ground_speed_limit_ms, results.control_gain_scaler_XY);
     results.control_gain_scaler_Z = 1;
+
+    results.control_height_limit_valid = EKF2.getHeightControlLimit(results.control_height_limit_m);
 }
 
 bool AP_AHRS_NavEKF2::pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF2.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF2.cpp
@@ -214,6 +214,9 @@ void AP_AHRS_NavEKF2::get_results(AP_AHRS_Backend::Estimates &results)
     results.variances_valid = EKF2.getVariances(results.velVar, results.posVar, results.hgtVar, results.magVar, results.tasVar, offset);
 
     results.terrain_alt_variance_valid = EKF2.getTerrainAltVariance(results.terrain_alt_variance);
+
+    EKF2.getEkfControlLimits(results.control_ground_speed_limit_ms, results.control_gain_scaler_XY);
+    results.control_gain_scaler_Z = 1;
 }
 
 bool AP_AHRS_NavEKF2::pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF2.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF2.h
@@ -64,10 +64,6 @@ public:
 
     bool pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const override;
 
-    void get_control_limits(float &ekfGndSpdLimit, float &controlScaleXY) const override {
-        return EKF2.getEkfControlLimits(ekfGndSpdLimit, controlScaleXY);
-    }
-
     // // return the innovations for the specified instance
     // // An out of range instance (eg -1) returns data for the primary instance
     bool get_innovations(Vector3f &velInnov, Vector3f &posInnov, Vector3f &magInnov, float &tasInnov, float &yawInnov) const override {

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
@@ -218,6 +218,8 @@ void AP_AHRS_NavEKF3::get_results(AP_AHRS_Backend::Estimates &results)
 
     EKF3.getEkfControlLimits(results.control_ground_speed_limit_ms, results.control_gain_scaler_XY);
     results.control_gain_scaler_Z = 1;
+
+    results.control_height_limit_valid = EKF3.getHeightControlLimit(results.control_height_limit_m);
 }
 
 bool AP_AHRS_NavEKF3::pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
@@ -215,6 +215,9 @@ void AP_AHRS_NavEKF3::get_results(AP_AHRS_Backend::Estimates &results)
     results.variances_valid = EKF3.getVariances(results.velVar, results.posVar, results.hgtVar, results.magVar, results.tasVar, offset);
 
     results.terrain_alt_variance_valid = EKF3.getTerrainAltVariance(results.terrain_alt_variance);
+
+    EKF3.getEkfControlLimits(results.control_ground_speed_limit_ms, results.control_gain_scaler_XY);
+    results.control_gain_scaler_Z = 1;
 }
 
 bool AP_AHRS_NavEKF3::pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF3.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF3.h
@@ -70,10 +70,6 @@ public:
 
     bool pre_arm_check(bool requires_position, char *failure_msg, uint8_t failure_msg_len) const override;
 
-    void get_control_limits(float &ekfGndSpdLimit, float &controlScaleXY) const override {
-        return EKF3.getEkfControlLimits(ekfGndSpdLimit, controlScaleXY);
-    }
-
     // return the innovations for the specified instance
     // An out of range instance (eg -1) returns data for the primary instance
     bool get_innovations(Vector3f &velInnov, Vector3f &posInnov, Vector3f &magInnov, float &tasInnov, float &yawInnov) const override {

--- a/libraries/AP_AHRS/AP_AHRS_SIM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_SIM.cpp
@@ -216,6 +216,10 @@ void AP_AHRS_SIM::get_results(AP_AHRS_Backend::Estimates &results)
     results.control_gain_scaler_XY = 1;
     results.control_gain_scaler_Z = 1;
 
+    // control height is never limited:
+    // results.control_height_limit_valid = false;
+    // results.control_height_limit_m = 0;
+
 #if HAL_NAVEKF3_AVAILABLE
     if (_sitl->odom_enable) {
         // use SITL states to write body frame odometry data at 20Hz

--- a/libraries/AP_AHRS/AP_AHRS_SIM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_SIM.cpp
@@ -53,13 +53,6 @@ bool AP_AHRS_SIM::get_filter_status(nav_filter_status &status) const
     return true;
 }
 
-void AP_AHRS_SIM::get_control_limits(float &ekfGndSpdLimit, float &ekfNavVelGainScaler) const
-{
-    // same as EKF2 for no optical flow
-    ekfGndSpdLimit = 400.0f;
-    ekfNavVelGainScaler = 1.0f;
-}
-
 bool AP_AHRS_SIM::get_origin(Location &ret) const
 {
     if (_sitl == nullptr) {
@@ -217,6 +210,11 @@ void AP_AHRS_SIM::get_results(AP_AHRS_Backend::Estimates &results)
 
     // terrain_alt_variance = 0;
     results.terrain_alt_variance_valid = true;
+
+    // very loose limits on velocities and no gain scaling:
+    results.control_ground_speed_limit_ms = 400.0;
+    results.control_gain_scaler_XY = 1;
+    results.control_gain_scaler_Z = 1;
 
 #if HAL_NAVEKF3_AVAILABLE
     if (_sitl->odom_enable) {

--- a/libraries/AP_AHRS/AP_AHRS_SIM.h
+++ b/libraries/AP_AHRS/AP_AHRS_SIM.h
@@ -79,7 +79,6 @@ public:
     // relative-origin functions for fallback in AP_InertialNav
     bool get_origin(Location &ret) const override;
 
-    void get_control_limits(float &ekfGndSpdLimit, float &controlScaleXY) const override;
     bool get_innovations(Vector3f &velInnov, Vector3f &posInnov, Vector3f &magInnov, float &tasInnov, float &yawInnov) const override;
 
 private:


### PR DESCRIPTION
### Summary

Moves the limits being imposed by the estimator into the estimates structure

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Moves the limits from being various method callbacks (pure-virtual on the backends, method with explicit DCM check in the frontends) to being entries in the results structure.

I took the opportunity here to adjust the naming, and to split the method which previously had two return parameters for the different control limits into 2 parts, one for the gain scaling and one for the XY velocity limit (there was already a method to return the Z-scaler)
