### PR TITLE
RC_Channel: reserve AuxFunc IDs 250 through 254 for external use

### DIFF
--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -404,6 +404,14 @@ public:
         // inputs 248-249 are reserved for the Skybrush fork at
         // https://github.com/skybrush-io/ardupilot
 
+        // inputs 250-254 are reserved for the custom integrations.
+        // No code which uses these auxiliary channel options will be
+        // merged into ArduPilot master, so external code can use this
+        // an not conflict when rebased on newer ArduPilot codebases.
+        // No guarantees are made in terms of conflicting with other
+        // external projects.  See the SCRIPTING_1 range instead if
+        // you are writing a Lua script.
+
 #if AP_SCRIPTING_ENABLED
         // inputs for the use of onboard lua scripting
         SCRIPTING_1 =        300,


### PR DESCRIPTION
### Summary

Reserve a range of Auxiliary function IDs that external trees can use without conflicting with ArduPilot's uses.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request


### Description

Reserves 5 IDs.

These are different to the existing `USER_FUNC1` - an external user doesn't want to see the handling code for those functions when looking for their code.
