### PR TITLE
AC_WPNav: Loiter: start break delay from last pilot roll/pitch input ignoring coordinated turns

### DIFF
--- a/libraries/AC_WPNav/AC_Loiter.cpp
+++ b/libraries/AC_WPNav/AC_Loiter.cpp
@@ -177,10 +177,12 @@ void AC_Loiter::set_pilot_desired_acceleration_rad(float euler_roll_angle_rad, f
 
     // convert our desired attitude to an acceleration vector assuming we are not accelerating vertically
     const Vector3f desired_euler_rad {euler_roll_angle_rad, euler_pitch_angle_rad, _ahrs.yaw};
-    const Vector3f desired_accel_ned_mss = _pos_control.lean_angles_rad_to_accel_NED_mss(desired_euler_rad);
+    _desired_accel_ne_mss = _pos_control.lean_angles_rad_to_accel_NED_mss(desired_euler_rad).xy();
 
-    _desired_accel_ne_mss.x = desired_accel_ned_mss.x;
-    _desired_accel_ne_mss.y = desired_accel_ned_mss.y;
+    // Reset brake timer if there is pilot input
+    if (!_desired_accel_ne_mss.is_zero()) {
+        _brake_timer_ms = AP_HAL::millis();
+    }
 
     // Compute attitude error between desired and predicted lean angles
     Vector2f angle_error_euler_rad(wrap_PI(euler_roll_angle_rad - _predicted_euler_angle_rad.x), wrap_PI(euler_pitch_angle_rad - _predicted_euler_angle_rad.y));
@@ -349,16 +351,11 @@ void AC_Loiter::calc_desired_velocity(bool avoidance_on)
         // Apply drag: deceleration proportional to current velocity
         float drag_decel_mss = pilot_acceleration_max_mss * desired_speed_ms / gnd_speed_limit_ms;
 
-        // Determine braking acceleration based on stick release and delay timer
+        // Determine braking acceleration based on stick release and delay timer, stick must have been released for at least a full loop
         float loiter_brake_accel_mss = 0.0f;
-        if (_desired_accel_ne_mss.is_zero()) {
-            if ((AP_HAL::millis() - _brake_timer_ms) > _brake_delay_s * 1000.0) {
-                float brake_gain = _pos_control.NE_get_vel_pid().kP() * 0.5f;
-                loiter_brake_accel_mss = constrain_float(sqrt_controller(desired_speed_ms, brake_gain, _brake_jerk_max_msss, dt_s), 0.0f, _brake_accel_max_mss);
-            }
-        } else {
-            loiter_brake_accel_mss = 0.0f;
-            _brake_timer_ms = AP_HAL::millis();
+        if ((AP_HAL::millis() - _brake_timer_ms) > MAX(_brake_delay_s, dt_s) * 1000.0) {
+            const float brake_gain = _pos_control.NE_get_vel_pid().kP() * 0.5f;
+            loiter_brake_accel_mss = constrain_float(sqrt_controller(desired_speed_ms, brake_gain, _brake_jerk_max_msss, dt_s), 0.0f, _brake_accel_max_mss);
         }
 
         // Integrate jerk-limited brake acceleration


### PR DESCRIPTION
### Summary

<!-- Put a one or two line summary of what your PR does here -->

The new turn coordination loiter option effectively prevents loiter breaking from kicking in. This change makes breaking the same with and without the turn coordination option.

This is a example from master showing breaking with and without the option:

<img width="1864" height="453" alt="image" src="https://github.com/user-attachments/assets/c9f78503-110f-4785-a0eb-9fd533a0f2fd" />


### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

Currently breaking will only kick in if `_desired_accel_ne_mss` is zero here:

https://github.com/ArduPilot/ardupilot/blob/13a59be5db95f04a05ea04a7a6c26acfae4dbe87/libraries/AC_WPNav/AC_Loiter.cpp#L354

`_desired_accel_ne_mss` is populated from the pilot roll/pitch input here:

https://github.com/ArduPilot/ardupilot/blob/13a59be5db95f04a05ea04a7a6c26acfae4dbe87/libraries/AC_WPNav/AC_Loiter.cpp#L182-L183

However, it is also updated by the new turn coordination option here:

https://github.com/ArduPilot/ardupilot/blob/13a59be5db95f04a05ea04a7a6c26acfae4dbe87/libraries/AC_WPNav/AC_Loiter.cpp#L200-L206

This means that `_desired_accel_ne_mss` is no longer zero when the pilot releases the sticks. This results in the vehicle coasting a long way as breaking no longer kick in.

The fix is to reset the brake timer based only on the pilot input.


<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
