### PR TITLE
AP_Logger: scale PrepForArming log-open budget by SITL speedup

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -17220,6 +17220,7 @@ RTL_ALT_M 111
         self.set_parameters({
             "MAV_GCS_SYSID": 250,
             "SIM_RC_FAIL": 1,  # no-pulses
+            "LOG_DISARMED": 1,  # we are timing sensitive, avoid stall on log open
         })
         self.reboot_sitl()
 

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -18455,6 +18455,7 @@ RTL_ALT_M 111
         self.set_parameters({
             "MAV_GCS_SYSID": 250,
             "SIM_RC_FAIL": 1,  # no-pulses
+            "LOG_DISARMED": 1,  # we are timing sensitive, avoid stall on log open
         })
         self.reboot_sitl()
 

--- a/libraries/AP_Logger/AP_Logger_File.cpp
+++ b/libraries/AP_Logger/AP_Logger_File.cpp
@@ -733,11 +733,20 @@ void AP_Logger_File::PrepForArming_start_logging()
     }
 
     uint32_t start_ms = AP_HAL::millis();
-    const uint32_t open_limit_ms = 1000;
+    uint32_t open_limit_ms = 1000;
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL && !defined(HAL_BUILD_AP_PERIPH)
+    // the log open happens in the io_timer thread, which is writing to
+    // a physical disk.  Scale the startup time appropriately.
+    SITL::SIM *sitl = AP::sitl();
+    if (sitl != nullptr && sitl->speedup > 0) {
+        open_limit_ms *= sitl->speedup;
+    }
+#endif
 
     /*
       log open happens in the io_timer thread. We allow for a maximum
-      of 1s to complete the open
+      of 1s (scaled by SITL speedup, see above) to complete the open
      */
     start_new_log_pending = true;
     EXPECT_DELAY_MS(1000);


### PR DESCRIPTION
### Summary

Scales log file opening time according to sim speedup

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

PrepForArming_start_logging() allows the IO thread a fixed 1 second to open the new log file before the logging arming check gives up.  That open happens on a physical disk which does not obey the SITL speedup, so the real time available shrinks as speedup rises: 1s of SIM time is only ~125ms real at the default speedup of 8, and less at higher speedups.

On a loaded CI runner an otherwise healthy open can occasionally take longer than that, which trips the arming check ("Arm: Logging not started"); and because start_new_log() pre-sets _open_error_ms, the follow-up logging_failed() check then also reports "PreArm: Logging failed".  This shows up as an intermittent heli FlyEachFrame autotest failure (that test restarts SITL for every frame, so it opens many logs).

Scale the open budget by speedup in SITL, exactly as io_thread_alive() already does for the same reason.  Flight (ChibiOS) behaviour is unchanged.
