### PR TITLE
hwdef: remove board-hwdef defines which are the default values

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/SkyDroid-S3/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/SkyDroid-S3/hwdef.dat
@@ -173,9 +173,6 @@ define HAL_I2C_INTERNAL_MASK 0
 # enable FAT filesystem support (needs a microSD defined via SDMMC)
 define HAL_OS_FATFS_IO 1
 
-define HAL_BOARD_LOG_DIRECTORY "/APM/LOGS"
-define HAL_BOARD_TERRAIN_DIRECTORY "/APM/TERRAIN"
-
 DMA_PRIORITY  ADC* SPI1* TIM*UP*
 DMA_NOSHARE  SPI1* TIM*UP*
 

--- a/libraries/AP_HAL_ChibiOS/hwdef/sparknavi-blue/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/sparknavi-blue/hwdef.dat
@@ -203,9 +203,6 @@ DMA_PRIORITY SDMMC* UART8* ADC* UART* USART* SPI* TIM*
 # enable FAT filesystem support (needs a microSD defined via SDMMC)
 define HAL_OS_FATFS_IO 1
 
-define HAL_BOARD_LOG_DIRECTORY "/APM/LOGS"
-define HAL_BOARD_TERRAIN_DIRECTORY "/APM/TERRAIN"
-
 ROMFS io_firmware.bin Tools/IO_Firmware/iofirmware_f103_8MHz_lowpolh.bin
 
 PE15 VDD_BRICK_VALID INPUT PULLDOWN


### PR DESCRIPTION
### Summary

Removes defines from hwdefs which are the default values.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change (when hwdef changes excluded)
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board,plane
SkyDroid-S3,*
sparknavi-blue,*
```


### Description

boards coming in with stale defines.  The defines are several versions old, so I don't think it's really worth adding code to enforce no-more-merging of these bad defines.
