### PR TITLE
AP_HAL_SITL: add FreeBSD build support

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem_posix.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_posix.cpp
@@ -26,6 +26,9 @@
 
 #if defined(__APPLE__) || defined(__OpenBSD__)
 #include <sys/mount.h>
+#elif defined(__FreeBSD__)
+#include <sys/param.h>
+#include <sys/mount.h>
 #elif CONFIG_HAL_BOARD != HAL_BOARD_QURT
 #include <sys/vfs.h>
 #endif

--- a/libraries/AP_HAL_SITL/UART_utils.cpp
+++ b/libraries/AP_HAL_SITL/UART_utils.cpp
@@ -19,7 +19,7 @@
 
 #include "UARTDriver.h"
 
-#if defined(__CYGWIN__) || defined(__CYGWIN64__) || defined(__APPLE__) || defined(__OpenBSD__)
+#if defined(__CYGWIN__) || defined(__CYGWIN64__) || defined(__APPLE__) || defined(__OpenBSD__) || defined(__FreeBSD__)
 #define USE_TERMIOS
 #endif
 


### PR DESCRIPTION
This recreates the FreeBSD SITL build fix from a clean branch based on current master.

Tested on FreeBSD 15:
- ./waf configure --board sitl
- ./waf copter