### PR TITLE
AP_NavEKF3: prevent yaw measurement time delay exceeding IMU buffer age

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -1051,7 +1051,12 @@ void NavEKF3_core::writeEulerYawAngle(float yawAngle, float yawAngleErr, uint32_
     } else {
         return;
     }
-    yawAngDataNew.time_ms = timeStamp_ms;
+    // Prevent time delay exceeding age of oldest IMU data in the buffer. Without
+    // this a configured delay larger than the fusion time horizon leaves every
+    // measurement outside the recall window and the yaw source silently stops
+    // fusing. The raw timestamp is still used for new-measurement detection and
+    // rate limiting via yawMeasTime_ms
+    yawAngDataNew.time_ms = MAX(timeStamp_ms, imuDataDelayed.time_ms);
 
     storedYawAng.push(yawAngDataNew);
 


### PR DESCRIPTION
### Summary

The EKF sizes its fusion time horizon with the GPS delay limited to
250ms, but gps_yaw_deg() subtracts the full configured delay from the
measurement timestamp. A GPS_DELAY_MS above approximately 350ms
therefore produced yaw measurements more than 100ms older than the
fusion horizon, outside the buffer recall window, so every sample was
silently discarded and the GPS yaw source went dead while GPS
position, which clamps its timestamps, kept working.

Clamp the buffered measurement time to the fusion horizon in the same
way as readGpsData and readBaroData. The raw timestamp is still used
for new-measurement detection and rate limiting. A measurement older
than the horizon now fuses with bounded staleness and is protected by
the innovation gate instead of being silently dropped.


### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
