### PR TITLE
Copter: set-target-angle-and-climbrate scaling fix

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -381,7 +381,7 @@ bool Copter::set_target_angle_and_climbrate(float roll_deg, float pitch_deg, flo
     Quaternion q;
     q.from_euler(radians(roll_deg),radians(pitch_deg),radians(yaw_deg));
 
-    mode_guided.set_angle(q, Vector3f{}, climb_rate_ms*100, false);
+    mode_guided.set_angle(q, Vector3f{}, climb_rate_ms, false);
     return true;
 }
 


### PR DESCRIPTION
### Summary

This fixes a climb rate scaling bug in the [Copter:set_angle_target_and_climbrate()](https://github.com/ArduPilot/ardupilot/blob/master/ArduCopter/Copter.cpp#L384) function used by scripting.  The bug was introduced by PR https://github.com/ArduPilot/ardupilot/pull/30756

I've tested this in SITL using a version of the [set-angle.lua](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Scripting/examples/set-angle.lua) script modified to set the climb rate to +-0.5m/s.  Below are before vs after screenshots of the vehicle's climb rate.  We can see in BEFORE that the climb rate far exceeds the specified 0.5 m/s while AFTER it does the right thing.

<img width="1204" height="1136" alt="randy-set-angle-scaling-fix" src="https://github.com/user-attachments/assets/8fa1386b-a7b6-419c-8905-17caa09e3770" />

Thanks very much to @andyp1per for finding this!

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request
