### PR TITLE
Kludge up sim_vehicle.py to avoid vehicleinfo.json/arducopter.py hackery

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -13180,14 +13180,6 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         vinfo = vehicleinfo.VehicleInfo()
         copter_vinfo_options = vinfo.options[self.vehicleinfo_key()]
         known_broken_frames = {
-            'heli-compound': "wrong binary, different takeoff regime",
-            'heli-dual': "wrong binary, different takeoff regime",
-            'heli': "wrong binary, different takeoff regime",
-            'heli-gas': "wrong binary, different takeoff regime",
-            'heli-blade360': "wrong binary, different takeoff regime",
-            'heli-ddvptail': "wrong binary, different takeoff regime",
-            'heli-ddfptail': "wrong binary, different takeoff regime",
-            'heli-quad': "wrong binary, different takeoff regime",
             "quad-can" : "needs CAN periph",
         }
         for frame in sorted(copter_vinfo_options["frames"].keys()):

--- a/Tools/autotest/pysim/vehicleinfo.json
+++ b/Tools/autotest/pysim/vehicleinfo.json
@@ -204,52 +204,6 @@
                 ],
                 "external": true
             },
-            "heli": {
-                "waf_target": "bin/arducopter-heli",
-                "default_params_filename": "default_params/copter-heli.parm"
-            },
-            "heli-gas": {
-                "waf_target": "bin/arducopter-heli",
-                "default_params_filename": [
-                    "default_params/copter-heli.parm",
-                    "default_params/copter-heli-gas.parm"
-                ]
-            },
-            "heli-ddvptail": {
-                "waf_target": "bin/arducopter-heli",
-                "default_params_filename": [
-                    "default_params/copter-heli.parm",
-                    "default_params/copter-heli-ddvptail.parm"
-                ]
-            },
-            "heli-ddfptail": {
-                "waf_target": "bin/arducopter-heli",
-                "default_params_filename": [
-                    "default_params/copter-heli.parm",
-                    "default_params/copter-heli-ddfptail.parm"
-                ]
-            },
-            "heli-dual": {
-                "waf_target": "bin/arducopter-heli",
-                "default_params_filename": [
-                    "default_params/copter-heli.parm",
-                    "default_params/copter-heli-dual.parm"
-                ]
-            },
-            "heli-blade360": {
-                "waf_target": "bin/arducopter-heli",
-                "default_params_filename": [
-                    "default_params/copter-heli.parm"
-                ]
-            },
-            "heli-quad": {
-                "model": "heli-quad:@ROMFS/models/heliquad.json",
-                "waf_target": "bin/arducopter-heli",
-                "default_params_filename": [
-                    "default_params/copter-heli.parm",
-                    "default_params/copter-heliquad.parm"
-                ]
-            },
             "singlecopter": {
                 "waf_target": "bin/arducopter",
                 "default_params_filename": "default_params/copter-single.parm"

--- a/Tools/autotest/pysim/vehicleinfo.py
+++ b/Tools/autotest/pysim/vehicleinfo.py
@@ -29,6 +29,28 @@ class VehicleInfo(object):
         default_frame = self.default_frame(vehicle)
         return self.options[vehicle]["frames"][default_frame]["waf_target"]
 
+    # frame-name prefixes that map onto a shared frame entry, longest first
+    frame_prefixes = ["octa", "tri", "y6", "firefly", "heli", "gazebo", "last_letter", "jsbsim", "quadplane", "plane-elevon", "plane-vtail", "plane", "airsim"]
+
+    def frame_in_vehicle(self, frame, vehicle):
+        """Return True if frame resolves to a concrete entry under vehicle.
+
+        Mirrors the resolution in options_for_frame (exact match, shared
+        prefix, or the -heli suffix) so callers can pick the vehicle that
+        actually owns a frame before asking for its options.
+        """
+        if vehicle not in self.options:
+            return False
+        frames = self.options[vehicle]["frames"]
+        if frame in frames:
+            return True
+        for p in self.frame_prefixes:
+            if frame.startswith(p) and p in frames:
+                return True
+        if frame.endswith("-heli") and "heli" in frames:
+            return True
+        return False
+
     def options_for_frame(self, frame, vehicle, opts):
         """Return information about how to sitl for frame e.g. build-type==sitl"""
         ret = None
@@ -36,7 +58,7 @@ class VehicleInfo(object):
         if frame in frames:
             ret = self.options[vehicle]["frames"][frame]
         else:
-            for p in ["octa", "tri", "y6", "firefly", "heli", "gazebo", "last_letter", "jsbsim", "quadplane", "plane-elevon", "plane-vtail", "plane", "airsim"]:
+            for p in self.frame_prefixes:
                 if frame.startswith(p):
                     ret = self.options[vehicle]["frames"][p]
                     break

--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -1682,8 +1682,11 @@ if cmd_opts.gui:
         sys.exit(0)
 
     if cmd_opts.vehicle == 'Helicopter':
+        # heli is built from the ArduCopter source tree; the frame-owning
+        # vehicle is resolved separately when looking up frame options.
         cmd_opts.vehicle = 'ArduCopter'
-        cmd_opts.frame = 'heli'
+        if cmd_opts.frame is None:
+            cmd_opts.frame = 'heli'
 
 if cmd_opts.list_vehicle:
     print(' '.join(vinfo.options.keys()))
@@ -1775,8 +1778,19 @@ You could also try changing directory to e.g. the ArduCopter subdirectory
 if cmd_opts.frame is None:
     cmd_opts.frame = vinfo.options[cmd_opts.vehicle]["default_frame"]
 
+# heli frames are defined under the Helicopter vehicle in vehicleinfo but
+# are built from the ArduCopter source tree; if the requested vehicle does
+# not own the frame, search the other vehicles for the one that does so
+# "-v ArduCopter -f heli" still resolves the arducopter-heli build target.
+frame_vehicle = cmd_opts.vehicle
+if not vinfo.frame_in_vehicle(cmd_opts.frame, frame_vehicle):
+    for candidate in vinfo.options:
+        if vinfo.frame_in_vehicle(cmd_opts.frame, candidate):
+            frame_vehicle = candidate
+            break
+
 frame_infos = vinfo.options_for_frame(cmd_opts.frame,
-                                      cmd_opts.vehicle,
+                                      frame_vehicle,
                                       cmd_opts)
 
 vehicle_dir = os.path.realpath(os.path.join(root_dir, cmd_opts.vehicle))


### PR DESCRIPTION
### Summary

Removes hackery required to allow `sim_vehicle.py -f heli` to work from vehicleinfo.json and arducopter.py and replace it with different hackery within `sim_vehicle.py`

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request


### Description

When adding a heli frame one had to go and duplicate that information in the json file udner ArduCopter so that sim_vehicle.py didn't break.  We then had to skip the frame in Copter's FlyEachFrame as ArduCopter doesn't know how to fly the heli frame!

Put hackery into sim_vehicle.py to make things generally work.  We have to look through the frames for the different vehicles to work out which one to use.
