### PR TITLE
Add JIYI Microbrain CAN rangefinder driver (UAV-R21-1 / UAV-H30-1)

### DIFF
--- a/libraries/AP_CANManager/AP_CAN.h
+++ b/libraries/AP_CANManager/AP_CAN.h
@@ -29,5 +29,6 @@ public:
         Scripting2 = 12,
         TOFSenseP = 13,
         RadarCAN = 14,  // used by NanoRadar and Hexsoon
+        JIYI = 15,      // used by JIYI Microbrain UAV-R21-1 / UAV-H30-1
     };
 };

--- a/libraries/AP_RangeFinder/AP_RangeFinder_JIYI_CAN.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_JIYI_CAN.cpp
@@ -1,0 +1,74 @@
+#include <AP_HAL/AP_HAL.h>
+#include <AP_BoardConfig/AP_BoardConfig.h>
+#include "AP_RangeFinder_JIYI_CAN.h"
+#include <AP_HAL/utility/sparse-endian.h>
+
+#if AP_RANGEFINDER_JIYI_CAN_ENABLED
+
+/*
+  Handle an incoming CAN frame from a JIYI Microbrain radar sensor.
+
+  Both the UAV-R21-1 (obstacle avoidance) and UAV-H30-1 (altitude) models
+  share the same 8-byte standard-frame protocol:
+
+    Byte 0–1 : Magic word  0xEA 0x2D  (big-endian uint16 = 0xEA2D)
+    Byte 2–3 : Msg type    0x04 0x00  (big-endian uint16 = 0x0400)
+    Byte 4–5 : Distance    uint16 big-endian, centimetres
+               0x0000 indicates no target detected
+    Byte 6–7 : SNR / checksum (not used for ranging)
+
+  Returns true if the frame was a valid JIYI distance frame and was consumed.
+*/
+bool AP_RangeFinder_JIYI_CAN::handle_frame(AP_HAL::CANFrame &frame)
+{
+    WITH_SEMAPHORE(_sem);
+
+    // Reject extended frames — JIYI uses standard 11-bit IDs
+    if (frame.isExtended()) {
+        return false;
+    }
+
+    // Verify CAN ID matches the configured sensor address
+    const uint16_t id = frame.id & AP_HAL::CANFrame::MaskStdID;
+    if (!is_correct_id(id)) {
+        return false;
+    }
+
+    // Must be exactly 8 bytes
+    if (frame.dlc != 8) {
+        return false;
+    }
+
+    // ---------------------------------------------------------------
+    // Byte 0–1: magic word (big-endian)
+    // ---------------------------------------------------------------
+    const uint16_t magic = be16toh_ptr(&frame.data[0]);
+    if (magic != JIYI_MAGIC) {
+        return false;
+    }
+
+    // ---------------------------------------------------------------
+    // Byte 2–3: message type word (big-endian)
+    // Only process distance-data frames; silently discard others.
+    // ---------------------------------------------------------------
+    const uint16_t msg_type = be16toh_ptr(&frame.data[2]);
+    if (msg_type != JIYI_MSG_DIST) {
+        return true;  // consumed but not a distance frame
+    }
+
+    // ---------------------------------------------------------------
+    // Byte 4–5: distance in centimetres (big-endian uint16)
+    // ---------------------------------------------------------------
+    const uint16_t dist_cm = be16toh_ptr(&frame.data[4]);
+
+    if (dist_cm == JIYI_NO_TARGET) {
+        // Sensor reports no target — do not update the distance
+        return true;
+    }
+
+    accumulate_distance_m(dist_cm * 0.01f);
+
+    return true;
+}
+
+#endif  // AP_RANGEFINDER_JIYI_CAN_ENABLED

--- a/libraries/AP_RangeFinder/AP_RangeFinder_JIYI_CAN.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_JIYI_CAN.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "AP_RangeFinder_config.h"
+
+#if AP_RANGEFINDER_JIYI_CAN_ENABLED
+
+#include "AP_RangeFinder_Backend_CAN.h"
+
+/*
+  Driver for JIYI Microbrain Intelligent millimeter-wave radar sensors
+  communicating over CAN at 500 Kbps.
+
+  Supported models:
+    - UAV-R21-1  Obstacle Avoidance Radar  (forward/rear, 79 GHz, 1.5–27 m)
+    - UAV-H30-1  Altitude Radar            (downward,    77 GHz, 0.2–27 m)
+
+  CAN frame format (both models, standard 11-bit ID, DLC = 8):
+    Byte 0–1 : Header / magic word  (0xEA 0x2D — big-endian)
+    Byte 2–3 : Message type word    (0x04 0x00 for distance data)
+    Byte 4–5 : Distance, cm         (uint16, big-endian; 0x0000 = no target)
+    Byte 6–7 : SNR / checksum       (informational, not used for ranging)
+
+  Default CAN IDs (standard frame):
+    UAV-R21-1 front  : 0x073C   (29-bit extended per datasheet,
+    UAV-R21-1 rear   : 0x074C    but observed data uses 11-bit standard 0x00D6)
+    UAV-H30-1        : 0x075C
+    Observed on bus  : 0x00D6   (confirmed from captured CSV data)
+
+  ArduPilot protocol registration: AP_CAN::Protocol::JIYI
+*/
+
+class AP_RangeFinder_JIYI_CAN : public AP_RangeFinder_Backend_CAN
+{
+public:
+    AP_RangeFinder_JIYI_CAN(RangeFinder::RangeFinder_State &_state,
+                             AP_RangeFinder_Params &_params)
+        : AP_RangeFinder_Backend_CAN(_state, _params,
+                                     AP_CAN::Protocol::JIYI,
+                                     "jiyi")
+    {}
+
+    // Return sensor type — both models are laser/radar rangefinders
+    MAV_DISTANCE_SENSOR _get_mav_distance_sensor_type() const override {
+        return MAV_DISTANCE_SENSOR_RADAR;
+    }
+
+    // Handle an incoming CAN frame; returns true if the frame was consumed
+    bool handle_frame(AP_HAL::CANFrame &frame) override;
+
+private:
+    // Magic word in bytes 0–1 (big-endian): 0xEA2D
+    static constexpr uint16_t JIYI_MAGIC     = 0xEA2D;
+
+    // Message-type word in bytes 2–3 that carries distance data: 0x0400
+    static constexpr uint16_t JIYI_MSG_DIST  = 0x0400;
+
+    // Sentinel value meaning "no target detected"
+    static constexpr uint16_t JIYI_NO_TARGET = 0x0000;
+};
+
+#endif  // AP_RANGEFINDER_JIYI_CAN_ENABLED


### PR DESCRIPTION
Adds a CAN rangefinder driver for two JIYI Microbrain radar sensors 
used in our indoor navigation stack:

- UAV-R21-1: forward obstacle avoidance (79 GHz, 1.5–27m)
- UAV-H30-1: downward altitude sensing (77 GHz, 0.2–27m)

Both sensors use the same 8-byte standard CAN frame (ID 0x00D6, 
500 Kbps). Protocol was decoded from captured bus data taken at 1m:
bytes 0-1 are a fixed magic word (0xEA2D), bytes 2-3 identify the 
message type, bytes 4-5 carry the distance in cm as a big-endian 
uint16, and bytes 6-7 are SNR/checksum. Zero in bytes 4-5 means 
no target detected.

Driver modeled on the existing Benewake CAN driver pattern.

Files added:
- libraries/AP_RangeFinder/AP_RangeFinder_JIYI_CAN.h
- libraries/AP_RangeFinder/AP_RangeFinder_JIYI_CAN.cpp

Modified:
- libraries/AP_CANManager/AP_CAN.h (Protocol::JIYI = 15)

Still needed for full build integration:
- enable macro in AP_RangeFinder_config.h
- include and instantiation case in AP_RangeFinder.cpp
- Type enum entry in AP_RangeFinder_Params.h
- @Values doc line in AP_RangeFinder_Params.cpp