### PR TITLE
Tidy use of various singleton simulation devices

### DIFF
--- a/libraries/AP_HAL_SITL/SITL_Periph_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_Periph_State.cpp
@@ -121,9 +121,6 @@ void SITL_State::init(int argc, char * const argv[]) {
     sitl_model = NEW_NOTHROW SimMCast("");
 
     _sitl = AP::sitl();
-
-    _sitl->i2c_sim.init();
-    sitl_model->set_i2c(&_sitl->i2c_sim);
 }
 
 void SITL_State::wait_clock(uint64_t wait_time_usec)

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -55,6 +55,16 @@ void SITL_State::_sitl_setup()
         }
 #endif
 
+#if AP_SIM_PRECLAND_ENABLED
+        // seed the precland simulator's beacon location from home.  This
+        // is done before parameters are loaded from storage so that the
+        // location-is-zero check inside set_default_location sees the
+        // unloaded (zero) values; parameters present in storage then
+        // overwrite the seed, while any absent ones keep it
+        const Location &home = sitl_model->get_home();
+        _sitl->precland_sim.set_default_location(home.lat * 1.0e-7f, home.lng * 1.0e-7f, static_cast<int16_t>(sitl_model->get_home_yaw()));
+#endif
+
         if (_use_fg_view) {
             fprintf(stdout, "FGView: %s:%u\n", _fg_address, _fg_view_port);
             fg_socket.connect(_fg_address, _fg_view_port);

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -55,17 +55,6 @@ void SITL_State::_sitl_setup()
         }
 #endif
 
-        sitl_model->set_buzzer(&_sitl->buzzer_sim);
-        sitl_model->set_sprayer(&_sitl->sprayer_sim);
-        sitl_model->set_gripper_servo(&_sitl->gripper_sim);
-        sitl_model->set_gripper_epm(&_sitl->gripper_epm_sim);
-        sitl_model->set_parachute(&_sitl->parachute_sim);
-        sitl_model->set_precland(&_sitl->precland_sim);
-        _sitl->i2c_sim.init();
-        sitl_model->set_i2c(&_sitl->i2c_sim);
-#if AP_TEST_DRONECAN_DRIVERS
-        sitl_model->set_dronecan_device(&_sitl->dronecan_sim);
-#endif
         if (_use_fg_view) {
             fprintf(stdout, "FGView: %s:%u\n", _fg_address, _fg_view_port);
             fg_socket.connect(_fg_address, _fg_view_port);

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -1181,11 +1181,7 @@ void Aircraft::update_external_payload(const struct sitl_input &input)
 #endif  // AP_SIM_PARACHUTE_ENABLED
 
 #if AP_SIM_PRECLAND_ENABLED
-    // update precland.  The beacon default location is seeded from home
-    // (set_default_location is idempotent); the sim is also consumed directly
-    // by the IRLock / PrecLand SITL backends, so it must stay seeded regardless
-    // of whether the sim is "enabled".
-    sitl->precland_sim.set_default_location(home.lat * 1.0e-7f, home.lng * 1.0e-7f, static_cast<int16_t>(get_home_yaw()));
+    // update precland
     if (sitl->precland_sim.is_enabled()) {
         sitl->precland_sim.update(get_location());
         if (sitl->precland_sim._over_precland_base) {

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -1129,11 +1129,13 @@ void Aircraft::update_external_payload(const struct sitl_input &input)
 {
     external_payload_mass = 0;
 
+#if AP_SIM_SPRAYER_ENABLED
     // update sprayer
     if (sitl->sprayer_sim.is_enabled()) {
         sitl->sprayer_sim.update(input);
         external_payload_mass += sitl->sprayer_sim.payload_mass();
     }
+#endif  // AP_SIM_SPRAYER_ENABLED
 
     {
         const float range = rangefinder_range();
@@ -1148,28 +1150,37 @@ void Aircraft::update_external_payload(const struct sitl_input &input)
     // update i2c
     sitl->i2c_sim.update(*this);
 
+#if AP_SIM_BUZZER_ENABLED
     // update buzzer
     if (sitl->buzzer_sim.is_enabled()) {
         sitl->buzzer_sim.update(input);
     }
+#endif  // AP_SIM_BUZZER_ENABLED
 
     // update grippers
+#if AP_SIM_GRIPPER_ENABLED
     if (sitl->gripper_sim.is_enabled()) {
         sitl->gripper_sim.set_alt(hagl());
         sitl->gripper_sim.update(input);
         external_payload_mass += sitl->gripper_sim.payload_mass();
     }
+#endif  // AP_SIM_GRIPPER_ENABLED
+#if AP_SIM_GRIPPER_EPM_ENABLED
     if (sitl->gripper_epm_sim.is_enabled()) {
         sitl->gripper_epm_sim.update(input);
         external_payload_mass += sitl->gripper_epm_sim.payload_mass();
     }
+#endif  // AP_SIM_GRIPPER_EPM_ENABLED
 
+#if AP_SIM_PARACHUTE_ENABLED
     // update parachute
     if (sitl->parachute_sim.is_enabled()) {
         sitl->parachute_sim.update(input);
         // TODO: add drag to vehicle, presumably proportional to velocity
     }
+#endif  // AP_SIM_PARACHUTE_ENABLED
 
+#if AP_SIM_PRECLAND_ENABLED
     // update precland.  The beacon default location is seeded from home
     // (set_default_location is idempotent); the sim is also consumed directly
     // by the IRLock / PrecLand SITL backends, so it must stay seeded regardless
@@ -1181,6 +1192,7 @@ void Aircraft::update_external_payload(const struct sitl_input &input)
             local_ground_level += sitl->precland_sim._device_height;
         }
     }
+#endif  // AP_SIM_PRECLAND_ENABLED
 
     // update RichenPower generator
     if (richenpower) {

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -151,11 +151,6 @@ float Aircraft::ambient_outside_pressure_Pascal() const
     return AP::baro().get_pressure();
 }
 
-void Aircraft::set_precland(SIM_Precland *_precland) {
-    precland = _precland;
-    precland->set_default_location(home.lat * 1.0e-7f, home.lng * 1.0e-7f, static_cast<int16_t>(get_home_yaw()));
-}
-
 /*
    return current height above ground level (metres)
 */
@@ -1135,9 +1130,9 @@ void Aircraft::update_external_payload(const struct sitl_input &input)
     external_payload_mass = 0;
 
     // update sprayer
-    if (sprayer && sprayer->is_enabled()) {
-        sprayer->update(input);
-        external_payload_mass += sprayer->payload_mass();
+    if (sitl->sprayer_sim.is_enabled()) {
+        sitl->sprayer_sim.update(input);
+        external_payload_mass += sitl->sprayer_sim.payload_mass();
     }
 
     {
@@ -1151,36 +1146,39 @@ void Aircraft::update_external_payload(const struct sitl_input &input)
     }
 
     // update i2c
-    if (i2c) {
-        i2c->update(*this);
-    }
+    sitl->i2c_sim.update(*this);
 
     // update buzzer
-    if (buzzer && buzzer->is_enabled()) {
-        buzzer->update(input);
+    if (sitl->buzzer_sim.is_enabled()) {
+        sitl->buzzer_sim.update(input);
     }
 
     // update grippers
-    if (gripper && gripper->is_enabled()) {
-        gripper->set_alt(hagl());
-        gripper->update(input);
-        external_payload_mass += gripper->payload_mass();
+    if (sitl->gripper_sim.is_enabled()) {
+        sitl->gripper_sim.set_alt(hagl());
+        sitl->gripper_sim.update(input);
+        external_payload_mass += sitl->gripper_sim.payload_mass();
     }
-    if (gripper_epm && gripper_epm->is_enabled()) {
-        gripper_epm->update(input);
-        external_payload_mass += gripper_epm->payload_mass();
+    if (sitl->gripper_epm_sim.is_enabled()) {
+        sitl->gripper_epm_sim.update(input);
+        external_payload_mass += sitl->gripper_epm_sim.payload_mass();
     }
 
     // update parachute
-    if (parachute && parachute->is_enabled()) {
-        parachute->update(input);
+    if (sitl->parachute_sim.is_enabled()) {
+        sitl->parachute_sim.update(input);
         // TODO: add drag to vehicle, presumably proportional to velocity
     }
 
-    if (precland && precland->is_enabled()) {
-        precland->update(get_location());
-        if (precland->_over_precland_base) {
-            local_ground_level += precland->_device_height;
+    // update precland.  The beacon default location is seeded from home
+    // (set_default_location is idempotent); the sim is also consumed directly
+    // by the IRLock / PrecLand SITL backends, so it must stay seeded regardless
+    // of whether the sim is "enabled".
+    sitl->precland_sim.set_default_location(home.lat * 1.0e-7f, home.lng * 1.0e-7f, static_cast<int16_t>(get_home_yaw()));
+    if (sitl->precland_sim.is_enabled()) {
+        sitl->precland_sim.update(get_location());
+        if (sitl->precland_sim._over_precland_base) {
+            local_ground_level += sitl->precland_sim._device_height;
         }
     }
 
@@ -1216,9 +1214,7 @@ void Aircraft::update_external_payload(const struct sitl_input &input)
     }
 
 #if AP_TEST_DRONECAN_DRIVERS
-    if (dronecan) {
-        dronecan->update();
-    }
+    sitl->dronecan_sim.update();
 #endif
 
 #if AP_SIM_GPIO_LED_1_ENABLED

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -24,17 +24,11 @@
 
 #include "SITL.h"
 #include "SITL_Input.h"
-#include "SIM_Sprayer.h"
-#include "SIM_Gripper_Servo.h"
-#include "SIM_Gripper_EPM.h"
-#include "SIM_Parachute.h"
-#include "SIM_Precland.h"
 #include "SIM_RichenPower.h"
 #include "SIM_Loweheiser.h"
 #include "SIM_FETtecOneWireESC.h"
 #include "SIM_Volz.h"
 #include "SIM_I2C.h"
-#include "SIM_Buzzer.h"
 #include "SIM_Battery.h"
 #include <Filter/Filter.h>
 #include "SIM_JSON_Master.h"
@@ -157,9 +151,6 @@ public:
     const Location &get_home() const { return home; }
     float get_home_yaw() const { return home_yaw; }
 
-    void set_buzzer(Buzzer *_buzzer) { buzzer = _buzzer; }
-    void set_sprayer(Sprayer *_sprayer) { sprayer = _sprayer; }
-    void set_parachute(Parachute *_parachute) { parachute = _parachute; }
     void set_richenpower(RichenPower *_richenpower) { richenpower = _richenpower; }
     void set_adsb(class ADSB *_adsb) { adsb = _adsb; }
 #if AP_SIM_LOWEHEISER_ENABLED
@@ -170,13 +161,6 @@ public:
     void set_volz(Volz *_volz) { volz = _volz; }
 #endif
     void set_ie24(IntelligentEnergy24 *_ie24) { ie24 = _ie24; }
-    void set_gripper_servo(Gripper_Servo *_gripper) { gripper = _gripper; }
-    void set_gripper_epm(Gripper_EPM *_gripper_epm) { gripper_epm = _gripper_epm; }
-    void set_precland(SIM_Precland *_precland);
-    void set_i2c(class I2C *_i2c) { i2c = _i2c; }
-#if AP_TEST_DRONECAN_DRIVERS
-    void set_dronecan_device(DroneCANDevice *_dronecan) { dronecan = _dronecan; }
-#endif
     float get_battery_voltage() const { return battery_voltage; }
     float get_battery_temperature_degC() const { return battery_temperature_degC; }
     float get_battery_current() const { return battery_current; }
@@ -413,11 +397,6 @@ private:
         Location location;
     } smoothing;
 
-    Buzzer *buzzer;
-    Sprayer *sprayer;
-    Gripper_Servo *gripper;
-    Gripper_EPM *gripper_epm;
-    Parachute *parachute;
     RichenPower *richenpower;
 #if AP_SIM_LOWEHEISER_ENABLED
     Loweheiser *loweheiser;
@@ -428,11 +407,6 @@ private:
 #endif  // AP_SIM_VOLZ_ENABLED
 
     IntelligentEnergy24 *ie24;
-    SIM_Precland *precland;
-    class I2C *i2c;
-#if AP_TEST_DRONECAN_DRIVERS
-    DroneCANDevice *dronecan;
-#endif
 
 
 #if AP_SIM_GPIO_LED_1_ENABLED

--- a/libraries/SITL/SIM_I2C.cpp
+++ b/libraries/SITL/SIM_I2C.cpp
@@ -233,6 +233,11 @@ struct i2c_device_at_address {
 
 void I2C::init()
 {
+    if (initialised) {
+        return;
+    }
+    initialised = true;
+
     for (auto &i : i2c_devices) {
         i.device.init();
     }
@@ -258,6 +263,8 @@ void I2C::init()
 
 void I2C::update(const class Aircraft &aircraft)
 {
+    init();  // lazily set up the device table on first use
+
     for (auto daa : i2c_devices) {
         daa.device.update(aircraft);
     }
@@ -282,6 +289,8 @@ int I2C::ioctl_rdwr(i2c_rdwr_ioctl_data *data)
 
 int I2C::ioctl(uint8_t ioctl_type, void *data)
 {
+    init();  // lazily set up the device table on first use
+
     switch ((IOCtlType) ioctl_type) {
     case IOCtlType::RDWR:
         return ioctl_rdwr((i2c_rdwr_ioctl_data*)data);

--- a/libraries/SITL/SIM_I2C.h
+++ b/libraries/SITL/SIM_I2C.h
@@ -29,8 +29,6 @@ class I2C {
 public:
     I2C() {}
 
-    void init();
-
     // update i2c state
     void update(const class Aircraft &aircraft);
 
@@ -53,6 +51,12 @@ public:
     // end "the following"
 
 private:
+    // one-time setup of the simulated device table.  Self-guarded by
+    // initialised and called lazily from update()/ioctl() (either may
+    // run first), so the simulated bus needs no external init() call.
+    void init();
+    bool initialised;
+
     int ioctl_rdwr(i2c_rdwr_ioctl_data *data);
 
 };

--- a/libraries/SITL/SIM_config.h
+++ b/libraries/SITL/SIM_config.h
@@ -315,6 +315,34 @@
 #define AP_SIM_VOLZ_ENABLED AP_SIM_ENABLED
 #endif  // AP_SIM_VOLZ_ENABLED
 
+// simulated payload / actuator devices owned by SITL::SIM and driven by the
+// aircraft model
+#ifndef AP_SIM_BUZZER_ENABLED
+#define AP_SIM_BUZZER_ENABLED AP_SIM_ENABLED
+#endif  // AP_SIM_BUZZER_ENABLED
+
+#ifndef AP_SIM_SPRAYER_ENABLED
+#define AP_SIM_SPRAYER_ENABLED AP_SIM_ENABLED
+#endif  // AP_SIM_SPRAYER_ENABLED
+
+#ifndef AP_SIM_GRIPPER_ENABLED
+#define AP_SIM_GRIPPER_ENABLED AP_SIM_ENABLED
+#endif  // AP_SIM_GRIPPER_ENABLED
+
+#ifndef AP_SIM_GRIPPER_EPM_ENABLED
+#define AP_SIM_GRIPPER_EPM_ENABLED AP_SIM_ENABLED
+#endif  // AP_SIM_GRIPPER_EPM_ENABLED
+
+#ifndef AP_SIM_PARACHUTE_ENABLED
+#define AP_SIM_PARACHUTE_ENABLED AP_SIM_ENABLED
+#endif  // AP_SIM_PARACHUTE_ENABLED
+
+// the precland sim is also consumed by the IRLock / PrecLand SITL backends, so
+// it must remain enabled whenever those are built
+#ifndef AP_SIM_PRECLAND_ENABLED
+#define AP_SIM_PRECLAND_ENABLED AP_SIM_ENABLED
+#endif  // AP_SIM_PRECLAND_ENABLED
+
 #ifndef AP_SIM_VICON_ENABLED
 #define AP_SIM_VICON_ENABLED 1
 #endif  // AP_SIM_VICON_ENABLED

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -302,15 +302,21 @@ const AP_Param::GroupInfo SIM::var_info2[] = {
     // @DisplayName: RC channel count
     // @Description: SITL RC channel count
     AP_GROUPINFO("RC_CHANCOUNT",21, SIM,  rc_chancount, 16),
+#if AP_SIM_SPRAYER_ENABLED
     // @Group: SPR_
     // @Path: ./SIM_Sprayer.cpp
     AP_SUBGROUPINFO(sprayer_sim, "SPR_", 22, SIM, Sprayer),
+#endif  // AP_SIM_SPRAYER_ENABLED
+#if AP_SIM_GRIPPER_ENABLED
     // @Group: GRPS_
     // @Path: ./SIM_Gripper_Servo.cpp
     AP_SUBGROUPINFO(gripper_sim, "GRPS_", 23, SIM, Gripper_Servo),
+#endif  // AP_SIM_GRIPPER_ENABLED
+#if AP_SIM_GRIPPER_EPM_ENABLED
     // @Group: GRPE_
     // @Path: ./SIM_Gripper_EPM.cpp
     AP_SUBGROUPINFO(gripper_epm_sim, "GRPE_", 24, SIM, Gripper_EPM),
+#endif  // AP_SIM_GRIPPER_EPM_ENABLED
 
     // @Param: WOW_PIN
     // @DisplayName: Weight on Wheels Pin
@@ -325,18 +331,22 @@ const AP_Param::GroupInfo SIM::var_info2[] = {
     // @Vector3Parameter: 1
     AP_GROUPINFO("VIB_FREQ",   26, SIM,  vibe_freq, 0),
 
+#if AP_SIM_PARACHUTE_ENABLED
     // @Group: PARA_
     // @Path: ./SIM_Parachute.cpp
     AP_SUBGROUPINFO(parachute_sim, "PARA_", 27, SIM, Parachute),
+#endif  // AP_SIM_PARACHUTE_ENABLED
 
     // @Param: BAUDLIMIT_EN
     // @DisplayName: Telemetry bandwidth limitting
     // @Description: SITL enable bandwidth limitting on telemetry ports with non-zero values
     AP_GROUPINFO("BAUDLIMIT_EN",   28, SIM,  telem_baudlimit_enable, 0),
 
+#if AP_SIM_PRECLAND_ENABLED
     // @Group: PLD_
     // @Path: ./SIM_Precland.cpp
     AP_SUBGROUPINFO(precland_sim, "PLD_", 29, SIM, SIM_Precland),
+#endif  // AP_SIM_PRECLAND_ENABLED
 
     // @Param: SHOVE_X
     // @DisplayName: Acceleration of shove x
@@ -462,9 +472,11 @@ const AP_Param::GroupInfo SIM::var_info2[] = {
     // @Units: us
     AP_GROUPINFO("LOOP_DELAY",  55, SIM,  loop_delay, 0),
 
+#if AP_SIM_BUZZER_ENABLED
     // @Group: BZ_
     // @Path: ./SIM_Buzzer.cpp
     AP_SUBGROUPINFO(buzzer_sim, "BZ_", 56, SIM, Buzzer),
+#endif  // AP_SIM_BUZZER_ENABLED
 
     // @Group: TA_
     // @Path: ./SIM_ToneAlarm.cpp

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -552,17 +552,29 @@ public:
         return spi_sim.ioctl(bus, cs_pin, spi_operation, data);
     }
 
+#if AP_SIM_SPRAYER_ENABLED
     Sprayer sprayer_sim;
+#endif  // AP_SIM_SPRAYER_ENABLED
 
+#if AP_SIM_GRIPPER_ENABLED
     Gripper_Servo gripper_sim;
+#endif  // AP_SIM_GRIPPER_ENABLED
+#if AP_SIM_GRIPPER_EPM_ENABLED
     Gripper_EPM gripper_epm_sim;
+#endif  // AP_SIM_GRIPPER_EPM_ENABLED
 
+#if AP_SIM_PARACHUTE_ENABLED
     Parachute parachute_sim;
+#endif  // AP_SIM_PARACHUTE_ENABLED
+#if AP_SIM_BUZZER_ENABLED
     Buzzer buzzer_sim;
+#endif  // AP_SIM_BUZZER_ENABLED
     I2C i2c_sim;
     SPI spi_sim;
     ToneAlarm tonealarm_sim;
+#if AP_SIM_PRECLAND_ENABLED
     SIM_Precland precland_sim;
+#endif  // AP_SIM_PRECLAND_ENABLED
     RichenPower richenpower_sim;
 #if AP_SIM_LOWEHEISER_ENABLED
     Loweheiser loweheiser_sim;


### PR DESCRIPTION
### Summary

Stop passing pointers into the aircraft when it already knows everything around them.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Tidies up the setup of these devices.  It was needlessly complex.

We're throwing a lot more into the base aircraft model than was intended to be there.  But this is the way things seem to be moving...

Also adds defines around these things (compiling for SoH can be tight!)
