### PR TITLE
AP_Math: fix Polygon_closest_distance_line to include closing edge

### DIFF
--- a/libraries/AP_Math/polygon.cpp
+++ b/libraries/AP_Math/polygon.cpp
@@ -184,9 +184,13 @@ float Polygon_closest_distance_line(const Vector2f *V, unsigned N, const Vector2
         return -sqrtf(sq(intersection.x - p2.x) + sq(intersection.y - p2.y));
     }
     float closest_sq = FLT_MAX;
-    for (uint8_t i=0; i<N-1; i++) {
+    for (uint8_t i=0; i<N; i++) {
+        uint8_t j = i+1;
+        if (j >= N) {
+            j = 0;
+        }
         const Vector2f &v1 = V[i];
-        const Vector2f &v2 = V[i+1];
+        const Vector2f &v2 = V[j];
 
         float dist_sq = Vector2f::closest_distance_between_lines_squared(v1, v2, p1, p2);
         if (dist_sq < closest_sq) {

--- a/libraries/AP_Math/tests/test_polygon.cpp
+++ b/libraries/AP_Math/tests/test_polygon.cpp
@@ -177,6 +177,25 @@ TEST(Polygon, circle_outside_square)
     }
 }
 
+TEST(Polygon, closest_distance_line_wraps_closing_edge)
+{
+    // unclosed representation (4 points, no duplicated closing vertex), as
+    // stored by AC_PolyFence_loader for a real inclusion/exclusion fence
+    const Vector2f square[] = {{0.0f,0.0f}, {0.0f,10.0f}, {10.0f,10.0f}, {10.0f,0.0f}};
+
+    // query segment just below the polygon's closing edge V[3]->V[0]
+    const float dist_below = Polygon_closest_distance_line(square, 4, Vector2f{3.0f,-1.0f}, Vector2f{7.0f,-1.0f});
+    // true perpendicular distance to that edge is 1.0; before the fix this
+    // edge was never tested and the function returned sqrtf(10) instead,
+    // incorrectly reporting a much larger clearance
+    EXPECT_NEAR(1.0f, dist_below, 1.0e-3f);
+
+    // sanity check: a query near the top edge (unaffected by the missing
+    // wrap-around) must still return the same correct answer
+    const float dist_above = Polygon_closest_distance_line(square, 4, Vector2f{3.0f,11.0f}, Vector2f{7.0f,11.0f});
+    EXPECT_NEAR(1.0f, dist_above, 1.0e-3f);
+}
+
 struct PB_long {
     Vector2l point;
     Vector2l boundary[3];


### PR DESCRIPTION
## Summary

`Polygon_closest_distance_line()` in `libraries/AP_Math/polygon.cpp` silently skips a polygon's closing edge.

When the query line does not cross the polygon, the function falls back to checking the perpendicular distance to each polygon edge:

```cpp
float closest_sq = FLT_MAX;
for (uint8_t i=0; i<N-1; i++) {
    const Vector2f &v1 = V[i];
    const Vector2f &v2 = V[i+1];
    ...
}
```

This loop bound (`i<N-1`) never tests the closing edge `V[N-1]->V[0]`. Every other polygon helper in the same file already wraps around to include this edge:
- `Polygon_intersects()` (a few lines above, same file): `j = i+1; if (j >= N) j = 0;`
- `Polygon_outside()`
- `Polygon_closest_distance_point()` (fixed for the identical bug in commit abaa64a754 back in 2024-12, but `Polygon_closest_distance_line()` was never touched)

## Why this matters

The sole caller is `AP_OABendyRuler::calc_margin_from_inclusion_and_exclusion_polygons()` (`libraries/AC_Avoidance/AP_OABendyRuler.cpp`), which uses the result directly as the fence-clearance margin for obstacle-avoidance path scoring. It's fed inclusion/exclusion polygons from `AC_PolyFence_loader::get_inclusion_polygon()` / `get_exclusion_polygon()`, which return the raw uploaded vertex count with **no duplicated closing vertex** — so in real fences the closing edge is a genuine edge that gets silently skipped, and the reported margin near that edge is overestimated (i.e. BendyRuler is complacent about a real fence boundary near the last-to-first edge).

## Fix

Minimal, surgical change mirroring the wrap-around style already used in `Polygon_intersects()` a few lines above in the same file:

```cpp
float closest_sq = FLT_MAX;
for (uint8_t i=0; i<N; i++) {
    uint8_t j = i+1;
    if (j >= N) {
        j = 0;
    }
    const Vector2f &v1 = V[i];
    const Vector2f &v2 = V[j];
    ...
}
```

This is safe for both unclosed and "closed" (duplicated first/last point) polygon representations: if `V[N-1] == V[0]`, the added wrap-around edge degenerates to a zero-length segment, which `closest_distance_between_lines_squared()` already handles correctly (harmless redundant check) — no regression for either representation.

## Testing

Added `TEST(Polygon, closest_distance_line_wraps_closing_edge)` in `libraries/AP_Math/tests/test_polygon.cpp` using a simple 4-vertex unclosed square (matching the real `AC_Fence` storage format):
- A query segment just outside the polygon's closing edge now correctly returns `1.0` (previously returned `sqrt(10) ≈ 3.16`, because the closing edge was never checked).
- A query segment near the top edge (unaffected by the missing wrap-around) is unchanged, confirming no regression elsewhere.

I also independently verified the before/after behavior with a standalone harness assembled from the actual (verbatim) `Vector2` math and polygon functions, compiled and run outside the ArduPilot build tree, reproducing the same before/after numbers described above.

No existing test previously covered `Polygon_closest_distance_line()` at all.

## Disclosure

Generative AI (Claude) was used to help investigate this issue and implement this fix. All changes were reviewed by me before submission.
