### PR TITLE
AP_SCripting: fix quadplane_terrain_avoid.lua backward compatiblty

### DIFF
--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -3046,8 +3046,8 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.wait_ready_to_arm()
 
         # TopOfTheWord "ground" is at over 1km altitude
-        expected_terrain_height = 1101
-        if abs(report.terrain_height - expected_terrain_height) > 1.0:
+        expected_terrain_height = 1102
+        if abs(report.terrain_height - expected_terrain_height) > 2.0:
             raise NotAchievedException("Expected terrain height=%f got=%f" %
                                        (expected_terrain_height, report.terrain_height))
 
@@ -3094,6 +3094,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.wait_text("TerrAvoid: CMTC loiter left", check_context=True, regex=True)
         self.wait_text("TerrAvoid: CMTC STOP", check_context=True, regex=True)
         self.wait_text("TerrAvoid: CMTC Done", check_context=True, regex=True)
+        self.context_clear_collection('STATUSTEXT')
 
         self.wait_text("TerrAvoid: high terrain detected", check_context=True, regex=True, timeout=60)
 
@@ -3101,7 +3102,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.progress("CMTC alt #4 is %f" % self.get_altitude(relative=False, timeout=2))
         self.wait_text("TerrAvoid: high terrain detected", check_context=True, regex=True, timeout=60)
         self.wait_text("TerrAvoid: CMTC loiter left", check_context=True, regex=True)
-        self.progress("CMTC alt #6 is %f" % self.get_altitude(relative=False, timeout=2))
+        self.progress("CMTC alt #5 is %f" % self.get_altitude(relative=False, timeout=2))
         self.wait_text("TerrAvoid: CMTC STOP", check_context=True, regex=True)
         self.wait_text("TerrAvoid: CMTC Done", check_context=True, regex=True)
 
@@ -3109,31 +3110,42 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
 
         self.wait_text("TerrAvoid: CMTC STOP", check_context=True, regex=True)
         self.wait_text("TerrAvoid: CMTC Done", check_context=True, regex=True)
+        self.context_clear_collection('STATUSTEXT')
 
-        self.progress("#Pitching alt is %f" % self.get_altitude(relative=False, timeout=2))
+        self.progress("#Pitching #1 alt is %f" % self.get_altitude(relative=False, timeout=2))
         self.wait_text("TerrAvoid: Pitching Started", check_context=True, regex=True, timeout=600)
-        self.wait_text("TerrAvoid: Terrain Ok", check_context=True, regex=True, timeout=60)
+
+        # CMTC triggered while still in pitching, expect CMTC start followed by Pitching DONE
         self.wait_text("TerrAvoid: CMTC loiter left", check_context=True, regex=True)
-        self.progress("CMTC alt #7 is %f" % self.get_altitude(relative=False, timeout=2))
+        self.progress("CMTC alt #6 is %f" % self.get_altitude(relative=False, timeout=2))
+
         self.wait_text("TerrAvoid: Pitching DONE", check_context=True, regex=True)
-        self.progress("#Pitching DONE alt is %f" % self.get_altitude(relative=False, timeout=2))
+        self.progress("#Pitching#1 DONE alt is %f" % self.get_altitude(relative=False, timeout=2))
 
         # After Pitching CMTC to 1170m +- 30
         self.wait_altitude(1140, 1200, timeout=120, relative=False, minimum_duration=5)
+        self.wait_text("TerrAvoid: CMTC Done", check_context=True, regex=True)
+        self.context_clear_collection('STATUSTEXT')
 
+        self.wait_text("TerrAvoid: CMTC loiter right", check_context=True, regex=True, timeout=60)
+        self.progress("CMTC alt #7 is %f" % self.get_altitude(relative=False, timeout=2))
         self.wait_text("TerrAvoid: CMTC STOP", check_context=True, regex=True)
         self.wait_text("TerrAvoid: CMTC Done", check_context=True, regex=True)
         # wait for 1 more CMTC's
         self.wait_text("TerrAvoid: CMTC Done", check_context=True, regex=True)
+        self.context_clear_collection('STATUSTEXT')
 
-        # now we get a guaranteed quadding
-        self.wait_text("TerrAvoid: Pitching started", check_context=True, regex=True, timeout=120)
-        self.progress("Pitching alt #1 is %f" % self.get_altitude(relative=False, timeout=2))
-        self.wait_text("TerrAvoid: Pitching DONE", check_context=True, regex=True)
-        self.progress("Pitching alt #2 is %f" % self.get_altitude(relative=False, timeout=2))
+        # now we get either pitching or quading, its kind of random
+        self.wait_text("TerrAvoid: (Pitching|Quading) started", check_context=True, regex=True, timeout=120)
+        self.progress("Pitching alt #2 started is %f" % self.get_altitude(relative=False, timeout=2))
+        self.wait_text("TerrAvoid: (Pitching|Quading) DONE", check_context=True, regex=True)
+        self.progress("Pitching alt #3 DONE is %f" % self.get_altitude(relative=False, timeout=2))
+        self.context_clear_collection('STATUSTEXT')
 
         # wait for 1 more CMTC
-        self.wait_text("TerrAvoid: CMTC Done", check_context=True, regex=True)
+        self.wait_text("TerrAvoid: CMTC Done", check_context=True, regex=True, timeout=120)
+        self.progress("CMTC alt #8 is %f" % self.get_altitude(relative=False, timeout=2))
+        self.context_clear_collection('STATUSTEXT')
 
         self.wait_statustext('Land complete', timeout=600)
         self.wait_disarmed(timeout=120) # give quadplane a long time to land

--- a/libraries/AP_Scripting/applets/quadplane_terrain_avoid.lua
+++ b/libraries/AP_Scripting/applets/quadplane_terrain_avoid.lua
@@ -35,7 +35,7 @@ CMTC can be disabled by setting TA_CMTC_ENABLE = 0. The loiter radius will be TA
 
 SCRIPT_NAME = "Terrain Avoid"
 SCRIPT_NAME_SHORT = "TerrAvoid"
-SCRIPT_VERSION = "4.6.0-023"
+SCRIPT_VERSION = "4.7.0-024"
 
 STARTUP_DELAY = 25  -- wait this many seconds for the FC to come up before starting the script
 
@@ -250,46 +250,6 @@ THROTTLE_HOVER_PWM = (THROTTLE_CHANNEL_MAX - THROTTLE_CHANNEL_MIN) * 0.5 + THROT
 PITCH_TOLERANCE = 1.1
 QUAD_TOLERANCE = 1.5
 
-local vehicle_mode = vehicle:get_mode()
-
-local current_location = ahrs:get_location()
-local current_wp_bearing_deg = 0.0
-local previous_location
-local current_altitude_m = 0.0
-local current_location_target
-local current_heading_deg = -1
-local new_location_target
-local terrain_altitude = terrain:height_above_terrain(true)
-local terrain_max_exceeded = false
-local groundspeed_vector = ahrs:groundspeed_vector()
-local groundspeed_current = groundspeed_vector:length()
-local airspeed_current = ahrs:airspeed_EAS()
-local airspeed_desired = airspeed_current
-
-local now_ms = millis()
-local old_now_ms = now_ms
-
-local pitch_last_good_timestamp_ms = now_ms
-local pitch_last_bad_timestamp_ms = now_ms
-local pitch_bad_timer = -10
-
-local slowdown_quading = false
-
-local q_wvane_enable_save = Q_WVANE_ENABLE:get()
-local avoid_enter_mode = -1
-
--- function forward declarations
-local avoid_terrain
-local terrain_approaching
-local pitch_obstacle_detected
-local pitch_obstacle_down
-local pitch_obstacle_forward
-local quading
-
-local mavlink = require("mavlink_wrappers")
-
-local location_tracker  -- forward declaration. See below for definition and instantiation.
-
 -------------------------------------------------
 -- deal with deprecations in 4.7
 -------------------------------------------------
@@ -333,6 +293,56 @@ function Get_Pitch_Deg()
     return math.deg(Get_Pitch_Function(ahrs))
 end
 
+-- airspeed_estimate changed to airspeed_EAS() in 4.7
+Get_Airspeed_Function = ahrs.airspeed_EAS
+if Get_Airspeed_Function == nil then
+    ---@diagnostic disable-next-line:deprecated
+    Get_Airspeed_Function = ahrs.airspeed_estimate
+end
+
+-------------------------------------------------
+-- variable declarations
+-------------------------------------------------
+
+local vehicle_mode = vehicle:get_mode()
+
+local current_location = ahrs:get_location()
+local current_wp_bearing_deg = 0.0
+local previous_location
+local current_altitude_m = 0.0
+local current_location_target
+local current_heading_deg = -1
+local new_location_target
+local terrain_altitude = terrain:height_above_terrain(true)
+local terrain_max_exceeded = false
+local groundspeed_vector = ahrs:groundspeed_vector()
+local groundspeed_current = groundspeed_vector:length()
+local airspeed_current = Get_Airspeed_Function(ahrs)
+local airspeed_desired = airspeed_current
+
+local now_ms = millis()
+local old_now_ms = now_ms
+
+local pitch_last_good_timestamp_ms = now_ms
+local pitch_last_bad_timestamp_ms = now_ms
+local pitch_bad_timer = -10
+
+local slowdown_quading = false
+
+local q_wvane_enable_save = Q_WVANE_ENABLE:get()
+local avoid_enter_mode = -1
+
+-- function forward declarations
+local avoid_terrain
+local terrain_approaching
+local pitch_obstacle_detected
+local pitch_obstacle_down
+local pitch_obstacle_forward
+local quading
+
+local mavlink = require("mavlink_wrappers")
+
+local location_tracker  -- forward declaration. See below for definition and instantiation.
 
 -- constrain a value between limits
 local function constrain(v, vmin, vmax)
@@ -1223,7 +1233,7 @@ function Update()
     current_heading_deg = math.deg(Get_Yaw_Function(ahrs) or 0)
     groundspeed_vector = ahrs:groundspeed_vector()
     groundspeed_current = groundspeed_vector:length()
-    airspeed_current = ahrs:airspeed_EAS()
+    airspeed_current = Get_Airspeed_Function(ahrs)
 
     -- save the previous target location only if in auto mode, if restoring it in AUTO mode
     -- don't update it if already pitching or quading because the altitude change will mess up the history


### PR DESCRIPTION
### Summary

The quadplane_terrain_avoid.lua script fails when run on 4.6 because the AHRS:airspeed_estimate() method was replaced by airspeed_EAS(). This fixes the script by adding explicit backward compatibility.

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [X] Non-functional change
- [X] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [X] Automated test(s) verify changes (e.g. unit test, autotest)
- [X] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Tested in SITL on 4.6 and master.

### Description

When PR #31511 was added the quadplane_terrain_avoid.lua script broke on 4.6. There is 4.6/4.7 backward compatibility code for other methods and users expect to be able to run the same script on 4.6, 4.7 or master interchangeably. This adds backward compatibility for airspeed_EAS().
