### PR TITLE
AP_AHRS: privatise AP_NavEKF?::started, use attitude_valid instead

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -1314,7 +1314,7 @@ AP_AHRS::EKFType AP_AHRS::_active_EKF_type(void) const
 #if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO: {
         // do we have an EKF2 yet?
-        if (!ekf2.started) {
+        if (!ekf2_estimates.attitude_valid) {
             return fallback_active_EKF_type();
         }
         if (always_use_EKF()) {
@@ -1331,7 +1331,7 @@ AP_AHRS::EKFType AP_AHRS::_active_EKF_type(void) const
 #if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE: {
         // do we have an EKF3 yet?
-        if (!ekf3.started) {
+        if (!ekf3_estimates.attitude_valid) {
             return fallback_active_EKF_type();
         }
         if (always_use_EKF()) {
@@ -1472,13 +1472,13 @@ AP_AHRS::EKFType AP_AHRS::fallback_active_EKF_type(void) const
 #endif
 
 #if HAL_NAVEKF3_AVAILABLE
-    if (ekf3.started) {
+    if (ekf3_estimates.attitude_valid) {
         return EKFType::THREE;
     }
 #endif
 
 #if HAL_NAVEKF2_AVAILABLE
-    if (ekf2.started) {
+    if (ekf2_estimates.attitude_valid) {
         return EKFType::TWO;
     }
 #endif

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -1289,7 +1289,7 @@ AP_AHRS::EKFType AP_AHRS::_active_EKF_type(void) const
 #if HAL_NAVEKF2_AVAILABLE
     case EKFType::TWO: {
         // do we have an EKF2 yet?
-        if (!ekf2.started) {
+        if (!ekf2_estimates.attitude_valid) {
             return fallback_active_EKF_type();
         }
         if (always_use_EKF()) {
@@ -1306,7 +1306,7 @@ AP_AHRS::EKFType AP_AHRS::_active_EKF_type(void) const
 #if HAL_NAVEKF3_AVAILABLE
     case EKFType::THREE: {
         // do we have an EKF3 yet?
-        if (!ekf3.started) {
+        if (!ekf3_estimates.attitude_valid) {
             return fallback_active_EKF_type();
         }
         if (always_use_EKF()) {
@@ -1447,13 +1447,13 @@ AP_AHRS::EKFType AP_AHRS::fallback_active_EKF_type(void) const
 #endif
 
 #if HAL_NAVEKF3_AVAILABLE
-    if (ekf3.started) {
+    if (ekf3_estimates.attitude_valid) {
         return EKFType::THREE;
     }
 #endif
 
 #if HAL_NAVEKF2_AVAILABLE
-    if (ekf2.started) {
+    if (ekf2_estimates.attitude_valid) {
         return EKFType::TWO;
     }
 #endif

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF2.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF2.h
@@ -96,6 +96,8 @@ public:
     // this is out here so parameters can be poked into it
     static NavEKF2 EKF2;
 
+private:
+
     bool start();
     bool started;
     uint32_t start_time_ms;  // timer used to delay starting the filter

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF2.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF2.h
@@ -86,6 +86,8 @@ public:
     // this is out here so parameters can be poked into it
     static NavEKF2 EKF2;
 
+private:
+
     bool start();
     bool started;
     uint32_t start_time_ms;  // timer used to delay starting the filter

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF3.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF3.h
@@ -95,6 +95,8 @@ public:
     // this is out here so parameters can be poked into it
     static NavEKF3 EKF3;
 
+private:
+
     bool start();
     bool started;
     uint32_t start_time_ms;  // timer used to delay starting the filter

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF3.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF3.h
@@ -85,6 +85,8 @@ public:
     // this is out here so parameters can be poked into it
     static NavEKF3 EKF3;
 
+private:
+
     bool start();
     bool started;
     uint32_t start_time_ms;  // timer used to delay starting the filter


### PR DESCRIPTION
### Summary

Avoids using an EKF-backend-specific state variable when deciding on which backends to use for primary/secondary etc

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board,antennatracker,blimp,bootloader,copter,heli,plane,rover,sub
CubeOrangePlus,0,0,*,0,0,0,0,0
```

### Description

Since the EKFs set attitude_valid *from* the started boolean, this is a no-op.

Only the EKF AHRS backends have this started concept, but all of the backends have attitude_valid.

Switching to using attitude_valid will allow us to generalise the selection of which AHRS backend to use - I don't think there's ever a reason to prefer a backend if it can't provide a vehicle attitude, so it makes sense in both places it is used in here.
