### PR TITLE
AP_HAL_ESP32: fix serial RC (CRSF/ELRS) input never decoding

### DIFF
--- a/libraries/AP_HAL_ESP32/UARTDriver.cpp
+++ b/libraries/AP_HAL_ESP32/UARTDriver.cpp
@@ -61,16 +61,28 @@ void UARTDriver::_begin(uint32_t b, uint16_t rxS, uint16_t txS)
                          uart_desc[uart_num].rx,
                          UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE);
             //uart_driver_install(p, 2*UART_FIFO_LEN, 0, 0, nullptr, 0);
-            uart_driver_install(p, 2*UART_HW_FIFO_LEN(p), 0, 0, nullptr, 0);
+            // Enlarge the ESP-IDF RX ring for headroom: the previous size (2*HW FIFO = 256 B) is easily
+            // overrun by a continuous fast signal (e.g. 420k CRSF/ELRS) clocked at a wrong baud
+            // during AP_RCProtocol's serial-RC baud scan. Install runs once at first-init, so the
+            // size cannot depend on the eventual protocol; applied to all ports (cost ~1 KB each).
+            uart_driver_install(p, MAX(1024, 2*UART_HW_FIFO_LEN(p)), 0, 0, nullptr, 0);
             _readbuf.set_size(RX_BUF_SIZE);
             _writebuf.set_size(TX_BUF_SIZE);
             _uart_owner_thd = xTaskGetCurrentTaskHandle();
 
             _initialized = true;
         } else {
-            flush();
             uart_set_baudrate(p, b);
-
+            // uart_set_baudrate() only reprograms the clock divider; it does NOT reset the RX
+            // state machine. Switching baud under a continuous fast signal (e.g. CRSF/ELRS during
+            // AP_RCProtocol's serial-RC baud scan) can leave the RX FIFO/framing stuck so it never
+            // recovers once the scan reaches the correct baud (e.g. 416666). Discard RX AFTER the
+            // change with uart_flush_input(), which resets the RX FIFO, so it is clean at the new
+            // baud. (Was flushed BEFORE the change, which left the receiver stuck.) Use the ESP-IDF
+            // call directly rather than flush(): AP_HAL's _flush() is TX-oriented on other HALs (e.g.
+            // ChibiOS), and relying on ESP32's flush() aliasing RX-discard would silently break if
+            // that is ever corrected.
+            uart_flush_input(p);
         }
     }
     _baudrate = b;


### PR DESCRIPTION
## Summary

Serial-based RC receivers (`SERIALn_PROTOCOL = 23`, e.g. CRSF/ELRS) never decoded
on the ESP32 HAL: `RC_CHANNELS` reported `chancount = 0` and no channels ever
appeared, even though the plumbing is already in place — `AP_SerialManager`
registers the port with `AP_RCProtocol` via `add_uart()`, and `AP_HAL_ESP32`'s
`RCInput::_timer_tick()` already drives `AP_RCProtocol::new_input()`.

The bug is in `AP_HAL_ESP32::UARTDriver::_begin()`. Its re-baud branch flushed RX
**before** calling `uart_set_baudrate()`. `uart_set_baudrate()` only reprograms the
clock divider — it does **not** reset the RX state machine. So when
`AP_RCProtocol`'s serial-RC baud scan changes baud under the continuously-driven,
fast CRSF/ELRS signal, the RX FIFO/framing is left in a bad state and the port
stops delivering bytes; it never recovers once the scan reaches the CRSF rate
(416666), so no frames are ever parsed.

## Fix

In the re-baud branch, discard RX **after** `uart_set_baudrate()` using
`uart_flush_input()` (which resets the RX FIFO), so the receiver is clean at the
new baud. The ESP-IDF call is used directly rather than the HAL `flush()` because
`AP_HAL::UARTDriver::_flush()` is TX-oriented on other HALs (e.g. ChibiOS); on
ESP32 `flush()` only happens to alias RX-discard, and relying on that would
silently break the fix if that were ever corrected.

The ESP-IDF RX ring is also enlarged from the previous size (`2 * HW FIFO` = 256 B) to
`MAX(1024, 2 * UART_HW_FIFO_LEN)` for headroom during the scan. Driver install
happens once at first-init, so the size cannot depend on the eventual protocol;
this applies to every opened UART (cost ~1 KB each — a handful on ESP32).

Both changes are in the shared re-baud path, so they also apply to other callers
that re-baud an open port (e.g. `AP_GPS` baud detection). Discarding RX after the
baud change is equally correct there — bytes captured at the old baud are stale.
The RMT/`HAL_ESP32_RCIN` PPM/SBUS path is untouched.

## Testing

Hardware: ESP32-S3, BetaFPV ELRS 2.4 GHz receiver output as CRSF into a UART
(`SERIALn_PROTOCOL = 23`).

- Before: `chancount = 0`, no channels.
- After: `chancount = 16`; channels track the transmitter sticks (verified over
  MAVLink `RC_CHANNELS` — e.g. throttle swept ~988→~1900 as the stick moved).

Existing PPM/SBUS-over-RMT behaviour is unchanged. Builds clean for
`esp32s3devkit` (Copter); `Tools/scripts/check_branch_conventions.py` passes.

## Related

Relates to #32341 (ESP32 RC/DShot work). Enabling serial RC over a UART lets the
board use CRSF/ELRS without the RMT RC-in path, freeing the RMT channels.

Independent of #33555 (the RMT RC-in migration): this fixes the *UART* RC path
(`UARTDriver.cpp`), a different input path in different files, with no dependency
either way — it can be reviewed and merged on its own.
