### PR TITLE
Copter: circle mode ignore pilot yaw and throttle when manual control disabled

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -909,6 +909,7 @@ public:
     bool has_manual_throttle() const override { return false; }
     bool allows_arming(AP_Arming::Method method) const override { return false; };
     bool is_autopilot() const override { return true; }
+    bool use_pilot_yaw() const override;
 
 protected:
 

--- a/ArduCopter/mode_circle.cpp
+++ b/ArduCopter/mode_circle.cpp
@@ -103,8 +103,12 @@ void ModeCircle::run()
         }
     }
 
-    // get pilot desired climb rate (or zero if in radio failsafe)
-    float target_climb_rate_ms = get_pilot_desired_climb_rate_ms();
+    // get pilot desired climb rate only when manual control is enabled
+    // when manual control is disabled (CIRCLE_OPTIONS bit0 not set) ignore pilot throttle
+    float target_climb_rate_ms = 0.0f;
+    if (copter.circle_nav->pilot_control_enabled()) {
+        target_climb_rate_ms = get_pilot_desired_climb_rate_ms();
+    }
 
     // get avoidance adjusted climb rate
     target_climb_rate_ms = get_avoidance_adjusted_climbrate_ms(target_climb_rate_ms);
@@ -128,6 +132,13 @@ void ModeCircle::run()
 
     // call attitude controller with auto yaw
     attitude_control->input_thrust_vector_heading(pos_control->get_thrust_vector(), auto_yaw.get_heading());
+}
+
+// returns true if pilot's yaw input should be used to adjust vehicle's heading
+// yaw is only passed through when manual control is enabled (CIRCLE_OPTIONS bit0)
+bool ModeCircle::use_pilot_yaw() const
+{
+    return copter.circle_nav->pilot_control_enabled();
 }
 
 float ModeCircle::wp_distance_m() const

--- a/libraries/AC_WPNav/AC_Circle.cpp
+++ b/libraries/AC_WPNav/AC_Circle.cpp
@@ -28,7 +28,7 @@ const AP_Param::GroupInfo AC_Circle::var_info[] = {
     // @Param: OPTIONS
     // @DisplayName: Circle options
     // @Description: Circle behaviour options
-    // @Bitmask: 0:RC pitch and roll control radius and rate, 1:Face direction of travel, 2:Start at center rather than on perimeter, 3:Make Mount ROI the center of the circle
+    // @Bitmask: 0:RC controls radius and rate and yaw and throttle, 1:Face direction of travel, 2:Start at center rather than on perimeter, 3:Make Mount ROI the center of the circle
     // @User: Standard
     AP_GROUPINFO("OPTIONS", 2, AC_Circle, _options, 1),
 

--- a/libraries/AC_WPNav/AC_Circle.h
+++ b/libraries/AC_WPNav/AC_Circle.h
@@ -187,7 +187,7 @@ private:
     AC_PosControl&              _pos_control;
 
     enum CircleOptions {
-        MANUAL_CONTROL           = 1U << 0, // Enables pilot stick input to adjust circle radius and turn rate.
+        MANUAL_CONTROL           = 1U << 0, // Enables pilot stick input to adjust circle radius, turn rate, yaw and throttle.
         FACE_DIRECTION_OF_TRAVEL = 1U << 1, // Yaw aligns with direction of travel (tangent to circle path).
         INIT_AT_CENTER           = 1U << 2, // Initializes circle with center at current position (instead of radius ahead).
         ROI_AT_CENTER            = 1U << 3, // Sets camera mount ROI to circle center during circle mode.


### PR DESCRIPTION
### Summary

Extends the existing `CIRCLE_OPTIONS` bit 0 ("manual control") to also gate/ignore pilot yaw and throttle inputs when disabled, matching its existing behavior for radius and rate control.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Tested manually via SITL to ensure that with `CIRCLE_OPTIONS` bit 0 set to 0, pilot yaw and throttle sticks are ignored during circular flight, while keeping normal altitude hold behavior.

### Description

Currently, Copter's circle mode accepts user input for roll, pitch, yaw, and throttle. While `CIRCLE_OPTIONS` allows roll and pitch (radius and rate) to be ignored via bit 0, it was not possible to ignore pilot yaw and throttle. 

Following the recommendation in issue #33677, this PR:
1. Gates pilot throttle inputs on `pilot_control_enabled()` (bit 0 of `CIRCLE_OPTIONS`) in `ModeCircle::run()`.
2. Overrides `use_pilot_yaw()` for `ModeCircle` to return `pilot_control_enabled()`.
3. Updates `CIRCLE_OPTIONS` parameter documentation (`@Bitmask` description) and internal comments to reflect the updated bit 0 behavior.
