### PR TITLE
AP_Proximity: fix reset_face using wrong face in RPLidar and LD06 drivers

### DIFF
--- a/libraries/AP_Proximity/AP_Proximity_LD06.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_LD06.cpp
@@ -200,7 +200,7 @@ void AP_Proximity_LD06::parse_response_data()
                     frontend.boundary.set_face_attributes(_last_face, _last_angle_deg, _last_distance_m, state.instance);
                 } else {
                     // reset distance from last face
-                    frontend.boundary.reset_face(face, state.instance);
+                    frontend.boundary.reset_face(_last_face, state.instance);
                 }
 
                 // initialize the new face

--- a/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_RPLidarA2.cpp
@@ -487,7 +487,7 @@ void AP_Proximity_RPLidarA2::parse_response_data()
                 frontend.boundary.set_face_attributes(_last_face, _last_angle_deg, _last_distance_m, state.instance);
             } else {
                 // reset distance from last face
-                frontend.boundary.reset_face(face, state.instance);
+                frontend.boundary.reset_face(_last_face, state.instance);
             }
 
             // initialize the new face
@@ -628,7 +628,7 @@ void AP_Proximity_RPLidarA2::parse_response_express(const uint8_t *buf)
             frontend.boundary.set_face_attributes(_last_face, _last_angle_deg, _last_distance_m, state.instance);
         } else {
             // reset distance from last face
-            frontend.boundary.reset_face(face, state.instance);
+            frontend.boundary.reset_face(_last_face, state.instance);
         }
 
         // initialize the new face


### PR DESCRIPTION
Fixes #12919

In the RPLidar and LD06 proximity drivers, when transitioning between faces, if the old face had no valid readings, the code was resetting the **new** face instead of the **old** face.

This caused valid data from a previous cycle on the new face to be incorrectly erased. The `set_face_attributes` call on the line above already correctly uses `_last_face`.

**Fix**

Change `reset_face(face, ...)` to `reset_face(_last_face, ...)` in three locations:

- `AP_Proximity_RPLidarA2.cpp` lines 490 and 631
- `AP_Proximity_LD06.cpp` line 203

The LightWareSF40C driver already handles this correctly.

**Platform**
All platforms with RPLidar or LD06 proximity sensor

**Logs**
Verified via SITL build.
