### PR TITLE
Update AHRS output reset information when estimator changes

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -310,8 +310,8 @@ private:
 #endif
 
 
-    // system time in milliseconds of last recorded yaw reset from ekf
-    uint32_t ekfYawReset_ms;
+    // old value of counter which increments when our yaw estimate is reset
+    uint16_t ahrs_yaw_reset_count;
     // old value of counter which increments when our attitude estimate is reset
     uint16_t attitude_reset_count;
 

--- a/ArduCopter/ekf_check.cpp
+++ b/ArduCopter/ekf_check.cpp
@@ -249,11 +249,10 @@ void Copter::check_ekf_reset()
 {
     // check for yaw reset
     float yaw_angle_change_rad;
-    uint32_t new_ekfYawReset_ms = ahrs.getLastYawResetAngle(yaw_angle_change_rad);
-    if (new_ekfYawReset_ms != ekfYawReset_ms) {
+    const uint16_t new_yaw_reset_count = ahrs.get_yaw_reset_count(yaw_angle_change_rad);
+    if (new_yaw_reset_count != ahrs_yaw_reset_count) {
         attitude_control->inertial_frame_reset();
-        ekfYawReset_ms = new_ekfYawReset_ms;
-        LOGGER_WRITE_EVENT(LogEvent::EKF_YAW_RESET);
+        ahrs_yaw_reset_count = new_yaw_reset_count;
     }
 
     // check for change in primary EKF, reset attitude target and log.  AC_PosControl handles position target adjustment

--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -764,11 +764,10 @@ void Plane::check_ahrs_reset()
 
     // Check for yaw reset
     float yaw_angle_change_rad;
-    const uint32_t yaw_reset_ms = ahrs.getLastYawResetAngle(yaw_angle_change_rad);
-    if (ahrs_check.last_yaw_reset_ms != yaw_reset_ms) {
+    const uint16_t new_yaw_reset_count = ahrs.get_yaw_reset_count(yaw_angle_change_rad);
+    if (ahrs_check.ahrs_yaw_reset_count != new_yaw_reset_count) {
         should_reset = true;
-        ahrs_check.last_yaw_reset_ms = yaw_reset_ms;
-        LOGGER_WRITE_EVENT(LogEvent::EKF_YAW_RESET);
+        ahrs_check.ahrs_yaw_reset_count = new_yaw_reset_count;
     }
 
     // check for change in primary EKF, or EKF lane.

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -938,7 +938,7 @@ private:
     // Check if there has been a change in attitude estimate which the attitude controllers should be told about
     void check_ahrs_reset();
     struct {
-        uint32_t last_yaw_reset_ms;
+        uint16_t ahrs_yaw_reset_count;
         uint16_t attitude_reset_count;
     } ahrs_check;
 

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2306,7 +2306,7 @@ void QuadPlane::PosControlState::set_state(enum position_control_state s)
         } else if (s == QPOS_LAND_FINAL) {
             // remember last pos reset to handle GPS glitch in LAND_FINAL
             Vector2f rpos;
-            last_pos_reset_ms = plane.ahrs.getLastPosNorthEastReset(rpos);
+            ahrs_position_NE_reset_count = plane.ahrs.get_position_NE_reset_count(rpos);
             qp.landing_detect.land_start_ms = 0;
             qp.landing_detect.lower_limit_start_ms = 0;
         }
@@ -2762,7 +2762,7 @@ void QuadPlane::vtol_position_controller(void)
             Vector2f zero;
             Vector2f vel_ne_ms = poscontrol.target_vel_ms.xy() + landing_velocity_ne_ms;
             Vector2f rpos;
-            const uint32_t last_reset_ms = plane.ahrs.getLastPosNorthEastReset(rpos);
+            const uint16_t last_reset_count = plane.ahrs.get_position_NE_reset_count(rpos);
             /* we use velocity control when we may be touching the
               ground or if we've had a position reset from AHRS. This
               helps us handle a GPS glitch in the final land phase,
@@ -2770,7 +2770,7 @@ void QuadPlane::vtol_position_controller(void)
             */
             if (motors->limit.throttle_lower ||
                 motors->get_throttle() < 0.5*motors->get_throttle_hover() ||
-                last_reset_ms != poscontrol.last_pos_reset_ms) {
+                last_reset_count != poscontrol.ahrs_position_NE_reset_count) {
                 pos_control->input_vel_accel_NE_m(vel_ne_ms, zero);
             } else {
                 // otherwise use full pos control

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -522,7 +522,7 @@ private:
         uint32_t last_velocity_match_ms;
         float target_speed_ms;
         float target_accel_mss;
-        uint32_t last_pos_reset_ms;
+        uint16_t ahrs_position_NE_reset_count;
         bool overshoot;
 
         float override_descent_rate_ms;

--- a/ArduSub/Attitude.cpp
+++ b/ArduSub/Attitude.cpp
@@ -44,10 +44,10 @@ float Sub::get_pilot_desired_yaw_rate(int16_t stick_angle) const
 void Sub::check_ekf_yaw_reset()
 {
     float yaw_angle_change_rad;
-    uint32_t new_ekfYawReset_ms = ahrs.getLastYawResetAngle(yaw_angle_change_rad);
-    if (new_ekfYawReset_ms != ekfYawReset_ms) {
+    const uint16_t new_ahrs_yaw_reset_count = ahrs.get_yaw_reset_count(yaw_angle_change_rad);
+    if (new_ahrs_yaw_reset_count != ahrs_yaw_reset_count) {
         attitude_control.inertial_frame_reset();
-        ekfYawReset_ms = new_ekfYawReset_ms;
+        ahrs_yaw_reset_count = new_ahrs_yaw_reset_count;
     }
 }
 

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -170,8 +170,8 @@ private:
     AP_OSD osd;
 #endif
 
-    // system time in milliseconds of last recorded yaw reset from ekf
-    uint32_t ekfYawReset_ms = 0;
+    // count number of times the AHRS yaw has been reset:
+    uint16_t ahrs_yaw_reset_count;
 
     // GCS selection
     GCS_Sub _gcs; // avoid using this; use gcs()

--- a/Blimp/Blimp.cpp
+++ b/Blimp/Blimp.cpp
@@ -57,8 +57,6 @@ const AP_Scheduler::Task Blimp::scheduler_tasks[] = {
     FAST_TASK(read_AHRS),
     // Inertial Nav
     FAST_TASK(read_inertia),
-    // check if ekf has reset target heading or position
-    FAST_TASK(check_ekf_reset),
     // run the attitude controllers
     FAST_TASK(update_flight_mode),
     // update home from EKF if necessary

--- a/Blimp/Blimp.h
+++ b/Blimp/Blimp.h
@@ -115,9 +115,6 @@ private:
     // Arming/Disarming management class
     AP_Arming_Blimp arming;
 
-    // system time in milliseconds of last recorded yaw reset from ekf
-    uint32_t ekfYawReset_ms;
-
     // vibration check
     struct {
         bool high_vibes;    // true while high vibration are detected
@@ -293,7 +290,6 @@ private:
     bool ekf_over_threshold();
     void failsafe_ekf_event();
     void failsafe_ekf_off_event(void);
-    void check_ekf_reset();
     void check_vibration();
 
     // events.cpp

--- a/Blimp/ekf_check.cpp
+++ b/Blimp/ekf_check.cpp
@@ -174,18 +174,6 @@ void Blimp::failsafe_ekf_off_event(void)
     LOGGER_WRITE_ERROR(LogErrorSubsystem::FAILSAFE_EKFINAV, LogErrorCode::FAILSAFE_RESOLVED);
 }
 
-// check for ekf yaw reset and adjust target heading, also log position reset
-void Blimp::check_ekf_reset()
-{
-    // check for yaw reset
-    float yaw_angle_change_rad;
-    uint32_t new_ekfYawReset_ms = ahrs.getLastYawResetAngle(yaw_angle_change_rad);
-    if (new_ekfYawReset_ms != ekfYawReset_ms) {
-        ekfYawReset_ms = new_ekfYawReset_ms;
-        LOGGER_WRITE_EVENT(LogEvent::EKF_YAW_RESET);
-    }
-}
-
 // check for high vibrations affecting altitude control
 void Blimp::check_vibration()
 {

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -12012,6 +12012,64 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.do_RTL()
 
+    def AHRSSwitchBackendYawReset(self):
+        '''vehicle must not spin when the active AHRS estimator is changed with divergent yaws'''
+        # fly with a mis-oriented compass and the GSF emergency yaw
+        # reset disabled so EKF3's yaw estimate is persistently wrong,
+        # while the SIM backend continues to report truth.  Switching
+        # estimators then implies a yaw reset which must be handled by
+        # the attitude controller or the vehicle physically rotates to
+        # chase the apparent heading error.
+        self.context_push()
+        self.set_parameters({
+            "COMPASS_ORIENT": 1,    # yaw 45 degrees
+            "COMPASS_USE2": 0,      # disable backup compasses to avoid pre-arm failures
+            "COMPASS_USE3": 0,
+            "EK3_GSF_USE_MASK": 0,  # do not let the GSF fix the bad yaw
+            "FS_EKF_THRESH": 1,     # the bad yaw inflates variances; don't failsafe
+        })
+        self.reboot_sitl()
+
+        self.takeoff(20, mode='GUIDED')
+
+        # hold in LOITER; poor position hold (toilet-bowling) is
+        # expected with this much yaw error:
+        self.set_rc(3, 1500)
+        self.change_mode('LOITER')
+        self.delay_sim_time(10, reason="let the vehicle settle in LOITER")
+
+        estimated_yaw_deg = self.get_heading()
+        truth_yaw_deg = math.degrees(self.assert_receive_message('SIMSTATE').yaw)
+        divergence = self.heading_delta(estimated_yaw_deg, truth_yaw_deg)
+        self.progress(f"truth_yaw={truth_yaw_deg:.1f} estimated_yaw={estimated_yaw_deg:.1f} divergence={divergence:.1f}")
+        if divergence < 18:
+            raise PreconditionFailedException(f"yaw estimates did not diverge ({divergence:.1f}deg)")
+
+        start_truth_yaw_deg = math.degrees(self.assert_receive_message('SIMSTATE').yaw)
+        self.context_collect('STATUSTEXT')
+        self.progress("Switching active estimator from EKF3 to SIM")
+        self.set_parameter("AHRS_EKF_TYPE", 10)
+        self.wait_statustext("AHRS: SIM active", check_context=True, timeout=10)
+
+        # the vehicle must not physically rotate; an unhandled yaw
+        # reset makes the attitude controller rotate the vehicle by
+        # the divergence to chase its stale yaw target:
+        rotated = 0
+        tstart = self.get_sim_time()
+        while self.get_sim_time() - tstart < 20:
+            current_truth_yaw_deg = math.degrees(self.assert_receive_message('SIMSTATE').yaw)
+            rotated = self.heading_delta(current_truth_yaw_deg, start_truth_yaw_deg)
+            self.progress(f"truth_yaw={current_truth_yaw_deg:.1f} rotated={rotated:.1f}")
+            if rotated > 20:
+                raise NotAchievedException(f"Vehicle rotated {rotated:.1f}deg after estimator switch")
+        if rotated > 10:
+            raise NotAchievedException(f"Vehicle heading displaced {rotated:.1f}deg by estimator switch")
+        self.progress("Vehicle heading held across estimator switch")
+
+        self.do_RTL()
+        self.context_pop()
+        self.reboot_sitl()
+
     def EKFYawResetLogged(self):
         '''in-filter EKF yaw resets must propagate through AHRS and be logged'''
         self.context_push()
@@ -18294,6 +18352,7 @@ return update, 1000
             self.GSF_reset,
             self.EKFBootstrapReset,
             self.AHRSSwitchBackendPositionNEReset,
+            self.AHRSSwitchBackendYawReset,
             self.EK3SrcSwitchPosDownReset,
             self.EKFYawResetLogged,
             self.AP_Avoidance,

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -11893,6 +11893,162 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.do_RTL()
 
+    def AHRSSwitchBackendPositionNEReset(self):
+        '''vehicle must not lurch when the active AHRS estimator is changed with divergent NE positions'''
+        # glitch the GPS; EKF3 eventually adopts the glitched position
+        # while the SIM backend continues to report truth.  Switching
+        # estimators then implies a large NE position reset which must
+        # be handled by the position controller.
+        self.set_parameter("FS_EKF_THRESH", 1)  # avoid EKF failsafe while the glitch is being rejected
+        self.takeoff(20, mode='GUIDED')
+
+        # hold in LOITER; unlike GUIDED it moves the position target,
+        # not the vehicle, when handling an estimate reset:
+        self.set_rc(3, 1500)
+        self.change_mode('LOITER')
+
+        self.progress("Applying GPS glitch")
+        self.set_parameter("SIM_GPS1_GLTCH_X", 0.0003)  # ~33m north
+
+        self.progress("Waiting for EKF3 to adopt the glitched position")
+        tstart = self.get_sim_time()
+        divergence = 0
+        while divergence < 15:
+            if self.get_sim_time_cached() - tstart > 120:
+                raise PreconditionFailedException(f"estimates did not diverge ({divergence:.1f}m)")
+            divergence = self.get_distance(self.sim_location(), self.get_mav_location())
+            self.progress(f"NE divergence={divergence:.1f}m")
+        self.delay_sim_time(10, reason="let position controller settle after glitch adoption")
+
+        start_loc = self.sim_location()
+        self.context_collect('STATUSTEXT')
+        self.progress("Switching active estimator from EKF3 to SIM")
+        self.set_parameter("AHRS_EKF_TYPE", 10)
+        self.wait_statustext("AHRS: SIM active", check_context=True, timeout=10)
+
+        # the vehicle must stay physically put; an unhandled reset
+        # leaves it permanently displaced by the position controller's
+        # error limit:
+        moved = 0
+        tstart = self.get_sim_time()
+        while self.get_sim_time() - tstart < 20:
+            moved = self.get_distance(start_loc, self.sim_location())
+            self.progress(f"moved={moved:.1f}m")
+            if moved > 8:
+                raise NotAchievedException(f"Vehicle lurched {moved:.1f}m after estimator switch")
+        if moved > 3:
+            raise NotAchievedException(f"Vehicle displaced {moved:.1f}m by estimator switch")
+        self.progress("Vehicle stayed put across estimator switch")
+
+        # remove the glitch and switch back to EKF3 - yet another
+        # reset which must be handled.  Flying home on EKF3 also
+        # ensures we navigate in the frame home was recorded in:
+        self.set_parameter("SIM_GPS1_GLTCH_X", 0)
+        self.set_parameter("AHRS_EKF_TYPE", 3)
+        self.wait_statustext("AHRS: EKF3 active", check_context=True, timeout=10)
+
+        # wait for EKF3 to shed the glitch so the vehicle agrees with
+        # truth about where it is:
+        tstart = self.get_sim_time()
+        while True:
+            residual = self.get_distance(self.sim_location(), self.get_mav_location())
+            self.progress(f"post-switch-back residual={residual:.1f}m")
+            if residual < 5:
+                break
+            if self.get_sim_time_cached() - tstart > 60:
+                raise NotAchievedException(f"EKF3 did not shed the GPS glitch (residual={residual:.1f}m)")
+
+        self.do_RTL()
+
+    def EK3SrcSwitchPosDownReset(self):
+        '''in-filter EKF position-down resets must be handled by the position controller'''
+        # EKF3 uses the baro for height by default; drift the baro,
+        # then switch EKF3's height source to GPS mid-flight.  EKF3
+        # performs an in-filter position-down reset (ResetPositionD)
+        # which must flow through the AHRS reset counters to the
+        # position controller.
+        self.takeoff(30, mode='GUIDED')
+        self.set_rc(3, 1500)
+        self.change_mode('LOITER')
+
+        self.progress("Diverging EKF3 altitude from truth using baro drift")
+        self.set_parameter("SIM_BARO_DRIFT", -0.3)
+        self.delay_sim_time(75, reason="allow altitude estimates to diverge")
+        self.set_parameter("SIM_BARO_DRIFT", 0)
+        self.wait_climbrate(-0.1, 0.1, minimum_duration=10, timeout=60)
+
+        truth_alt = self.get_altitude(altitude_source='SIM_STATE.alt')
+        estimated_alt = self.get_altitude(altitude_source='GLOBAL_POSITION_INT.alt')
+        divergence = abs(truth_alt - estimated_alt)
+        self.progress(f"truth_alt={truth_alt:.1f} estimated_alt={estimated_alt:.1f} divergence={divergence:.1f}")
+        if divergence < 8:
+            raise PreconditionFailedException(f"estimates did not diverge ({divergence:.1f}m)")
+
+        self.progress("Switching EKF3 height source to GPS")
+        self.set_parameter("EK3_SRC1_POSZ", 3)
+
+        # EKF3 resets its height estimate to the GPS altitude; the
+        # vehicle must stay physically put:
+        moved = 0
+        tstart = self.get_sim_time()
+        while self.get_sim_time() - tstart < 20:
+            current_truth_alt = self.get_altitude(altitude_source='SIM_STATE.alt')
+            moved = abs(current_truth_alt - truth_alt)
+            self.progress(f"truth_alt={current_truth_alt:.1f} moved={moved:.1f}")
+            if moved > 5:
+                raise NotAchievedException(f"Vehicle lurched {moved:.1f}m after height source switch")
+        if moved > 1.5:
+            raise NotAchievedException(f"Vehicle displaced {moved:.1f}m by height source switch")
+
+        # confirm the EKF actually adopted the GPS height, else the
+        # test is vacuous:
+        estimated_alt = self.get_altitude(altitude_source='GLOBAL_POSITION_INT.alt')
+        current_truth_alt = self.get_altitude(altitude_source='SIM_STATE.alt')
+        residual = abs(current_truth_alt - estimated_alt)
+        self.progress(f"post-switch estimate residual={residual:.1f}m")
+        if residual > 5:
+            raise NotAchievedException(f"EKF3 did not adopt GPS height (residual {residual:.1f}m)")
+        self.progress("In-filter height reset handled cleanly")
+
+        self.do_RTL()
+
+    def EKFYawResetLogged(self):
+        '''in-filter EKF yaw resets must propagate through AHRS and be logged'''
+        self.context_push()
+        self.set_parameters({
+            "COMPASS_ORIENT": 4,    # yaw 180
+            "COMPASS_USE2": 0,      # disable backup compasses to avoid pre-arm failures
+            "COMPASS_USE3": 0,
+        })
+        self.reboot_sitl()
+        self.change_mode('GUIDED')
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+        self.user_takeoff(alt_min=5)
+
+        # the mis-oriented compass causes an in-filter emergency yaw
+        # reset shortly after takeoff:
+        self.wait_text("EKF3 IMU. emergency yaw reset", timeout=5, regex=True)
+        self.delay_sim_time(5, reason="let the event reach the log")
+        self.do_RTL()
+
+        # the EKF's internal yaw reset must be noticed by AHRS, which
+        # logs an EKF_YAW_RESET event:
+        dfreader = self.dfreader_for_current_onboard_log()
+        armed = False
+        while True:
+            m = dfreader.recv_match(type='EV')
+            if m is None:
+                raise NotAchievedException("Did not find EKF_YAW_RESET event after arming")
+            if m.Id == 10:  # LogEvent::ARMED
+                armed = True
+            if armed and m.Id == 62:  # LogEvent::EKF_YAW_RESET
+                break
+        self.progress("Found EKF_YAW_RESET event in log")
+
+        self.context_pop()
+        self.reboot_sitl()
+
     def FlyRangeFinderMAVlink(self):
         '''fly mavlink-connected rangefinder'''
         self.fly_rangefinder_mavlink_distance_sensor()
@@ -18137,6 +18293,9 @@ return update, 1000
             self.GSF,
             self.GSF_reset,
             self.EKFBootstrapReset,
+            self.AHRSSwitchBackendPositionNEReset,
+            self.EK3SrcSwitchPosDownReset,
+            self.EKFYawResetLogged,
             self.AP_Avoidance,
             self.RTL_ALT_FINAL_M,
             self.SMART_RTL,

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -11893,6 +11893,62 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.do_RTL()
 
+    def AHRSSwitchBackendPositionReset(self):
+        '''vehicle must not lurch when the active AHRS estimator is changed in flight'''
+        # drift the baro so EKF3's altitude estimate (baro-based by
+        # default) diverges from truth, then switch to the SIM backend,
+        # which always reports truth.  The jump in the published
+        # altitude estimate must be handled as a position reset by the
+        # position controller or the vehicle will aggressively
+        # "correct" the apparent altitude error.
+        self.takeoff(30, mode='GUIDED')
+
+        # hold in LOITER; unlike GUIDED it moves the position target,
+        # not the vehicle, when handling an estimate reset:
+        self.set_rc(3, 1500)
+        self.change_mode('LOITER')
+
+        self.progress("Diverging EKF3 altitude from truth using baro drift")
+        self.set_parameter("SIM_BARO_DRIFT", -0.3)
+        self.delay_sim_time(75, reason="allow altitude estimates to diverge")
+        # baro drift accumulates in the simulator, so zeroing the rate
+        # freezes the accumulated offset:
+        self.set_parameter("SIM_BARO_DRIFT", 0)
+        # the vehicle chases the drifting estimate, so let it settle:
+        self.wait_climbrate(-0.1, 0.1, minimum_duration=10, timeout=60)
+
+        truth_alt = self.get_altitude(altitude_source='SIM_STATE.alt')
+        estimated_alt = self.get_altitude(altitude_source='GLOBAL_POSITION_INT.alt')
+        divergence = abs(truth_alt - estimated_alt)
+        self.progress(f"truth_alt={truth_alt:.1f} estimated_alt={estimated_alt:.1f} divergence={divergence:.1f}")
+        if divergence < 8:
+            raise PreconditionFailedException(f"estimates did not diverge ({divergence:.1f}m)")
+
+        self.context_collect('STATUSTEXT')
+        self.progress("Switching active estimator from EKF3 to SIM")
+        self.set_parameter("AHRS_EKF_TYPE", 10)
+        self.wait_statustext("AHRS: SIM active", check_context=True, timeout=10)
+
+        # the vehicle must stay physically put.  If the switch is not
+        # handled as a reset the position controller's error limit
+        # rebases the target onto the new estimate, but that still
+        # leaves the vehicle permanently displaced by the error limit
+        # (~2.5m); a properly-handled reset moves the target instead,
+        # so the vehicle does not move at all:
+        moved = 0
+        tstart = self.get_sim_time()
+        while self.get_sim_time() - tstart < 20:
+            current_truth_alt = self.get_altitude(altitude_source='SIM_STATE.alt')
+            moved = abs(current_truth_alt - truth_alt)
+            self.progress(f"truth_alt={current_truth_alt:.1f} moved={moved:.1f}")
+            if moved > 5:
+                raise NotAchievedException(f"Vehicle lurched {moved:.1f}m after estimator switch")
+        if moved > 1.5:
+            raise NotAchievedException(f"Vehicle displaced {moved:.1f}m by estimator switch")
+        self.progress("Vehicle stayed put across estimator switch")
+
+        self.do_RTL()
+
     def AHRSSwitchBackendPositionNEReset(self):
         '''vehicle must not lurch when the active AHRS estimator is changed with divergent NE positions'''
         # glitch the GPS; EKF3 eventually adopts the glitched position
@@ -18351,6 +18407,7 @@ return update, 1000
             self.GSF,
             self.GSF_reset,
             self.EKFBootstrapReset,
+            self.AHRSSwitchBackendPositionReset,
             self.AHRSSwitchBackendPositionNEReset,
             self.AHRSSwitchBackendYawReset,
             self.EK3SrcSwitchPosDownReset,

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -3306,12 +3306,95 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
                 f"SERVO17_FUNCTION default: expected {k_motor1} got {got}"
             )
 
+    def AHRSSwitchBackendResets(self):
+        '''vehicle must not move or rotate when the active AHRS estimator changes to a divergent backend'''
+        # fly on the SIM backend, which reports truth, while DCM's
+        # estimates are made to diverge on all axes: a mis-oriented
+        # compass corrupts its yaw, a GPS glitch its position and baro
+        # drift its altitude.  Neither backend supplies reset
+        # timestamps, so before AHRS kept reset counts a switch
+        # between them was undetectable and the attitude and position
+        # controllers chased their now-stale targets.
+        self.set_parameter("AHRS_EKF_TYPE", 10)
+        self.reboot_sitl()
+
+        self.takeoff(20, mode='QLOITER')
+
+        self.progress("Diverging DCM estimates from truth on all axes")
+        self.set_parameters({
+            "COMPASS_ORIENT": 1,        # yaw 45 degrees; corrupts DCM yaw
+            "SIM_GPS1_GLTCH_X": 0.0003,  # ~33m north; corrupts DCM position
+            "SIM_BARO_DRIFT": -0.3,     # corrupts DCM altitude
+        })
+        self.delay_sim_time(60, reason="allow DCM estimates to diverge")
+        # baro drift accumulates in the simulator, so zeroing the rate
+        # freezes the accumulated offset:
+        self.set_parameter("SIM_BARO_DRIFT", 0)
+        self.delay_sim_time(5, reason="let things settle")
+
+        truth_yaw_deg = math.degrees(self.assert_receive_message('SIMSTATE').yaw)
+        truth_loc = self.sim_location()
+        truth_alt = self.get_altitude(altitude_source='SIM_STATE.alt')
+
+        self.context_collect('STATUSTEXT')
+        self.progress("Switching active estimator from SIM to DCM")
+        self.set_parameter("AHRS_EKF_TYPE", 0)
+        self.wait_statustext("AHRS: DCM active", check_context=True, timeout=10)
+
+        # ensure the switch really implied resets on each axis, else
+        # this test is vacuous:
+        yaw_divergence = self.heading_delta(self.get_heading(), truth_yaw_deg)
+        ne_divergence = self.get_distance(self.get_mav_location(), truth_loc)
+        alt_divergence = abs(self.get_altitude(altitude_source='GLOBAL_POSITION_INT.alt') - truth_alt)
+        self.progress(f"divergences: yaw={yaw_divergence:.1f}deg NE={ne_divergence:.1f}m alt={alt_divergence:.1f}m")
+        if yaw_divergence < 20:
+            raise PreconditionFailedException(f"yaw estimates did not diverge ({yaw_divergence:.1f}deg)")
+        if ne_divergence < 15:
+            raise PreconditionFailedException(f"NE estimates did not diverge ({ne_divergence:.1f}m)")
+        if alt_divergence < 8:
+            raise PreconditionFailedException(f"altitude estimates did not diverge ({alt_divergence:.1f}m)")
+
+        # the vehicle must stay physically put on all axes; unhandled
+        # resets rotate the vehicle to chase its stale yaw target and
+        # leave it displaced by the position controller error limits:
+        rotated = 0
+        moved_ne = 0
+        moved_alt = 0
+        tstart = self.get_sim_time()
+        while self.get_sim_time() - tstart < 20:
+            rotated = self.heading_delta(math.degrees(self.assert_receive_message('SIMSTATE').yaw), truth_yaw_deg)
+            moved_ne = self.get_distance(truth_loc, self.sim_location())
+            moved_alt = abs(self.get_altitude(altitude_source='SIM_STATE.alt') - truth_alt)
+            self.progress(f"rotated={rotated:.1f}deg moved_ne={moved_ne:.1f}m moved_alt={moved_alt:.1f}m")
+            if rotated > 20:
+                raise NotAchievedException(f"Vehicle rotated {rotated:.1f}deg after estimator switch")
+            if moved_ne > 8:
+                raise NotAchievedException(f"Vehicle lurched {moved_ne:.1f}m horizontally after estimator switch")
+            if moved_alt > 5:
+                raise NotAchievedException(f"Vehicle lurched {moved_alt:.1f}m vertically after estimator switch")
+        if rotated > 10:
+            raise NotAchievedException(f"Vehicle heading displaced {rotated:.1f}deg by estimator switch")
+        if moved_ne > 3:
+            raise NotAchievedException(f"Vehicle displaced {moved_ne:.1f}m horizontally by estimator switch")
+        if moved_alt > 1.5:
+            raise NotAchievedException(f"Vehicle displaced {moved_alt:.1f}m vertically by estimator switch")
+        self.progress("Vehicle stayed put across estimator switch")
+
+        # return to sane estimates before coming home:
+        self.set_parameters({
+            "COMPASS_ORIENT": 0,
+            "SIM_GPS1_GLTCH_X": 0,
+            "AHRS_EKF_TYPE": 10,
+        })
+        self.do_RTL()
+
     def tests(self):
         '''return list of all tests'''
 
         ret = super(AutoTestQuadPlane, self).tests()
         ret.extend([
             self.FwdThrInVTOL,
+            self.AHRSSwitchBackendResets,
             self.AirMode,
             self.TestMotorMask,
             self.PilotYaw,

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -1683,7 +1683,7 @@ float AC_PosControl::calculate_overspeed_gain()
 void AC_PosControl::NE_init_ekf_reset()
 {
     Vector2f pos_shift;
-    _ekf_ne_reset_ms = _ahrs.getLastPosNorthEastReset(pos_shift);
+    _ahrs_position_NE_reset_count = _ahrs.get_position_NE_reset_count(pos_shift);
 }
 
 // Handles NE position reset detection and response (e.g., clearing accumulated errors).
@@ -1691,11 +1691,11 @@ void AC_PosControl::NE_handle_ekf_reset()
 {
     // Check for EKF-reported NE position shift since last update
     Vector2f pos_shift_ne_m;
-    uint32_t reset_ms = _ahrs.getLastPosNorthEastReset(pos_shift_ne_m);
+    const uint16_t reset_count = _ahrs.get_position_NE_reset_count(pos_shift_ne_m);
     // todo: the actual difference in position and velocity estimation.
     // This will prevent the need to pause error calculation for one cycle.
 
-    if (reset_ms != _ekf_ne_reset_ms) {
+    if (reset_count != _ahrs_position_NE_reset_count) {
         // This ensures controller output remains continuous after EKF realigns the origin.
 
         // Reconstruct position target relative to the to new EKF estimation to maintain the current position error
@@ -1718,7 +1718,7 @@ void AC_PosControl::NE_handle_ekf_reset()
             _vel_offset_ned_ms.xy() += delta_vel_estimate_ne_ms;
             break;
         }
-        _ekf_ne_reset_ms = reset_ms;
+        _ahrs_position_NE_reset_count = reset_count;
     }
 }
 
@@ -1726,7 +1726,7 @@ void AC_PosControl::NE_handle_ekf_reset()
 void AC_PosControl::D_init_ekf_reset()
 {
     float alt_shift_d_m;
-    _ekf_d_reset_ms = _ahrs.getLastPosDownReset(alt_shift_d_m);
+    _ahrs_position_D_reset_count = _ahrs.get_position_D_reset_count(alt_shift_d_m);
 }
 
 // Handles U EKF reset detection and response.
@@ -1734,11 +1734,11 @@ void AC_PosControl::D_handle_ekf_reset()
 {
     // Check for EKF-reported Down-axis shift since last update
     float pos_shift_d_m;
-    uint32_t reset_ms = _ahrs.getLastPosDownReset(pos_shift_d_m);
+    const uint16_t reset_count = _ahrs.get_position_D_reset_count(pos_shift_d_m);
     // todo: the actual difference in position and velocity estimation.
     // This will prevent the need to pause error calculation for one cycle.
 
-    if (reset_ms != 0 && reset_ms != _ekf_d_reset_ms) {
+    if (reset_count != _ahrs_position_D_reset_count) {
         // This ensures controller output remains continuous after EKF realigns the origin.
         // Reconstruct position target relative to the to new EKF estimation to maintain the current position error
         postype_t delta_pos_estimate_d_m = _p_pos_d_m.get_error() - (_pos_target_ned_m.z - _pos_estimate_ned_m.z);
@@ -1760,7 +1760,7 @@ void AC_PosControl::D_handle_ekf_reset()
             _vel_offset_ned_ms.z += delta_vel_estimate_d_ms;
             break;
         }
-        _ekf_d_reset_ms = reset_ms;
+        _ahrs_position_D_reset_count = reset_count;
     }
 }
 

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -777,8 +777,8 @@ protected:
     uint32_t    _posvelaccel_offset_target_d_ms;    // system time that pos, vel, accel targets were set (used to implement timeouts)
 
     // ekf reset handling
-    uint32_t    _ekf_ne_reset_ms;       // system time of last recorded ekf ne position reset
-    uint32_t    _ekf_d_reset_ms;        // system time of last recorded ekf altitude reset
+    uint16_t    _ahrs_position_NE_reset_count;       // count of ekf ne position resets
+    uint16_t    _ahrs_position_D_reset_count;        // count of ekf altitude resets
     EKFResetMethod _ekf_reset_method = EKFResetMethod::MoveTarget;  // EKF reset handling method.  Loiter should use MoveTarget, Auto should use MoveVehicle
 
     // high vibration handling

--- a/libraries/APM_Control/AR_PosControl.cpp
+++ b/libraries/APM_Control/AR_PosControl.cpp
@@ -407,7 +407,7 @@ void AR_PosControl::write_log()
 void AR_PosControl::init_ekf_xy_reset()
 {
     Vector2f pos_shift;
-    _ekf_xy_reset_ms = AP::ahrs().getLastPosNorthEastReset(pos_shift);
+    _ekf_xy_reset_count = AP::ahrs().get_position_NE_reset_count(pos_shift);
 }
 
 /// handle_ekf_xy_reset - check for ekf position reset and adjust loiter or brake target position
@@ -415,8 +415,8 @@ void AR_PosControl::handle_ekf_xy_reset()
 {
     // check for position shift
     Vector2f pos_shift;
-    uint32_t reset_ms = AP::ahrs().getLastPosNorthEastReset(pos_shift);
-    if (reset_ms != _ekf_xy_reset_ms) {
+    const uint16_t reset_count = AP::ahrs().get_position_NE_reset_count(pos_shift);
+    if (reset_count != _ekf_xy_reset_count) {
         Vector2p pos_ne_m;
         if (!AP::ahrs().get_relative_position_NE_origin(pos_ne_m)) {
             return;
@@ -429,6 +429,6 @@ void AR_PosControl::handle_ekf_xy_reset()
         }
         _vel_desired = vel_NED.xy() + _pid_vel.get_error();
 
-        _ekf_xy_reset_ms = reset_ms;
+        _ekf_xy_reset_count = reset_count;
     }
 }

--- a/libraries/APM_Control/AR_PosControl.h
+++ b/libraries/APM_Control/AR_PosControl.h
@@ -126,5 +126,5 @@ private:
     float _desired_lat_accel;       // desired lateral acceleration (for reporting only)
 
     // ekf reset handling
-    uint32_t _ekf_xy_reset_ms;      // system time of last recorded ekf xy position reset
+    uint16_t _ekf_xy_reset_count;      // count of ekf xy position resets
 };

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -558,6 +558,54 @@ void AP_AHRS::try_set_common_origin(const AP_AHRS_Backend &source_backend, const
     done_common_origin = true;
 }
 
+// method responsible for updating the reset counters in the AHRS.
+// These can get bumped if we change backends or the count in the
+// current backend changes.
+void AP_AHRS::update_reset_counters()
+{
+    if (state.active_EKF_type != last_active_ekf_type) {
+        const auto *last = estimates_for_type(last_active_ekf_type);
+
+        // deltas across the estimator change come from differencing
+        // old and new backend estimates; zero if either side invalid
+        float yaw_delta = 0;
+        Vector2f pos_ne_delta;
+        float pos_d_delta = 0;
+        if (last != nullptr) {
+            if (active_estimates->attitude_valid && last->attitude_valid) {
+                yaw_delta = wrap_PI(active_estimates->yaw_rad - last->yaw_rad);
+            }
+            if (active_estimates->position_NE_valid && last->position_NE_valid) {
+                pos_ne_delta = (active_estimates->position_NE - last->position_NE).tofloat();
+            }
+            if (active_estimates->position_D_valid && last->position_D_valid) {
+                pos_d_delta = active_estimates->position_D - last->position_D;
+            }
+        }
+
+        attitude_reset_count++;
+        active_estimates_attitude_reset_count = active_estimates->attitude_reset_count;
+        yaw_reset_tracker.fill(active_estimates->yaw_reset_count, yaw_delta);
+        position_NE_reset_tracker.fill(active_estimates->position_NE_reset_count, pos_ne_delta);
+        position_D_reset_tracker.fill(active_estimates->position_D_reset_count, pos_d_delta);
+        LOGGER_WRITE_EVENT(LogEvent::EKF_YAW_RESET);
+        return;
+    }
+
+    if (active_estimates_attitude_reset_count != active_estimates->attitude_reset_count) {
+        active_estimates_attitude_reset_count = active_estimates->attitude_reset_count;
+        attitude_reset_count++;
+    }
+    if (yaw_reset_tracker.update(active_estimates->yaw_reset_count,
+                                 active_estimates->yaw_reset_delta)) {
+        LOGGER_WRITE_EVENT(LogEvent::EKF_YAW_RESET);
+    }
+    position_NE_reset_tracker.update(active_estimates->position_NE_reset_count,
+                                     active_estimates->position_NE_reset_delta);
+    position_D_reset_tracker.update(active_estimates->position_D_reset_count,
+                                    active_estimates->position_D_reset_delta);
+}
+
 // update run at loop rate
 void AP_AHRS::update(bool skip_ins_update)
 {
@@ -620,22 +668,15 @@ void AP_AHRS::update(bool skip_ins_update)
     // update blinking lights, buzzer etc bsaed on active EKF type:
     update_notify_from_filter_status(active_estimates->filter_status);
 
-    bool attitude_was_reset = false;
+    // update result reset counters.  Note that this *must* be called
+    // before assignment of state.active_EKF_type to
+    // last_active_ekf_type as it uses the difference between these
+    // two values to determine what sort of reset to do
+    update_reset_counters();
+
     if (state.active_EKF_type != last_active_ekf_type) {
         last_active_ekf_type = state.active_EKF_type;
         GCS_SEND_TEXT(MAV_SEVERITY_INFO, "AHRS: %s active", active_backend->shortname());
-        last_active_estimates_attitude_reset_count = active_estimates->attitude_reset_count;
-        attitude_was_reset = true;
-    } else {
-        // estimator has not changed - but perhaps the estimator's
-        // output might have reset:
-        if (active_estimates->attitude_reset_count != last_active_estimates_attitude_reset_count) {
-            last_active_estimates_attitude_reset_count = active_estimates->attitude_reset_count;
-            attitude_was_reset = true;
-        }
-    }
-    if (attitude_was_reset) {
-        state.attitude_reset_count++;
     }
 
     // update published state, including copying state from the active backend:

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -363,12 +363,13 @@ void AP_AHRS::init()
     }
 #endif
 
-    last_active_ekf_type = (EKFType)_ekf_type.get();
-
     // we may have updated ekf_type()'s results, so set the backend again:
     update_configured_ekf_type();
     update_active_EKF_type();
     update_secondary_backend_pointers();
+
+    // initialise this as no-change from the active type:
+    last_active_ekf_type = state.active_EKF_type;
 
 #if AP_CUSTOMROTATIONS_ENABLED
     // convert to new custom rotation

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -369,32 +369,29 @@ public:
     bool getMagOffsets(uint8_t mag_idx, Vector3f &magOffsets) const;
 
     // return the amount of yaw angle change due to the last yaw angle reset in radians
-    // returns the time of the last yaw angle reset or 0 if no reset has ever occurred
-    uint32_t getLastYawResetAngle(float &yawAng) {
-        return active_backend->getLastYawResetAngle(yawAng);
+    // returns the number of times the yaw angle has been reset
+    uint16_t get_yaw_reset_count(float &yawAng) const {
+        yawAng = yaw_reset_tracker.delta();
+        return yaw_reset_tracker.count();
     }
 
     // return the amount of NE position change in meters due to the last reset
-    // returns the time of the last reset or 0 if no reset has ever occurred
-    uint32_t getLastPosNorthEastReset(Vector2f &pos) {
-        return active_backend->getLastPosNorthEastReset(pos);
-    }
-
-    // return the amount of NE velocity change in meters/sec due to the last reset
-    // returns the time of the last reset or 0 if no reset has ever occurred
-    uint32_t getLastVelNorthEastReset(Vector2f &vel) const {
-        return active_backend->getLastVelNorthEastReset(vel);
+    // returns the number of times position NE has been reset
+    uint16_t get_position_NE_reset_count(Vector2f &pos) const {
+        pos = position_NE_reset_tracker.delta();
+        return position_NE_reset_tracker.count();
     }
 
     // return the amount of vertical position change due to the last reset in meters
-    // returns the time of the last reset or 0 if no reset has ever occurred
-    uint32_t getLastPosDownReset(float &posDelta) {
-        return active_backend->getLastPosDownReset(posDelta);
+    // returns the number of times position-down has been reset
+    uint16_t get_position_D_reset_count(float &posDelta) const {
+        posDelta = position_D_reset_tracker.delta();
+        return position_D_reset_tracker.count();
     }
 
     // returns a counter which is incremented each time the estimator's output resets
     uint16_t get_last_attitude_reset_count() const {
-        return state.attitude_reset_count;
+        return attitude_reset_count;
     }
 
     // Resets the baro so that it reads zero at the current height
@@ -1016,7 +1013,6 @@ private:
         bool airspeed_TAS_vec_ok;
         Quaternion quat;
         bool quat_ok;
-        uint16_t attitude_reset_count;
         Location location;
         bool location_ok;
         Vector2f ground_speed_vec;
@@ -1125,7 +1121,18 @@ private:
     AP_AHRS_Backend *active_backend;
     AP_AHRS_Backend::Estimates *active_estimates;
 
-    uint16_t last_active_estimates_attitude_reset_count;
+    // method responsible for updating the reset counters in the AHRS.
+    // These can get bumped if we change backends or the count in the
+    // current backend changes.
+    void update_reset_counters();
+    // reset counters.  These are updated if the backend changes or if
+    // the backend results change (e.g. switching core)
+    uint16_t attitude_reset_count;
+    uint16_t active_estimates_attitude_reset_count;
+
+    AP_AHRS_ResetTracker<float, uint16_t> yaw_reset_tracker;
+    AP_AHRS_ResetTracker<Vector2f, uint16_t> position_NE_reset_tracker;
+    AP_AHRS_ResetTracker<float, uint16_t> position_D_reset_tracker;
 
     // secondary estimates - used for reporting purposes.  If the
     // primary backend fails this is the backend/result pair likely to

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -85,6 +85,8 @@ public:
         Matrix3f dcm_matrix;
         Quaternion quaternion;
         uint16_t attitude_reset_count;  // counter incremented each time a sudden shift happens in attitude
+        uint16_t yaw_reset_count;  // incremented when a sudden shift happens in yaw
+        float yaw_reset_delta;  // shift amount last time yaw reset
 
         // backends must always return the result in the vehicle body
         // frame.  A backend using the autopilot sensors will need to
@@ -158,8 +160,13 @@ public:
         // origin-relative position:
         Vector2p position_NE;
         bool position_NE_valid;  // true if position_NE is valid
+        uint16_t position_NE_reset_count;  // incremented when a sudden shift happens in position
+        Vector2f position_NE_reset_delta;  // shift amount last time it reset
+
         postype_t position_D;
         bool position_D_valid;   // true if position_D is valid
+        uint16_t position_D_reset_count;  // incremented when a sudden shift happens in position (down)
+        float position_D_reset_delta;  // shift amount last time it reset
 
         bool get_hagl(float &height) const WARN_IF_UNUSED {
             height = hagl;
@@ -301,30 +308,6 @@ public:
     // return true if we will use compass for yaw
     virtual bool use_compass(void) = 0;
 
-    // return the amount of yaw angle change due to the last yaw angle reset in radians
-    // returns the time of the last yaw angle reset or 0 if no reset has ever occurred
-    virtual uint32_t getLastYawResetAngle(float &yawAng) {
-        return 0;
-    };
-
-    // return the amount of NE position change in metres due to the last reset
-    // returns the time of the last reset or 0 if no reset has ever occurred
-    virtual uint32_t getLastPosNorthEastReset(Vector2f &pos) WARN_IF_UNUSED {
-        return 0;
-    };
-
-    // return the amount of NE velocity change in metres/sec due to the last reset
-    // returns the time of the last reset or 0 if no reset has ever occurred
-    virtual uint32_t getLastVelNorthEastReset(Vector2f &vel) const WARN_IF_UNUSED {
-        return 0;
-    };
-
-    // return the amount of vertical position change due to the last reset in meters
-    // returns the time of the last reset or 0 if no reset has ever occurred
-    virtual uint32_t getLastPosDownReset(float &posDelta) WARN_IF_UNUSED {
-        return 0;
-    };
-
     // Resets the baro so that it reads zero at the current height
     // Resets the EKF height to zero
     // Adjusts the EKf origin height so that the EKF height + origin height is the same as before
@@ -337,4 +320,47 @@ public:
     }
 
     virtual void get_control_limits(float &ekfGndSpdLimit, float &controlScaleXY) const = 0;
+};
+
+// Converts an upstream "something changed" key (an EKF reset
+// timestamp, or another tracker's count) into a monotonic local count
+// plus a latched delta.  KeyT is the upstream key type.
+template <typename DeltaT, typename KeyT>
+class AP_AHRS_ResetTracker {
+public:
+    // latch delta and bump count if the upstream key changed.
+    // Returns true if a reset was recorded.
+    bool update(KeyT new_key, const DeltaT &new_delta) {
+        if (new_key == last_key) {
+            return false;
+        }
+        fill(new_key, new_delta);
+        return true;
+    }
+
+    // unconditionally record a reset with an externally computed
+    // delta, re-seating the key so the next update() doesn't
+    // double-count.  Used when the active estimator changes and the
+    // delta comes from differencing old/new backend estimates.
+    void fill(KeyT new_key, const DeltaT &new_delta) {
+        last_key = new_key;
+        reset_delta = new_delta;
+        reset_count++;
+    }
+
+    // copy the current reset count and latched delta out, e.g. into a
+    // backend's published Estimates.  Deliberately not named like the
+    // mutating fill() so the two can't be confused at a call site.
+    void get(uint16_t &count, DeltaT &delta) const {
+        count = reset_count;
+        delta = reset_delta;
+    }
+
+    uint16_t count() const { return reset_count; }
+    const DeltaT &delta() const { return reset_delta; }
+
+private:
+    KeyT last_key;
+    DeltaT reset_delta;
+    uint16_t reset_count;
 };

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF2.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF2.cpp
@@ -61,6 +61,15 @@ void AP_AHRS_NavEKF2::update()
         LOGGER_WRITE_ERROR(LogErrorSubsystem::EKF_PRIMARY, LogErrorCode(primary_core));
         GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "EKF2 primary changed:%d", (unsigned)primary_core);
     }
+
+    float yaw_delta;
+    yaw_reset_tracker.update(EKF2.getLastYawResetAngle(yaw_delta), yaw_delta);
+
+    Vector2f pos_ne_delta;
+    position_NE_reset_tracker.update(EKF2.getLastPosNorthEastReset(pos_ne_delta), pos_ne_delta);
+
+    float pos_d_delta;
+    position_D_reset_tracker.update(EKF2.getLastPosDownReset(pos_d_delta), pos_d_delta);
 }
 
 void AP_AHRS_NavEKF2::get_results(AP_AHRS_Backend::Estimates &results)
@@ -114,6 +123,9 @@ void AP_AHRS_NavEKF2::get_results(AP_AHRS_Backend::Estimates &results)
 
     results.attitude_reset_count = attitude_reset_count;
 
+    // copy results from the yaw reset tracker into results:
+    yaw_reset_tracker.get(results.yaw_reset_count, results.yaw_reset_delta);
+
     /*
      * acceleration estimates
      */
@@ -157,7 +169,12 @@ void AP_AHRS_NavEKF2::get_results(AP_AHRS_Backend::Estimates &results)
 
     // origin-relative position:
     results.position_NE_valid = EKF2.getPosNE(results.position_NE);
+    // copy results from the position_NE reset tracker into results:
+    position_NE_reset_tracker.get(results.position_NE_reset_count, results.position_NE_reset_delta);
+
     results.position_D_valid = EKF2.getPosD(results.position_D);
+    // copy results from the position_D reset tracker into results:
+    position_D_reset_tracker.get(results.position_D_reset_count, results.position_D_reset_delta);
 
     results.hagl_valid = EKF2.getHAGL(results.hagl);
 

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF2.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF2.h
@@ -58,18 +58,6 @@ public:
         return EKF2.use_compass();
     }
 
-    uint32_t getLastYawResetAngle(float &yawAng) override {
-        return EKF2.getLastYawResetAngle(yawAng);
-    };
-    uint32_t getLastPosNorthEastReset(Vector2f &pos) override WARN_IF_UNUSED {
-        return EKF2.getLastPosNorthEastReset(pos);
-    };
-    uint32_t getLastVelNorthEastReset(Vector2f &vel) const override WARN_IF_UNUSED {
-        return EKF2.getLastVelNorthEastReset(vel);
-    };
-    uint32_t getLastPosDownReset(float &posDelta) override WARN_IF_UNUSED {
-        return EKF2.getLastPosDownReset(posDelta);
-    };
     void resetHeightDatum(void) override {
         EKF2.resetHeightDatum();
     }
@@ -103,6 +91,10 @@ public:
     // a counter which is incremented each time the primary core changes:
     uint16_t attitude_reset_count;
     int8_t old_primary_core;
+
+    AP_AHRS_ResetTracker<float, uint32_t> yaw_reset_tracker;
+    AP_AHRS_ResetTracker<Vector2f, uint32_t> position_NE_reset_tracker;
+    AP_AHRS_ResetTracker<float, uint32_t> position_D_reset_tracker;
 };
 
 #endif  // AP_AHRS_NAVEKF2_ENABLED

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
@@ -38,6 +38,7 @@ bool AP_AHRS_NavEKF3::start()
         return false;
     }
 
+    // try to start the filter:
     return EKF3.InitialiseFilter();
 }
 
@@ -60,6 +61,15 @@ void AP_AHRS_NavEKF3::update()
         LOGGER_WRITE_ERROR(LogErrorSubsystem::EKF_PRIMARY, LogErrorCode(primary_core));
         GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "EKF3 primary changed:%d", (unsigned)primary_core);
     }
+
+    float yaw_delta;
+    yaw_reset_tracker.update(EKF3.getLastYawResetAngle(yaw_delta), yaw_delta);
+
+    Vector2f pos_ne_delta;
+    position_NE_reset_tracker.update(EKF3.getLastPosNorthEastReset(pos_ne_delta), pos_ne_delta);
+
+    float pos_d_delta;
+    position_D_reset_tracker.update(EKF3.getLastPosDownReset(pos_d_delta), pos_d_delta);
 }
 
 void AP_AHRS_NavEKF3::get_results(AP_AHRS_Backend::Estimates &results)
@@ -113,6 +123,9 @@ void AP_AHRS_NavEKF3::get_results(AP_AHRS_Backend::Estimates &results)
 
     results.attitude_reset_count = attitude_reset_count;
 
+    // copy results from the yaw reset tracker into results:
+    yaw_reset_tracker.get(results.yaw_reset_count, results.yaw_reset_delta);
+
     /*
      * acceleration estimates
      */
@@ -157,7 +170,12 @@ void AP_AHRS_NavEKF3::get_results(AP_AHRS_Backend::Estimates &results)
 
     // origin-relative position:
     results.position_NE_valid = EKF3.getPosNE(results.position_NE);
+    // copy results from the position_NE reset tracker into results:
+    position_NE_reset_tracker.get(results.position_NE_reset_count, results.position_NE_reset_delta);
+
     results.position_D_valid = EKF3.getPosD(results.position_D);
+    // copy results from the position_D reset tracker into results:
+    position_D_reset_tracker.get(results.position_D_reset_count, results.position_D_reset_delta);
 
     results.hagl_valid = EKF3.getHAGL(results.hagl);
 

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF3.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF3.h
@@ -58,18 +58,6 @@ public:
         return EKF3.use_compass();
     }
 
-    uint32_t getLastYawResetAngle(float &yawAng) override {
-        return EKF3.getLastYawResetAngle(yawAng);
-    };
-    uint32_t getLastPosNorthEastReset(Vector2f &pos) override WARN_IF_UNUSED {
-        return EKF3.getLastPosNorthEastReset(pos);
-    };
-    uint32_t getLastVelNorthEastReset(Vector2f &vel) const override WARN_IF_UNUSED {
-        return EKF3.getLastVelNorthEastReset(vel);
-    };
-    uint32_t getLastPosDownReset(float &posDelta) override WARN_IF_UNUSED {
-        return EKF3.getLastPosDownReset(posDelta);
-    };
     void resetHeightDatum(void) override {
         EKF3.resetHeightDatum();
     }
@@ -102,6 +90,10 @@ public:
     // a counter which is incremented each time the primary core changes:
     uint16_t attitude_reset_count;
     int8_t old_primary_core;
+
+    AP_AHRS_ResetTracker<float, uint32_t> yaw_reset_tracker;
+    AP_AHRS_ResetTracker<Vector2f, uint32_t> position_NE_reset_tracker;
+    AP_AHRS_ResetTracker<float, uint32_t> position_D_reset_tracker;
 };
 
 #endif  // AP_AHRS_NAVEKF3_ENABLED

--- a/libraries/AP_AHRS/AP_AHRS_View.h
+++ b/libraries/AP_AHRS/AP_AHRS_View.h
@@ -149,12 +149,12 @@ public:
         return ahrs.get_accel_ef();
     }
 
-    uint32_t getLastPosNorthEastReset(Vector2f &pos) WARN_IF_UNUSED {
-        return ahrs.getLastPosNorthEastReset(pos);
+    uint16_t get_position_NE_reset_count(Vector2f &pos) WARN_IF_UNUSED {
+        return ahrs.get_position_NE_reset_count(pos);
     }
 
-    uint32_t getLastPosDownReset(float &posDelta) WARN_IF_UNUSED {
-        return ahrs.getLastPosDownReset(posDelta);
+    uint16_t get_position_D_reset_count(float &posDelta) WARN_IF_UNUSED {
+        return ahrs.get_position_D_reset_count(posDelta);
     }
 
     // rotate a 2D vector from earth frame to body frame


### PR DESCRIPTION
### Summary

Switches to using a counter for the reset monitoring and updates the counter if the active backend changes

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

This isn't free:
```
Board,antennatracker,blimp,bootloader,copter,heli,plane,rover,sub
```

Several new tests to prevent regressions, several even newer tests to prevent regressions in the future.  These are looking for glitching in the vehicle position and attitude when we switch backends.  These tests have been stress-tested.

### Description

Has the AHRS itself keep track of position, yaw reset information itself.

Entirely removes the reset-tracking for velocity as nothing was using it.

If a backend's count changes then that is reflected in the AHRS results.

If we change estimators that is also reflected in the results.

This means changing from a wacky DCM to a sensible EKF will not cause weirdness.  More to the point, in the future if an ExternalAHRS goes bad and we fall back to our internal estimators then we will smoothly handle that transition by having e.g. AC_PosControl handle the transition.
