### PR TITLE
Use TKOFF_THR_IDLE also in AUTO

### DIFF
--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -636,10 +636,13 @@ void Plane::set_throttle(void)
             // throttle is suppressed (above) to zero in final flare in auto mode, but we allow instead thr_min if user prefers, eg turbines:
             SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, aparm.throttle_min.get());
 
-        } else if ((flight_stage == AP_FixedWing::FlightStage::TAKEOFF)
-                    && (aparm.takeoff_throttle_idle.get() > 0)
+        } else if ((aparm.takeoff_throttle_idle.get() > 0)
+                    && (flight_stage == AP_FixedWing::FlightStage::TAKEOFF
+                        || (control_mode == &mode_auto
+                            && mission.get_current_nav_cmd().id == MAV_CMD_NAV_TAKEOFF))
                   ) {
-            // we want to spin at idle throttle before the takeoff conditions are met
+            // we want to spin at idle throttle before the takeoff conditions are met.
+            // AUTO mode doesnt trigger FlightStage::TAKEOFF therefor check for the takeoff command.
             SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, aparm.takeoff_throttle_idle.get());
         } else {
             // default

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -5626,6 +5626,38 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
         self.fly_home_land_and_disarm()
 
+    def TakeoffIdleThrottleAuto(self):
+        '''Apply idle throttle before a takeoff command in an AUTO mission.'''
+        self.customise_SITL_commandline(
+            [],
+            model='plane-catapult',
+            defaults_filepath=self.model_defaults_filepath("plane")
+        )
+        self.set_parameters({
+            "TKOFF_THR_IDLE": 20.0,
+            "TKOFF_THR_MINSPD": 3.0,
+        })
+        self.upload_simple_relhome_mission([
+            (mavutil.mavlink.MAV_CMD_NAV_TAKEOFF, 0, 0, 50),
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 300, 0, 50),
+        ])
+        self.change_mode("AUTO")
+
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+
+        # While the AUTO mission waits on the takeoff command for launch, the
+        # throttle should idle at TKOFF_THR_IDLE. In AUTO the flight stage is
+        # not yet TAKEOFF, so this exercises the current-mission-command path.
+        expected_idle_throttle = 1000 + 10 * self.get_parameter("TKOFF_THR_IDLE")
+        self.wait_servo_channel_in_range(3, expected_idle_throttle - 10, expected_idle_throttle + 10, timeout=15)
+
+        # Launch the catapult and confirm we leave idle and climb.
+        self.set_servo(7, 2000)
+        self.wait_altitude(20, 45, relative=True, timeout=30)
+
+        self.disarm_vehicle(force=True)
+
     def TakeoffBadLevelOff(self):
         '''Ensure that the takeoff can be completed under 0 pitch demand.'''
         '''
@@ -8463,6 +8495,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.TakeoffTakeoff5,
             self.TakeoffGround,
             self.TakeoffIdleThrottle,
+            self.TakeoffIdleThrottleAuto,
             self.TakeoffBadLevelOff,
             self.TakeoffLevelOffWind,
             self.ForcedDCM,


### PR DESCRIPTION
### Summary

Make `TKOFF_THR_IDLE` also apply during the takeoff command of an AUTO mission (previously it only worked in TAKEOFF mode).

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

New autotest `Plane.TakeoffIdleThrottleAuto` (plane-catapult): arms an AUTO
mission on a NAV_TAKEOFF, asserts the throttle idles at `TKOFF_THR_IDLE`,
then releases the catapult and confirms it leaves idle and climbs. Passes
locally; also reproduced the original problem and the fix in SITL.

Also tested on a actual hardware with Speedybee f405 Wing in a bench setup. Can provide log if needed.

### Description

`TKOFF_THR_IDLE` was gated on `flight_stage == TAKEOFF`. In an AUTO mission
the flight stage stays `NORMAL` while the throttle is suppressed waiting for
launch (only TAKEOFF mode force-sets `TAKEOFF` during the wait), so the idle
throttle was never output in AUTO.

This also applies the idle when in AUTO and the current mission command is a
`NAV_TAKEOFF`. The branch is still inside `suppress_throttle()`, so it only
runs pre-launch; once launch is detected the throttle is un-suppressed and
normal takeoff throttle takes over (idle is not applied during the climb).
