### PR TITLE
autotest: widen Blimp FlyManualFinned heading tolerance to 15 degrees

### DIFF
--- a/Tools/autotest/blimp.py
+++ b/Tools/autotest/blimp.py
@@ -106,7 +106,7 @@ class AutoTestBlimp(TestSuite):
     def FlyManualFinned(self):
         '''test manual mode on the finned blimp frame'''
         speed_accuracy = 0.07
-        heading_accuracy = 10
+        heading_accuracy = 15
 
         def stop_blimp():
             self.progress("Stopping.")


### PR DESCRIPTION
### Summary

Widen error margin in Blimp test

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

This didn't fail in 1000 runs... so I ran it some more.

### Description

The per-stop heading check in FlyManualFinned is born-marginal.  MANUAL mode does not hold heading (ModeManual::run is open-loop), so the finned blimp's translation-into-yaw coupling lets the heading settle several degrees off after a stop, and the old +-10 degree limit was right at the top of that distribution - which is why the test occasionally trips in CI (e.g. 349 deg / 11 deg off on an unrelated PR).

A 1000-run campaign measuring the true settled drift (worst offset over a settle window, not the closest approach the lenient wait_heading check happens to catch) found the drift reaches 12 deg, with 5.8% of runs settling past 10 deg.  15 degrees clears the whole observed distribution with ~3 degrees of headroom while remaining a meaningful check that MANUAL translation does not spin the blimp.

