### PR TITLE
AP_AHRS: use configuredToUseGPSForPosXY for EKF3 gps-pos-source flag

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
@@ -175,7 +175,7 @@ void AP_AHRS_NavEKF3::get_results(AP_AHRS_Backend::Estimates &results)
     // true if GPS is configured as the horizontal position source
     // for this estimator.  Used to decide whether GPS will set
     // the navigation origin:
-    results.configured_to_use_gps_for_pos_XY = EKF3.configuredToUseGPSForPos();
+    results.configured_to_use_gps_for_pos_XY = EKF3.configuredToUseGPSForPosXY();
 
     // are we consuming yaw from an external (e.g. vision-based) source?
     results.using_extnav_for_yaw = EKF3.using_extnav_for_yaw();


### PR DESCRIPTION
### Summary

Makes EKF3 consistent with EKF2 in terms of setting Estimates state

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

The configured_to_use_gps_for_pos_XY estimate is documented as, and named for, "GPS is configured as the horizontal position source for this estimator".  EKF3 was populating it from
configuredToUseGPSForPos(), which is also true when GPS is configured only as the vertical (height) position source - unlike EKF2, which uses configuredToUseGPSForPosXY().

The sole consumer, use_recorded_origin_maybe(), uses this flag to decide whether to fall back to a recorded origin: when GPS is only the height source it will not set the horizontal origin, so the recorded origin should be used.  Align EKF3 with the field name and documentation, and with EKF2's population of the same field.

This was noted as a deferred change during review of the move of these source methods into the backend estimates structure.


Problem was missed in review of https://github.com/ArduPilot/ardupilot/commit/55a6b081ce6062f724eb784f399093e3f17c1a49

Problem was noticed in https://github.com/ArduPilot/ardupilot/pull/33292#pullrequestreview-4409530957 and I suggested I would fix it as a separate PR.  Which is what this is.
