### PR TITLE
AP_FlashStorage: set current_sector during init

### DIFF
--- a/libraries/AP_FlashStorage/AP_FlashStorage.cpp
+++ b/libraries/AP_FlashStorage/AP_FlashStorage.cpp
@@ -95,6 +95,9 @@ bool AP_FlashStorage::init(void)
         first_sector = 0;
     }
 
+    // update current sector in case first sector has changed
+    current_sector = first_sector;
+
     // load data from any current sectors
     for (uint8_t i=0; i<2; i++) {
         uint8_t sector = (first_sector + i) & 1;


### PR DESCRIPTION
### Summary

AP_FlashStorage: set current_sector during init

Related discussion https://discuss.ardupilot.org/t/potential-incomplete-initialization-on-ap-flashstorage/144440
Perhaps resolves: https://github.com/ArduPilot/ardupilot/issues/33538

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

While troubleshooting aninternal error 0x200000 I noticed that parameters could no longer be saved permanently. Notably, the parameters STAT_BOOTCNT and STAT_RUNTIME—which usually increment automatically—kept reverting to their previous values ​​after a restart. Further analysis revealed that:
Sector 0 was marked with status [SECTOR_STATE_AVAILABLE] Sector 1 was marked with status [SECTOR_STATE_IN_USE] Consequently, the current parameters were being loaded from Sector 1. However, when writing new parameters, the system attempted to write to Sector 0. In my opinion, the cause of this is that the variable current_sector is not set to the active sector during initialization.
I was able to resolve the issue—at least for testing purposes—by inserting the initialization of the current_sector variable after the following code block:

// work out the first sector to read from using sector states
enum SectorState states[2] {header[0].get_state(), header[1].get_state()}; 
uint8_t first_sector; 

if (states[0] == states[1]) {
if (states[0] != SECTOR_STATE_AVAILABLE) {
return erase_all(); 
}
first_sector = 0; 
} else if (states[0] == SECTOR_STATE_FULL) {
first_sector = 0; 
} else if (states[1] == SECTOR_STATE_FULL) {
first_sector = 1; 
} else if (states[0] == SECTOR_STATE_IN_USE) {
first_sector = 0; 
} else if (states[1] == SECTOR_STATE_IN_USE) {
first_sector = 1; 
} else {
// doesn't matter which is first
first_sector = 0; 
}

//added initialization current_sector
current_sector = first_sector;


<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
