### PR TITLE
AC_Circle: clarify options parameter descriptions

### DIFF
--- a/libraries/AC_WPNav/AC_Circle.cpp
+++ b/libraries/AC_WPNav/AC_Circle.cpp
@@ -27,8 +27,8 @@ const AP_Param::GroupInfo AC_Circle::var_info[] = {
 
     // @Param: OPTIONS
     // @DisplayName: Circle options
-    // @Description: 0:Enable or disable using the pitch/roll stick control circle mode's radius and rate
-    // @Bitmask: 0:manual control, 1:face direction of travel, 2:Start at center rather than on perimeter, 3:Make Mount ROI the center of the circle
+    // @Description: Circle behaviour options
+    // @Bitmask: 0:RC pitch and roll control radius and rate, 1:Face direction of travel, 2:Start at center rather than on perimeter, 3:Make Mount ROI the center of the circle
     // @User: Standard
     AP_GROUPINFO("OPTIONS", 2, AC_Circle, _options, 1),
 


### PR DESCRIPTION
### Summary

This improves the CIRCLE_OPTIONS parameter description to make it more clear what the first bit means.  The high level description was also pretty terrible.

This is in response to [this 4.7 beta testing thread](https://discuss.ardupilot.org/t/heading-stuck-in-circle-mode/144486).

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
