### PR TITLE
.github: tidy autotests allowed path

### DIFF
--- a/.github/workflows/test_sitl_blimp.yml
+++ b/.github/workflows/test_sitl_blimp.yml
@@ -56,6 +56,7 @@ on:
       - 'Tools/autotest/rover.py'
       - 'Tools/autotest/sailboat.py'
       - 'Tools/autotest/swarminit.txt'
+      - 'Tools/autotest/sim_vehicle.py'
       # Remove markdown files as irrelevant
       - '**.md'
       # Remove dotfile at root directory
@@ -137,6 +138,7 @@ on:
       - 'Tools/autotest/rover.py'
       - 'Tools/autotest/sailboat.py'
       - 'Tools/autotest/swarminit.txt'
+      - 'Tools/autotest/sim_vehicle.py'
       # Remove markdown files as irrelevant
       - '**.md'
       # Remove dotfile at root directory

--- a/.github/workflows/test_sitl_copter.yml
+++ b/.github/workflows/test_sitl_copter.yml
@@ -48,11 +48,13 @@ on:
       - 'Tools/autotest/arduplane.py'
       - 'Tools/autotest/ardusub.py'
       - 'Tools/autotest/balancebot.py'
+      - 'Tools/autotest/blimp.py'
       - 'Tools/autotest/location.txt'
       - 'Tools/autotest/quadplane.py'
       - 'Tools/autotest/rover.py'
       - 'Tools/autotest/sailboat.py'
       - 'Tools/autotest/swarminit.txt'
+      - 'Tools/autotest/sim_vehicle.py'
       # Remove markdown files as irrelevant
       - '**.md'
       # Remove dotfile at root directory
@@ -126,11 +128,13 @@ on:
       - 'Tools/autotest/arduplane.py'
       - 'Tools/autotest/ardusub.py'
       - 'Tools/autotest/balancebot.py'
+      - 'Tools/autotest/blimp.py'
       - 'Tools/autotest/location.txt'
       - 'Tools/autotest/quadplane.py'
       - 'Tools/autotest/rover.py'
       - 'Tools/autotest/sailboat.py'
       - 'Tools/autotest/swarminit.txt'
+      - 'Tools/autotest/sim_vehicle.py'
       # Remove markdown files as irrelevant
       - '**.md'
       # Remove dotfile at root directory

--- a/.github/workflows/test_sitl_periph.yml
+++ b/.github/workflows/test_sitl_periph.yml
@@ -47,12 +47,14 @@ on:
       - 'Tools/autotest/arduplane.py'
       - 'Tools/autotest/ardusub.py'
       - 'Tools/autotest/balancebot.py'
+      - 'Tools/autotest/blimp.py'
       - 'Tools/autotest/helicopter.py'
       - 'Tools/autotest/location.txt'
       - 'Tools/autotest/quadplane.py'
       - 'Tools/autotest/rover.py'
       - 'Tools/autotest/sailboat.py'
       - 'Tools/autotest/swarminit.txt'
+      - 'Tools/autotest/sim_vehicle.py'
       # Remove markdown files as irrelevant
       - '**.md'
       # Remove dotfile at root directory
@@ -124,12 +126,14 @@ on:
       - 'Tools/autotest/arduplane.py'
       - 'Tools/autotest/ardusub.py'
       - 'Tools/autotest/balancebot.py'
+      - 'Tools/autotest/blimp.py'
       - 'Tools/autotest/helicopter.py'
       - 'Tools/autotest/location.txt'
       - 'Tools/autotest/quadplane.py'
       - 'Tools/autotest/rover.py'
       - 'Tools/autotest/sailboat.py'
       - 'Tools/autotest/swarminit.txt'
+      - 'Tools/autotest/sim_vehicle.py'
       # Remove markdown files as irrelevant
       - '**.md'
       # Remove dotfile at root directory

--- a/.github/workflows/test_sitl_plane.yml
+++ b/.github/workflows/test_sitl_plane.yml
@@ -49,11 +49,13 @@ on:
       - 'Tools/autotest/arducopter.py'
       - 'Tools/autotest/ardusub.py'
       - 'Tools/autotest/balancebot.py'
+      - 'Tools/autotest/blimp.py'
       - 'Tools/autotest/helicopter.py'
       - 'Tools/autotest/location.txt'
       - 'Tools/autotest/rover.py'
       - 'Tools/autotest/sailboat.py'
       - 'Tools/autotest/swarminit.txt'
+      - 'Tools/autotest/sim_vehicle.py'
       # Remove markdown files as irrelevant
       - '**.md'
       # Remove dotfile at root directory
@@ -127,11 +129,13 @@ on:
       - 'Tools/autotest/arducopter.py'
       - 'Tools/autotest/ardusub.py'
       - 'Tools/autotest/balancebot.py'
+      - 'Tools/autotest/blimp.py'
       - 'Tools/autotest/helicopter.py'
       - 'Tools/autotest/location.txt'
       - 'Tools/autotest/rover.py'
       - 'Tools/autotest/sailboat.py'
       - 'Tools/autotest/swarminit.txt'
+      - 'Tools/autotest/sim_vehicle.py'
       # Remove markdown files as irrelevant
       - '**.md'
       # Remove dotfile at root directory

--- a/.github/workflows/test_sitl_rover.yml
+++ b/.github/workflows/test_sitl_rover.yml
@@ -49,10 +49,12 @@ on:
       - 'Tools/autotest/arducopter.py'
       - 'Tools/autotest/arduplane.py'
       - 'Tools/autotest/ardusub.py'
+      - 'Tools/autotest/blimp.py'
       - 'Tools/autotest/helicopter.py'
       - 'Tools/autotest/location.txt'
       - 'Tools/autotest/quadplane.py'
       - 'Tools/autotest/swarminit.txt'
+      - 'Tools/autotest/sim_vehicle.py'
       # Remove markdown files as irrelevant
       - '**.md'
       # Remove dotfile at root directory
@@ -126,10 +128,12 @@ on:
       - 'Tools/autotest/arducopter.py'
       - 'Tools/autotest/arduplane.py'
       - 'Tools/autotest/ardusub.py'
+      - 'Tools/autotest/blimp.py'
       - 'Tools/autotest/helicopter.py'
       - 'Tools/autotest/location.txt'
       - 'Tools/autotest/quadplane.py'
       - 'Tools/autotest/swarminit.txt'
+      - 'Tools/autotest/sim_vehicle.py'
       # Remove markdown files as irrelevant
       - '**.md'
       # Remove dotfile at root directory

--- a/.github/workflows/test_sitl_sub.yml
+++ b/.github/workflows/test_sitl_sub.yml
@@ -49,12 +49,14 @@ on:
       - 'Tools/autotest/arducopter.py'
       - 'Tools/autotest/arduplane.py'
       - 'Tools/autotest/balancebot.py'
+      - 'Tools/autotest/blimp.py'
       - 'Tools/autotest/helicopter.py'
       - 'Tools/autotest/location.txt'
       - 'Tools/autotest/quadplane.py'
       - 'Tools/autotest/rover.py'
       - 'Tools/autotest/sailboat.py'
       - 'Tools/autotest/swarminit.txt'
+      - 'Tools/autotest/sim_vehicle.py'
       # Remove markdown files as irrelevant
       - '**.md'
       # Remove dotfile at root directory
@@ -128,12 +130,14 @@ on:
       - 'Tools/autotest/arducopter.py'
       - 'Tools/autotest/arduplane.py'
       - 'Tools/autotest/balancebot.py'
+      - 'Tools/autotest/blimp.py'
       - 'Tools/autotest/helicopter.py'
       - 'Tools/autotest/location.txt'
       - 'Tools/autotest/quadplane.py'
       - 'Tools/autotest/rover.py'
       - 'Tools/autotest/sailboat.py'
       - 'Tools/autotest/swarminit.txt'
+      - 'Tools/autotest/sim_vehicle.py'
       # Remove markdown files as irrelevant
       - '**.md'
       # Remove dotfile at root directory

--- a/.github/workflows/test_sitl_tracker.yml
+++ b/.github/workflows/test_sitl_tracker.yml
@@ -49,12 +49,14 @@ on:
       - 'Tools/autotest/arduplane.py'
       - 'Tools/autotest/ardusub.py'
       - 'Tools/autotest/balancebot.py'
+      - 'Tools/autotest/blimp.py'
       - 'Tools/autotest/helicopter.py'
       - 'Tools/autotest/location.txt'
       - 'Tools/autotest/quadplane.py'
       - 'Tools/autotest/rover.py'
       - 'Tools/autotest/sailboat.py'
       - 'Tools/autotest/swarminit.txt'
+      - 'Tools/autotest/sim_vehicle.py'
       # Remove markdown files as irrelevant
       - '**.md'
       # Remove dotfile at root directory
@@ -128,12 +130,14 @@ on:
       - 'Tools/autotest/arduplane.py'
       - 'Tools/autotest/ardusub.py'
       - 'Tools/autotest/balancebot.py'
+      - 'Tools/autotest/blimp.py'
       - 'Tools/autotest/helicopter.py'
       - 'Tools/autotest/location.txt'
       - 'Tools/autotest/quadplane.py'
       - 'Tools/autotest/rover.py'
       - 'Tools/autotest/sailboat.py'
       - 'Tools/autotest/swarminit.txt'
+      - 'Tools/autotest/sim_vehicle.py'
       # Remove markdown files as irrelevant
       - '**.md'
       # Remove dotfile at root directory


### PR DESCRIPTION
don't check sim_vehicle.py and blimp.py

### Summary
extract from https://github.com/ArduPilot/ardupilot/pull/33575

don't check sim_vehicle.py and blimp.py for autotest suite CI

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
