### PR TITLE
follow init and if fix

### DIFF
--- a/ArduCopter/mode_follow.cpp
+++ b/ArduCopter/mode_follow.cpp
@@ -99,9 +99,11 @@ void ModeFollow::run()
                 Vector3p pos_ned_m;  // vector to lead vehicle
                 Vector3f vel_ned_ms;  // velocity of lead vehicle
                 Vector3f accel_ned_mss;  // accel of lead vehicle
-                if (g2.follow.get_target_pos_vel_accel_NED_m(pos_ned_m, vel_ned_ms, accel_ned_mss))
-                if (pos_ned_m.xy().length_squared() > 1.0) {
-                    yaw_rad = (pos_ned_m.xy() - pos_control->get_pos_target_NED_m().xy()).tofloat().angle();
+                if (g2.follow.get_target_pos_vel_accel_NED_m(pos_ned_m, vel_ned_ms, accel_ned_mss)) {
+                    const Vector2p vec_to_lead_ne_m = pos_ned_m.xy() - pos_control->get_pos_target_NED_m().xy();
+                    if (vec_to_lead_ne_m.length_squared() > 1.0) {
+                        yaw_rad = vec_to_lead_ne_m.angle();
+                    }
                 }
                 break;
             }

--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -617,7 +617,7 @@ float AP_Follow::calc_max_velocity_change(float accel_max, float jerk_max, float
     } else {
         // timeout too short: pure triangle profile
         const float t_half = timeout_sec * 0.5f;
-        return 0.5f * jerk_max * sq(t_half);
+        return jerk_max * sq(t_half);
     }
 }
 

--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -301,8 +301,9 @@ void AP_Follow::update_estimates()
         _estimate_pos_ned_m = _target_pos_ned_m + delta_pos_m.topostype();
         _estimate_vel_ned_ms = _target_vel_ned_ms + delta_vel_ms;
         _estimate_accel_ned_mss = _target_accel_ned_mss;
-        _estimate_heading_rad = radians(_target_heading_deg) + delta_heading_rad;  
-        _estimate_heading_rate_rads = radians(_target_heading_rate_degs);  
+        _estimate_heading_rad = radians(_target_heading_deg) + delta_heading_rad;
+        _estimate_heading_rate_rads = radians(_target_heading_rate_degs);
+        _estimate_heading_accel_radss = 0.0;
         _estimate_valid = true;
     }
 
@@ -598,6 +599,12 @@ bool AP_Follow::estimate_error_too_large() const
 // Calculates max velocity change under trapezoidal or triangular acceleration profile (jerk-limited).
 float AP_Follow::calc_max_velocity_change(float accel_max, float jerk_max, float timeout_sec) const
 {
+    // a non-positive jerk limit means "no jerk limit": acceleration can be
+    // applied instantly, so the profile is a pure trapezoid. Guarding here also
+    // avoids a divide-by-zero when the FOLL_JERK_* parameter is set to zero.
+    if (!is_positive(jerk_max)) {
+        return accel_max * timeout_sec;
+    }
     const float t_jerk = accel_max / jerk_max;
     const float t_total_jerk = 2.0f * t_jerk;
 


### PR DESCRIPTION
### Summary

1. Initialises the yaw acceleration to zero.

2. The triangular (short-timeout) branch of calc_max_velocity_change() returned only half the profile's velocity change. It didn't account for both ramp up and ramp down hence the factor of 2.

3. Tidies up a malformed if statement in ModeFollow::run()'s YAW_BEHAVE_FACE_LEAD_VEHICLE case. The target-validity check and the distance check were written as two separate braceless if statements stacked on top of each other:

```
if (g2.follow.get_target_pos_vel_accel_NED_m(pos_ned_m, vel_ned_ms, accel_ned_mss))
if (pos_ned_m.xy().length_squared() > 1.0) {
    yaw_rad = ...;
}
```

This is now a single guarded block:

```
if (g2.follow.get_target_pos_vel_accel_NED_m(pos_ned_m, vel_ned_ms, accel_ned_mss) &&
    pos_ned_m.xy().length_squared() > 1.0) {
    yaw_rad = ...;
}
```

Behaviour

No functional change. The two forms are logically identical — both only update yaw_rad when the target estimate is valid and the lead vehicle is more than 1 m away. This block also already sits inside the get_ofs_pos_vel_accel_NED_m() success branch, which gates on the same _estimate_valid flag, so the target fetch here always returns true in practice anyway.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->
