### PR TITLE
Tidy SITL atmosphere calculations

### DIFF
--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -418,17 +418,6 @@ void AP_Baro::update_calibration()
 }
 #endif  // AP_BARO_CALIBRATION_ENABLED
 
-// return air density / sea level density - decreases as altitude climbs
-float AP_Baro::_get_air_density_ratio(void)
-{
-    const float eas2tas = _get_EAS2TAS();
-    if (eas2tas > 0.0f) {
-        return 1.0f/(sq(eas2tas));
-    } else {
-        return 1.0f;
-    }
-}
-
 // return current climb_rate estimate relative to time that calibrate()
 // was called. Returns climb rate in meters/s, positive means up
 // note that this relies on read() being called regularly to get new data

--- a/libraries/AP_Baro/AP_Baro.h
+++ b/libraries/AP_Baro/AP_Baro.h
@@ -146,10 +146,6 @@ public:
     // once per loop. Please use AP::ahrs().get_EAS2TAS()
     float _get_EAS2TAS(void) const;
 
-    // get air density / sea level density - decreases as altitude climbs
-    // please use AP::ahrs()::get_air_density_ratio()
-    float _get_air_density_ratio(void);
-
     // get current climb rate in meters/s. A positive number means
     // going up
     float get_climb_rate(void);

--- a/libraries/AP_Baro/AP_Baro_SITL.cpp
+++ b/libraries/AP_Baro/AP_Baro_SITL.cpp
@@ -186,7 +186,10 @@ float AP_Baro_SITL::wind_pressure_correction(uint8_t instance)
         error += bp.wcof_zn * sqz;
     }
 
-    return error * 0.5 * SSL_AIR_DENSITY * AP::baro()._get_air_density_ratio();
+    // use the air density at the simulated vehicle's true altitude;
+    // the vehicle's own estimates must play no part in simulating
+    // the physical pressure error:
+    return error * 0.5 * AP_Baro::get_air_density_for_alt_amsl(AP::sitl()->state.altitude);
 }
 
 #endif  // AP_SIM_BARO_ENABLED

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -31,7 +31,6 @@
 #include <AP_BoardConfig/AP_BoardConfig.h>
 #include <AP_JSON/AP_JSON.h>
 #include <AP_Filesystem/AP_Filesystem.h>
-#include <AP_AHRS/AP_AHRS.h>
 #include <AP_HAL_SITL/HAL_SITL_Class.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 
@@ -729,12 +728,6 @@ void Aircraft::update_model(const struct sitl_input &input)
 void Aircraft::update_dynamics(const Vector3f &rot_accel)
 {
     WITH_SEMAPHORE(pose_sem);
-
-    // update eas2tas and air density
-#if AP_AHRS_ENABLED
-    eas2tas = AP::ahrs().get_EAS2TAS();
-#endif
-    air_density = SSL_AIR_DENSITY / sq(eas2tas);
 
     const float delta_time = frame_time_us * 1.0e-6f;
 

--- a/libraries/SITL/SIM_Glider.cpp
+++ b/libraries/SITL/SIM_Glider.cpp
@@ -42,7 +42,6 @@
 
 #include <stdio.h>
 #include <AP_Logger/AP_Logger.h>
-#include <AP_AHRS/AP_AHRS.h>
 #include <GCS_MAVLink/GCS.h>
 
 extern const AP_HAL::HAL& hal;
@@ -85,7 +84,7 @@ Vector3f Glider::getTorque(float inputAileron, float inputElevator, float inputR
     const float aileron_rad = inputAileron * radians(m.aileronDeflectionLimitDeg);
     const float elevator_rad = inputElevator * radians(m.elevatorDeflectionLimitDeg);
     const float rudder_rad = inputRudder * radians(m.rudderDeflectionLimitDeg);
-    const float tas = MAX(airspeed * AP::ahrs().get_EAS2TAS(), 1);
+    const float tas = MAX(airspeed * eas2tas, 1);
 
     float Cl = (m.Cl2 * sq(alpharad) + m.Cl1 * alpharad + m.Cl0) * betarad;
     float Cm = m.Cm2 * sq(alpharad) + m.Cm1 * alpharad + m.Cm0;

--- a/libraries/SITL/SIM_StratoBlimp.cpp
+++ b/libraries/SITL/SIM_StratoBlimp.cpp
@@ -276,9 +276,6 @@ void StratoBlimp::calculate_forces(const struct sitl_input &input, Vector3f &bod
  */
 void StratoBlimp::update(const struct sitl_input &input)
 {
-    air_density = get_air_density(location.alt*0.01);
-    EAS2TAS = sqrtf(SSL_AIR_DENSITY / air_density);
-
     calculate_coefficients();
 
     float delta_time = frame_time_us * 1.0e-6f;

--- a/libraries/SITL/SIM_StratoBlimp.h
+++ b/libraries/SITL/SIM_StratoBlimp.h
@@ -57,8 +57,6 @@ private:
                   Vector3f &drag_linear, Vector3f &drag_rotaccel);
     float get_lift(float altitude);
 
-    float air_density;
-    float EAS2TAS;
     float drag_yaw;
     bool released;
     bool helper_balloon_attached = true;


### PR DESCRIPTION
### Summary

Fixes a variety of oddities and cross-contamination problems to do with atmosphere in SITL

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

 - stops AP_Baro_SITL using vehicle-side data to work out air density; instead uses simulation state
 - removes pointless assignments in update_dynamics (they're assigned to with other data immediately below)
 - stops SIM_Glider using data from the wrong side (we *have* the true simulation eas2tas already!
 - removes unused EAS2TAS in StratoBlimp and stops it futzing with the global air_density variable (the one-up call is responsible for maintaining this variable)