### PR TITLE
AP_HAL_SITL: fix Semaphore ownership race in give()

### DIFF
--- a/libraries/AP_HAL_SITL/Semaphores.cpp
+++ b/libraries/AP_HAL_SITL/Semaphores.cpp
@@ -22,11 +22,11 @@ Semaphore::Semaphore()
 bool Semaphore::give()
 {
     take_count--;
-    if (pthread_mutex_unlock(&_lock) != 0) {
-        AP_HAL::panic("Bad semaphore usage");
-    }
     if (take_count == 0) {
         owner = (pthread_t)-1;
+    }
+    if (pthread_mutex_unlock(&_lock) != 0) {
+        AP_HAL::panic("Bad semaphore usage");
     }
     return true;
 }


### PR DESCRIPTION
### Summary

Release ownership of a semaphore while still holding it when count goes to zero

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

give() cleared the owner field after releasing the mutex.  In the window between the unlock and the owner=-1 assignment another thread could take the lock and set itself as owner; we would then clobber that ownership, causing a spurious "Wrong owner" panic when the victim thread next called check_owner().

owner is now cleared while the lock is still held, so it is only ever mutated under lock protection.  This is exercised when two threads share a bus semaphore, e.g. a driver with its own thread and a periodic-callback driver on the same simulated SPI bus.
