### PR TITLE
Avoid potential backend data cross-leak in AP_AHRS

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_Backend.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.cpp
@@ -273,7 +273,7 @@ void AP_AHRS::Log_Write_Home_And_Origin()
 
 // get apparent to true airspeed ratio
 float AP_AHRS_Backend::get_EAS2TAS(void) {
-    return AP::baro()._get_EAS2TAS();
+    return AP::baro().get_EAS2TAS();
 }
 
 // return current vibration vector for primary IMU

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -965,6 +965,10 @@ void AP_Baro::update(void)
     update_field_elevation();
 #endif
 
+    // update the cached EAS2TAS value, a function of the primary
+    // baro's altitude:
+    _EAS2TAS = _get_EAS2TAS();
+
     // logging
 #if HAL_LOGGING_ENABLED
     if (should_log()) {

--- a/libraries/AP_Baro/AP_Baro.h
+++ b/libraries/AP_Baro/AP_Baro.h
@@ -142,8 +142,15 @@ public:
     float get_sealevel_pressure(float pressure, float altitude) const;
 
     // get scale factor required to convert equivalent to true
-    // airspeed. This should only be used to update the AHRS value
-    // once per loop. Please use AP::ahrs().get_EAS2TAS()
+    // airspeed.  This is a cached value, updated once per loop in
+    // update().  You probably want AP::ahrs().get_EAS2TAS() - the
+    // value could reasonably come from an ExternalAHRS system instead
+    // of this library.
+    float get_EAS2TAS(void) const { return _EAS2TAS; }
+
+    // calculate scale factor required to convert equivalent to true
+    // airspeed.  This is called once per loop from update() to
+    // refresh the value returned by get_EAS2TAS():
     float _get_EAS2TAS(void) const;
 
     // get current climb rate in meters/s. A positive number means
@@ -311,6 +318,7 @@ private:
 
     AP_Float                            _alt_offset;
     float                               _alt_offset_active;
+    float                               _EAS2TAS = 1.0;         // cached scale factor converting equivalent to true airspeed, updated in update()
     AP_Float                            _field_elevation;       // field elevation in meters
     float                               _field_elevation_active;
     uint32_t                            _field_elevation_last_ms;

--- a/libraries/AP_Baro/AP_Baro.h
+++ b/libraries/AP_Baro/AP_Baro.h
@@ -148,11 +148,6 @@ public:
     // of this library.
     float get_EAS2TAS(void) const { return _EAS2TAS; }
 
-    // calculate scale factor required to convert equivalent to true
-    // airspeed.  This is called once per loop from update() to
-    // refresh the value returned by get_EAS2TAS():
-    float _get_EAS2TAS(void) const;
-
     // get current climb rate in meters/s. A positive number means
     // going up
     float get_climb_rate(void);
@@ -319,6 +314,12 @@ private:
     AP_Float                            _alt_offset;
     float                               _alt_offset_active;
     float                               _EAS2TAS = 1.0;         // cached scale factor converting equivalent to true airspeed, updated in update()
+
+    // calculate scale factor required to convert equivalent to true
+    // airspeed.  This is called once per loop from update() to
+    // refresh the value returned by get_EAS2TAS():
+    float _get_EAS2TAS(void) const;
+
     AP_Float                            _field_elevation;       // field elevation in meters
     float                               _field_elevation_active;
     uint32_t                            _field_elevation_last_ms;

--- a/libraries/AP_DAL/AP_DAL.cpp
+++ b/libraries/AP_DAL/AP_DAL.cpp
@@ -67,7 +67,11 @@ void AP_DAL::start_frame(AP_DAL::FrameType frametype)
     _RFRN.lat = _home.lat;
     _RFRN.lng = _home.lng;
     _RFRN.alt = _home.alt;
-    _RFRN.EAS2TAS = ahrs.get_EAS2TAS();
+    // EAS2TAS is essentially a sensor input to the EKFs, so it is
+    // deliberately taken from the barometer's atmosphere model
+    // rather than the AHRS, lest a state estimator's output be fed
+    // back into the EKFs as an input:
+    _RFRN.EAS2TAS = AP::baro().get_EAS2TAS();
     _RFRN.vehicle_class = (uint8_t)ahrs.get_vehicle_class();
     _RFRN.fly_forward = ahrs.get_fly_forward();
     _RFRN.takeoff_expected = ahrs.get_takeoff_expected();

--- a/libraries/AP_DAL/AP_DAL.h
+++ b/libraries/AP_DAL/AP_DAL.h
@@ -180,9 +180,9 @@ public:
         return _RFRN.ahrs_airspeed_sensor_enabled;
     }
 
-    // this replaces AP::ahrs()->EAS2TAS(), which should probably go
-    // away in favour of just using the Baro method.
-    // get apparent to true airspeed ratio
+    // get apparent to true airspeed ratio; this is a sensor input
+    // to the EKFs, captured from the barometer's atmosphere model
+    // in start_frame():
     float get_EAS2TAS(void) const {
         return _RFRN.EAS2TAS;
     }


### PR DESCRIPTION
### Summary

EAS2TAS is an *input* into the EKFs via the DAL.  But `AP::AHRS().get_EAS2TAS()` may be an output from a backend.  Stop that happening.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Currently the `AP_AHRS_Backend::get_EAS2TAS` is static - no backend returns anything clever.  But an external AHRS definitely could.

Make sure the DAL gets its information from sensor data, not from another backend by sourcing data from the Baro library.  The Baro library moves to calculating the value once per update() call - there's some heavy maths behind `_get_EAS2TAS`
