### PR TITLE
GCS_MAVLink/AP_Landing: check GPS status before using ground_speed

### DIFF
--- a/libraries/AP_Landing/AP_Landing_Slope.cpp
+++ b/libraries/AP_Landing/AP_Landing_Slope.cpp
@@ -96,8 +96,7 @@ bool AP_Landing::type_slope_verify_land(const Location &prev_WP_loc, Location &n
 
     height_flare_log = height;
 
-    const AP_GPS &gps = AP::gps();
-    const float gps_ground_speed = gps.status() >= AP_GPS_FixType::FIX_3D ? gps.ground_speed() : 0.0f;
+    const float ground_speed = AP::ahrs().groundspeed();
 
     if ((on_approach_stage && below_flare_alt) ||
         (on_approach_stage && below_flare_sec && (wp_proportion > 0.5)) ||
@@ -107,11 +106,11 @@ bool AP_Landing::type_slope_verify_land(const Location &prev_WP_loc, Location &n
         if (type_slope_stage != SlopeStage::FINAL) {
             type_slope_flags.post_stats = true;
             if (is_flying && (AP_HAL::millis()-last_flying_ms) > 3000) {
-                GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Flare crash detected: speed=%.1f", (double)gps_ground_speed);
+                GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Flare crash detected: speed=%.1f", (double)ground_speed);
             } else {
                 GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Flare %.1fm sink=%.2f speed=%.1f dist=%.1f",
                                   (double)height, (double)sink_rate,
-                                  (double)gps_ground_speed,
+                                  (double)ground_speed,
                                   (double)current_loc.get_distance(next_WP_loc));
             }
             
@@ -128,7 +127,7 @@ bool AP_Landing::type_slope_verify_land(const Location &prev_WP_loc, Location &n
 #endif
         }
 
-        if (gps_ground_speed < 3) {
+        if (ground_speed < 3) {
             // reload any airspeed or groundspeed parameters that may have
             // been set for landing. We don't do this till ground
             // speed drops below 3.0 m/s as otherwise we will change
@@ -169,8 +168,8 @@ bool AP_Landing::type_slope_verify_land(const Location &prev_WP_loc, Location &n
 
     if (mission.continue_after_land() &&
         type_slope_stage == SlopeStage::FINAL &&
-        gps.status() >= AP_GPS_FixType::FIX_3D &&
-        gps.ground_speed() < 1) {
+        AP::gps().status() >= AP_GPS_FixType::FIX_3D &&
+        AP::ahrs().groundspeed() < 1) {
         /*
           user has requested to continue with mission after a
           landing. Return true to allow for continue

--- a/libraries/AP_Landing/AP_Landing_Slope.cpp
+++ b/libraries/AP_Landing/AP_Landing_Slope.cpp
@@ -97,6 +97,7 @@ bool AP_Landing::type_slope_verify_land(const Location &prev_WP_loc, Location &n
     height_flare_log = height;
 
     const AP_GPS &gps = AP::gps();
+    const float gps_ground_speed = gps.status() >= AP_GPS_FixType::FIX_3D ? gps.ground_speed() : 0.0f;
 
     if ((on_approach_stage && below_flare_alt) ||
         (on_approach_stage && below_flare_sec && (wp_proportion > 0.5)) ||
@@ -106,11 +107,11 @@ bool AP_Landing::type_slope_verify_land(const Location &prev_WP_loc, Location &n
         if (type_slope_stage != SlopeStage::FINAL) {
             type_slope_flags.post_stats = true;
             if (is_flying && (AP_HAL::millis()-last_flying_ms) > 3000) {
-                GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Flare crash detected: speed=%.1f", (double)gps.ground_speed());
+                GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Flare crash detected: speed=%.1f", (double)gps_ground_speed);
             } else {
                 GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Flare %.1fm sink=%.2f speed=%.1f dist=%.1f",
                                   (double)height, (double)sink_rate,
-                                  (double)gps.ground_speed(),
+                                  (double)gps_ground_speed,
                                   (double)current_loc.get_distance(next_WP_loc));
             }
             
@@ -127,7 +128,7 @@ bool AP_Landing::type_slope_verify_land(const Location &prev_WP_loc, Location &n
 #endif
         }
 
-        if (gps.ground_speed() < 3) {
+        if (gps_ground_speed < 3) {
             // reload any airspeed or groundspeed parameters that may have
             // been set for landing. We don't do this till ground
             // speed drops below 3.0 m/s as otherwise we will change

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3472,7 +3472,10 @@ float GCS_MAVLINK::vfr_hud_airspeed() const
     // because most vehicles don't have airspeed sensors, we return a
     // different sort of speed estimate in the relevant field for
     // comparison's sake.
-    return AP::gps().ground_speed();
+    const AP_GPS &gps = AP::gps();
+    if (gps.status() >= AP_GPS_FixType::FIX_3D) {
+        return gps.ground_speed();
+    }
 #endif
 
     return 0.0;


### PR DESCRIPTION
Fixes #14213

Check that GPS has a 3D fix before using ground_speed() in two locations:

GCS_MAVLink/GCS_Common.cpp (vfr_hud_airspeed()): Returns 0.0 when GPS has no fix instead of potentially stale ground speed data.

AP_Landing/AP_Landing_Slope.cpp (type_slope_verify_land()): Replaces direct gps.ground_speed() calls with AP::ahrs().groundspeed(), which provides a fused sensor estimate (GPS + IMU). AHRS handles GPS health internally, so the manual FIX_3D status check is removed for the flare section. The continue_after_land GPS fix gate is preserved as a deliberate safety condition.

The pattern gps.status() >= AP_GPS_FixType::FIX_3D is used 9+ times across the codebase for the same purpose.

Platform
X Plane

Testing
- SITL build passes (Plane)
- AutoLandMode test passed
- MainFlight test passed
- RTL_CLIMB_MIN test passed