### PR TITLE
AP_GPS: SBF clear yaw accuracy flag on errored attitude covariance

### DIFF
--- a/libraries/AP_GPS/AP_GPS_SBF.cpp
+++ b/libraries/AP_GPS/AP_GPS_SBF.cpp
@@ -598,7 +598,7 @@ AP_GPS_SBF::process_message(void)
                 state.gps_yaw_accuracy = sqrtf(temp.Cov_HeadHead);
                 state.have_gps_yaw_accuracy = true;
             } else {
-                state.gps_yaw_accuracy = false;
+                state.have_gps_yaw_accuracy = false;
             }
         }
         break;


### PR DESCRIPTION
### Summary

state.gps_yaw_accuracy = false assigned 0.0 to the accuracy value and
left have_gps_yaw_accuracy set, so once one good AttEulerCov message
had been received, an errored or do-not-use heading covariance was
reported as a perfect 0 degree yaw accuracy instead of falling back to
the 10 degree default in AP_GPS::gps_yaw_deg.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

