### PR TITLE
AP_AHRS: use direct active_backend access in place of state structure entries

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -258,7 +258,6 @@ AP_AHRS::AP_AHRS(uint8_t flags) :
     // Copter and Sub force the use of EKF
     _ekf_flags |= AP_AHRS::FLAG_ALWAYS_USE_EKF;
 #endif
-    state.dcm_matrix.identity();
 
     // initialise the controller-to-autopilot-body trim state:
     _last_trim = _trim.get();
@@ -464,8 +463,6 @@ void AP_AHRS::update_state(void)
 #endif
     state.primary_gyro = primary_gyro;
 
-    state.primary_accel = active_estimates->primary_accel;
-
     state.EAS2TAS = AP_AHRS_Backend::get_EAS2TAS();
     state.airspeed_EAS_ok = _airspeed_EAS(state.airspeed_EAS, state.airspeed_estimate_type);
     state.airspeed_TAS_ok = _airspeed_TAS(state.airspeed_TAS);
@@ -475,26 +472,16 @@ void AP_AHRS::update_state(void)
     pitch = active_estimates->pitch_rad;
     yaw = active_estimates->yaw_rad;
 
-    state.dcm_matrix = active_estimates->dcm_matrix;
-
-    state.gyro_estimate = active_estimates->gyro_estimate;
-    state.gyro_drift = active_estimates->gyro_drift;
-
-    state.accel_ef = active_estimates->accel_ef;
-    state.accel_bias = active_estimates->accel_bias;
-
     update_cd_values();
     update_trig();
 
-    state.quat_ok = active_estimates->get_quaternion(state.quat);
     state.location_ok = _get_location(state.location);
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     if (state.location_ok && !state.location.initialised()) {
         AP_HAL::panic("uninitialised location returned by _get_location");
     }
 #endif  // CONFIG_HAL_BOARD == HAL_BOARD_SITL
-    state.ground_speed_vec = active_estimates->velocity_NE;
-    state.ground_speed = state.ground_speed_vec.length();
+    state.ground_speed = active_estimates->velocity_NE.length();
     state.corrected_dv_valid = _getCorrectedDeltaVelocityNED(state.corrected_dv, state.corrected_dv_dt);
 
     // check if origin has been set
@@ -519,8 +506,6 @@ void AP_AHRS::update_state(void)
     if (!state.origin_ok) {
         use_recorded_origin_maybe();
     }
-
-    state.velocity_NED_ok = active_estimates->get_velocity_NED(state.velocity_NED);
 }
 
 void AP_AHRS::try_set_common_origin(const AP_AHRS_Backend &source_backend, const AP_AHRS_Backend::Estimates &source_estimates)
@@ -1733,7 +1718,7 @@ bool AP_AHRS::_getCorrectedDeltaVelocityNED(Vector3f& ret, float& dt) const
         return false;
     }
     ret -= active_estimates->accel_bias * dt;
-    ret = state.dcm_matrix * get_rotation_autopilot_body_to_vehicle_body() * ret;
+    ret = active_estimates->dcm_matrix * get_rotation_autopilot_body_to_vehicle_body() * ret;
     ret.z += GRAVITY_MSS*dt;
     return true;
 }
@@ -2363,26 +2348,11 @@ bool AP_AHRS::airspeed_vector_TAS(Vector3f &vec) const
     return state.airspeed_TAS_vec_ok;
 }
 
-// return the quaternion defining the rotation from NED to XYZ (body) axes
-bool AP_AHRS::get_quaternion(Quaternion &quat) const
-{
-    quat = state.quat;
-    return state.quat_ok;
-}
-
 // returns the inertial navigation origin in lat/lon/alt
 bool AP_AHRS::get_origin(Location &ret) const
 {
     ret = state.origin;
     return state.origin_ok;
-}
-
-// return a ground velocity in meters/second, North/East/Down
-// order. Must only be called if have_inertial_nav() is true
-bool AP_AHRS::get_velocity_NED(Vector3f &vec) const
-{
-    vec = state.velocity_NED;
-    return state.velocity_NED_ok;
 }
 
 // return location corresponding to vector relative to the

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -90,10 +90,10 @@ public:
     }
 
     // return the smoothed gyro vector corrected for drift
-    const Vector3f &get_gyro(void) const { return state.gyro_estimate; }
+    const Vector3f &get_gyro(void) const { return active_estimates->gyro_estimate; }
 
     // return the current drift correction integrator value
-    const Vector3f &get_gyro_drift(void) const { return state.gyro_drift; }
+    const Vector3f &get_gyro_drift(void) const { return active_estimates->gyro_drift; }
 
     // reset the current gyro drift estimate
     //  should be called if gyro offsets are recalculated
@@ -210,7 +210,9 @@ public:
     bool use_compass();
 
     // return the quaternion defining the rotation from NED to XYZ (body) axes
-    bool get_quaternion(Quaternion &quat) const WARN_IF_UNUSED;
+    bool get_quaternion(Quaternion &quat) const WARN_IF_UNUSED {
+        return active_estimates->get_quaternion(quat);
+    }
 
     // return secondary estimates; note that this may return nullptr!
     const AP_AHRS_Backend::Estimates *get_secondary_estimates() const {
@@ -218,13 +220,13 @@ public:
     }
 
     // EKF has a better ground speed vector estimate
-    const Vector2f &groundspeed_vector() const { return state.ground_speed_vec; }
+    const Vector2f &groundspeed_vector() const { return active_estimates->velocity_NE; }
 
     // return ground speed estimate in meters/second. Used by ground vehicles.
     float groundspeed(void) const { return state.ground_speed; }
 
     const Vector3f &get_accel_ef() const {
-        return state.accel_ef;
+        return active_estimates->accel_ef;
     }
 
     // Retrieves the corrected NED delta velocity in use by the inertial navigation
@@ -264,7 +266,9 @@ public:
 
     // return a ground velocity in meters/second, North/East/Down
     // order. Must only be called if have_inertial_nav() is true
-    bool get_velocity_NED(Vector3f &vec) const WARN_IF_UNUSED;
+    bool get_velocity_NED(Vector3f &vec) const WARN_IF_UNUSED {
+        return active_estimates->get_velocity_NED(vec);
+    }
 
     // return the relative position NED from home
     // return true if the estimate is valid
@@ -469,7 +473,7 @@ public:
     uint8_t get_active_airspeed_index() const;
 
     // get the index of the current primary accelerometer sensor
-    uint8_t get_primary_accel_index(void) const { return state.primary_accel; }
+    uint8_t get_primary_accel_index(void) const { return active_estimates->primary_accel; }
 
     // get the index of the current primary gyro sensor
     uint8_t get_primary_gyro_index(void) const { return state.primary_gyro; }
@@ -673,7 +677,7 @@ public:
     int32_t pitch_sensor;
     int32_t yaw_sensor;
 
-    const Matrix3f &get_rotation_body_to_ned(void) const { return state.dcm_matrix; }
+    const Matrix3f &get_rotation_body_to_ned(void) const { return active_estimates->dcm_matrix; }
 
     // return a Quaternion representing our current attitude in NED frame
     void get_quat_body_to_ned(Quaternion &quat) const;
@@ -716,7 +720,7 @@ public:
     // get_accel() vector to get best current body frame accel
     // estimate
     const Vector3f &get_accel_bias(void) const {
-        return state.accel_bias;
+        return active_estimates->accel_bias;
     }
     
     /*
@@ -1000,12 +1004,6 @@ private:
         EKFType active_EKF_type;  // EKFType of backend these results are for
         EKFType configured_ekf_type;  // vetted parameter-configured EKFType
         uint8_t primary_gyro;
-        uint8_t primary_accel;
-        Vector3f gyro_estimate;
-        Matrix3f dcm_matrix;
-        Vector3f gyro_drift;
-        Vector3f accel_ef;
-        Vector3f accel_bias;
         float EAS2TAS;
         bool airspeed_EAS_ok;
         float airspeed_EAS;
@@ -1014,20 +1012,15 @@ private:
         float airspeed_TAS;
         Vector3f airspeed_TAS_vec;
         bool airspeed_TAS_vec_ok;
-        Quaternion quat;
-        bool quat_ok;
         uint16_t attitude_reset_count;
         Location location;
         bool location_ok;
-        Vector2f ground_speed_vec;
         float ground_speed;
         bool corrected_dv_valid;
         Vector3f corrected_dv;
         float corrected_dv_dt;
         Location origin;
         bool origin_ok;
-        Vector3f velocity_NED;
-        bool velocity_NED_ok;
     } state;
 
     /*

--- a/libraries/AP_AHRS/AP_AHRS_Logging.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_Logging.cpp
@@ -135,9 +135,9 @@ void AP_AHRS::write_video_stabilisation() const
     const struct log_Video_Stabilisation pkt {
         LOG_PACKET_HEADER_INIT(LOG_VIDEO_STABILISATION_MSG),
         time_us         : AP_HAL::micros64(),
-        gyro_x          : state.gyro_estimate.x,
-        gyro_y          : state.gyro_estimate.y,
-        gyro_z          : state.gyro_estimate.z,
+        gyro_x          : active_estimates->gyro_estimate.x,
+        gyro_y          : active_estimates->gyro_estimate.y,
+        gyro_z          : active_estimates->gyro_estimate.z,
         accel_x         : accel.x,
         accel_y         : accel.y,
         accel_z         : accel.z,


### PR DESCRIPTION
### Summary

Stops copying the data simply available from the backend pointer into state, just take it straight from the pointer

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

We don't need this indirection - remove it.

The matrix identity wasn't surviving long anyway, so remove it.
