### PR TITLE
.github: workflows: pin DDS workflow image

### DIFF
--- a/.github/workflows/colcon.yml
+++ b/.github/workflows/colcon.yml
@@ -149,7 +149,8 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     container:
-      image: ardupilot/ardupilot-dev-ros:latest
+      # pinned by digest as :latest is re-pushed nightly; this is v0.2.0 (2026-06-25)
+      image: ardupilot/ardupilot-dev-ros@sha256:4f60bb4aaf08eddd2463f61a9f2d2d12d52de56c8dcb9687ef2b53dc7164960e
     steps:
       # Sparse checkout to make .github/actions/* available without polluting the colcon workspace
       - uses: actions/checkout@v7

--- a/.github/workflows/test_dds.yml
+++ b/.github/workflows/test_dds.yml
@@ -148,7 +148,8 @@ jobs:
       actions: write  # save-ccache prunes the previous cache entry
     runs-on: ubuntu-22.04
     container:
-      image: ardupilot/ardupilot-dev-ros:latest
+      # pinned by digest as :latest is re-pushed nightly; this is v0.2.0 (2026-06-25)
+      image: ardupilot/ardupilot-dev-ros@sha256:4f60bb4aaf08eddd2463f61a9f2d2d12d52de56c8dcb9687ef2b53dc7164960e
       options: --user 1001
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails


### PR DESCRIPTION
### Summary

Pins the machine to something before we started getting segfaults.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

getting segfaults in the newer machine

Also stops our stuff changing because the ROS project commits stuff, apparently.
