### PR TITLE
GCS_MAVLink: require accel calibration for SYS_STATUS health

### DIFF
--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -522,7 +522,7 @@ void GCS::update_sensor_status_flags()
     if (!ins.calibrating()) {
         control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_3D_ACCEL;
         control_sensors_enabled |= MAV_SYS_STATUS_SENSOR_3D_GYRO;
-        if (ins.get_accel_health_all()) {
+        if (ins.get_accel_health_all() && ins.accel_calibrated_ok_all()) {
             control_sensors_health |= MAV_SYS_STATUS_SENSOR_3D_ACCEL;
         }
         if (ins.get_gyro_health_all() && ins.gyro_calibrated_ok_all()) {


### PR DESCRIPTION
### Summary

Require accelerometer calibration to be valid before reporting `MAV_SYS_STATUS_SENSOR_3D_ACCEL` as healthy in `SYS_STATUS`.

This makes accelerometer health reporting consistent with gyro health reporting, which already requires both sensor health and calibration.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Tested manually in SITL with an uncalibrated accelerometer state.



In the test case, accelerometer instance 0 was present, but not calibrated:

- `INS_ACC_ID` was set
- `INS_ACCSCAL_X/Y/Z` were `0.000`
- QGroundControl showed `PreArm: 3D Accel calibration needed`

<img width="1370" height="819" alt="Screenshot from 2026-07-08 11-43-35" src="https://github.com/user-attachments/assets/35f57a3e-4c87-4315-8bda-e24d9851f17f" />
<img width="1370" height="819" alt="Screenshot from 2026-07-08 11-37-23" src="https://github.com/user-attachments/assets/20121ba0-bf3b-4e52-a693-7bfbbb15e4ff" />

After this change, `SYS_STATUS` reported:

- `MAV_SYS_STATUS_SENSOR_3D_ACCEL` present: set
- `MAV_SYS_STATUS_SENSOR_3D_ACCEL` enabled: set
- `MAV_SYS_STATUS_SENSOR_3D_ACCEL` health: not set

This is the expected behavior because the accelerometer exists and is enabled, but should not be reported as healthy until calibration is valid.

<img width="1370" height="819" alt="Screenshot from 2026-07-08 11-37-45" src="https://github.com/user-attachments/assets/d2ea0cb9-2fec-42a5-b22d-fa7c95868510" />

### Description

`SYS_STATUS` currently reports the `MAV_SYS_STATUS_SENSOR_3D_ACCEL` health bit based only on accelerometer health:

```cpp
if (ins.get_accel_health_all()) {
    control_sensors_health |= MAV_SYS_STATUS_SENSOR_3D_ACCEL;
}