### PR TITLE
AP_RangeFinder: backport DroneCAN rangefinder state handling to 4.6

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_DroneCAN.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_DroneCAN.cpp
@@ -87,16 +87,22 @@ void AP_RangeFinder_DroneCAN::update()
     if ((AP_HAL::millis() - _last_reading_ms) > 500) {
         //if data is older than 500ms, report NoData
         set_status(RangeFinder::Status::NoData);
-    } else if (_status == RangeFinder::Status::Good && new_data) {
-        //copy over states
-        state.distance_m = _distance_cm * 0.01f;
-        state.last_reading_ms = _last_reading_ms;
+        return;
+    }
+    if (!new_data) {
+        return;
+    } 
+    state.distance_m = _distance_cm * 0.01f;
+    state.last_reading_ms = _last_reading_ms;  
+    new_data = false;
+    if (_status == RangeFinder::Status::Good) {
+        // copy over states
         update_status();
-        new_data = false;
-    } else if (_status != RangeFinder::Status::Good) {
-        //handle additional states received by measurement handler
+    } else {
+        // handle additional states received by measurement handler
         set_status(_status);
     }
+    
 }
 
 //RangeFinder message handler
@@ -121,14 +127,18 @@ void AP_RangeFinder_DroneCAN::handle_measurement(AP_DroneCAN *ap_dronecan, const
         //Additional states supported by RFND message
         case UAVCAN_EQUIPMENT_RANGE_SENSOR_MEASUREMENT_READING_TYPE_TOO_CLOSE:
         {
+            driver->_distance_cm = msg.range*100.0f;
             driver->_last_reading_ms = AP_HAL::millis();
             driver->_status = RangeFinder::Status::OutOfRangeLow;
+            driver->new_data = true;
             break;
         }
         case UAVCAN_EQUIPMENT_RANGE_SENSOR_MEASUREMENT_READING_TYPE_TOO_FAR:
         {
+            driver->_distance_cm = msg.range*100.0f;
             driver->_last_reading_ms = AP_HAL::millis();
             driver->_status = RangeFinder::Status::OutOfRangeHigh;
+            driver->new_data = true;
             break;
         }
         default:


### PR DESCRIPTION
### Summary

Backport DroneCAN rangefinder state propagation changes from ArduPilot 4.7 to ArduPilot-4.6.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

### Description

This PR backports DroneCAN rangefinder state propagation fixes from ArduPilot 4.7 to the ArduPilot-4.6 branch.

Previously, `AP_RangeFinder_DroneCAN` only updated the rangefinder status when the DroneCAN measurement state was `Good`. Other valid states reported by the DroneCAN rangefinder node were not propagated to the RangeFinder frontend.

This caused incorrect rangefinder behavior when the sensor reported states such as:

- `OutOfRangeLow`
- `OutOfRangeHigh`

With this update, DroneCAN rangefinder states are correctly forwarded to the RangeFinder frontend, allowing ArduPilot to handle these conditions properly.

### Testing

- Built ArduCopter successfully on CubeOrange target.
- Verified `AP_RangeFinder_DroneCAN.cpp` compilation successfully.
- Tested on real hardware with a DroneCAN rangefinder.
- Compared rangefinder behavior before and after the code update using flight logs.
- Confirmed correct rangefinder value update after handling `OutOfRangeLow` condition.

### Test Evidence

**Before code update:**

`rangefinder1_value_before_code_update`

The rangefinder value remained at last value
<img width="1620" height="441" alt="Rangefinder1_value_before_update" src="https://github.com/user-attachments/assets/86f44018-0580-4693-8420-74a7e9ffbb06" />
 after the sensor entered the `OutOfRangeLow` condition. The value was not updated correctly because the DroneCAN rangefinder state was not propagated to the RangeFinder frontend.

**After code update:**
<img width="1632" height="461" alt="Rangefinder1_value_after_update" src="https://github.com/user-attachments/assets/e81d7f6c-e8cd-45c9-84a5-5627e3d3fa0d" />
`rangefinder1_value_after_code_update`

The rangefinder shows the expected behavior after the fix. The DroneCAN rangefinder state is correctly handled, and the RangeFinder value updates properly according to the sensor state.
Logs are upload here:
https://drive.google.com/drive/folders/18ZytFIZrYJXygaZ40uUWpejdgRrof-XT?usp=drive_link
