### PR TITLE
AP_GPS_NMEA: set MODE ROVER for single antenna Unicore GPS

### DIFF
--- a/libraries/AP_GPS/AP_GPS_NMEA.cpp
+++ b/libraries/AP_GPS/AP_GPS_NMEA.cpp
@@ -862,14 +862,17 @@ void AP_GPS_NMEA::send_config(void)
         port->printf("\r\nCONFIG HEADING FIXLENGTH\r\n" \
                      "CONFIG UNDULATION AUTO\r\n" \
                      "CONFIG\r\n" \
+                     "MODE MOVINGBASE\r\n" \
                      "UNIHEADINGA %.3f\r\n",
                      rate_s);
         state.gps_yaw_configured = true;
         FALLTHROUGH;
 
     case AP_GPS::GPS_TYPE_UNICORE_NMEA: {
+        if (get_type() == AP_GPS::GPS_TYPE_UNICORE_NMEA) {
+            port->printf("\r\nMODE ROVER\r\n");
+        }
         port->printf("\r\nAGRICA %.3f\r\n" \
-                     "MODE MOVINGBASE\r\n" \
                      "GNGGA %.3f\r\n" \
                      "GNRMC %.3f\r\n",
                      rate_s, rate_s, rate_s);


### PR DESCRIPTION
### Summary

It appears that we always set `MODE MOVINGBASE` for any Unicore GPS. The UM980 is a single antenna module, and setting it in a base mode seems to preclude RTCM3 injection. This PR explicitly sets `MODE ROVER` for non-moving baseline applications

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Awaiting code review and user testing to confirm this fix works as intended.