### PR TITLE
Do not fuse synthetic airspeed if not fly-forward

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -12299,6 +12299,72 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             raise NotAchievedException("Changed to ALT_HOLD with no altitude estimate")
         self.disarm_vehicle(force=True)
 
+    def DeadReckoningInWind(self):
+        '''ensure copter dead-reckoning on drag does not destabilise the EKF in wind'''
+        # When GPS is lost in wind, the EKF dead-reckons the vehicle's
+        # position using the drift produced by bluff-body drag
+        # (EK3_DRAG_BCOEF_X/Y, EK3_DRAG_MCOEF).  Once GPS is gone the wind
+        # states become unobservable, at which point the EKF freezes its
+        # last airspeed estimate and synthesises an airspeed measurement
+        # from it.  That synthetic airspeed is only valid for fly-forward
+        # vehicles (it assumes zero sideslip); fusing it on a multicopter
+        # corrupts the attitude and velocity states, which is dramatic
+        # when the true airspeed no longer matches the frozen estimate
+        # (e.g. the wind changes during the outage).  See issue #33451.
+        self.context_push()
+        self.set_parameters({
+            # enable wind estimation and drag-based dead reckoning:
+            "EK3_DRAG_BCOEF_X": 9.5,
+            "EK3_DRAG_BCOEF_Y": 9.5,
+            "EK3_DRAG_MCOEF": 0.082,
+            # stop the dead-reckoning and EKF failsafes from changing
+            # the flight mode so that we observe the raw EKF behaviour:
+            "FS_DR_ENABLE": 0,
+            "FS_EKF_ACTION": 0,
+            # moderate wind from the North:
+            "SIM_WIND_DIR": 0,
+            "SIM_WIND_SPD": 5,
+        })
+        self.reboot_sitl()
+
+        # take off in LOITER so that the helper leaves the throttle at
+        # the hover point and the vehicle holds station in the wind:
+        self.takeoff(50, mode='LOITER')
+        # let the EKF learn the wind from drag while GPS is still available:
+        self.delay_sim_time(60, reason="learn wind via drag fusion")
+
+        self.progress("Disabling GPS to force dead-reckoning")
+        self.set_parameter("SIM_GPS1_ENABLE", 0)
+        # the wind drops away during the GPS outage.  The EKF froze its
+        # last airspeed estimate when the wind became unobservable; with
+        # the regression it keeps fusing that now-stale airspeed, which
+        # corrupts the attitude/velocity estimate:
+        self.set_parameter("SIM_WIND_SPD", 0)
+
+        # While dead-reckoning the vehicle's *position* drifts (there is
+        # no absolute position reference), so the reported position cannot
+        # be used to detect a problem.  Instead we compare the EKF's
+        # *attitude* estimate (ATTITUDE) against simulation truth
+        # (SIMSTATE): with the fix the EKF stays stable and tracks attitude
+        # to a couple of degrees (measured ~2deg), whereas fusing the
+        # stale synthetic airspeed destabilises the estimate (measured
+        # ~16deg and climbing).  An 8deg threshold separates the two.
+        tstart = self.get_sim_time()
+        max_err = 0
+        while self.get_sim_time() - tstart < 90:
+            sim = self.assert_receive_message('SIMSTATE')
+            att = self.assert_receive_message('ATTITUDE')
+            err = math.degrees(max(abs(att.roll - sim.roll), abs(att.pitch - sim.pitch)))
+            max_err = max(max_err, err)
+            if err > 8:
+                raise NotAchievedException(
+                    "EKF attitude diverged from truth by %.1f deg while dead-reckoning" % err)
+        self.progress("Maximum EKF attitude error while dead-reckoning was %.1f deg" % max_err)
+
+        self.disarm_vehicle(force=True)
+        self.context_pop()
+        self.reboot_sitl()
+
     def EK3_NoGPSLeakWhenNotSource(self):
         '''verify EKF does not leak GPS position when GPS is not the configured source'''
         # With EKF configured to use optical flow (POSXY source is
@@ -17921,6 +17987,7 @@ return update, 1000
             self.WP_SPEED_DN,
             self.DO_WINCH,
             self.SensorErrorFlags,
+            self.DeadReckoningInWind,
             self.GPSForYaw,
             self.GPS_INPUT,
             self.DefaultIntervalsFromFiles,

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -880,7 +880,10 @@ void NavEKF3_core::readAirSpdData()
         }
         // Check the buffer for measurements that have been overtaken by the fusion time horizon and need to be fused
         tasDataToFuse = storedTAS.recall(tasDataDelayed,imuDataDelayed.time_ms);
-    } else {
+    } else if (assume_zero_sideslip()) {
+        // synthetic airspeed is only valid for 'fly forward' vehicles that
+        // do not sideslip; fusing it on a multicopter corrupts the attitude
+        // and velocity states when dead reckoning (see issue #33451)
         if (is_positive(defaultAirSpeed)) {
             // this is the preferred method with the autopilot providing a model based airspeed estimate
             if (imuDataDelayed.time_ms - prevTasStep_ms > 200 ) {
@@ -908,6 +911,9 @@ void NavEKF3_core::readAirSpdData()
                 tasDataDelayed.allowFusion = false;
             }
         }
+    } else {
+        tasDataToFuse = false;
+        tasDataDelayed.allowFusion = false;
     }
 }
 


### PR DESCRIPTION
### Summary

Prevents fusing a probably-bad airspeed estimate.

Closes https://github.com/ArduPilot/ardupilot/issues/33451

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
  ┌────────────────────┬───────────────────────────────────┬─────────────────────┬───────┐
  │       Commit       │               Role                │ DeadReckoningInWind │ Error │
  ├────────────────────┼───────────────────────────────────┼─────────────────────┼───────┤
  │ e53416e77b         │ parent (just before the series)   │ PASS                │ 1.7°  │
  ├────────────────────┼───────────────────────────────────┼─────────────────────┼───────┤
  │ 324d5da811         │ first commit of the rework series │ FAIL                │ 18.6° │
  ├────────────────────┼───────────────────────────────────┼─────────────────────┼───────┤
  │ 61874da020         │ tip of the rework series          │ FAIL                │ 14.4° │
  ├────────────────────┼───────────────────────────────────┼─────────────────────┼───────┤
  │ … master (current) │ post-rework + 2 yrs               │ FAIL                │ 16.7° │
  ├────────────────────┼───────────────────────────────────┼─────────────────────┼───────┤
  │ master + fix       │ —                                 │ PASS                │ 2.0°  │
  └────────────────────┴───────────────────────────────────┴─────────────────────┴───────┘

  So the answer to your question: yes, it fails immediately after the regression — and more than that, the bisect lands on the exact commit. 324d5da811 ("AP_NavEKF3: Use last observed wind
  states to enable dead reckoning", 2024-06-09) is the first commit where the test fails; its direct parent e53416e77b passes. That commit added the windStateLastObs synthetic-airspeed
  branch in readAirSpdData() with no assume_zero_sideslip() gate, so multicopters began fusing a synthetic airspeed. 61874da020 later reworked that same branch (to the lastAspdEstIsValid
  form on current master), but the regression was already live as of 324d5da811.

  Each failure was confirmed genuine (clean takeoff → wind-learning → GPS-off → divergence during dead-reckoning, no pre-divergence crash), and the parent pass was verified airborne in the
  dataflash log.
```


### Description

@pavloblindnology 's patch does seem to fix the Copter problem.... can it create others? 
