### PR TITLE
AP_HAL_Linux: Navio2: detect RCIO pwmchip index at runtime

### DIFF
--- a/libraries/AP_HAL_Linux/HAL_Linux_Class.cpp
+++ b/libraries/AP_HAL_Linux/HAL_Linux_Class.cpp
@@ -218,7 +218,31 @@ static RCOutput_Bebop rcoutDriver(i2c_mgr_instance.get_device(HAL_RCOUT_BEBOP_BL
 #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_DISCO
 static RCOutput_Disco rcoutDriver(i2c_mgr_instance.get_device(HAL_RCOUT_DISCO_BLDC_I2C_BUS, HAL_RCOUT_DISCO_BLDC_I2C_ADDR));
 #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_NAVIO2
-static RCOutput_Sysfs rcoutDriver(0, 0, 14);
+// The Navio2 RCIO co-processor exposes 14 PWM channels as a sysfs pwmchip.
+// Its index depends on the Pi model: 0 on Pi 4 (BCM), 6 on Pi 5 (the RP1
+// shifts pwmchip enumeration). Locate it at runtime by its channel count so a
+// single binary works on both, instead of hard-coding the index.
+// Uses raw stdio, not the Util file helpers, because rcoutDriver is a
+// static global constructed before hal.util is available.
+static uint8_t navio2_rcio_pwmchip()
+{
+    for (uint8_t i = 0; i < 32; i++) {
+        char path[64];
+        snprintf(path, sizeof(path), "/sys/class/pwm/pwmchip%u/npwm", (unsigned)i);
+        FILE *f = fopen(path, "r");
+        if (f == nullptr) {
+            continue;
+        }
+        unsigned npwm = 0;
+        const int got = fscanf(f, "%u", &npwm);
+        fclose(f);
+        if (got == 1 && npwm >= 14) {
+            return i;
+        }
+    }
+    return 0;  // fall back to the Pi 4 / BCM default
+}
+static RCOutput_Sysfs rcoutDriver(navio2_rcio_pwmchip(), 0, 14);
 #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_AERO
 static ap::RCOutput_Tap rcoutDriver;
 #elif CONFIG_HAL_BOARD_SUBTYPE == HAL_BOARD_SUBTYPE_LINUX_EDGE


### PR DESCRIPTION
### Summary
Detect the Navio2 RCIO pwmchip index at runtime so a single navio2 binary works on both Raspberry Pi 4 and Pi 5.

### Classification & Testing
- [x] Checked by a human programmer
- [x] Tested manually, description below
- [x] Tested on hardware
- [x] Logs attached

Run on a Raspberry Pi 5 + Navio2 (ArduRover). The driver selects pwmchip6 and all 14 RCIO PWM channels export at 50 Hz with 1500 us neutral; QGC shows Motor outputs / control: Normal. On Pi 4 the same detection returns pwmchip0.

```
Init ArduRover V4.8.0-dev
MS5611 found on bus 1 address 0x77

RCIO PWM controller found at pwmchip6 on Pi 5, 14 channels exported:
cat /sys/class/pwm/pwmchip6/npwm   -> 14
ls  /sys/class/pwm/pwmchip6/pwm*   -> pwm0 .. pwm13   (14 channels)
pwm0: period=20000000ns duty=1500000ns enable=1   (50 Hz, 1500 us neutral)
pwm2: period=20000000ns duty=1500000ns enable=1
pwmchip0 (SoC) and pwmchip2 (RP1): no exports - driver bound only to the RCIO chip
```

Reproducing on a Pi 5 needs the Navio2 RCIO driver ported to RP1; setup guide: https://github.com/axonbf/navio2-rpi5-ardupilot

<img width="388" height="1032" alt="Screenshot from 2026-07-05 13-12-39" src="https://github.com/user-attachments/assets/8f52bb1a-59fe-4b6c-89af-30cd5fdcd339" />

<img width="1834" height="463" alt="Screenshot from 2026-07-05 13-12-10" src="https://github.com/user-attachments/assets/df2f4554-f3f9-4a0b-b5d8-3336b37e7725" />

### Description
The Navio2 RCIO PWM controller appears as a sysfs pwmchip whose index depends on the host: pwmchip0 on Pi 4 (BCM SoC) but pwmchip6 on Pi 5, where the RP1 I/O controller adds its own PWM controllers ahead of it and shifts enumeration. A hard-coded index only works on one generation. This detects the RCIO chip at runtime by its 14-channel count.

The corresponding Navio2 Driver changes can be found here:
- https://github.com/emlid/rcio-dkms/pull/11
- https://github.com/emlid/rcio-dkms/pull/12

Replaces #33648 (closed).
