### PR TITLE
Avoid use of fixed ports, offset numbers correctly

### DIFF
--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -1158,7 +1158,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
 
         self.progress("Connecting to telemetry port")
         mav2 = mavutil.mavlink_connection(
-            "tcp:localhost:5763",
+            "tcp:localhost:%u" % self.adjust_ardupilot_port(5763),
             robust_parsing=True,
             source_system=self.mav.source_system,
             source_component=self.mav.source_component,

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -3225,7 +3225,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             self.progress("ensure a mavlink1 connection can't do anything useful with new item types")
             self.set_parameter("SERIAL2_PROTOCOL", 1)
             self.reboot_sitl()
-            mav2 = mavutil.mavlink_connection("tcp:localhost:5763",
+            mav2 = mavutil.mavlink_connection("tcp:localhost:%u" % self.adjust_ardupilot_port(5763),
                                               robust_parsing=True,
                                               source_system=7,
                                               source_component=7)
@@ -3649,7 +3649,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.drain_mav()
 
         self.start_subtest("No clear mission while it is being uploaded by a different node")
-        mav2 = mavutil.mavlink_connection("tcp:localhost:5763",
+        mav2 = mavutil.mavlink_connection("tcp:localhost:%u" % self.adjust_ardupilot_port(5763),
                                           robust_parsing=True,
                                           source_system=7,
                                           source_component=7)
@@ -6408,7 +6408,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         # execute these commands:
         self.set_parameter("MAV3_OPTIONS", 2)
         self.reboot_sitl()  # mavlink-private is reboot-required
-        mav2 = mavutil.mavlink_connection("tcp:localhost:5763",
+        mav2 = mavutil.mavlink_connection("tcp:localhost:%u" % self.adjust_ardupilot_port(5763),
                                           robust_parsing=True,
                                           source_system=7,
                                           source_component=7)


### PR DESCRIPTION
### Summary

Stop using a fixed port number, allow the suite to adjust it if required

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Tested as part of autotest-parallel

### Description

When running in parallel you can't assume that 5763 is *your* ardupilot - so allow the suite to modify it  autotest-parallel adjusts the adjustment method to adjust the port number based on an instance ID.

