### PR TITLE
Arm Disarm mavlink checks component

### DIFF
--- a/AntennaTracker/GCS_MAVLink_Tracker.cpp
+++ b/AntennaTracker/GCS_MAVLink_Tracker.cpp
@@ -374,6 +374,10 @@ MAV_RESULT GCS_MAVLINK_Tracker::handle_command_int_packet(const mavlink_command_
 
         // mavproxy/mavutil sends this when auto command is entered 
     case MAV_CMD_MISSION_START:
+        if (command_addressed_to_other_component(packet)) {
+            // don't start the mission on a command addressed to another component
+            return MAV_RESULT_DENIED;
+        }
         tracker.set_mode(tracker.mode_auto, ModeReason::GCS_COMMAND);
         return MAV_RESULT_ACCEPTED;
 

--- a/AntennaTracker/GCS_MAVLink_Tracker.cpp
+++ b/AntennaTracker/GCS_MAVLink_Tracker.cpp
@@ -344,6 +344,10 @@ MAV_RESULT GCS_MAVLINK_Tracker::_handle_command_preflight_calibration_baro(const
 
 MAV_RESULT GCS_MAVLINK_Tracker::handle_command_component_arm_disarm(const mavlink_command_int_t &packet)
 {
+    if ((packet.target_component != MAV_COMP_ID_ALL) && (packet.target_component != mavlink_system.compid)) {
+        // Make sure an arm/disarm command addressed to a component doesn't arm or disarm the tracker.
+        return MAV_RESULT_DENIED;
+    }
     if (is_equal(packet.param1,1.0f)) {
         tracker.arm_servos();
         return MAV_RESULT_ACCEPTED;

--- a/AntennaTracker/GCS_MAVLink_Tracker.cpp
+++ b/AntennaTracker/GCS_MAVLink_Tracker.cpp
@@ -344,8 +344,8 @@ MAV_RESULT GCS_MAVLINK_Tracker::_handle_command_preflight_calibration_baro(const
 
 MAV_RESULT GCS_MAVLINK_Tracker::handle_command_component_arm_disarm(const mavlink_command_int_t &packet)
 {
-    if ((packet.target_component != MAV_COMP_ID_ALL) && (packet.target_component != mavlink_system.compid)) {
-        // Make sure an arm/disarm command addressed to a component doesn't arm or disarm the tracker.
+    if (command_addressed_to_other_component(packet)) {
+        // don't arm/disarm the tracker on a command addressed to another component
         return MAV_RESULT_DENIED;
     }
     if (is_equal(packet.param1,1.0f)) {

--- a/ArduCopter/GCS_MAVLink_Copter.cpp
+++ b/ArduCopter/GCS_MAVLink_Copter.cpp
@@ -577,6 +577,10 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_command_mount(const mavlink_command_int_t 
 
 MAV_RESULT GCS_MAVLINK_Copter::handle_MAV_CMD_NAV_TAKEOFF(const mavlink_command_int_t &packet)
 {
+    if (command_addressed_to_other_component(packet)) {
+        // don't take off on a command addressed to another component
+        return MAV_RESULT_DENIED;
+    }
     if (packet.frame != MAV_FRAME_GLOBAL_RELATIVE_ALT) {
         return MAV_RESULT_DENIED;  // meaning some parameters are bad
     }
@@ -662,6 +666,10 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_MAV_CMD_DO_CHANGE_SPEED(const mavlink_comm
 #if MODE_AUTO_ENABLED
 MAV_RESULT GCS_MAVLINK_Copter::handle_MAV_CMD_MISSION_START(const mavlink_command_int_t &packet)
 {
+        if (command_addressed_to_other_component(packet)) {
+            // don't start the mission on a command addressed to another component
+            return MAV_RESULT_DENIED;
+        }
         if (!is_zero(packet.param1) || !is_zero(packet.param2)) {
             // first-item/last item not supported
             return MAV_RESULT_DENIED;
@@ -682,6 +690,10 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_MAV_CMD_MISSION_START(const mavlink_comman
 #if HAL_PARACHUTE_ENABLED
 MAV_RESULT GCS_MAVLINK_Copter::handle_MAV_CMD_DO_PARACHUTE(const mavlink_command_int_t &packet)
 {
+        if (command_addressed_to_other_component(packet)) {
+            // don't operate the parachute on a command addressed to another component
+            return MAV_RESULT_DENIED;
+        }
         // configure or release parachute
         switch ((uint16_t)packet.param1) {
         case PARACHUTE_DISABLE:
@@ -701,6 +713,10 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_MAV_CMD_DO_PARACHUTE(const mavlink_command
 
 MAV_RESULT GCS_MAVLINK_Copter::handle_MAV_CMD_DO_MOTOR_TEST(const mavlink_command_int_t &packet)
 {
+        if (command_addressed_to_other_component(packet)) {
+            // don't run a motor test on a command addressed to another component
+            return MAV_RESULT_DENIED;
+        }
         // param1 : motor sequence number (a number from 1 to max number of motors on the vehicle)
         // param2 : throttle type (0=throttle percentage, 1=PWM, 2=pilot throttle channel pass-through. See MOTOR_TEST_THROTTLE_TYPE enum)
         // param3 : throttle (range depends upon param2)
@@ -744,6 +760,10 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_MAV_CMD_DO_WINCH(const mavlink_command_int
 #if AC_MAVLINK_SOLO_BUTTON_COMMAND_HANDLING_ENABLED
 MAV_RESULT GCS_MAVLINK_Copter::handle_MAV_CMD_SOLO_BTN_FLY_CLICK(const mavlink_command_int_t &packet)
 {
+        if (command_addressed_to_other_component(packet)) {
+            // don't action a Solo button command addressed to another component
+            return MAV_RESULT_DENIED;
+        }
         if (copter.failsafe.radio) {
             return MAV_RESULT_ACCEPTED;
         }
@@ -782,6 +802,10 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_MAV_CMD_SOLO_BTN_FLY_HOLD(const mavlink_co
 
 MAV_RESULT GCS_MAVLINK_Copter::handle_MAV_CMD_SOLO_BTN_PAUSE_CLICK(const mavlink_command_int_t &packet)
 {
+        if (command_addressed_to_other_component(packet)) {
+            // don't action a Solo button command addressed to another component
+            return MAV_RESULT_DENIED;
+        }
         if (copter.failsafe.radio) {
             return MAV_RESULT_ACCEPTED;
         }

--- a/ArduCopter/GCS_MAVLink_Copter.cpp
+++ b/ArduCopter/GCS_MAVLink_Copter.cpp
@@ -757,6 +757,10 @@ MAV_RESULT GCS_MAVLINK_Copter::handle_MAV_CMD_SOLO_BTN_FLY_CLICK(const mavlink_c
 
 MAV_RESULT GCS_MAVLINK_Copter::handle_MAV_CMD_SOLO_BTN_FLY_HOLD(const mavlink_command_int_t &packet)
 {
+        if (command_addressed_to_other_component(packet)) {
+            // don't arm the autopilot on a command addressed to another component
+            return MAV_RESULT_DENIED;
+        }
         if (copter.failsafe.radio) {
             return MAV_RESULT_ACCEPTED;
         }
@@ -1202,6 +1206,10 @@ void GCS_MAVLINK_Copter::handle_message(const mavlink_message_t &msg)
 }
 
 MAV_RESULT GCS_MAVLINK_Copter::handle_flight_termination(const mavlink_command_int_t &packet) {
+    if (command_addressed_to_other_component(packet)) {
+        // don't terminate the flight on a command addressed to another component
+        return MAV_RESULT_DENIED;
+    }
 #if AP_COPTER_ADVANCED_FAILSAFE_ENABLED
     if (GCS_MAVLINK::handle_flight_termination(packet) == MAV_RESULT_ACCEPTED) {
         return MAV_RESULT_ACCEPTED;

--- a/ArduPlane/GCS_MAVLink_Plane.cpp
+++ b/ArduPlane/GCS_MAVLink_Plane.cpp
@@ -810,6 +810,10 @@ MAV_RESULT GCS_MAVLINK_Plane::handle_command_int_packet(const mavlink_command_in
         return MAV_RESULT_FAILED;
 
     case MAV_CMD_MISSION_START:
+        if (command_addressed_to_other_component(packet)) {
+            // don't start the mission on a command addressed to another component
+            return MAV_RESULT_DENIED;
+        }
         if (!is_zero(packet.param1) || !is_zero(packet.param2)) {
             // first-item/last item not supported
             return MAV_RESULT_DENIED;
@@ -889,6 +893,10 @@ void GCS_MAVLINK_Plane::convert_COMMAND_LONG_to_COMMAND_INT(const mavlink_comman
 
 MAV_RESULT GCS_MAVLINK_Plane::handle_command_MAV_CMD_NAV_TAKEOFF(const mavlink_command_int_t &packet)
 {
+    if (command_addressed_to_other_component(packet)) {
+        // don't take off on a command addressed to another component
+        return MAV_RESULT_DENIED;
+    }
     float takeoff_alt = packet.z;
     switch (packet.frame) {
     case MAV_FRAME_LOCAL_OFFSET_NED:  // "NED local tangent frame with origin that travels with the vehicle"
@@ -917,6 +925,10 @@ MAV_RESULT GCS_MAVLINK_Plane::handle_MAV_CMD_DO_AUTOTUNE_ENABLE(const mavlink_co
 #if HAL_PARACHUTE_ENABLED
 MAV_RESULT GCS_MAVLINK_Plane::handle_MAV_CMD_DO_PARACHUTE(const mavlink_command_int_t &packet)
 {
+        if (command_addressed_to_other_component(packet)) {
+            // don't operate the parachute on a command addressed to another component
+            return MAV_RESULT_DENIED;
+        }
         // configure or release parachute
         switch ((uint16_t)packet.param1) {
         case PARACHUTE_DISABLE:
@@ -950,6 +962,10 @@ MAV_RESULT GCS_MAVLINK_Plane::handle_MAV_CMD_DO_PARACHUTE(const mavlink_command_
 #if HAL_QUADPLANE_ENABLED
 MAV_RESULT GCS_MAVLINK_Plane::handle_MAV_CMD_DO_MOTOR_TEST(const mavlink_command_int_t &packet)
 {
+        if (command_addressed_to_other_component(packet)) {
+            // don't run a motor test on a command addressed to another component
+            return MAV_RESULT_DENIED;
+        }
         // param1 : motor sequence number (a number from 1 to max number of motors on the vehicle)
         // param2 : throttle type (0=throttle percentage, 1=PWM, 2=pilot throttle channel pass-through. See MOTOR_TEST_THROTTLE_TYPE enum)
         // param3 : throttle (range depends upon param2)

--- a/ArduSub/GCS_MAVLink_Sub.cpp
+++ b/ArduSub/GCS_MAVLink_Sub.cpp
@@ -501,6 +501,10 @@ MAV_RESULT GCS_MAVLINK_Sub::handle_MAV_CMD_DO_CHANGE_SPEED(const mavlink_command
 
 MAV_RESULT GCS_MAVLINK_Sub::handle_MAV_CMD_MISSION_START(const mavlink_command_int_t &packet)
 {
+        if (command_addressed_to_other_component(packet)) {
+            // don't start the mission on a command addressed to another component
+            return MAV_RESULT_DENIED;
+        }
         if (sub.motors.armed() && sub.set_mode(Mode::Number::AUTO, ModeReason::GCS_COMMAND)) {
             return MAV_RESULT_ACCEPTED;
         }
@@ -509,6 +513,10 @@ MAV_RESULT GCS_MAVLINK_Sub::handle_MAV_CMD_MISSION_START(const mavlink_command_i
 
 MAV_RESULT GCS_MAVLINK_Sub::handle_MAV_CMD_DO_MOTOR_TEST(const mavlink_command_int_t &packet)
 {
+        if (command_addressed_to_other_component(packet)) {
+            // don't run a motor test on a command addressed to another component
+            return MAV_RESULT_DENIED;
+        }
         // param1 : motor sequence number (a number from 1 to max number of motors on the vehicle)
         // param2 : throttle type (0=throttle percentage, 1=PWM, 2=pilot throttle channel pass-through. See MOTOR_TEST_THROTTLE_TYPE enum)
         // param3 : throttle (range depends upon param2)

--- a/ArduSub/GCS_MAVLink_Sub.cpp
+++ b/ArduSub/GCS_MAVLink_Sub.cpp
@@ -776,6 +776,10 @@ uint64_t GCS_MAVLINK_Sub::capabilities() const
 
 MAV_RESULT GCS_MAVLINK_Sub::handle_flight_termination(const mavlink_command_int_t &packet)
 {
+    if (command_addressed_to_other_component(packet)) {
+        // don't terminate the flight on a command addressed to another component
+        return MAV_RESULT_DENIED;
+    }
     if (packet.param1 > 0.5f) {
         sub.arming.disarm(AP_Arming::Method::TERMINATION);
         return MAV_RESULT_ACCEPTED;

--- a/Blimp/GCS_MAVLink_Blimp.cpp
+++ b/Blimp/GCS_MAVLink_Blimp.cpp
@@ -274,6 +274,10 @@ void GCS_MAVLINK_Blimp::handle_message(const mavlink_message_t &msg)
 
 MAV_RESULT GCS_MAVLINK_Blimp::handle_flight_termination(const mavlink_command_int_t &packet)
 {
+    if (command_addressed_to_other_component(packet)) {
+        // don't terminate the flight on a command addressed to another component
+        return MAV_RESULT_DENIED;
+    }
     MAV_RESULT result = MAV_RESULT_FAILED;
     if (packet.param1 > 0.5f) {
         blimp.arming.disarm(AP_Arming::Method::TERMINATION);

--- a/Rover/GCS_MAVLink_Rover.cpp
+++ b/Rover/GCS_MAVLink_Rover.cpp
@@ -481,6 +481,10 @@ MAV_RESULT GCS_MAVLINK_Rover::handle_command_int_packet(const mavlink_command_in
         return MAV_RESULT_FAILED;
 
     case MAV_CMD_DO_MOTOR_TEST:
+        if (command_addressed_to_other_component(packet)) {
+            // don't run a motor test on a command addressed to another component
+            return MAV_RESULT_DENIED;
+        }
         // param1 : motor sequence number (a number from 1 to max number of motors on the vehicle)
         // param2 : throttle type (0=throttle percentage, 1=PWM, 2=pilot throttle channel pass-through. See MOTOR_TEST_THROTTLE_TYPE enum)
         // param3 : throttle (range depends upon param2)
@@ -492,6 +496,10 @@ MAV_RESULT GCS_MAVLINK_Rover::handle_command_int_packet(const mavlink_command_in
                                               packet.param4);
 
     case MAV_CMD_MISSION_START:
+        if (command_addressed_to_other_component(packet)) {
+            // don't start the mission on a command addressed to another component
+            return MAV_RESULT_DENIED;
+        }
         if (!is_zero(packet.param1) || !is_zero(packet.param2)) {
             // first-item/last item not supported
             return MAV_RESULT_DENIED;

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -14499,6 +14499,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
              self.AutoTune,
              self.AutoTuneYawD,
              self.NoRCOnBootPreArmFailure,
+             self.CommandComponentID,
         ])
         return ret
 
@@ -15126,6 +15127,39 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.assert_prearm_failure("safety switch")
         self.run_cmd_int(mavutil.mavlink.MAV_CMD_DO_SET_SAFETY_SWITCH_STATE, mavutil.mavlink.SAFETY_SWITCH_STATE_DANGEROUS)
         self.wait_ready_to_arm()
+
+    def CommandComponentID(self):
+        '''autopilot-wide commands addressed to another component must be denied'''
+        # A command addressed to a specific component that is neither the
+        # autopilot nor the broadcast component must be denied, not actioned
+        # (see GCS_MAVLINK::command_addressed_to_other_component). Covers the
+        # shared base handlers plus Copter's SOLO_BTN and flight-termination
+        # overrides.
+        self.wait_ready_to_arm()
+        for command in (
+                mavutil.mavlink.MAV_CMD_COMPONENT_ARM_DISARM,
+                mavutil.mavlink.MAV_CMD_DO_SET_MODE,
+                mavutil.mavlink.MAV_CMD_DO_FLIGHTTERMINATION,
+                mavutil.mavlink.MAV_CMD_SOLO_BTN_FLY_HOLD,
+        ):
+            self.run_cmd_int(
+                command,
+                p1=1,
+                target_compid=mavutil.mavlink.MAV_COMP_ID_GIMBAL,
+                want_result=mavutil.mavlink.MAV_RESULT_DENIED,
+            )
+        if self.armed():
+            raise NotAchievedException("Armed by a command addressed to another component")
+
+        # positive control: the same arm command addressed to the autopilot is accepted
+        self.run_cmd_int(
+            mavutil.mavlink.MAV_CMD_COMPONENT_ARM_DISARM,
+            p1=1,
+            target_compid=1,
+            want_result=mavutil.mavlink.MAV_RESULT_ACCEPTED,
+        )
+        self.wait_armed()
+        self.disarm_vehicle()
 
     def ArmSwitchAfterReboot(self):
         '''test that the arming switch does not trigger after a reboot'''

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -15133,20 +15133,31 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         # A command addressed to a specific component that is neither the
         # autopilot nor the broadcast component must be denied, not actioned
         # (see GCS_MAVLINK::command_addressed_to_other_component). Covers the
-        # shared base handlers plus Copter's SOLO_BTN and flight-termination
-        # overrides.
+        # shared base handlers plus the Copter arm / motor-test / takeoff /
+        # parachute / mission-start / Solo-button / flight-termination handlers.
+        # Params are chosen so that MAV_RESULT_DENIED can only come from the
+        # component-id guard, not from an unrelated pre-check in the handler
+        # (e.g. MISSION_START rejects p1!=0, NAV_TAKEOFF rejects a non
+        # GLOBAL_RELATIVE_ALT frame - so those would give DENIED even without
+        # the guard).
         self.wait_ready_to_arm()
-        for command in (
-                mavutil.mavlink.MAV_CMD_COMPONENT_ARM_DISARM,
-                mavutil.mavlink.MAV_CMD_DO_SET_MODE,
-                mavutil.mavlink.MAV_CMD_DO_FLIGHTTERMINATION,
-                mavutil.mavlink.MAV_CMD_SOLO_BTN_FLY_HOLD,
-        ):
+        for command, kwargs in [
+                (mavutil.mavlink.MAV_CMD_COMPONENT_ARM_DISARM, {"p1": 1}),
+                (mavutil.mavlink.MAV_CMD_DO_SET_MODE, {"p1": 1}),
+                (mavutil.mavlink.MAV_CMD_DO_FLIGHTTERMINATION, {"p1": 1}),
+                (mavutil.mavlink.MAV_CMD_DO_MOTOR_TEST, {"p1": 1}),
+                (mavutil.mavlink.MAV_CMD_MISSION_START, {"p1": 0}),
+                (mavutil.mavlink.MAV_CMD_DO_PARACHUTE, {"p1": mavutil.mavlink.PARACHUTE_ENABLE}),
+                (mavutil.mavlink.MAV_CMD_NAV_TAKEOFF, {"frame": mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT}),
+                (mavutil.mavlink.MAV_CMD_SOLO_BTN_FLY_HOLD, {}),
+                (mavutil.mavlink.MAV_CMD_SOLO_BTN_FLY_CLICK, {}),
+                (mavutil.mavlink.MAV_CMD_SOLO_BTN_PAUSE_CLICK, {}),
+        ]:
             self.run_cmd_int(
                 command,
-                p1=1,
                 target_compid=mavutil.mavlink.MAV_COMP_ID_GIMBAL,
                 want_result=mavutil.mavlink.MAV_RESULT_DENIED,
+                **kwargs,
             )
         if self.armed():
             raise NotAchievedException("Armed by a command addressed to another component")

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -630,6 +630,14 @@ protected:
     void handle_set_gps_global_origin(const mavlink_message_t &msg);
 #endif  // AP_MAVLINK_SET_GPS_GLOBAL_ORIGIN_MESSAGE_ENABLED
     void handle_setup_signing(const mavlink_message_t &msg) const;
+
+    // returns true if the command is addressed to a specific component
+    // other than this autopilot (i.e. neither the broadcast component nor
+    // our own component id). Autopilot-wide commands (arm/disarm, reboot,
+    // set-mode, calibration, flight termination, etc) must not be actioned
+    // in that case, as there is no per-component version of those actions.
+    bool command_addressed_to_other_component(const mavlink_command_int_t &packet) const;
+
     virtual MAV_RESULT handle_preflight_reboot(const mavlink_command_int_t &packet, const mavlink_message_t &msg);
 #if AP_MAVLINK_FAILURE_CREATION_ENABLED
     struct {

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3526,7 +3526,7 @@ bool GCS_MAVLINK::command_addressed_to_other_component(const mavlink_command_int
 }
 
 /*
-  handle a MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN command 
+  handle a MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN command
 
   Optionally disable PX4IO overrides. This is done for quadplanes to
   prevent the mixer running while rebooting which can start the VTOL
@@ -3535,8 +3535,8 @@ bool GCS_MAVLINK::command_addressed_to_other_component(const mavlink_command_int
  */
 MAV_RESULT GCS_MAVLINK::handle_preflight_reboot(const mavlink_command_int_t &packet, const mavlink_message_t &msg)
 {
-    if ((packet.target_component != MAV_COMP_ID_ALL) && (packet.target_component != mavlink_system.compid)) {
-        // Make sure reboot/shutdown commands sent to a component don't cause the autopilot to reboot.
+    if (command_addressed_to_other_component(packet)) {
+        // don't reboot/shutdown the autopilot on a command addressed to another component
         return MAV_RESULT_DENIED;
     }
 
@@ -3729,6 +3729,10 @@ void GCS_MAVLINK::deadlock_sem(void)
  */
 MAV_RESULT GCS_MAVLINK::handle_flight_termination(const mavlink_command_int_t &packet)
 {
+    if (command_addressed_to_other_component(packet)) {
+        // don't terminate the flight on a command addressed to another component
+        return MAV_RESULT_DENIED;
+    }
 #if AP_ADVANCEDFAILSAFE_ENABLED
     AP_AdvancedFailsafe *failsafe = AP::advancedfailsafe();
     if (failsafe == nullptr) {
@@ -4877,6 +4881,10 @@ MAV_RESULT GCS_MAVLINK::handle_command_do_set_global_origin(const mavlink_comman
 #if AP_BOOTLOADER_FLASHING_ENABLED
 MAV_RESULT GCS_MAVLINK::handle_command_flash_bootloader(const mavlink_command_int_t &packet)
 {
+    if (command_addressed_to_other_component(packet)) {
+        // don't reflash the autopilot's bootloader on a command addressed to another component
+        return MAV_RESULT_DENIED;
+    }
     if (packet.x != 290876) {
         GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Magic not set");
         return MAV_RESULT_FAILED;
@@ -4999,6 +5007,10 @@ MAV_RESULT GCS_MAVLINK::_handle_command_preflight_calibration(const mavlink_comm
 
 MAV_RESULT GCS_MAVLINK::handle_command_preflight_calibration(const mavlink_command_int_t &packet, const mavlink_message_t &msg)
 {
+    if (command_addressed_to_other_component(packet)) {
+        // don't calibrate the autopilot on a command addressed to another component
+        return MAV_RESULT_DENIED;
+    }
     if (hal.util->get_soft_armed()) {
         // *preflight*, remember?
         GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "Disarm to allow calibration");
@@ -5122,6 +5134,10 @@ MAV_RESULT GCS_MAVLINK::handle_command_request_autopilot_capabilities(const mavl
 
 MAV_RESULT GCS_MAVLINK::handle_command_do_set_mode(const mavlink_command_int_t &packet)
 {
+    if (command_addressed_to_other_component(packet)) {
+        // don't change the autopilot's mode on a command addressed to another component
+        return MAV_RESULT_DENIED;
+    }
     const uint8_t _base_mode = (uint8_t)packet.param1;
     const uint32_t _custom_mode = (uint32_t)packet.param2;
 
@@ -5270,8 +5286,8 @@ MAV_RESULT GCS_MAVLINK::handle_command_mount(const mavlink_command_int_t &packet
 #if AP_ARMING_ENABLED
 MAV_RESULT GCS_MAVLINK::handle_command_component_arm_disarm(const mavlink_command_int_t &packet)
 {
-    if ((packet.target_component != MAV_COMP_ID_ALL) && (packet.target_component != mavlink_system.compid)) {
-        // Make sure an arm/disarm command addressed to a component doesn't arm or disarm the autopilot. Arming is vehicle-wide; there is no per-component arming.
+    if (command_addressed_to_other_component(packet)) {
+        // don't arm/disarm the autopilot on a command addressed to another component
         return MAV_RESULT_DENIED;
     }
     if (is_equal(packet.param1,1.0f)) {
@@ -5632,6 +5648,10 @@ MAV_RESULT GCS_MAVLINK::handle_command_do_set_roi(const mavlink_command_int_t &p
 #if AP_FILESYSTEM_FORMAT_ENABLED
 MAV_RESULT GCS_MAVLINK::handle_command_storage_format(const mavlink_command_int_t &packet, const mavlink_message_t &msg)
 {
+    if (command_addressed_to_other_component(packet)) {
+        // don't format the autopilot's storage on a command addressed to another component
+        return MAV_RESULT_DENIED;
+    }
     if (!is_equal(packet.param1, 1.0f) ||
         !is_equal(packet.param2, 1.0f)) {
         return MAV_RESULT_UNSUPPORTED;
@@ -5650,6 +5670,10 @@ MAV_RESULT GCS_MAVLINK::handle_command_storage_format(const mavlink_command_int_
 
 MAV_RESULT GCS_MAVLINK::handle_do_set_safety_switch_state(const mavlink_command_int_t &packet, const mavlink_message_t &msg)
 {
+    if (command_addressed_to_other_component(packet)) {
+        // don't change the autopilot's safety state on a command addressed to another component
+        return MAV_RESULT_DENIED;
+    }
     switch ((SAFETY_SWITCH_STATE)packet.param1) {
     case SAFETY_SWITCH_STATE_DANGEROUS:
         // turn safety off (pwm outputs flow to the motors)
@@ -5843,6 +5867,10 @@ MAV_RESULT GCS_MAVLINK::handle_command_int_packet(const mavlink_command_int_t &p
         return handle_command_preflight_calibration(packet, msg);
 
     case MAV_CMD_PREFLIGHT_STORAGE:
+        if (command_addressed_to_other_component(packet)) {
+            // don't reset the autopilot's parameters on a command addressed to another component
+            return MAV_RESULT_DENIED;
+        }
         if (uint8_t(packet.param1) == PARAM_RESET_FACTORY_DEFAULT ||
             uint8_t(packet.param1) == PARAM_RESET_ALL_DEFAULT) {
             AP_Param::erase_all();

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3514,6 +3514,17 @@ void GCS_MAVLINK::send_vfr_hud()
 }
 #endif  // AP_AHRS_ENABLED
 
+// returns true if this command is addressed to a specific component other
+// than this autopilot (i.e. neither the broadcast component nor our own
+// component id). Autopilot-wide commands (arm/disarm, reboot, set-mode,
+// calibration, flight termination, etc) must not be actioned in that case,
+// as there is no per-component version of those actions.
+bool GCS_MAVLINK::command_addressed_to_other_component(const mavlink_command_int_t &packet) const
+{
+    return (packet.target_component != MAV_COMP_ID_ALL) &&
+           (packet.target_component != mavlink_system.compid);
+}
+
 /*
   handle a MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN command 
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -5259,6 +5259,10 @@ MAV_RESULT GCS_MAVLINK::handle_command_mount(const mavlink_command_int_t &packet
 #if AP_ARMING_ENABLED
 MAV_RESULT GCS_MAVLINK::handle_command_component_arm_disarm(const mavlink_command_int_t &packet)
 {
+    if ((packet.target_component != MAV_COMP_ID_ALL) && (packet.target_component != mavlink_system.compid)) {
+        // Make sure an arm/disarm command addressed to a component doesn't arm or disarm the autopilot. Arming is vehicle-wide; there is no per-component arming.
+        return MAV_RESULT_DENIED;
+    }
     if (is_equal(packet.param1,1.0f)) {
         if (AP::arming().is_armed()) {
             return MAV_RESULT_ACCEPTED;


### PR DESCRIPTION
### Summary

Problem

A MAVLink command addressed to a specific component (e.g. a gimbal or camera) but sent to the vehicle's system ID is still processed locally by the autopilot — MAVLink routing forces local handling when there's no learned route to the target component. So a command addressed to another component could arm the vehicle, spin motors, take off, fire the parachute, etc.

Change

Added a shared predicate GCS_MAVLINK::command_addressed_to_other_component(packet) (true when target_component is neither broadcast nor this autopilot's component id) and used it to reject such commands with MAV_RESULT_DENIED at every autopilot-wide/dangerous command handler:

Arm/disarm, reboot, set-mode, calibration, storage-format, factory-reset, safety-switch, flash-bootloader, flight-termination
Motor test, takeoff, parachute, mission-start, Solo buttons
Covers all vehicles (Copter/Plane/Rover/Sub/Blimp/Tracker), including the flight_termination overrides that don't chain to base

### Classification & Testing (check all that apply and add your own)

- [ ] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request