### PR TITLE
AP_Math: fix lateral acceleration spike at velocity zero-crossing in limit_accel_xy

### DIFF
--- a/libraries/AP_Math/control.cpp
+++ b/libraries/AP_Math/control.cpp
@@ -27,6 +27,14 @@
 // control default definitions
 #define CORNER_ACCELERATION_RATIO   1.0/safe_sqrt(2.0)   // acceleration reduction to enable zero overshoot corners
 
+// Speed (m/s) below which limit_accel_xy() fades out cross-track prioritisation.
+// Near zero speed the direction of travel is ill-defined, so prioritising
+// "cross-track" acceleration re-projects a saturated command onto a rapidly
+// rotating axis and injects a lateral acceleration spike (e.g. the roll wobble
+// seen at the zero-crossing of a hard Loiter stick reversal). Below this speed
+// we fade to an isotropic magnitude limit that preserves the commanded direction.
+#define LIMIT_ACCEL_XY_MIN_SPEED_MS   1.0f
+
 // Projects velocity forward in time using acceleration, constrained by directional limit.
 // - If `limit` is non-zero, it defines a direction in which acceleration is constrained.
 // - The `vel_error` value defines the direction of velocity error (its sign matters, not its magnitude).
@@ -442,31 +450,51 @@ bool limit_accel_xy(const Vector2f& vel, Vector2f& accel, float accel_max)
     if (!is_positive(accel_max)) {
         return false;
     }
-    // limit acceleration to accel_max while prioritizing cross track acceleration
-    if (accel.length_squared() > sq(accel_max)) {
-        if (vel.is_zero()) {
-            // We do not have a direction of travel so do a simple vector length limit
-            accel.limit_length(accel_max);
-        } else {
-            // calculate acceleration in the direction of and perpendicular to the velocity input
-            const Vector2f vel_unit = vel.normalized();
-            // acceleration in the direction of travel
-            float accel_dir = vel_unit * accel;
-            // cross track acceleration
-            Vector2f accel_cross = accel - (vel_unit * accel_dir);
-            if (accel_cross.limit_length(accel_max)) {
-                accel_dir = 0.0;
-            } else {
-                // limit_length can't absolutely guarantee this subtraction
-                // won't be slightly negative, so safe_sqrt is used
-                float accel_max_dir = safe_sqrt(sq(accel_max) - accel_cross.length_squared());
-                accel_dir = constrain_float(accel_dir, -accel_max_dir, accel_max_dir);
-            }
-            accel = accel_cross + vel_unit * accel_dir;
-        }
+    // nothing to do unless the acceleration vector exceeds the limit
+    if (accel.length_squared() <= sq(accel_max)) {
+        return false;
+    }
+
+    // isotropic (direction-preserving) magnitude limit. Used directly when there
+    // is no meaningful direction of travel, and blended in at low speed below.
+    Vector2f accel_isotropic = accel;
+    accel_isotropic.limit_length(accel_max);
+
+    const float speed_ms = vel.length();
+    if (!is_positive(speed_ms)) {
+        // We do not have a direction of travel so do a simple vector length limit
+        accel = accel_isotropic;
         return true;
     }
-    return false;
+
+    // limit acceleration to accel_max while prioritizing cross track acceleration
+    // calculate acceleration in the direction of and perpendicular to the velocity input
+    const Vector2f vel_unit = vel / speed_ms;
+    // acceleration in the direction of travel
+    float accel_dir = vel_unit * accel;
+    // cross track acceleration
+    Vector2f accel_cross = accel - (vel_unit * accel_dir);
+    if (accel_cross.limit_length(accel_max)) {
+        accel_dir = 0.0;
+    } else {
+        // limit_length can't absolutely guarantee this subtraction
+        // won't be slightly negative, so safe_sqrt is used
+        float accel_max_dir = safe_sqrt(sq(accel_max) - accel_cross.length_squared());
+        accel_dir = constrain_float(accel_dir, -accel_max_dir, accel_max_dir);
+    }
+    const Vector2f accel_prioritised = accel_cross + vel_unit * accel_dir;
+
+    // Fade between the isotropic limit (at zero speed) and the cross-track
+    // prioritised limit (at and above LIMIT_ACCEL_XY_MIN_SPEED_MS). As the
+    // velocity vector rotates through zero (e.g. a hard stick reversal in
+    // Loiter), vel_unit spins and the prioritised split would re-project the
+    // saturated braking command into a lateral acceleration spike. Fading to the
+    // direction-preserving limit removes that spike. Both blend inputs have
+    // magnitude <= accel_max, so the result does too.
+    const float prioritise_ratio = constrain_float(speed_ms / LIMIT_ACCEL_XY_MIN_SPEED_MS, 0.0f, 1.0f);
+    accel = accel_isotropic * (1.0f - prioritise_ratio) + accel_prioritised * prioritise_ratio;
+
+    return true;
 }
 
 // Limits a 2D acceleration vector with direction-dependent prioritisation.

--- a/libraries/AP_Math/control.h
+++ b/libraries/AP_Math/control.h
@@ -134,6 +134,9 @@ void shape_angle_vel_accel(float angle_desired, float angle_vel_desired, float a
 // - `vel` defines the current direction of motion (used to split the acceleration).
 // - `accel` is modified in-place to remain within `accel_max`.
 // - If the full acceleration vector exceeds `accel_max`, it is reshaped to prioritize lateral correction.
+// - Near zero speed the cross-track prioritisation is faded out to a simple
+//   direction-preserving magnitude limit, avoiding a lateral acceleration spike
+//   as the direction of travel rotates through zero (e.g. a hard stick reversal).
 // - If `vel` is zero, a simple magnitude limit is applied.
 // Returns true if the acceleration vector was modified.
 bool limit_accel_xy(const Vector2f& vel, Vector2f& accel, float accel_max);

--- a/libraries/AP_Math/tests/test_control.cpp
+++ b/libraries/AP_Math/tests/test_control.cpp
@@ -630,5 +630,31 @@ TEST(Control, test_limit_accel)
     sigaction(SIGFPE, &old_sa_fpe, nullptr);
 }
 
+TEST(Control, test_limit_accel_reversal_no_lateral_spike)
+{
+    // A saturated braking command aligned with the North axis must not inject a
+    // lateral (East) acceleration as the velocity vector rotates through zero
+    // during a hard reversal (roll wobble at the Loiter stop). A small residual
+    // lateral velocity is what makes vel_unit rotate through the crossing.
+    const float accel_max = 5.0f;
+    // braking command pointing South, saturating the limit
+    const float accel_cmd_n = -1.5f * accel_max;
+    const float residual_e = 0.05f;   // small lateral residual velocity (m/s)
+
+    float worst_east = 0.0f;
+    // sweep the North velocity through zero
+    for (float vn = 2.0f; vn >= -2.0f; vn -= 0.01f) {
+        const Vector2f vel{vn, residual_e};
+        Vector2f accel{accel_cmd_n, 0.0f};
+        limit_accel_xy(vel, accel, accel_max);
+        // command has zero East; output East is pure injected cross-axis error
+        worst_east = MAX(worst_east, fabsf(accel.y));
+        // magnitude must always respect the limit
+        EXPECT_LE(accel.length(), accel_max * 1.001f);
+    }
+    // Without the low-speed fade this reaches ~0.2*accel_max. Assert it stays small.
+    EXPECT_LT(worst_east, 0.1f * accel_max);
+}
+
 AP_GTEST_MAIN()
 int hal = 0;


### PR DESCRIPTION
I've now had a couple of users complain about roll-wobble during hard reversals on the pitch axis and vice versa. This PR fixes the root cause! 😁

## Summary

`limit_accel_xy()` injects a large **lateral acceleration spike** whenever the commanded acceleration saturates the maximum lean angle *and* the velocity vector passes through zero. In flight this shows up as a **roll wobble at the moment a Loiter stop reverses direction** (hard forward stick → hard reverse), and in logs as a `PSCE.TAE` (East accel target) spike at every `PSCN.VN` (North velocity) zero-crossing during hard reversals.

## Root cause

`limit_accel_xy()` decomposes the acceleration command into along-track and cross-track components using `vel.normalized()`, and prioritises the cross-track component when the command exceeds `accel_max`:

```cpp
const Vector2f vel_unit = vel.normalized();
float accel_dir = vel_unit * accel;              // along-track
Vector2f accel_cross = accel - vel_unit*accel_dir; // cross-track (prioritised)
```

The `vel` here is the position controller's **feed-forward** velocity (`_vel_desired_ned_ms`). During a hard reversal it slides through zero along the travel axis. With any small residual lateral velocity (crosswind crab angle, residual velocity from prior manoeuvring), `vel_unit` does not blink out at the crossing — it rotates continuously through ~180°. The saturated longitudinal braking command is then re-projected onto that spinning axis and partly reclassified as "cross-track", which is preserved while the braking (along-track) is clipped. The result is a lateral acceleration lobe of up to ~0.7·`accel_max` that flips sign through the crossing → roll wobble.

The existing `vel.is_zero()` guard only catches the (rare) perfectly-collinear, calm case where both axis components reach zero simultaneously; any lateral residual defeats it.

## Fix

Fade the cross-track prioritisation out to a direction-preserving (isotropic) magnitude limit as speed drops below `LIMIT_ACCEL_XY_MIN_SPEED_MS` (1 m/s):

- **Above 1 m/s**: behaviour is unchanged — path/corner tracking is unaffected.
- **Below 1 m/s**: blends to `accel.limit_length(accel_max)`, preserving the commanded direction. No lateral injection through the zero-crossing.
- Both blend inputs have magnitude ≤ `accel_max`, so the limiter contract is preserved.

## Why precision position hold is unaffected

`limit_accel_xy()` only modifies the command when it **saturates the max lean angle**. Normal position hold needs only a few m/s² of lean, well below `accel_max`, so the function is a no-op there and the fix is never reached. Stationary hold in extreme wind already drives the feed-forward velocity to exactly zero and hit the pre-existing `is_zero()` isotropic branch — identical to the new behaviour. The only regime that changes is *saturating* the lean limit while moving below 1 m/s, i.e. transient aggressive manoeuvring, where preserving the commanded direction is if anything more correct.

## Testing

- Added regression test `test_limit_accel_reversal_no_lateral_spike` in `libraries/AP_Math/tests/test_control.cpp`: sweeps velocity through zero with a small lateral residual and asserts the injected lateral acceleration stays `< 10%` of `accel_max` (unpatched code reaches ~70%), and that the magnitude limit is always respected.
- Numerical model of old vs new over a full zero-crossing sweep: worst injected lateral acceleration drops from **71%** to **5%** of `accel_max`.

Field/SITL confirmation of the roll wobble disappearing at the stop is welcome from reviewers with a Loiter reversal + crosswind setup.