### PR TITLE
Tradheli-fix 4.7 bug that doesn't clear land complete flag unless gov engage in manual throttle modes

### DIFF
--- a/ArduCopter/heli.cpp
+++ b/ArduCopter/heli.cpp
@@ -101,6 +101,10 @@ void Copter::update_heli_control_dynamics(void)
 
     // set hover roll trim scalar, will ramp from 0 to 1 over 1 second after we think helicopter has taken off
     attitude_control->set_hover_roll_trim_scalar((float) hover_roll_trim_scalar_slew/(float) scheduler.get_loop_rate_hz());
+
+    // set manual collective mode in motors to aid in runup complete determination in RSC
+    // if copter is set to a manual throttle flight mode, then heli is using a manual collective mode
+    motors->set_using_manual_collective_mode(flightmode->has_manual_throttle());
 }
 
 bool Copter::should_use_landing_swash() const

--- a/Tools/autotest/helicopter.py
+++ b/Tools/autotest/helicopter.py
@@ -224,6 +224,62 @@ class AutoTestHelicopter(AutoTestCopter):
         self.takeoff(10)
         self.do_RTL()
 
+    def GovernorNotEngagedManualThrottle(self):
+        '''check runup complete and land-complete clear in manual throttle modes when governor never engages'''
+        self.customise_SITL_commandline(
+            [],
+            defaults_filepath=self.model_defaults_filepath('heli-gas'),
+            model="heli-gas",
+            wipe=True,
+        )
+        # AutoThrottle RSC mode with the rotor speed sensor removed;
+        # without RPM feedback the governor can never engage:
+        self.set_parameters({
+            "H_RSC_MODE": 4,
+            "RPM1_TYPE": 0,
+        })
+        self.reboot_sitl()
+
+        self.context_collect('STATUSTEXT')
+        self.context_set_message_rate_hz(id=mavutil.mavlink.MAVLINK_MSG_ID_EXTENDED_SYS_STATE, rate_hz=1)
+
+        self.change_mode('ALT_HOLD')
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+        self.progress("Raising rotor speed")
+        self.set_rc(8, 2000)
+
+        # wait beyond the rotor ramp and runup timers:
+        runup_time = (self.get_parameter("H_RSC_RAMP_TIME") +
+                      self.get_parameter("H_RSC_RUNUP_TIME"))
+        self.delay_sim_time(runup_time + 10, reason="rotor ramp and runup timers to expire")
+
+        # in a non-manual-throttle mode runup must not be declared
+        # complete until the governor engages:
+        if self.statustext_in_collections("Runup Complete") is not None:
+            raise NotAchievedException(
+                "Runup completed without governor engaged in non-manual throttle mode")
+
+        self.progress("Switching to a manual throttle mode")
+        self.change_mode('STABILIZE')
+        self.wait_statustext("Governor Failed to Engage when Runup Completed", check_context=True, timeout=30)
+
+        self.progress("Take off and check land-complete is cleared")
+        self.assert_extended_sys_state(
+            vtol_state=mavutil.mavlink.MAV_VTOL_STATE_MC,
+            landed_state=mavutil.mavlink.MAV_LANDED_STATE_ON_GROUND,
+        )
+        self.set_rc(3, 1700)
+        self.wait_altitude(5, 30, relative=True, timeout=60)
+        self.hover()
+        self.wait_extended_sys_state(
+            vtol_state=mavutil.mavlink.MAV_VTOL_STATE_MC,
+            landed_state=mavutil.mavlink.MAV_LANDED_STATE_IN_AIR,
+            timeout=10,
+        )
+
+        self.do_RTL()
+
     def DDFPTail(self):
         # simple check to ensure servo output to DDFP tail is working
         '''Test DDFP Tail Rotor'''
@@ -1359,6 +1415,7 @@ class AutoTestHelicopter(AutoTestCopter):
             self.Autorotation,
             self.ManAutorotation,
             self.governortest,
+            self.GovernorNotEngagedManualThrottle,
             self.FlyEachFrame,
             self.AirspeedDrivers,
             self.TurbineStart,

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -107,6 +107,9 @@ public:
     // helper for vehicle code to request autorotation states in the RSC.
     void set_autorotation_active(bool tf) { _main_rotor.autorotation.set_active(tf, false); }
 
+    // true if we are using a manual collective flight mode
+    void set_using_manual_collective_mode(bool using_manual_collective_mode) { _main_rotor.set_using_manual_collective_mode(using_manual_collective_mode); }
+
     // helper to force the RSC autorotation state to deactivated
     void force_deactivate_autorotation(void) { _main_rotor.autorotation.set_active(false, true); }
 

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
@@ -560,7 +560,9 @@ void AP_MotorsHeli_RSC::update_rotor_ramp(float rotor_ramp_input, float dt)
     }
 }
 
-// update_rotor_runup - function to slew rotor runup scalar, outputs float scalar to _rotor_runup_ouptut
+// update_rotor_runup - function to slew rotor runup scalar, outputs float scalar to _rotor_runup_output
+// Relies on set_using_manual_collective_mode() having been called first.  This method requires this information
+// to determine if the governor must be engaged for runup to be complete when using autothrottle RSC mode.
 void AP_MotorsHeli_RSC::update_rotor_runup(float dt)
 {
     float runup_time = _runup_time;
@@ -602,10 +604,18 @@ void AP_MotorsHeli_RSC::update_rotor_runup(float dt)
         return;
     }
 
-    // if rotor ramp and runup are both at full speed, then run-up has been completed
-    if (!_runup_complete && (_rotor_ramp_output >= 1.0f) && (_rotor_runup_output >= 1.0f) && (_rsc_control_mode == ROTOR_CONTROL_MODE_AUTOTHROTTLE ? _governor_engage : true)) {
+    // rotor runup complete depends on the use of autothrottle RSC mode and the manual collective flight mode
+    // if autothrottle is used and a non-manual collective mode is used, then the governor must be engaged for runup to be complete. Otherwise,
+    // runup is complete when the rotor ramp and runup outputs are both at 1.0.  
+    if (!_runup_complete && (_rotor_ramp_output >= 1.0f) && (_rotor_runup_output >= 1.0f) && 
+        (_using_manual_collective_mode || _rsc_control_mode != ROTOR_CONTROL_MODE_AUTOTHROTTLE || _governor_engage)) {
+        // warn user if runup timer completed but governor not engaged when using manual collective mode and autothrottle RSC mode
+        if (_using_manual_collective_mode && _rsc_control_mode == ROTOR_CONTROL_MODE_AUTOTHROTTLE && _governor_engage == false) {
+            GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Governor Failed to Engage when Runup Completed");
+        } else {
+            GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Runup Complete");
+        }
         _runup_complete = true;
-        GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Runup Complete");
     }
     // if rotor speed is less than critical speed, then run-up is not complete
     // this will prevent the case where the target rotor speed is less than critical speed

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.h
@@ -79,6 +79,9 @@ public:
     // true if we are considered to be autorotating or bailing out of an autorotation
     bool        in_autorotation(void) const;
 
+    // true if we are using a manual collective flight mode
+    void        set_using_manual_collective_mode(bool using_manual_collective_mode) { _using_manual_collective_mode = using_manual_collective_mode; }
+
     // turbine start initialize sequence
     void        set_turbine_start(bool turbine_start) {_turbine_start = turbine_start; }
 
@@ -175,6 +178,7 @@ private:
     float           _governor_torque_reference;   // governor reference for load calculations
     float           _idle_throttle;               // current idle throttle setting
     bool            _save_rsc_mode;               // flag to determine if we should save RSC mode changes to EEPROM, used to prevent saving changes to RSC mode param while armed.
+    bool            _using_manual_collective_mode; // flag to determine if we are using a manual collective flight mode
 
     // parameters
     AP_Int16        _power_slewrate;            // throttle slew rate (percentage per second)


### PR DESCRIPTION
### Summary

This PR fixes issue https://github.com/ArduPilot/ardupilot/issues/33612


### Classification & Testing

- [x] Checked by a human programmer
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs available on request


### Description

This PR still requires governor to be engaged before declaring runup complete for non-manual throttle modes.  However it does not require governor engaged for manual throttle modes and just declares runup complete based on the timer.  Other RSC modes still use timer to determine runup complete.

