### PR TITLE
AP_HAL_Linux: PWM_Sysfs: retry duty_cycle open on slow export

### DIFF
--- a/libraries/AP_HAL_Linux/PWM_Sysfs.cpp
+++ b/libraries/AP_HAL_Linux/PWM_Sysfs.cpp
@@ -65,7 +65,13 @@ void PWM_Sysfs_Base::init()
     Util::from(hal.util)->write_file(_export_path, "%u", _channel);
     free(_export_path);
 
-    _duty_cycle_fd = ::open(_duty_path, O_RDWR | O_CLOEXEC);
+    for (uint8_t attempt = 0; attempt < 50; attempt++) {
+        _duty_cycle_fd = ::open(_duty_path, O_RDWR | O_CLOEXEC);
+        if (_duty_cycle_fd >= 0) {
+            break;
+        }
+        hal.scheduler->delay_microseconds(10000);
+    }
     if (_duty_cycle_fd < 0) {
         AP_HAL::panic("LinuxPWM_Sysfs:Unable to open file %s: %s",
                       _duty_path, strerror(errno));


### PR DESCRIPTION
### Summary
Retry opening the duty_cycle sysfs file of a PWM channel so a slow export does not panic at startup.

### Classification & Testing
- [x] Checked by a human programmer
- [x] Tested manually, description below
- [x] Tested on hardware
- [x] Logs available on request

Built and run on Pi 5 + Navio2 (ArduRover); PWM comes up normally. The retry is a defensive fallback for slow exports; the normal (fast) path is unchanged, so it was not forced during testing.

Reproducing on a Pi 5 needs the Navio2 RCIO driver ported to RP1; setup guide: https://github.com/axonbf/navio2-rpi5-ardupilot

### Description
After exporting a PWM channel, the kernel can take a short time to create its duty_cycle attribute. On some platforms (for example the Pi 5 RP1 I/O controller) opening it immediately can fail, which currently panics at startup. This retries the open up to 50x with 10 ms delays (up to 500 ms) before giving up.

The corresponding Navio2 Driver changes can be found here:
- https://github.com/emlid/rcio-dkms/pull/11
- https://github.com/emlid/rcio-dkms/pull/12

Replaces #33647 (closed).
