### PR TITLE
AC_AutoTune: don't run level-timeout while yaw target is slewing to desired

### DIFF
--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -487,6 +487,58 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.wait_disarmed()
         self.reboot_sitl()  # far from home
 
+    def QAUTOTUNEYawRepoint(self):
+        '''check QAutoTune survives a slow position-hold yaw re-point'''
+        # Each tuning twitch displaces the vehicle a little; beyond 5m
+        # of drift autotune's position hold commands a yaw re-point
+        # along the drift direction (+90deg while tuning pitch).  With
+        # a low yaw target acceleration that re-point's traverse takes
+        # longer than the failed-to-level timeout while remaining below
+        # the yaw-rate-based timeout deferral threshold, so autotune
+        # must not run the level timeout while the yaw target is still
+        # slewing towards the desired yaw.
+        self.set_parameters({
+            "Q_A_ACC_Y_MAX": 5,
+            "Q_AUTOTUNE_AXES": 3,  # roll and pitch only
+            # adjust tune so QAUTOTUNE can cope:
+            "Q_AUTOTUNE_AGGR": 0.1,
+            "Q_AUTOTUNE_MIN_D": 0.0004,
+            "Q_A_RAT_RLL_P": 0.15,
+            "Q_A_RAT_RLL_I": 0.25,
+            "Q_A_RAT_RLL_D": 0.002,
+            "Q_A_RAT_PIT_P": 0.15,
+            "Q_A_RAT_PIT_I": 0.25,
+            "Q_A_RAT_PIT_D": 0.002,
+            "Q_A_RAT_YAW_P": 0.18,
+            "Q_A_RAT_YAW_I": 0.018,
+            "Q_A_ANG_RLL_P": 4.5,
+            "Q_A_ANG_PIT_P": 4.5,
+        })
+
+        self.takeoff(15, mode='GUIDED')
+        self.hover()
+        self.change_mode("QLOITER")
+        tstart = self.get_sim_time()
+        self.context_collect('STATUSTEXT')
+        self.change_mode("QAUTOTUNE")
+        self.wait_text(
+            "AutoTune: (Success|Failed to level).*",
+            timeout=5000,
+            check_context=True,
+            regex=True,
+        )
+        if self.re_match.group(1) != "Success":
+            raise NotAchievedException("autotune did not succeed")
+        self.progress("AUTOTUNE OK (%u seconds)" % (self.get_sim_time() - tstart))
+
+        # leave QAUTOTUNE before disarming so the tuned gains are not saved
+        self.change_mode("QLOITER")
+        self.disarm_vehicle(force=True)
+        self.reboot_sitl()  # may have drifted far from home
+
+    def hover(self, hover_throttle=1500):
+        self.set_rc(3, hover_throttle)
+
     def takeoff(self, height, mode, timeout=30):
         """climb to specified height and set throttle to 1500"""
         self.set_current_waypoint(0, check_afterwards=False)
@@ -3252,6 +3304,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             self.PilotYaw,
             self.ParameterChecks,
             self.QAUTOTUNE,
+            self.QAUTOTUNEYawRepoint,
             self.TestLogDownload,
             self.TestLogDownloadWrap,
             self.EXTENDED_SYS_STATE,

--- a/libraries/AC_AutoTune/AC_AutoTune.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune.cpp
@@ -332,6 +332,15 @@ bool AC_AutoTune::currently_level()
         // reset if the target yaw rate is above half the slew rate
         level_start_time_ms = now_ms;
     }
+    if (fabsf(wrap_PI(attitude_control->get_att_target_euler_rad().z - desired_yaw_rad)) > cd_to_rad(AUTOTUNE_LEVEL_ANGLE_CD)) {
+        // the attitude controller is still slewing its yaw target towards
+        // desired_yaw_rad (e.g. after position-hold commands a large
+        // re-point); the vehicle cannot be at the desired yaw until the
+        // commanded target arrives there, so do not run the level timeout.
+        // The rate check above does not catch this: a long smooth re-point
+        // runs well below half the slew rate.
+        level_start_time_ms = now_ms;
+    }
     if (now_ms - level_start_time_ms > 3 * AUTOTUNE_LEVEL_TIMEOUT_MS) {
         GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "AutoTune: Failed to level, please tune manually");
         mode = TuneMode::FAILED;


### PR DESCRIPTION
### Summary

Stops intermittent failure of QAUTOTUNE test (and probably problem on real aircraft, depending on their control)

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Contains an autotest which fails reliably before and reliably passes after.  In case the offered solution sucks.

### Description

When position hold commands a large yaw re-point (get_poshold_attitude points along the drift direction, +90deg when tuning pitch), the attitude controller slews its yaw target towards the new desired yaw over several seconds.  currently_level() measures yaw against the final desired yaw, so it reports not-level for the whole traverse and the 3 * AUTOTUNE_LEVEL_TIMEOUT_MS abort clock races the traverse: a ~125deg re-point at the ~25deg/s shaped slew rate takes ~5.5s against the 6s abort, and on the losing side of the race the tune dies with "AutoTune: Failed to level, please tune manually".

The existing guard ([eb3c110ad9](https://github.com/ArduPilot/ardupilot/commit/eb3c110ad94e25a9ee61d5d6913c00aa342386dc)) resets the clock when the target yaw rate exceeds half the slew limit, but a long smooth re-point runs well below that: in a failing QuadPlane CI log the shaped rate peaked around 28deg/s against a 30deg/s threshold (MIN(Q_A_RATE_Y_MAX=75, Q_A_RATE_WPY_MAX=60)/2), the clock was never reset and the abort fired exactly 6.000s after the level-wait began -- 0.2s before yaw would have arrived; roll and pitch were within 0.1deg throughout.

Also reset the clock while the shaped yaw target is more than the level threshold away from desired_yaw_rad: the vehicle cannot possibly be at the desired yaw before its commanded target arrives there, so the timeout should only run once success is geometrically possible.  A genuinely-unable-to-level vehicle still aborts: target shaping converges regardless of the vehicle response, after which the clock runs normally.

This was the cause of intermittent Plane QAUTOTUNE autotest failures ("Pitch Angle P Up 0%" repeated, then failure): repeated twitches drift the vehicle >5m, triggering the re-point.  Validation:
- natural conditions: stock failed 1/25 (unloaded) and 3/25 (host CPU contention); fixed passed 100/100 (50 unloaded + 50 under contention)
- deterministic repro (Q_A_ACC_Y_MAX=5 slows the traverse past the 6s timeout while staying under the rate-guard threshold): stock fails 8/8 with "Failed to level", fixed succeeds 8/8

```
  ┌─────────────────────┬───────────────────────┬─────────────────────────┐
  │      condition      │         stock         │          fixed          │
  ├─────────────────────┼───────────────────────┼─────────────────────────┤
  │ natural, unloaded   │ 1/25 fail             │ 50/50 pass              │
  ├─────────────────────┼───────────────────────┼─────────────────────────┤
  │ natural, stress-ng  │ 3/25 fail             │ 50/50 pass              │
  ├─────────────────────┼───────────────────────┼─────────────────────────┤
  │ deterministic repro │ 8/8 "Failed to level" │ 8/8 "AutoTune: Success" │
  └─────────────────────┴───────────────────────┴─────────────────────────┘
```
