### PR TITLE
AP_Scripting: fix typo in parameter name in EFI driver docs

### DIFF
--- a/libraries/AP_Scripting/drivers/EFI_DLA.md
+++ b/libraries/AP_Scripting/drivers/EFI_DLA.md
@@ -29,7 +29,7 @@ directly or via MAVFTP. The following key parameters should be set:
 - EFI_TYPE should be set to 7
 - EFI_DLA_ENABLE should be set to 1
 - SERIALn_PROTOCOL should be set to 28 for the connected EFI serial
-- RPM_TYPE1 should be set to 3
+- RPM1_TYPE should be set to 3
 - ICE_ENABLE should be set to 1
 
 then the flight controller should rebooted and parameters should be

--- a/libraries/AP_Scripting/drivers/Generator_SVFFI.md
+++ b/libraries/AP_Scripting/drivers/Generator_SVFFI.md
@@ -21,7 +21,7 @@ directly or via MAVFTP. The following key parameters should be set:
 - EFI_TYPE should be set to 7
 - EFI_SVF_ENABLE should be set to 1
 - SERIALn_PROTOCOL should be set to 28 for the connected serial port
-- RPM_TYPE1 should be set to 3
+- RPM1_TYPE should be set to 3
 
 then the flight controller should rebooted and parameters should be
 refreshed.

--- a/libraries/AP_Scripting/drivers/INF_Inject.md
+++ b/libraries/AP_Scripting/drivers/INF_Inject.md
@@ -30,7 +30,7 @@ directly or via MAVFTP. The following key parameters should be set:
 - EFI_TYPE should be set to 7
 - EFI_INF_ENABLE should be set to 1
 - SERIALn_PROTOCOL should be set to 28 for the connected EFI serial
-- RPM_TYPE1 should be set to 3
+- RPM1_TYPE should be set to 3
 - ICE_ENABLE should be set to 1
 
 then the flight controller should rebooted and parameters should be


### PR DESCRIPTION
### Summary

Documentation had `RPM_TYPE1` name which doesn't exist, `RPM1_TYPE` is the correct name.
<!-- Put a one or two line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

The new parameter name actually exists on the vehicle.

### Description

Changed the incorrect parameter name. Used `ripgrep` to make sure I didn't miss any
<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
