### PR TITLE
AP_NavEKF3: correct moving baseline GPS yaw for vehicle attitude

### DIFF
--- a/Tools/Replay/LR_MsgHandler.cpp
+++ b/Tools/Replay/LR_MsgHandler.cpp
@@ -240,6 +240,12 @@ void LR_MsgHandler_RGPJ::process_message(uint8_t *msgbytes)
     AP::dal().handle_message(msg);
 }
 
+void LR_MsgHandler_RGPK::process_message(uint8_t *msgbytes)
+{
+    MSG_CREATE(RGPK, msgbytes);
+    AP::dal().handle_message(msg);
+}
+
 void LR_MsgHandler_RMGH::process_message(uint8_t *msgbytes)
 {
     MSG_CREATE(RMGH, msgbytes);

--- a/Tools/Replay/LR_MsgHandler.cpp
+++ b/Tools/Replay/LR_MsgHandler.cpp
@@ -241,6 +241,12 @@ void LR_MsgHandler_RGPJ::process_message(uint8_t *msgbytes)
     AP::dal().handle_message(msg);
 }
 
+void LR_MsgHandler_RGPK::process_message(uint8_t *msgbytes)
+{
+    MSG_CREATE(RGPK, msgbytes);
+    AP::dal().handle_message(msg);
+}
+
 void LR_MsgHandler_RMGH::process_message(uint8_t *msgbytes)
 {
     MSG_CREATE(RMGH, msgbytes);

--- a/Tools/Replay/LR_MsgHandler.cpp
+++ b/Tools/Replay/LR_MsgHandler.cpp
@@ -241,11 +241,13 @@ void LR_MsgHandler_RGPJ::process_message(uint8_t *msgbytes)
     AP::dal().handle_message(msg);
 }
 
+#if AP_DAL_RGPK_LOGGING_ENABLED
 void LR_MsgHandler_RGPK::process_message(uint8_t *msgbytes)
 {
     MSG_CREATE(RGPK, msgbytes);
     AP::dal().handle_message(msg);
 }
+#endif
 
 void LR_MsgHandler_RMGH::process_message(uint8_t *msgbytes)
 {

--- a/Tools/Replay/LR_MsgHandler.h
+++ b/Tools/Replay/LR_MsgHandler.h
@@ -213,6 +213,12 @@ public:
     using LR_MsgHandler::LR_MsgHandler;
     void process_message(uint8_t *msg) override;
 };
+class LR_MsgHandler_RGPK : public LR_MsgHandler
+{
+public:
+    using LR_MsgHandler::LR_MsgHandler;
+    void process_message(uint8_t *msg) override;
+};
 
 class LR_MsgHandler_RMGH : public LR_MsgHandler
 {

--- a/Tools/Replay/LR_MsgHandler.h
+++ b/Tools/Replay/LR_MsgHandler.h
@@ -2,6 +2,7 @@
 
 #include "MsgHandler.h"
 #include <AP_AHRS/AP_AHRS.h>
+#include <AP_DAL/LogStructure.h>
 #include <AP_GPS/AP_GPS.h>
 #include <AP_NavEKF2/AP_NavEKF2.h>
 #include <AP_NavEKF3/AP_NavEKF3.h>
@@ -213,12 +214,14 @@ public:
     using LR_MsgHandler::LR_MsgHandler;
     void process_message(uint8_t *msg) override;
 };
+#if AP_DAL_RGPK_LOGGING_ENABLED
 class LR_MsgHandler_RGPK : public LR_MsgHandler
 {
 public:
     using LR_MsgHandler::LR_MsgHandler;
     void process_message(uint8_t *msg) override;
 };
+#endif
 
 class LR_MsgHandler_RMGH : public LR_MsgHandler
 {

--- a/Tools/Replay/LogReader.cpp
+++ b/Tools/Replay/LogReader.cpp
@@ -106,6 +106,8 @@ bool LogReader::handle_log_format_msg(const struct log_Format &f)
 	    msgparser[f.type] = NEW_NOTHROW LR_MsgHandler_RGPI(formats[f.type]);
     } else if (streq(name, "RGPJ")) {
         msgparser[f.type] = NEW_NOTHROW LR_MsgHandler_RGPJ(formats[f.type]);
+    } else if (streq(name, "RGPK")) {
+        msgparser[f.type] = NEW_NOTHROW LR_MsgHandler_RGPK(formats[f.type]);
 	} else if (streq(name, "RMGH")) {
 	    msgparser[f.type] = NEW_NOTHROW LR_MsgHandler_RMGH(formats[f.type]);
 	} else if (streq(name, "RMGI")) {

--- a/Tools/Replay/LogReader.cpp
+++ b/Tools/Replay/LogReader.cpp
@@ -106,8 +106,10 @@ bool LogReader::handle_log_format_msg(const struct log_Format &f)
 	    msgparser[f.type] = NEW_NOTHROW LR_MsgHandler_RGPI(formats[f.type]);
     } else if (streq(name, "RGPJ")) {
         msgparser[f.type] = NEW_NOTHROW LR_MsgHandler_RGPJ(formats[f.type]);
+#if AP_DAL_RGPK_LOGGING_ENABLED
     } else if (streq(name, "RGPK")) {
         msgparser[f.type] = NEW_NOTHROW LR_MsgHandler_RGPK(formats[f.type]);
+#endif
 	} else if (streq(name, "RMGH")) {
 	    msgparser[f.type] = NEW_NOTHROW LR_MsgHandler_RMGH(formats[f.type]);
 	} else if (streq(name, "RMGI")) {

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -14197,7 +14197,6 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         # A frame slip (e.g. rotating the offset by the published vehicle
         # attitude instead) would bias the yaw, and the large-Z baseline
         # amplifies that bias well past the tolerance below.
-        self.context_push()
         self.load_default_params_file("copter-gps-for-yaw.parm")
         self.set_parameters({
             # Antenna baseline: small fore-aft (X) plus large vertical (Z)
@@ -14278,8 +14277,6 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 break
 
         self.do_RTL()
-        self.context_pop()
-        self.reboot_sitl()
 
     def GPSForYawVerticalBaseline(self):
         '''Moving baseline GPS yaw must be rejected for a vertical baseline'''

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -14299,6 +14299,63 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.context_pop()
         self.reboot_sitl()
 
+    def GPSForYawCompassFallback(self):
+        '''EKF3 must fall back to the compass when GPS yaw is present but unusable'''
+        # With EK3_SRC1_YAW = 3 (GPS with compass fallback) the EKF falls
+        # back to the magnetometer once no usable GPS yaw has been seen for
+        # 10 seconds.  A moving-baseline yaw whose configured antenna offset
+        # is vertical carries no yaw information, so the EKF rejects the
+        # measurement geometrically instead of fusing it.  A rejected
+        # measurement must count as "no usable yaw": the GPS keeps
+        # publishing yaw, so if rejection refreshed the last-yaw timestamp
+        # the fallback would never engage and the vehicle would fly with no
+        # yaw aiding at all.
+        self.context_push()
+        self.load_default_params_file("copter-gps-for-yaw.parm")
+        self.set_parameters({
+            "EK3_SRC1_YAW": 3,  # GPS with compass fallback
+        })
+        self.reboot_sitl()
+
+        self.wait_gps_fix_type_gte(6, message_type="GPS2_RAW", verbose=True)
+        self.wait_ready_to_arm()
+
+        # fly with the healthy lateral baseline from copter-gps-for-yaw.parm
+        # so the EKF fuses GPS yaw and learns that the compass agrees with
+        # it, which arms the fallback
+        self.takeoff(10, mode='GUIDED')
+        self.delay_sim_time(10, reason="learning that the compass agrees with GPS yaw")
+
+        # reconfigure the antennas to a vertical baseline in flight.  The
+        # driver keeps publishing yaw: the simulated antennas keep 0.3 m of
+        # horizontal separation, and the baseline length and vertical drop
+        # still match the configured offsets, so every driver-side check
+        # passes.  The configured offset the yaw is calculated from is
+        # purely vertical, so the EKF rejects every measurement
+        self.context_collect('STATUSTEXT')
+        self.set_parameters({
+            "GPS1_POS_X": 0.0, "GPS1_POS_Y": 0.0, "GPS1_POS_Z": -0.45,
+            "GPS2_POS_X": 0.0, "GPS2_POS_Y": 0.0, "GPS2_POS_Z": 0.45,
+            "SIM_GPS1_POS_X": 0.0, "SIM_GPS1_POS_Y": -0.15, "SIM_GPS1_POS_Z": -0.44,
+            "SIM_GPS2_POS_X": 0.0, "SIM_GPS2_POS_Y": 0.15, "SIM_GPS2_POS_Z": 0.44,
+        })
+
+        # the fallback requires 10 seconds with no usable GPS yaw
+        self.wait_statustext("yaw fallback active", timeout=60, check_context=True)
+
+        # the compass must now be steering the EKF yaw: confirm it tracks truth
+        self.delay_sim_time(5, reason="letting compass fallback settle")
+        att = self.assert_receive_message("ATTITUDE")
+        sim = self.assert_receive_message("SIMSTATE")
+        yaw_err_deg = abs(mavextra.wrap_180(math.degrees(att.yaw) - math.degrees(sim.yaw)))
+        if yaw_err_deg > 20:
+            raise NotAchievedException(
+                "Yaw not tracking truth under compass fallback (err=%.1f deg)" % yaw_err_deg)
+
+        self.do_RTL()
+        self.context_pop()
+        self.reboot_sitl()
+
     def SMART_RTL_EnterLeave(self):
         '''check SmartRTL behaviour when entering/leaving'''
         # we had a bug where we would consume points when re-entering smartrtl
@@ -18689,6 +18746,7 @@ return update, 1000
             self.GPS_INPUT,
             self.GPSForYawAttitudeCorrection,
             self.GPSForYawVerticalBaseline,
+            self.GPSForYawCompassFallback,
             self.DefaultIntervalsFromFiles,
             self.GPSTypes,
             self.MultipleGPS,

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -14177,6 +14177,97 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             raise NotAchievedException("Never sent any GPS_INPUT messages")
         self.progress("Sent %u GPS_INPUT messages" % feeder.count)
 
+    def GPSForYawAttitudeCorrection(self):
+        '''Moving baseline GPS yaw must correct for vehicle roll/pitch'''
+        # The moving-baseline GPS reports the antenna baseline heading in the
+        # NED horizontal plane.  The GPS backend recovers the vehicle yaw by
+        # subtracting the bearing of the body-frame antenna offset, which is
+        # only exact when the vehicle is level.  EKF3 applies the residual
+        # attitude correction using its own roll/pitch estimate.  We give the
+        # baseline a large vertical (Z) component so that a modest vehicle
+        # lean swings the apparent horizontal bearing by tens of degrees:
+        # without the attitude correction the yaw fed to the EKF is then
+        # wrong by a similar amount.
+        self.context_push()
+        self.load_default_params_file("copter-gps-for-yaw.parm")
+        self.set_parameters({
+            # Antenna baseline: small fore-aft (X) plus large vertical (Z)
+            # separation, no lateral (Y).  When level the baseline is on the
+            # nose so the recovered yaw equals the vehicle yaw; under roll the
+            # vertical component projects into the horizontal plane.
+            "GPS1_POS_X": -0.15, "GPS1_POS_Y": 0.0, "GPS1_POS_Z": -0.45,
+            "GPS2_POS_X": 0.15, "GPS2_POS_Y": 0.0, "GPS2_POS_Z": 0.45,
+            "SIM_GPS1_POS_X": -0.15, "SIM_GPS1_POS_Y": 0.0, "SIM_GPS1_POS_Z": -0.45,
+            "SIM_GPS2_POS_X": 0.15, "SIM_GPS2_POS_Y": 0.0, "SIM_GPS2_POS_Z": 0.45,
+            # Remove the simulator's heading lag back-projection so the reported
+            # heading reflects the instantaneous attitude.  Otherwise the steady
+            # turn rate of the circle would add a lag term the correction does
+            # not undo, confounding the comparison against truth.
+            "SIM_GPS1_LAG_MS": 0,
+            "SIM_GPS2_LAG_MS": 0,
+        })
+        self.reboot_sitl()
+
+        self.wait_gps_fix_type_gte(6, message_type="GPS2_RAW", verbose=True)
+        self.wait_ready_to_arm()
+        self.takeoff(20, mode='GUIDED')
+
+        # fly a gentle circle to hold a steady, modest lean angle.  A large
+        # radius keeps the turn rate (and hence any residual yaw lag) small.
+        self.set_parameters({
+            "CIRCLE_RADIUS_M": 50,
+            "CIRCLE_RATE": 12,
+        })
+        self.change_mode('CIRCLE')
+
+        # Sample the EKF attitude against truth while the vehicle is banked.
+        # copter-gps-for-yaw.parm sets EK3_SRC1_YAW=2 so the moving-baseline
+        # GPS yaw is the EKF's only yaw source: with the attitude correction
+        # in place the EKF yaw tracks truth; without it the fused yaw is wrong
+        # by tens of degrees.  Also require the yaw innovation test ratio to
+        # stay below 1: a wrong measurement that is merely *rejected* by the
+        # innovation gate would leave the EKF yaw temporarily accurate while
+        # it coasts on the gyro, which must not count as a pass.
+        min_roll_deg = 10
+        max_yaw_err_deg = 15
+        wanted_samples = 10
+        good_samples = 0
+        tstart = self.get_sim_time()
+        while True:
+            if self.get_sim_time_cached() - tstart > 90:
+                raise NotAchievedException(
+                    "Only gathered %u/%u banked GPS-yaw samples" % (good_samples, wanted_samples))
+            att = self.assert_receive_message("ATTITUDE")
+            sim = self.assert_receive_message("SIMSTATE")
+            roll_deg = math.degrees(sim.roll)
+            if abs(roll_deg) < min_roll_deg:
+                continue
+            ekf_yaw_deg = math.degrees(att.yaw)
+            true_yaw_deg = math.degrees(sim.yaw)
+            yaw_err_deg = abs(mavextra.wrap_180(ekf_yaw_deg - true_yaw_deg))
+            ekf_status = self.assert_receive_message("EKF_STATUS_REPORT", timeout=10)
+            # compass_variance is sqrt(MAX(magTestRatio, yawTestRatio)) and no
+            # mag fusion runs with a GPS yaw source, so this recovers the EKF
+            # yaw innovation test ratio
+            yaw_test_ratio = ekf_status.compass_variance**2
+            self.progress("roll=%.1f ekf_yaw=%.1f true_yaw=%.1f err=%.1f yaw_test_ratio=%.2f" %
+                          (roll_deg, ekf_yaw_deg, true_yaw_deg, yaw_err_deg, yaw_test_ratio))
+            if yaw_err_deg > max_yaw_err_deg:
+                raise NotAchievedException(
+                    "EKF yaw not corrected for attitude (roll=%.1f deg, yaw err=%.1f deg)" %
+                    (roll_deg, yaw_err_deg))
+            if yaw_test_ratio > 1.0:
+                raise NotAchievedException(
+                    "EKF rejecting GPS yaw (roll=%.1f deg, yaw test ratio=%.2f)" %
+                    (roll_deg, yaw_test_ratio))
+            good_samples += 1
+            if good_samples >= wanted_samples:
+                break
+
+        self.do_RTL()
+        self.context_pop()
+        self.reboot_sitl()
+
     def SMART_RTL_EnterLeave(self):
         '''check SmartRTL behaviour when entering/leaving'''
         # we had a bug where we would consume points when re-entering smartrtl
@@ -18565,6 +18656,7 @@ return update, 1000
             self.DeadReckoningInWind,
             self.GPSForYaw,
             self.GPS_INPUT,
+            self.GPSForYawAttitudeCorrection,
             self.DefaultIntervalsFromFiles,
             self.GPSTypes,
             self.MultipleGPS,

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -14178,7 +14178,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.progress("Sent %u GPS_INPUT messages" % feeder.count)
 
     def GPSForYawAttitudeCorrection(self):
-        '''Moving baseline GPS yaw must correct for vehicle roll/pitch'''
+        '''Moving baseline GPS yaw must correct for vehicle roll/pitch, incl. under a large board mounting trim'''
         # The moving-baseline GPS reports the antenna baseline heading in the
         # NED horizontal plane.  The GPS backend recovers the vehicle yaw by
         # subtracting the bearing of the body-frame antenna offset, which is
@@ -14188,6 +14188,15 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         # lean swings the apparent horizontal bearing by tens of degrees:
         # without the attitude correction the yaw fed to the EKF is then
         # wrong by a similar amount.
+        #
+        # A large AHRS_TRIM (board-to-frame mounting offset) is also applied as
+        # a frame regression guard.  The EKF works in the autopilot (sensor)
+        # body frame and applies the trim only on output; the correction rotates
+        # the antenna offset by the EKF's own attitude and fuses the result in
+        # that same frame, so the recovered yaw must be unaffected by the trim.
+        # A frame slip (e.g. rotating the offset by the published vehicle
+        # attitude instead) would bias the yaw, and the large-Z baseline
+        # amplifies that bias well past the tolerance below.
         self.context_push()
         self.load_default_params_file("copter-gps-for-yaw.parm")
         self.set_parameters({
@@ -14205,6 +14214,10 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             # not undo, confounding the comparison against truth.
             "SIM_GPS1_LAG_MS": 0,
             "SIM_GPS2_LAG_MS": 0,
+            # large board mounting trim, near the AHRS_TRIM limit: exercises the
+            # sensor-vs-vehicle frame handling of the correction (see docstring).
+            "AHRS_TRIM_X": 0.1745,
+            "AHRS_TRIM_Y": 0.1745,
         })
         self.reboot_sitl()
 

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -14316,7 +14316,6 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         # publishing yaw, so if rejection refreshed the last-yaw timestamp
         # the fallback would never engage and the vehicle would fly with no
         # yaw aiding at all.
-        self.context_push()
         self.load_default_params_file("copter-gps-for-yaw.parm")
         self.set_parameters({
             "EK3_SRC1_YAW": 3,  # GPS with compass fallback
@@ -14359,8 +14358,6 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 "Yaw not tracking truth under compass fallback (err=%.1f deg)" % yaw_err_deg)
 
         self.do_RTL()
-        self.context_pop()
-        self.reboot_sitl()
 
     def SMART_RTL_EnterLeave(self):
         '''check SmartRTL behaviour when entering/leaving'''

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -14284,7 +14284,6 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         # in the horizontal plane, so a baseline with no horizontal separation
         # carries no yaw information: the reported heading is receiver noise.
         # The driver must reject the solution rather than publish it as yaw.
-        self.context_push()
         self.load_default_params_file("copter-gps-for-yaw.parm")
         self.set_parameters({
             "GPS1_POS_X": 0.0, "GPS1_POS_Y": 0.0, "GPS1_POS_Z": -0.45,
@@ -14305,9 +14304,6 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             if m.yaw not in [0, 65535]:
                 raise NotAchievedException(
                     "Got GPS yaw %.1f deg from a baseline with no horizontal separation" % (m.yaw * 0.01))
-
-        self.context_pop()
-        self.reboot_sitl()
 
     def GPSForYawCompassFallback(self):
         '''EKF3 must fall back to the compass when GPS yaw is present but unusable'''

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -14268,6 +14268,37 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.context_pop()
         self.reboot_sitl()
 
+    def GPSForYawVerticalBaseline(self):
+        '''Moving baseline GPS yaw must be rejected for a vertical baseline'''
+        # The moving-baseline GPS reports the heading of the antenna baseline
+        # in the horizontal plane, so a baseline with no horizontal separation
+        # carries no yaw information: the reported heading is receiver noise.
+        # The driver must reject the solution rather than publish it as yaw.
+        self.context_push()
+        self.load_default_params_file("copter-gps-for-yaw.parm")
+        self.set_parameters({
+            "GPS1_POS_X": 0.0, "GPS1_POS_Y": 0.0, "GPS1_POS_Z": -0.45,
+            "GPS2_POS_X": 0.0, "GPS2_POS_Y": 0.0, "GPS2_POS_Z": 0.45,
+            "SIM_GPS1_POS_X": 0.0, "SIM_GPS1_POS_Y": 0.0, "SIM_GPS1_POS_Z": -0.45,
+            "SIM_GPS2_POS_X": 0.0, "SIM_GPS2_POS_Y": 0.0, "SIM_GPS2_POS_Z": 0.45,
+        })
+        self.reboot_sitl()
+
+        self.wait_gps_fix_type_gte(6, message_type="GPS2_RAW", verbose=True)
+
+        # a yaw field of 0 means the GPS does not provide yaw and 65535 means
+        # it is configured for yaw but currently unable to provide it (north
+        # is reported as 36000)
+        tstart = self.get_sim_time()
+        while self.get_sim_time_cached() - tstart < 10:
+            m = self.assert_receive_message("GPS2_RAW")
+            if m.yaw not in [0, 65535]:
+                raise NotAchievedException(
+                    "Got GPS yaw %.1f deg from a baseline with no horizontal separation" % (m.yaw * 0.01))
+
+        self.context_pop()
+        self.reboot_sitl()
+
     def SMART_RTL_EnterLeave(self):
         '''check SmartRTL behaviour when entering/leaving'''
         # we had a bug where we would consume points when re-entering smartrtl
@@ -18657,6 +18688,7 @@ return update, 1000
             self.GPSForYaw,
             self.GPS_INPUT,
             self.GPSForYawAttitudeCorrection,
+            self.GPSForYawVerticalBaseline,
             self.DefaultIntervalsFromFiles,
             self.GPSTypes,
             self.MultipleGPS,

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -14862,7 +14862,6 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         # A frame slip (e.g. rotating the offset by the published vehicle
         # attitude instead) would bias the yaw, and the large-Z baseline
         # amplifies that bias well past the tolerance below.
-        self.context_push()
         self.load_default_params_file("copter-gps-for-yaw.parm")
         self.set_parameters({
             # Antenna baseline: small fore-aft (X) plus large vertical (Z)
@@ -14943,8 +14942,6 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 break
 
         self.do_RTL()
-        self.context_pop()
-        self.reboot_sitl()
 
     def GPSForYawVerticalBaseline(self):
         '''Moving baseline GPS yaw must be rejected for a vertical baseline'''

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -14964,6 +14964,63 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.context_pop()
         self.reboot_sitl()
 
+    def GPSForYawCompassFallback(self):
+        '''EKF3 must fall back to the compass when GPS yaw is present but unusable'''
+        # With EK3_SRC1_YAW = 3 (GPS with compass fallback) the EKF falls
+        # back to the magnetometer once no usable GPS yaw has been seen for
+        # 10 seconds.  A moving-baseline yaw whose configured antenna offset
+        # is vertical carries no yaw information, so the EKF rejects the
+        # measurement geometrically instead of fusing it.  A rejected
+        # measurement must count as "no usable yaw": the GPS keeps
+        # publishing yaw, so if rejection refreshed the last-yaw timestamp
+        # the fallback would never engage and the vehicle would fly with no
+        # yaw aiding at all.
+        self.context_push()
+        self.load_default_params_file("copter-gps-for-yaw.parm")
+        self.set_parameters({
+            "EK3_SRC1_YAW": 3,  # GPS with compass fallback
+        })
+        self.reboot_sitl()
+
+        self.wait_gps_fix_type_gte(6, message_type="GPS2_RAW", verbose=True)
+        self.wait_ready_to_arm()
+
+        # fly with the healthy lateral baseline from copter-gps-for-yaw.parm
+        # so the EKF fuses GPS yaw and learns that the compass agrees with
+        # it, which arms the fallback
+        self.takeoff(10, mode='GUIDED')
+        self.delay_sim_time(10, reason="learning that the compass agrees with GPS yaw")
+
+        # reconfigure the antennas to a vertical baseline in flight.  The
+        # driver keeps publishing yaw: the simulated antennas keep 0.3 m of
+        # horizontal separation, and the baseline length and vertical drop
+        # still match the configured offsets, so every driver-side check
+        # passes.  The configured offset the yaw is calculated from is
+        # purely vertical, so the EKF rejects every measurement
+        self.context_collect('STATUSTEXT')
+        self.set_parameters({
+            "GPS1_POS_X": 0.0, "GPS1_POS_Y": 0.0, "GPS1_POS_Z": -0.45,
+            "GPS2_POS_X": 0.0, "GPS2_POS_Y": 0.0, "GPS2_POS_Z": 0.45,
+            "SIM_GPS1_POS_X": 0.0, "SIM_GPS1_POS_Y": -0.15, "SIM_GPS1_POS_Z": -0.44,
+            "SIM_GPS2_POS_X": 0.0, "SIM_GPS2_POS_Y": 0.15, "SIM_GPS2_POS_Z": 0.44,
+        })
+
+        # the fallback requires 10 seconds with no usable GPS yaw
+        self.wait_statustext("yaw fallback active", timeout=60, check_context=True)
+
+        # the compass must now be steering the EKF yaw: confirm it tracks truth
+        self.delay_sim_time(5, reason="letting compass fallback settle")
+        att = self.assert_receive_message("ATTITUDE")
+        sim = self.assert_receive_message("SIMSTATE")
+        yaw_err_deg = abs(mavextra.wrap_180(math.degrees(att.yaw) - math.degrees(sim.yaw)))
+        if yaw_err_deg > 20:
+            raise NotAchievedException(
+                "Yaw not tracking truth under compass fallback (err=%.1f deg)" % yaw_err_deg)
+
+        self.do_RTL()
+        self.context_pop()
+        self.reboot_sitl()
+
     def SMART_RTL_EnterLeave(self):
         '''check SmartRTL behaviour when entering/leaving'''
         # we had a bug where we would consume points when re-entering smartrtl
@@ -19447,6 +19504,7 @@ return update, 1000
             self.GPS_INPUT,
             self.GPSForYawAttitudeCorrection,
             self.GPSForYawVerticalBaseline,
+            self.GPSForYawCompassFallback,
             self.DefaultIntervalsFromFiles,
             self.GPSTypes,
             self.MultipleGPS,

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -14843,7 +14843,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.progress("Sent %u GPS_INPUT messages" % feeder.count)
 
     def GPSForYawAttitudeCorrection(self):
-        '''Moving baseline GPS yaw must correct for vehicle roll/pitch'''
+        '''Moving baseline GPS yaw must correct for vehicle roll/pitch, incl. under a large board mounting trim'''
         # The moving-baseline GPS reports the antenna baseline heading in the
         # NED horizontal plane.  The GPS backend recovers the vehicle yaw by
         # subtracting the bearing of the body-frame antenna offset, which is
@@ -14853,6 +14853,15 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         # lean swings the apparent horizontal bearing by tens of degrees:
         # without the attitude correction the yaw fed to the EKF is then
         # wrong by a similar amount.
+        #
+        # A large AHRS_TRIM (board-to-frame mounting offset) is also applied as
+        # a frame regression guard.  The EKF works in the autopilot (sensor)
+        # body frame and applies the trim only on output; the correction rotates
+        # the antenna offset by the EKF's own attitude and fuses the result in
+        # that same frame, so the recovered yaw must be unaffected by the trim.
+        # A frame slip (e.g. rotating the offset by the published vehicle
+        # attitude instead) would bias the yaw, and the large-Z baseline
+        # amplifies that bias well past the tolerance below.
         self.context_push()
         self.load_default_params_file("copter-gps-for-yaw.parm")
         self.set_parameters({
@@ -14870,6 +14879,10 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             # not undo, confounding the comparison against truth.
             "SIM_GPS1_LAG_MS": 0,
             "SIM_GPS2_LAG_MS": 0,
+            # large board mounting trim, near the AHRS_TRIM limit: exercises the
+            # sensor-vs-vehicle frame handling of the correction (see docstring).
+            "AHRS_TRIM_X": 0.1745,
+            "AHRS_TRIM_Y": 0.1745,
         })
         self.reboot_sitl()
 

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -14949,7 +14949,6 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         # in the horizontal plane, so a baseline with no horizontal separation
         # carries no yaw information: the reported heading is receiver noise.
         # The driver must reject the solution rather than publish it as yaw.
-        self.context_push()
         self.load_default_params_file("copter-gps-for-yaw.parm")
         self.set_parameters({
             "GPS1_POS_X": 0.0, "GPS1_POS_Y": 0.0, "GPS1_POS_Z": -0.45,
@@ -14970,9 +14969,6 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             if m.yaw not in [0, 65535]:
                 raise NotAchievedException(
                     "Got GPS yaw %.1f deg from a baseline with no horizontal separation" % (m.yaw * 0.01))
-
-        self.context_pop()
-        self.reboot_sitl()
 
     def GPSForYawCompassFallback(self):
         '''EKF3 must fall back to the compass when GPS yaw is present but unusable'''

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -14933,6 +14933,37 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.context_pop()
         self.reboot_sitl()
 
+    def GPSForYawVerticalBaseline(self):
+        '''Moving baseline GPS yaw must be rejected for a vertical baseline'''
+        # The moving-baseline GPS reports the heading of the antenna baseline
+        # in the horizontal plane, so a baseline with no horizontal separation
+        # carries no yaw information: the reported heading is receiver noise.
+        # The driver must reject the solution rather than publish it as yaw.
+        self.context_push()
+        self.load_default_params_file("copter-gps-for-yaw.parm")
+        self.set_parameters({
+            "GPS1_POS_X": 0.0, "GPS1_POS_Y": 0.0, "GPS1_POS_Z": -0.45,
+            "GPS2_POS_X": 0.0, "GPS2_POS_Y": 0.0, "GPS2_POS_Z": 0.45,
+            "SIM_GPS1_POS_X": 0.0, "SIM_GPS1_POS_Y": 0.0, "SIM_GPS1_POS_Z": -0.45,
+            "SIM_GPS2_POS_X": 0.0, "SIM_GPS2_POS_Y": 0.0, "SIM_GPS2_POS_Z": 0.45,
+        })
+        self.reboot_sitl()
+
+        self.wait_gps_fix_type_gte(6, message_type="GPS2_RAW", verbose=True)
+
+        # a yaw field of 0 means the GPS does not provide yaw and 65535 means
+        # it is configured for yaw but currently unable to provide it (north
+        # is reported as 36000)
+        tstart = self.get_sim_time()
+        while self.get_sim_time_cached() - tstart < 10:
+            m = self.assert_receive_message("GPS2_RAW")
+            if m.yaw not in [0, 65535]:
+                raise NotAchievedException(
+                    "Got GPS yaw %.1f deg from a baseline with no horizontal separation" % (m.yaw * 0.01))
+
+        self.context_pop()
+        self.reboot_sitl()
+
     def SMART_RTL_EnterLeave(self):
         '''check SmartRTL behaviour when entering/leaving'''
         # we had a bug where we would consume points when re-entering smartrtl
@@ -19415,6 +19446,7 @@ return update, 1000
             self.GPSForYaw,
             self.GPS_INPUT,
             self.GPSForYawAttitudeCorrection,
+            self.GPSForYawVerticalBaseline,
             self.DefaultIntervalsFromFiles,
             self.GPSTypes,
             self.MultipleGPS,

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -14981,7 +14981,6 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         # publishing yaw, so if rejection refreshed the last-yaw timestamp
         # the fallback would never engage and the vehicle would fly with no
         # yaw aiding at all.
-        self.context_push()
         self.load_default_params_file("copter-gps-for-yaw.parm")
         self.set_parameters({
             "EK3_SRC1_YAW": 3,  # GPS with compass fallback
@@ -15024,8 +15023,6 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 "Yaw not tracking truth under compass fallback (err=%.1f deg)" % yaw_err_deg)
 
         self.do_RTL()
-        self.context_pop()
-        self.reboot_sitl()
 
     def SMART_RTL_EnterLeave(self):
         '''check SmartRTL behaviour when entering/leaving'''

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -14842,6 +14842,97 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             raise NotAchievedException("Never sent any GPS_INPUT messages")
         self.progress("Sent %u GPS_INPUT messages" % feeder.count)
 
+    def GPSForYawAttitudeCorrection(self):
+        '''Moving baseline GPS yaw must correct for vehicle roll/pitch'''
+        # The moving-baseline GPS reports the antenna baseline heading in the
+        # NED horizontal plane.  The GPS backend recovers the vehicle yaw by
+        # subtracting the bearing of the body-frame antenna offset, which is
+        # only exact when the vehicle is level.  EKF3 applies the residual
+        # attitude correction using its own roll/pitch estimate.  We give the
+        # baseline a large vertical (Z) component so that a modest vehicle
+        # lean swings the apparent horizontal bearing by tens of degrees:
+        # without the attitude correction the yaw fed to the EKF is then
+        # wrong by a similar amount.
+        self.context_push()
+        self.load_default_params_file("copter-gps-for-yaw.parm")
+        self.set_parameters({
+            # Antenna baseline: small fore-aft (X) plus large vertical (Z)
+            # separation, no lateral (Y).  When level the baseline is on the
+            # nose so the recovered yaw equals the vehicle yaw; under roll the
+            # vertical component projects into the horizontal plane.
+            "GPS1_POS_X": -0.15, "GPS1_POS_Y": 0.0, "GPS1_POS_Z": -0.45,
+            "GPS2_POS_X": 0.15, "GPS2_POS_Y": 0.0, "GPS2_POS_Z": 0.45,
+            "SIM_GPS1_POS_X": -0.15, "SIM_GPS1_POS_Y": 0.0, "SIM_GPS1_POS_Z": -0.45,
+            "SIM_GPS2_POS_X": 0.15, "SIM_GPS2_POS_Y": 0.0, "SIM_GPS2_POS_Z": 0.45,
+            # Remove the simulator's heading lag back-projection so the reported
+            # heading reflects the instantaneous attitude.  Otherwise the steady
+            # turn rate of the circle would add a lag term the correction does
+            # not undo, confounding the comparison against truth.
+            "SIM_GPS1_LAG_MS": 0,
+            "SIM_GPS2_LAG_MS": 0,
+        })
+        self.reboot_sitl()
+
+        self.wait_gps_fix_type_gte(6, message_type="GPS2_RAW", verbose=True)
+        self.wait_ready_to_arm()
+        self.takeoff(20, mode='GUIDED')
+
+        # fly a gentle circle to hold a steady, modest lean angle.  A large
+        # radius keeps the turn rate (and hence any residual yaw lag) small.
+        self.set_parameters({
+            "CIRCLE_RADIUS_M": 50,
+            "CIRCLE_RATE": 12,
+        })
+        self.change_mode('CIRCLE')
+
+        # Sample the EKF attitude against truth while the vehicle is banked.
+        # copter-gps-for-yaw.parm sets EK3_SRC1_YAW=2 so the moving-baseline
+        # GPS yaw is the EKF's only yaw source: with the attitude correction
+        # in place the EKF yaw tracks truth; without it the fused yaw is wrong
+        # by tens of degrees.  Also require the yaw innovation test ratio to
+        # stay below 1: a wrong measurement that is merely *rejected* by the
+        # innovation gate would leave the EKF yaw temporarily accurate while
+        # it coasts on the gyro, which must not count as a pass.
+        min_roll_deg = 10
+        max_yaw_err_deg = 15
+        wanted_samples = 10
+        good_samples = 0
+        tstart = self.get_sim_time()
+        while True:
+            if self.get_sim_time_cached() - tstart > 90:
+                raise NotAchievedException(
+                    "Only gathered %u/%u banked GPS-yaw samples" % (good_samples, wanted_samples))
+            att = self.assert_receive_message("ATTITUDE")
+            sim = self.assert_receive_message("SIMSTATE")
+            roll_deg = math.degrees(sim.roll)
+            if abs(roll_deg) < min_roll_deg:
+                continue
+            ekf_yaw_deg = math.degrees(att.yaw)
+            true_yaw_deg = math.degrees(sim.yaw)
+            yaw_err_deg = abs(mavextra.wrap_180(ekf_yaw_deg - true_yaw_deg))
+            ekf_status = self.assert_receive_message("EKF_STATUS_REPORT", timeout=10)
+            # compass_variance is sqrt(MAX(magTestRatio, yawTestRatio)) and no
+            # mag fusion runs with a GPS yaw source, so this recovers the EKF
+            # yaw innovation test ratio
+            yaw_test_ratio = ekf_status.compass_variance**2
+            self.progress("roll=%.1f ekf_yaw=%.1f true_yaw=%.1f err=%.1f yaw_test_ratio=%.2f" %
+                          (roll_deg, ekf_yaw_deg, true_yaw_deg, yaw_err_deg, yaw_test_ratio))
+            if yaw_err_deg > max_yaw_err_deg:
+                raise NotAchievedException(
+                    "EKF yaw not corrected for attitude (roll=%.1f deg, yaw err=%.1f deg)" %
+                    (roll_deg, yaw_err_deg))
+            if yaw_test_ratio > 1.0:
+                raise NotAchievedException(
+                    "EKF rejecting GPS yaw (roll=%.1f deg, yaw test ratio=%.2f)" %
+                    (roll_deg, yaw_test_ratio))
+            good_samples += 1
+            if good_samples >= wanted_samples:
+                break
+
+        self.do_RTL()
+        self.context_pop()
+        self.reboot_sitl()
+
     def SMART_RTL_EnterLeave(self):
         '''check SmartRTL behaviour when entering/leaving'''
         # we had a bug where we would consume points when re-entering smartrtl
@@ -19323,6 +19414,7 @@ return update, 1000
             self.DeadReckoningInWind,
             self.GPSForYaw,
             self.GPS_INPUT,
+            self.GPSForYawAttitudeCorrection,
             self.DefaultIntervalsFromFiles,
             self.GPSTypes,
             self.MultipleGPS,

--- a/libraries/AP_DAL/AP_DAL.cpp
+++ b/libraries/AP_DAL/AP_DAL.cpp
@@ -87,7 +87,7 @@ void AP_DAL::start_frame(AP_DAL::FrameType frametype)
 
     _ins.start_frame();
     _baro.start_frame();
-    _gps.start_frame();
+    _gps.start_frame(EK3_FEATURE_MOVING_BASELINE);
     _compass.start_frame();
     if (_airspeed) {
         _airspeed->start_frame();

--- a/libraries/AP_DAL/AP_DAL.cpp
+++ b/libraries/AP_DAL/AP_DAL.cpp
@@ -87,7 +87,7 @@ void AP_DAL::start_frame(AP_DAL::FrameType frametype)
 
     _ins.start_frame();
     _baro.start_frame();
-    _gps.start_frame(EK3_FEATURE_MOVING_BASELINE);
+    _gps.start_frame();
     _compass.start_frame();
     if (_airspeed) {
         _airspeed->start_frame();

--- a/libraries/AP_DAL/AP_DAL.h
+++ b/libraries/AP_DAL/AP_DAL.h
@@ -320,6 +320,9 @@ public:
     void handle_message(const log_RGPJ &msg) {
         _gps.handle_message(msg);
     }
+    void handle_message(const log_RGPK &msg) {
+        _gps.handle_message(msg);
+    }
 
     void handle_message(const log_RMGH &msg) {
         _compass.handle_message(msg);

--- a/libraries/AP_DAL/AP_DAL.h
+++ b/libraries/AP_DAL/AP_DAL.h
@@ -320,9 +320,11 @@ public:
     void handle_message(const log_RGPJ &msg) {
         _gps.handle_message(msg);
     }
+#if AP_DAL_RGPK_LOGGING_ENABLED
     void handle_message(const log_RGPK &msg) {
         _gps.handle_message(msg);
     }
+#endif
 
     void handle_message(const log_RMGH &msg) {
         _compass.handle_message(msg);

--- a/libraries/AP_DAL/AP_DAL_GPS.cpp
+++ b/libraries/AP_DAL/AP_DAL_GPS.cpp
@@ -8,6 +8,9 @@ AP_DAL_GPS::AP_DAL_GPS()
     for (uint8_t i=0; i<ARRAY_SIZE(_RGPI); i++) {
         _RGPI[i].instance = i;
         _RGPJ[i].instance = i;
+        // _RGPK defaults to a zero offset so replay of older logs with no
+        // RGPK messages applies no moving baseline yaw correction
+        _RGPK[i].instance = i;
     }
 }
 
@@ -47,8 +50,18 @@ void AP_DAL_GPS::start_frame()
         RGPI.speed_accuracy_returncode = gps.speed_accuracy(i, RGPJ.sacc);
         RGPI.gps_yaw_deg_returncode = gps.gps_yaw_deg(i, RGPJ.yaw_deg, RGPJ.yaw_accuracy_deg, RGPJ.yaw_deg_time_ms);
 
+        // RGPK holds the body-frame antenna offset used to calculate gps_yaw.
+        // The offset is derived from parameters but is zeroed while gps_yaw is
+        // not calculated from a moving baseline, so it tracks the active yaw
+        // source and yaw validity as well as parameter changes. All of these
+        // change rarely, so the message is only written when changed.
+        log_RGPK &RGPK = _RGPK[i];
+        const log_RGPK old_RGPK = RGPK;
+        RGPK.mb_yaw_offset = gps.get_mb_yaw_offset(i);
+
         WRITE_REPLAY_BLOCK_IFCHANGED(RGPI, RGPI, old_RGPI);
         WRITE_REPLAY_BLOCK_IFCHANGED(RGPJ, RGPJ, old_RGPJ);
+        WRITE_REPLAY_BLOCK_IFCHANGED(RGPK, RGPK, old_RGPK);
 
         tmp_location[i] = {
             RGPJ.lat,

--- a/libraries/AP_DAL/AP_DAL_GPS.cpp
+++ b/libraries/AP_DAL/AP_DAL_GPS.cpp
@@ -14,7 +14,7 @@ AP_DAL_GPS::AP_DAL_GPS()
     }
 }
 
-void AP_DAL_GPS::start_frame()
+void AP_DAL_GPS::start_frame(bool log_mb_yaw_offset)
 {
     const auto &gps = AP::gps();
 
@@ -54,10 +54,13 @@ void AP_DAL_GPS::start_frame()
         // The offset is derived from parameters but is zeroed while gps_yaw is
         // not calculated from a moving baseline, so it tracks the active yaw
         // source and yaw validity as well as parameter changes. All of these
-        // change rarely, so the message is only written when changed.
+        // change rarely, so the message is only written when changed. The
+        // offset is left at zero unless the EKF applies the correction, so a
+        // build that applies none never logs an offset Replay would then
+        // correct for.
         log_RGPK &RGPK = _RGPK[i];
         const log_RGPK old_RGPK = RGPK;
-        RGPK.mb_yaw_offset = gps.get_mb_yaw_offset(i);
+        RGPK.mb_yaw_offset = log_mb_yaw_offset ? gps.get_mb_yaw_offset(i) : Vector3f();
 
         WRITE_REPLAY_BLOCK_IFCHANGED(RGPI, RGPI, old_RGPI);
         WRITE_REPLAY_BLOCK_IFCHANGED(RGPJ, RGPJ, old_RGPJ);

--- a/libraries/AP_DAL/AP_DAL_GPS.cpp
+++ b/libraries/AP_DAL/AP_DAL_GPS.cpp
@@ -8,13 +8,15 @@ AP_DAL_GPS::AP_DAL_GPS()
     for (uint8_t i=0; i<ARRAY_SIZE(_RGPI); i++) {
         _RGPI[i].instance = i;
         _RGPJ[i].instance = i;
+#if AP_DAL_RGPK_LOGGING_ENABLED
         // _RGPK defaults to a zero offset so replay of older logs with no
         // RGPK messages applies no moving baseline yaw correction
         _RGPK[i].instance = i;
+#endif
     }
 }
 
-void AP_DAL_GPS::start_frame(bool log_mb_yaw_offset)
+void AP_DAL_GPS::start_frame()
 {
     const auto &gps = AP::gps();
 
@@ -50,21 +52,22 @@ void AP_DAL_GPS::start_frame(bool log_mb_yaw_offset)
         RGPI.speed_accuracy_returncode = gps.speed_accuracy(i, RGPJ.sacc);
         RGPI.gps_yaw_deg_returncode = gps.gps_yaw_deg(i, RGPJ.yaw_deg, RGPJ.yaw_accuracy_deg, RGPJ.yaw_deg_time_ms);
 
+#if AP_DAL_RGPK_LOGGING_ENABLED
         // RGPK holds the body-frame antenna offset used to calculate gps_yaw.
         // The offset is derived from parameters but is zeroed while gps_yaw is
         // not calculated from a moving baseline, so it tracks the active yaw
         // source and yaw validity as well as parameter changes. All of these
-        // change rarely, so the message is only written when changed. The
-        // offset is left at zero unless the EKF applies the correction, so a
-        // build that applies none never logs an offset Replay would then
-        // correct for.
+        // change rarely, so the message is only written when changed
         log_RGPK &RGPK = _RGPK[i];
         const log_RGPK old_RGPK = RGPK;
-        RGPK.mb_yaw_offset = log_mb_yaw_offset ? gps.get_mb_yaw_offset(i) : Vector3f();
+        RGPK.mb_yaw_offset = gps.get_mb_yaw_offset(i);
+#endif
 
         WRITE_REPLAY_BLOCK_IFCHANGED(RGPI, RGPI, old_RGPI);
         WRITE_REPLAY_BLOCK_IFCHANGED(RGPJ, RGPJ, old_RGPJ);
+#if AP_DAL_RGPK_LOGGING_ENABLED
         WRITE_REPLAY_BLOCK_IFCHANGED(RGPK, RGPK, old_RGPK);
+#endif
 
         tmp_location[i] = {
             RGPJ.lat,

--- a/libraries/AP_DAL/AP_DAL_GPS.h
+++ b/libraries/AP_DAL/AP_DAL_GPS.h
@@ -106,6 +106,13 @@ public:
         return _RGPI[instance].antenna_offset;
     }
 
+    // return the body-frame moving baseline antenna offset used to calculate
+    // the yaw returned by gps_yaw_deg for this instance, zero when that yaw
+    // is not derived from a moving baseline
+    const Vector3f &get_mb_yaw_offset(uint8_t instance) const {
+        return _RGPK[instance].mb_yaw_offset;
+    }
+
     void start_frame();
 
     void handle_message(const log_RGPH &msg) {
@@ -121,12 +128,18 @@ public:
         tmp_location[msg.instance].lng = msg.lng;
         tmp_location[msg.instance].alt = msg.alt;
     }
+    void handle_message(const log_RGPK &msg) {
+        if (msg.instance < ARRAY_SIZE(_RGPK)) {
+            _RGPK[msg.instance] = msg;
+        }
+    }
 
 private:
 
     struct log_RGPH _RGPH;
     struct log_RGPI _RGPI[GPS_MAX_INSTANCES];
     struct log_RGPJ _RGPJ[GPS_MAX_INSTANCES];
+    struct log_RGPK _RGPK[GPS_MAX_INSTANCES];
 
     Location tmp_location[GPS_MAX_INSTANCES];
 };

--- a/libraries/AP_DAL/AP_DAL_GPS.h
+++ b/libraries/AP_DAL/AP_DAL_GPS.h
@@ -113,7 +113,11 @@ public:
         return _RGPK[instance].mb_yaw_offset;
     }
 
-    void start_frame();
+    // log_mb_yaw_offset is the caller's EK3_FEATURE_MOVING_BASELINE. This file
+    // is compiled once and shared across vehicles so it cannot see the EKF
+    // feature macros itself, and the offset must only be logged when the EKF
+    // that consumes it applies the correction
+    void start_frame(bool log_mb_yaw_offset);
 
     void handle_message(const log_RGPH &msg) {
         _RGPH = msg;

--- a/libraries/AP_DAL/AP_DAL_GPS.h
+++ b/libraries/AP_DAL/AP_DAL_GPS.h
@@ -106,18 +106,16 @@ public:
         return _RGPI[instance].antenna_offset;
     }
 
+#if AP_DAL_RGPK_LOGGING_ENABLED
     // return the body-frame moving baseline antenna offset used to calculate
     // the yaw returned by gps_yaw_deg for this instance, zero when that yaw
     // is not derived from a moving baseline
     const Vector3f &get_mb_yaw_offset(uint8_t instance) const {
         return _RGPK[instance].mb_yaw_offset;
     }
+#endif
 
-    // log_mb_yaw_offset is the caller's EK3_FEATURE_MOVING_BASELINE. This file
-    // is compiled once and shared across vehicles so it cannot see the EKF
-    // feature macros itself, and the offset must only be logged when the EKF
-    // that consumes it applies the correction
-    void start_frame(bool log_mb_yaw_offset);
+    void start_frame();
 
     void handle_message(const log_RGPH &msg) {
         _RGPH = msg;
@@ -132,18 +130,22 @@ public:
         tmp_location[msg.instance].lng = msg.lng;
         tmp_location[msg.instance].alt = msg.alt;
     }
+#if AP_DAL_RGPK_LOGGING_ENABLED
     void handle_message(const log_RGPK &msg) {
         if (msg.instance < ARRAY_SIZE(_RGPK)) {
             _RGPK[msg.instance] = msg;
         }
     }
+#endif
 
 private:
 
     struct log_RGPH _RGPH;
     struct log_RGPI _RGPI[GPS_MAX_INSTANCES];
     struct log_RGPJ _RGPJ[GPS_MAX_INSTANCES];
+#if AP_DAL_RGPK_LOGGING_ENABLED
     struct log_RGPK _RGPK[GPS_MAX_INSTANCES];
+#endif
 
     Location tmp_location[GPS_MAX_INSTANCES];
 };

--- a/libraries/AP_DAL/LogStructure.h
+++ b/libraries/AP_DAL/LogStructure.h
@@ -27,6 +27,7 @@
     LOG_RGPH_MSG, \
     LOG_RGPI_MSG, \
     LOG_RGPJ_MSG, \
+    LOG_RGPK_MSG, \
     LOG_RASH_MSG, \
     LOG_RASI_MSG, \
     LOG_RBCH_MSG, \
@@ -343,6 +344,18 @@ struct log_RGPJ {
     uint8_t _end;
 };
 
+// @LoggerMessage: RGPK
+// @Description: Replay Data GPS Instance - moving baseline yaw antenna offset (low-rate, only logged when changed)
+// @Field: OX: moving baseline antenna offset used to calculate GPS yaw, X-axis
+// @Field: OY: moving baseline antenna offset used to calculate GPS yaw, Y-axis
+// @Field: OZ: moving baseline antenna offset used to calculate GPS yaw, Z-axis
+// @Field: I: GPS sensor instance number
+struct log_RGPK {
+    Vector3f mb_yaw_offset;
+    uint8_t instance;
+    uint8_t _end;
+};
+
 // @LoggerMessage: RASH
 // @Description: Replay Airspeed Sensor Header
 // @Field: Primary: airspeed instance number
@@ -649,6 +662,8 @@ struct log_RTER {
       "RGPI", "ffffBBBB", "OX,OY,OZ,Lg,Flags,Stat,NSats,I", "-------#", "--------" }, \
     { LOG_RGPJ_MSG, RLOG_SIZE(RGPJ),                                   \
       "RGPJ", "IffffffIiiiffHB", "TS,VX,VY,VZ,SA,Y,YA,YT,Lat,Lon,Alt,HA,VA,HD,I", "--------------#", "---------------" }, \
+    { LOG_RGPK_MSG, RLOG_SIZE(RGPK),                                   \
+      "RGPK", "fffB", "OX,OY,OZ,I", "---#", "----" }, \
     { LOG_RMGH_MSG, RLOG_SIZE(RMGH),                                   \
       "RMGH", "fBBBBBBB", "Dec,Avail,NumInst,AutoDec,NumEna,LOE,C,FUsable", "--------", "--------" },  \
     { LOG_RMGI_MSG, RLOG_SIZE(RMGI),                                   \

--- a/libraries/AP_DAL/LogStructure.h
+++ b/libraries/AP_DAL/LogStructure.h
@@ -1,10 +1,23 @@
 #pragma once
 
+#include <AP_GPS/AP_GPS_config.h>
 #include <AP_Logger/LogStructure.h>
 #include <AP_Math/vector3.h>
 #include <AP_Math/vector2.h>
 #include <AP_Math/matrix3.h>
 #include <AP_Math/quaternion.h>
+
+// RGPK carries the antenna offset a moving baseline GPS yaw was calculated
+// from, which Replay needs only to reproduce the EKF3 correction of that yaw
+#ifndef AP_DAL_RGPK_LOGGING_ENABLED
+#define AP_DAL_RGPK_LOGGING_ENABLED AP_GPS_MB_YAW_OFFSET_ENABLED
+#endif
+
+#if AP_DAL_RGPK_LOGGING_ENABLED
+#define LOG_ID_FROM_DAL_RGPK LOG_RGPK_MSG,
+#else
+#define LOG_ID_FROM_DAL_RGPK
+#endif
 
 #define LOG_IDS_FROM_DAL \
     LOG_RFRH_MSG, \
@@ -27,7 +40,7 @@
     LOG_RGPH_MSG, \
     LOG_RGPI_MSG, \
     LOG_RGPJ_MSG, \
-    LOG_RGPK_MSG, \
+    LOG_ID_FROM_DAL_RGPK \
     LOG_RASH_MSG, \
     LOG_RASI_MSG, \
     LOG_RBCH_MSG, \
@@ -344,6 +357,7 @@ struct log_RGPJ {
     uint8_t _end;
 };
 
+#if AP_DAL_RGPK_LOGGING_ENABLED
 // @LoggerMessage: RGPK
 // @Description: Replay Data GPS Instance - moving baseline yaw antenna offset (low-rate, only logged when changed)
 // @Field: OX: moving baseline antenna offset used to calculate GPS yaw, X-axis
@@ -355,6 +369,7 @@ struct log_RGPK {
     uint8_t instance;
     uint8_t _end;
 };
+#endif  // AP_DAL_RGPK_LOGGING_ENABLED
 
 // @LoggerMessage: RASH
 // @Description: Replay Airspeed Sensor Header
@@ -617,6 +632,14 @@ struct log_RTER {
 
 #define RLOG_SIZE(sname) 3+offsetof(struct log_ ##sname,_end)
 
+#if AP_DAL_RGPK_LOGGING_ENABLED
+#define LOG_STRUCTURE_FROM_DAL_RGPK                                    \
+    { LOG_RGPK_MSG, RLOG_SIZE(RGPK),                                   \
+      "RGPK", "fffB", "OX,OY,OZ,I", "---#", "----" },
+#else
+#define LOG_STRUCTURE_FROM_DAL_RGPK
+#endif
+
 #define LOG_STRUCTURE_FROM_DAL        \
     { LOG_RFRH_MSG, RLOG_SIZE(RFRH),                          \
       "RFRH", "QI", "TimeUS,TF", "s-", "F-" }, \
@@ -662,8 +685,7 @@ struct log_RTER {
       "RGPI", "ffffBBBB", "OX,OY,OZ,Lg,Flags,Stat,NSats,I", "-------#", "--------" }, \
     { LOG_RGPJ_MSG, RLOG_SIZE(RGPJ),                                   \
       "RGPJ", "IffffffIiiiffHB", "TS,VX,VY,VZ,SA,Y,YA,YT,Lat,Lon,Alt,HA,VA,HD,I", "--------------#", "---------------" }, \
-    { LOG_RGPK_MSG, RLOG_SIZE(RGPK),                                   \
-      "RGPK", "fffB", "OX,OY,OZ,I", "---#", "----" }, \
+    LOG_STRUCTURE_FROM_DAL_RGPK \
     { LOG_RMGH_MSG, RLOG_SIZE(RMGH),                                   \
       "RMGH", "fBBBBBBB", "Dec,Avail,NumInst,AutoDec,NumEna,LOE,C,FUsable", "--------", "--------" },  \
     { LOG_RMGI_MSG, RLOG_SIZE(RMGI),                                   \

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -1979,16 +1979,27 @@ bool AP_GPS::is_rtk_rover(uint8_t instance) const
 }
 
 /*
+  return the instance whose moving baseline rover solution provides the yaw
+  reported for this instance by gps_yaw_deg
+ */
+uint8_t AP_GPS::yaw_source_instance(uint8_t instance) const
+{
+#if GPS_MAX_RECEIVERS > 1
+    if (is_rtk_base(instance) && is_rtk_rover(instance^1)) {
+        // the yaw for a base is provided by its paired rover
+        instance ^= 1;
+    }
+#endif
+    return instance;
+}
+
+/*
   get GPS based yaw
  */
 bool AP_GPS::gps_yaw_deg(uint8_t instance, float &yaw_deg, float &accuracy_deg, uint32_t &time_ms) const
 {
-#if GPS_MAX_RECEIVERS > 1
-    if (is_rtk_base(instance) && is_rtk_rover(instance^1)) {
-        // return the yaw from the rover
-        instance ^= 1;
-    }
-#endif
+    // the yaw for a base is reported from its paired rover
+    instance = yaw_source_instance(instance);
     if (!have_gps_yaw(instance)) {
         return false;
     }
@@ -2009,6 +2020,21 @@ bool AP_GPS::gps_yaw_deg(uint8_t instance, float &yaw_deg, float &accuracy_deg, 
         accuracy_deg = 10;
     }
     return true;
+}
+
+/*
+  get the body-frame moving baseline antenna offset used to calculate the yaw
+  returned by gps_yaw_deg, zero when that yaw is not derived from a moving
+  baseline. The yaw is calculated assuming the offset is horizontal, so
+  consumers with an attitude estimate can use this offset to correct the yaw
+  for vehicle roll and pitch
+ */
+const Vector3f &AP_GPS::get_mb_yaw_offset(uint8_t instance) const
+{
+    // resolve the same instance whose yaw gps_yaw_deg reports, so the offset
+    // always describes the yaw it accompanies
+    const uint8_t yaw_instance = yaw_source_instance(instance);
+    return state[yaw_instance].mb_yaw_offset;
 }
 
 /*

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -2022,6 +2022,7 @@ bool AP_GPS::gps_yaw_deg(uint8_t instance, float &yaw_deg, float &accuracy_deg, 
     return true;
 }
 
+#if AP_GPS_MB_YAW_OFFSET_ENABLED
 /*
   get the body-frame moving baseline antenna offset used to calculate the yaw
   returned by gps_yaw_deg, zero when that yaw is not derived from a moving
@@ -2036,6 +2037,7 @@ const Vector3f &AP_GPS::get_mb_yaw_offset(uint8_t instance) const
     const uint8_t yaw_instance = yaw_source_instance(instance);
     return state[yaw_instance].mb_yaw_offset;
 }
+#endif  // AP_GPS_MB_YAW_OFFSET_ENABLED
 
 /*
  * Old parameter metadata.  Until we have versioned parameters, keeping

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -119,6 +119,10 @@ public:
     bool is_rtk_base(uint8_t instance) const;
     bool is_rtk_rover(uint8_t instance) const;
 
+    // return the instance whose moving baseline rover solution provides the
+    // yaw reported for this instance by gps_yaw_deg
+    uint8_t yaw_source_instance(uint8_t instance) const;
+
     // params for an instance:
     class Params {
     public:
@@ -239,6 +243,13 @@ public:
         float relPosD;                     ///< Reported Vertical distance in meters
         float accHeading;                  ///< Reported Heading Accuracy in degrees
         uint32_t relposheading_ts;        ///< True if new data has been received since last time it was false
+
+        // body-frame antenna offset used to calculate gps_yaw from a moving
+        // baseline, zero when gps_yaw is not derived from a moving baseline.
+        // gps_yaw is calculated assuming this offset is horizontal, so
+        // consumers with an attitude estimate can use this offset to correct
+        // gps_yaw for vehicle roll and pitch
+        Vector3f mb_yaw_offset;
     };
 
     /// Startup initialisation.
@@ -492,6 +503,11 @@ public:
 
     // return a 3D vector defining the offset of the GPS antenna in meters relative to the body frame origin
     const Vector3f &get_antenna_offset(uint8_t instance) const;
+
+    // return the body-frame moving baseline antenna offset used to calculate
+    // the yaw returned by gps_yaw_deg for this instance, zero when that yaw
+    // is not derived from a moving baseline
+    const Vector3f &get_mb_yaw_offset(uint8_t instance) const;
 
     // lock out a GPS port, allowing another application to use the port
     void lock_port(uint8_t instance, bool locked);

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -244,12 +244,14 @@ public:
         float accHeading;                  ///< Reported Heading Accuracy in degrees
         uint32_t relposheading_ts;        ///< True if new data has been received since last time it was false
 
+#if AP_GPS_MB_YAW_OFFSET_ENABLED
         // body-frame antenna offset used to calculate gps_yaw from a moving
         // baseline, zero when gps_yaw is not derived from a moving baseline.
         // gps_yaw is calculated assuming this offset is horizontal, so
         // consumers with an attitude estimate can use this offset to correct
         // gps_yaw for vehicle roll and pitch
         Vector3f mb_yaw_offset;
+#endif
     };
 
     /// Startup initialisation.
@@ -504,10 +506,12 @@ public:
     // return a 3D vector defining the offset of the GPS antenna in meters relative to the body frame origin
     const Vector3f &get_antenna_offset(uint8_t instance) const;
 
+#if AP_GPS_MB_YAW_OFFSET_ENABLED
     // return the body-frame moving baseline antenna offset used to calculate
     // the yaw returned by gps_yaw_deg for this instance, zero when that yaw
     // is not derived from a moving baseline
     const Vector3f &get_mb_yaw_offset(uint8_t instance) const;
+#endif
 
     // lock out a GPS port, allowing another application to use the port
     void lock_port(uint8_t instance, bool locked);

--- a/libraries/AP_GPS/AP_GPS_DroneCAN.cpp
+++ b/libraries/AP_GPS/AP_GPS_DroneCAN.cpp
@@ -503,6 +503,13 @@ void AP_GPS_DroneCAN::handle_heading_msg(const ardupilot_gnss_Heading& msg)
     if (interim_state.have_gps_yaw) {
         interim_state.gps_yaw_time_ms = AP_HAL::millis();
     }
+    // the Heading message cannot carry the antenna offset the yaw was
+    // calculated from (and for AP-origin senders such as an AP_Periph
+    // Heading fallback it may be level-assumed moving baseline yaw), so no
+    // attitude correction is possible here. Zero the offset so a stale value
+    // from an earlier relposheading calculation on this instance is never
+    // applied to it
+    interim_state.mb_yaw_offset.zero();
 
     interim_state.have_gps_yaw_accuracy = msg.heading_accuracy_valid;
     interim_state.gps_yaw_accuracy = degrees(msg.heading_accuracy_rad);

--- a/libraries/AP_GPS/AP_GPS_DroneCAN.cpp
+++ b/libraries/AP_GPS/AP_GPS_DroneCAN.cpp
@@ -509,7 +509,9 @@ void AP_GPS_DroneCAN::handle_heading_msg(const ardupilot_gnss_Heading& msg)
     // attitude correction is possible here. Zero the offset so a stale value
     // from an earlier relposheading calculation on this instance is never
     // applied to it
+#if AP_GPS_MB_YAW_OFFSET_ENABLED
     interim_state.mb_yaw_offset.zero();
+#endif
 
     interim_state.have_gps_yaw_accuracy = msg.heading_accuracy_valid;
     interim_state.gps_yaw_accuracy = degrees(msg.heading_accuracy_rad);

--- a/libraries/AP_GPS/AP_GPS_NMEA.cpp
+++ b/libraries/AP_GPS/AP_GPS_NMEA.cpp
@@ -271,6 +271,9 @@ bool AP_GPS_NMEA::_have_new_message()
         if (_last_AGRICA_ms != 0) {
             // we have lost AGRICA
             state.have_gps_yaw = false;
+            // the moving baseline offset must not outlive the yaw solution it
+            // was calculated for
+            state.mb_yaw_offset.zero();
             state.have_vertical_velocity = false;
             state.have_speed_accuracy = false;
             state.have_horizontal_accuracy = false;
@@ -389,6 +392,10 @@ bool AP_GPS_NMEA::_term_complete()
                 state.gps_yaw = wrap_360(_new_gps_yaw*0.01f);
                 state.have_gps_yaw = true;
                 state.gps_yaw_time_ms = now;
+                // this yaw is the device-reported heading, not one calculated
+                // from a moving baseline offset; clear any stale offset so no
+                // attitude correction is applied to it
+                state.mb_yaw_offset.zero();
                 // remember that we are setup to provide yaw. With
                 // a NMEA GPS we can only tell if the GPS is
                 // configured to provide yaw when it first sends a
@@ -447,6 +454,10 @@ bool AP_GPS_NMEA::_term_complete()
                     state.have_gps_yaw = true;
                     state.gps_yaw_time_ms = now;
                     state.gps_yaw_configured = true;
+                    // this yaw is the receiver's own heading, not one calculated
+                    // from the configured moving baseline offset; clear any stale
+                    // offset so no attitude correction is applied to it
+                    state.mb_yaw_offset.zero();
                 }
                 break;
 #if AP_GPS_NMEA_UNICORE_ENABLED

--- a/libraries/AP_GPS/AP_GPS_NMEA.cpp
+++ b/libraries/AP_GPS/AP_GPS_NMEA.cpp
@@ -271,9 +271,11 @@ bool AP_GPS_NMEA::_have_new_message()
         if (_last_AGRICA_ms != 0) {
             // we have lost AGRICA
             state.have_gps_yaw = false;
+#if AP_GPS_MB_YAW_OFFSET_ENABLED
             // the moving baseline offset must not outlive the yaw solution it
             // was calculated for
             state.mb_yaw_offset.zero();
+#endif
             state.have_vertical_velocity = false;
             state.have_speed_accuracy = false;
             state.have_horizontal_accuracy = false;
@@ -392,10 +394,12 @@ bool AP_GPS_NMEA::_term_complete()
                 state.gps_yaw = wrap_360(_new_gps_yaw*0.01f);
                 state.have_gps_yaw = true;
                 state.gps_yaw_time_ms = now;
+#if AP_GPS_MB_YAW_OFFSET_ENABLED
                 // this yaw is the device-reported heading, not one calculated
                 // from a moving baseline offset; clear any stale offset so no
                 // attitude correction is applied to it
                 state.mb_yaw_offset.zero();
+#endif
                 // remember that we are setup to provide yaw. With
                 // a NMEA GPS we can only tell if the GPS is
                 // configured to provide yaw when it first sends a
@@ -454,10 +458,12 @@ bool AP_GPS_NMEA::_term_complete()
                     state.have_gps_yaw = true;
                     state.gps_yaw_time_ms = now;
                     state.gps_yaw_configured = true;
+#if AP_GPS_MB_YAW_OFFSET_ENABLED
                     // this yaw is the receiver's own heading, not one calculated
                     // from the configured moving baseline offset; clear any stale
                     // offset so no attitude correction is applied to it
                     state.mb_yaw_offset.zero();
+#endif
                 }
                 break;
 #if AP_GPS_NMEA_UNICORE_ENABLED

--- a/libraries/AP_GPS/AP_GPS_config.h
+++ b/libraries/AP_GPS/AP_GPS_config.h
@@ -129,3 +129,11 @@
 #ifndef GPS_MOVING_BASELINE
 #define GPS_MOVING_BASELINE GPS_MAX_RECEIVERS > 1
 #endif
+
+// minimum horizontal separation between the antennas of a moving baseline
+// pair for the reported heading to carry usable yaw information (metres).
+// Shared by the GPS drivers and the EKF3 moving baseline yaw attitude
+// correction so the two gates stay in agreement
+#ifndef AP_GPS_MB_MIN_ANTENNA_SEPARATION_M
+#define AP_GPS_MB_MIN_ANTENNA_SEPARATION_M 0.05f
+#endif

--- a/libraries/AP_GPS/AP_GPS_config.h
+++ b/libraries/AP_GPS/AP_GPS_config.h
@@ -137,3 +137,13 @@
 #ifndef AP_GPS_MB_MIN_ANTENNA_SEPARATION_M
 #define AP_GPS_MB_MIN_ANTENNA_SEPARATION_M 0.05f
 #endif
+
+// export of the body-frame antenna offset a moving baseline yaw was calculated
+// from, on 2M boards. Its only consumer is the EKF3 attitude correction of that
+// yaw, so EK3_FEATURE_MOVING_BASELINE and AP_DAL_RGPK_LOGGING_ENABLED follow
+// this switch. It is free of any vehicle-dependent macro so that the AP_GPS and
+// AP_DAL objects waf compiles once and shares between vehicles agree with the
+// EKF on the size of a GPS_State and on the DAL replay message IDs
+#ifndef AP_GPS_MB_YAW_OFFSET_ENABLED
+#define AP_GPS_MB_YAW_OFFSET_ENABLED (GPS_MOVING_BASELINE) && (HAL_PROGRAM_SIZE_LIMIT_KB > 1024)
+#endif

--- a/libraries/AP_GPS/AP_GPS_config.h
+++ b/libraries/AP_GPS/AP_GPS_config.h
@@ -145,5 +145,5 @@
 // AP_DAL objects waf compiles once and shares between vehicles agree with the
 // EKF on the size of a GPS_State and on the DAL replay message IDs
 #ifndef AP_GPS_MB_YAW_OFFSET_ENABLED
-#define AP_GPS_MB_YAW_OFFSET_ENABLED (GPS_MOVING_BASELINE) && (HAL_PROGRAM_SIZE_LIMIT_KB > 1024)
+#define AP_GPS_MB_YAW_OFFSET_ENABLED ((GPS_MOVING_BASELINE) && (HAL_PROGRAM_SIZE_LIMIT_KB > 1024))
 #endif

--- a/libraries/AP_GPS/GPS_Backend.cpp
+++ b/libraries/AP_GPS/GPS_Backend.cpp
@@ -322,7 +322,7 @@ bool AP_GPS_Backend::calculate_moving_base_yaw(float reported_heading_deg, const
 }
 
 bool AP_GPS_Backend::calculate_moving_base_yaw(AP_GPS::GPS_State &interim_state, const float reported_heading_deg, const float reported_distance, const float reported_D) {
-    constexpr float minimum_antenna_seperation = 0.05; // meters
+    constexpr float minimum_antenna_separation = AP_GPS_MB_MIN_ANTENNA_SEPARATION_M;
     constexpr float permitted_error_length_pct = 0.2;  // percentage
 #if HAL_LOGGING_ENABLED || AP_AHRS_ENABLED
     float min_D = 0.0f;
@@ -351,16 +351,16 @@ bool AP_GPS_Backend::calculate_moving_base_yaw(AP_GPS::GPS_State &interim_state,
         const float offset_dist = offset.length();
         const float min_dist = MIN(offset_dist, reported_distance);
 
-        if (offset_dist < minimum_antenna_seperation) {
+        if (offset_dist < minimum_antenna_separation) {
             // offsets have to be sufficiently large to get a meaningful angle off of them
             Debug("Insufficent antenna offset (%f, %f, %f)", (double)offset.x, (double)offset.y, (double)offset.z);
             goto bad_yaw;
         }
 
-        if (reported_distance < minimum_antenna_seperation) {
+        if (reported_distance < minimum_antenna_separation) {
             // if the reported distance is less then the minimum separation it's not sufficiently robust
             Debug("Reported baseline distance (%f) was less then the minimum antenna separation (%f)",
-                  (double)reported_distance, (double)minimum_antenna_seperation);
+                  (double)reported_distance, (double)minimum_antenna_separation);
             goto bad_yaw;
         }
 
@@ -370,6 +370,21 @@ bool AP_GPS_Backend::calculate_moving_base_yaw(AP_GPS::GPS_State &interim_state,
             Debug("Offset=%.2f vs reported-distance=%.2f (max-delta=%.2f)",
                   offset_dist, reported_distance, (double)(min_dist * permitted_error_length_pct));
             goto bad_yaw;
+        }
+
+        {
+            // the reported heading is the bearing of the baseline in the horizontal
+            // plane, so its noise scales inversely with the horizontal separation of
+            // the antennas. A baseline close to vertical carries no usable yaw
+            // information regardless of the antenna separation, whether because of
+            // a vertical antenna installation or because vehicle attitude has
+            // rotated the baseline close to vertical
+            const float reported_horizontal_sq = sq(reported_distance) - sq(reported_D);
+            if (reported_horizontal_sq < sq(minimum_antenna_separation)) {
+                Debug("Insufficient horizontal separation %.2f of reported baseline (dist=%.2f, D=%.2f)",
+                      (double)safe_sqrt(reported_horizontal_sq), (double)reported_distance, (double)reported_D);
+                goto bad_yaw;
+            }
         }
 
 #if AP_AHRS_ENABLED

--- a/libraries/AP_GPS/GPS_Backend.cpp
+++ b/libraries/AP_GPS/GPS_Backend.cpp
@@ -404,16 +404,21 @@ bool AP_GPS_Backend::calculate_moving_base_yaw(AP_GPS::GPS_State &interim_state,
 
         {
             // at this point the offsets are looking okay, go ahead and actually calculate a useful heading
+            // the bearing of the offset is only exact when the vehicle is level; the
+            // offset is exported in mb_yaw_offset so consumers with an attitude
+            // estimate can correct the yaw for vehicle roll and pitch
             const float rotation_offset_rad = Vector2f(-offset.x, -offset.y).angle();
             interim_state.gps_yaw = wrap_360(reported_heading_deg - degrees(rotation_offset_rad));
             interim_state.have_gps_yaw = true;
             interim_state.gps_yaw_time_ms = AP_HAL::millis();
+            interim_state.mb_yaw_offset = offset;
         }
         goto good_yaw;
     }
 
 bad_yaw:
     interim_state.have_gps_yaw = false;
+    interim_state.mb_yaw_offset.zero();
 
 good_yaw:
 

--- a/libraries/AP_GPS/GPS_Backend.cpp
+++ b/libraries/AP_GPS/GPS_Backend.cpp
@@ -426,14 +426,18 @@ bool AP_GPS_Backend::calculate_moving_base_yaw(AP_GPS::GPS_State &interim_state,
             interim_state.gps_yaw = wrap_360(reported_heading_deg - degrees(rotation_offset_rad));
             interim_state.have_gps_yaw = true;
             interim_state.gps_yaw_time_ms = AP_HAL::millis();
+#if AP_GPS_MB_YAW_OFFSET_ENABLED
             interim_state.mb_yaw_offset = offset;
+#endif
         }
         goto good_yaw;
     }
 
 bad_yaw:
     interim_state.have_gps_yaw = false;
+#if AP_GPS_MB_YAW_OFFSET_ENABLED
     interim_state.mb_yaw_offset.zero();
+#endif
 
 good_yaw:
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
@@ -5,6 +5,7 @@
 
 #include <GCS_MAVLink/GCS.h>
 #include <AP_DAL/AP_DAL.h>
+#include <AP_GPS/AP_GPS_config.h>
 
 // minimum GPS horizontal speed required to use GPS ground course for yaw alignment (m/s)
 #if APM_BUILD_TYPE(APM_BUILD_ArduPlane)
@@ -209,6 +210,104 @@ void NavEKF3_core::realignYawGPS(bool emergency_reset)
     }
 }
 
+/*
+  build the body-to-earth rotation matrix at the current state attitude with
+  yaw set to zero, using the given Euler rotation order. Optionally returns
+  the yaw angle removed. Returns false if the rotation order is not supported
+*/
+bool NavEKF3_core::buildTbnZeroYaw(rotationOrder order, Matrix3F &Tbn, ftype *yawAng) const
+{
+    switch (order) {
+    case rotationOrder::TAIT_BRYAN_321: {
+        Vector3F euler321;
+        stateStruct.quat.to_euler(euler321.x, euler321.y, euler321.z);
+        Tbn.from_euler(euler321.x, euler321.y, 0.0f);
+        if (yawAng != nullptr) {
+            *yawAng = euler321.z;
+        }
+        return true;
+    }
+    case rotationOrder::TAIT_BRYAN_312: {
+        const Vector3F euler312 = stateStruct.quat.to_vector312();
+        Tbn.from_euler312(euler312.x, euler312.y, 0.0f);
+        if (yawAng != nullptr) {
+            *yawAng = euler312.z;
+        }
+        return true;
+    }
+    }
+    // rotation order not supported
+    return false;
+}
+
+#if EK3_FEATURE_MOVING_BASELINE
+/*
+  Correct a yaw measurement calculated from a moving baseline antenna offset
+  for vehicle attitude.
+
+  The GPS driver recovers the vehicle yaw from the reported baseline heading
+  by subtracting the bearing of the body-frame antenna offset, which is only
+  exact when the vehicle is level. The residual attitude correction is applied
+  here using this core's own roll and pitch estimate at the fusion time
+  horizon, which is time-aligned with the measurement. Using the core's own
+  attitude estimate rather than the published AHRS attitude keeps each lane
+  independent of the others and allows Replay to reproduce the fusion exactly.
+
+  The correction rotates attitude uncertainty into the yaw measurement in
+  proportion to the vertical component of the baseline, so yawAngErr is
+  inflated to match.
+
+  Returns false when the antenna baseline is too close to vertical at the
+  estimated attitude for the reported heading to contain usable yaw
+  information, or when the rotation order is not supported, in which case the
+  measurement must not be fused.
+*/
+bool NavEKF3_core::correctGPSYawForAntennaOffset(yaw_elements &yawAngData) const
+{
+    const Vector3F &antOffsetBody = yawAngData.antOffset;
+    if (antOffsetBody.is_zero()) {
+        // no antenna offset supplied so the measurement is used as reported
+        return true;
+    }
+
+    // calculate the rotation from body to earth frame with yaw set to zero
+    // using the rotation order of the measurement
+    Matrix3F Tbn_zeroYaw;
+    if (!buildTbnZeroYaw(yawAngData.order, Tbn_zeroYaw)) {
+        // rotation order not supported: fail closed rather than fusing a
+        // measurement known to need a correction that cannot be applied
+        return false;
+    }
+
+    const Vector3F antOffsetLevel = Tbn_zeroYaw * antOffsetBody;
+    const ftype antOffsetLevelXY = antOffsetLevel.xy().length();
+
+    // the heading noise of the receiver scales inversely with the horizontal
+    // separation of the antennas, so a baseline close to vertical at the
+    // estimated attitude carries no usable yaw information. The same
+    // threshold is enforced by the GPS driver against the receiver-reported
+    // baseline
+    const ftype minHorizontalSeparation = AP_GPS_MB_MIN_ANTENNA_SEPARATION_M;
+    if (antOffsetLevelXY < minHorizontalSeparation) {
+        return false;
+    }
+
+    // an attitude error rotates the vertical component of the baseline into
+    // the horizontal plane, changing the bearing of the offset by up to
+    // |z| / |xy| radians per radian of tilt error, so the correction adds
+    // that much uncertainty to the measurement
+    const ftype tiltSensitivity = fabsF(antOffsetLevel.z) / antOffsetLevelXY;
+    yawAngData.yawAngErr = sqrtF(sq(yawAngData.yawAngErr) + sq(tiltSensitivity) * MAX(tiltErrorVariance, 0.0f));
+
+    // replace the body-frame bearing of the antenna offset subtracted by the
+    // driver with the bearing of the offset at the estimated attitude
+    const ftype bearingBody = atan2F(-antOffsetBody.y, -antOffsetBody.x);
+    const ftype bearingLevel = atan2F(-antOffsetLevel.y, -antOffsetLevel.x);
+    yawAngData.yawAng = wrap_PI(yawAngData.yawAng + bearingBody - bearingLevel);
+    return true;
+}
+#endif // EK3_FEATURE_MOVING_BASELINE
+
 // align the yaw angle for the quaternion states to the given yaw angle which should be at the fusion horizon
 void NavEKF3_core::alignYawAngle(const yaw_elements &yawAngData)
 {
@@ -287,7 +386,21 @@ void NavEKF3_core::SelectMagFusion()
     // Handle case where we are using GPS yaw sensor instead of a magnetomer
     if (yaw_source_last == AP_NavEKF_Source::SourceYaw::GPS || yaw_source_last == AP_NavEKF_Source::SourceYaw::GPS_COMPASS_FALLBACK) {
         bool have_fused_gps_yaw = false;
+        // correct the measurement for vehicle attitude using this core's own attitude
+        // estimate. This is done once per recalled measurement, before all consumers of
+        // yawAngDataDelayed (alignYawAngle, fuseEulerYaw and learnMagBiasFromGPS).
+        // A measurement with no usable yaw information is treated the same as no
+        // measurement: it is not fused or used for alignment (which matters most for
+        // alignYawAngle as it accepts the measurement without an innovation check), it
+        // does not refresh last_gps_yaw_ms (so the compass fallback and the yaw source
+        // health reporting see the loss of usable yaw) and it does not block the
+        // synthetic yaw fusion and yaw source reset recovery branches below
+#if EK3_FEATURE_MOVING_BASELINE
+        if (storedYawAng.recall(yawAngDataDelayed,imuDataDelayed.time_ms) &&
+            correctGPSYawForAntennaOffset(yawAngDataDelayed)) {
+#else
         if (storedYawAng.recall(yawAngDataDelayed,imuDataDelayed.time_ms)) {
+#endif
             if (tiltAlignComplete && (!yawAlignComplete || yaw_source_reset)) {
                 alignYawAngle(yawAngDataDelayed);
                 yaw_source_reset = false;
@@ -942,13 +1055,8 @@ bool NavEKF3_core::fuseEulerYaw(yawFusionMethod method)
             return false;
         }
 
-        // Get the 321 euler angles
-        Vector3F euler321;
-        stateStruct.quat.to_euler(euler321.x, euler321.y, euler321.z);
-        yawAngPredicted = euler321.z;
-
-        // set the yaw to zero and calculate the zero yaw rotation from body to earth frame
-        Tbn_zeroYaw.from_euler(euler321.x, euler321.y, 0.0f);
+        // predicted yaw and zero yaw body to earth rotation matrix for this order
+        buildTbnZeroYaw(order, Tbn_zeroYaw, &yawAngPredicted);
 
     } else if (order == rotationOrder::TAIT_BRYAN_312) {
         // calculate 312 yaw observation matrix - option A or B to avoid singularity in derivation at +-90 degrees yaw
@@ -1002,12 +1110,8 @@ bool NavEKF3_core::fuseEulerYaw(yawFusionMethod method)
             return false;
         }
 
-        // Get the 312 Tait Bryan rotation angles
-        Vector3F euler312 = stateStruct.quat.to_vector312();
-        yawAngPredicted = euler312.z;
-
-        // set the yaw to zero and calculate the zero yaw rotation from body to earth frame
-        Tbn_zeroYaw.from_euler312(euler312.x, euler312.y, 0.0f);
+        // predicted yaw and zero yaw body to earth rotation matrix for this order
+        buildTbnZeroYaw(order, Tbn_zeroYaw, &yawAngPredicted);
     } else {
         // order not supported
         return false;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
@@ -1056,7 +1056,10 @@ bool NavEKF3_core::fuseEulerYaw(yawFusionMethod method)
         }
 
         // predicted yaw and zero yaw body to earth rotation matrix for this order
-        buildTbnZeroYaw(order, Tbn_zeroYaw, &yawAngPredicted);
+        if (!buildTbnZeroYaw(order, Tbn_zeroYaw, &yawAngPredicted)) {
+            // rotation order not supported: cannot build the predicted yaw and zero-yaw rotation
+            return false;
+        }
 
     } else if (order == rotationOrder::TAIT_BRYAN_312) {
         // calculate 312 yaw observation matrix - option A or B to avoid singularity in derivation at +-90 degrees yaw
@@ -1111,7 +1114,10 @@ bool NavEKF3_core::fuseEulerYaw(yawFusionMethod method)
         }
 
         // predicted yaw and zero yaw body to earth rotation matrix for this order
-        buildTbnZeroYaw(order, Tbn_zeroYaw, &yawAngPredicted);
+        if (!buildTbnZeroYaw(order, Tbn_zeroYaw, &yawAngPredicted)) {
+            // rotation order not supported: cannot build the predicted yaw and zero-yaw rotation
+            return false;
+        }
     } else {
         // order not supported
         return false;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -748,7 +748,11 @@ void NavEKF3_core::readGpsYawData()
         // normalised yaw innovations
         const ftype min_yaw_accuracy_deg = 5.0f;
         yaw_accuracy_deg = MAX(yaw_accuracy_deg, min_yaw_accuracy_deg);
+#if EK3_FEATURE_MOVING_BASELINE
+        writeEulerYawAngle(radians(yaw_deg), radians(yaw_accuracy_deg), yaw_time_ms, 2, gps.get_mb_yaw_offset(selected_gps));
+#else
         writeEulerYawAngle(radians(yaw_deg), radians(yaw_accuracy_deg), yaw_time_ms, 2);
+#endif
     }
 }
 
@@ -1040,7 +1044,7 @@ void NavEKF3_core::readRngBcnData()
 *              Independant yaw sensor measurements      *
 ********************************************************/
 
-void NavEKF3_core::writeEulerYawAngle(float yawAngle, float yawAngleErr, uint32_t timeStamp_ms, uint8_t type)
+void NavEKF3_core::writeEulerYawAngle(float yawAngle, float yawAngleErr, uint32_t timeStamp_ms, uint8_t type, const Vector3f &antOffset)
 {
     // limit update rate to maximum allowed by sensor buffers and fusion process
     // don't try to write to buffer until the filter has been initialised
@@ -1063,6 +1067,7 @@ void NavEKF3_core::writeEulerYawAngle(float yawAngle, float yawAngleErr, uint32_
     // fusing. The raw timestamp is still used for new-measurement detection and
     // rate limiting via yawMeasTime_ms
     yawAngDataNew.time_ms = MAX(timeStamp_ms, imuDataDelayed.time_ms);
+    yawAngDataNew.antOffset = antOffset.toftype();
 
     storedYawAng.push(yawAngDataNew);
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -1067,7 +1067,9 @@ void NavEKF3_core::writeEulerYawAngle(float yawAngle, float yawAngleErr, uint32_
     // fusing. The raw timestamp is still used for new-measurement detection and
     // rate limiting via yawMeasTime_ms
     yawAngDataNew.time_ms = MAX(timeStamp_ms, imuDataDelayed.time_ms);
+#if EK3_FEATURE_MOVING_BASELINE
     yawAngDataNew.antOffset = antOffset.toftype();
+#endif
 
     storedYawAng.push(yawAngDataNew);
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -388,8 +388,8 @@ void NavEKF3_core::InitialiseVariables()
 
     // yaw sensor fusion
     yawMeasTime_ms = 0;
-    memset(&yawAngDataNew, 0, sizeof(yawAngDataNew));
-    memset(&yawAngDataDelayed, 0, sizeof(yawAngDataDelayed));
+    yawAngDataNew = {};
+    yawAngDataDelayed = {};
 
 #if EK3_FEATURE_EXTERNAL_NAV
     // external nav data fusion

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -385,8 +385,8 @@ void NavEKF3_core::InitialiseVariables()
 
     // yaw sensor fusion
     yawMeasTime_ms = 0;
-    memset(&yawAngDataNew, 0, sizeof(yawAngDataNew));
-    memset(&yawAngDataDelayed, 0, sizeof(yawAngDataDelayed));
+    yawAngDataNew = {};
+    yawAngDataDelayed = {};
 
 #if EK3_FEATURE_EXTERNAL_NAV
     // external nav data fusion

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -385,8 +385,8 @@ void NavEKF3_core::InitialiseVariables()
 
     // yaw sensor fusion
     yawMeasTime_ms = 0;
-    yawAngDataNew = {};
-    yawAngDataDelayed = {};
+    memset((void *)&yawAngDataNew, 0, sizeof(yawAngDataNew));
+    memset((void *)&yawAngDataDelayed, 0, sizeof(yawAngDataDelayed));
 
 #if EK3_FEATURE_EXTERNAL_NAV
     // external nav data fusion

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -330,8 +330,10 @@ public:
      * all measurement lag and transmission delays.
      * type: An integer specifying Euler rotation order used to define the yaw angle.
      * type = 1 specifies a 312 (ZXY) rotation order, type = 2 specifies a 321 (ZYX) rotation order.
+     * antOffset: body-frame antenna offset the yaw angle was calculated from assuming the vehicle was
+     * level, zero (the default) when the measurement does not require attitude correction (m)
     */
-    void writeEulerYawAngle(float yawAngle, float yawAngleErr, uint32_t timeStamp_ms, uint8_t type);
+    void writeEulerYawAngle(float yawAngle, float yawAngleErr, uint32_t timeStamp_ms, uint8_t type, const Vector3f &antOffset=Vector3f());
 
     /*
     * Write position and quaternion data from an external navigation system
@@ -673,6 +675,8 @@ private:
         ftype         yawAng;         // yaw angle measurement (rad)
         ftype         yawAngErr;      // yaw angle 1SD measurement accuracy (rad)
         rotationOrder order;          // type specifiying Euler rotation order used, 0 = 321 (ZYX), 1 = 312 (ZXY)
+        Vector3F      antOffset;      // body-frame antenna offset the yaw measurement was calculated from assuming the
+                                      // vehicle was level, zero when the measurement does not require attitude correction (m)
     };
 
     struct ext_nav_elements : EKF_obs_element_t {
@@ -855,6 +859,21 @@ private:
 
     // align the yaw angle for the quaternion states to the given yaw angle which should be at the fusion horizon
     void alignYawAngle(const yaw_elements &yawAngData);
+
+    // build the body-to-earth rotation matrix at the current state attitude with yaw
+    // set to zero, using the given Euler rotation order. Optionally returns the yaw
+    // angle removed. Returns false if the rotation order is not supported
+    bool buildTbnZeroYaw(rotationOrder order, Matrix3F &Tbn, ftype *yawAng=nullptr) const;
+
+#if EK3_FEATURE_MOVING_BASELINE
+    // correct a yaw measurement calculated from a moving baseline antenna offset for
+    // vehicle attitude using this core's attitude estimate at the fusion time horizon,
+    // inflating yawAngErr by the attitude uncertainty the correction introduces.
+    // returns false when the baseline is too close to vertical at the estimated
+    // attitude for the measurement to contain usable yaw information, or when the
+    // rotation order is not supported
+    bool correctGPSYawForAntennaOffset(yaw_elements &yawAngData) const;
+#endif // EK3_FEATURE_MOVING_BASELINE
 
     // update mag field states and associated variances using magnetomer and declination data
     void resetMagFieldStates();

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -330,8 +330,10 @@ public:
      * all measurement lag and transmission delays.
      * type: An integer specifying Euler rotation order used to define the yaw angle.
      * type = 1 specifies a 312 (ZXY) rotation order, type = 2 specifies a 321 (ZYX) rotation order.
+     * antOffset: body-frame antenna offset the yaw angle was calculated from assuming the vehicle was
+     * level, zero (the default) when the measurement does not require attitude correction (m)
     */
-    void writeEulerYawAngle(float yawAngle, float yawAngleErr, uint32_t timeStamp_ms, uint8_t type);
+    void writeEulerYawAngle(float yawAngle, float yawAngleErr, uint32_t timeStamp_ms, uint8_t type, const Vector3f &antOffset=Vector3f());
 
     /*
     * Write position and quaternion data from an external navigation system
@@ -666,6 +668,8 @@ private:
         ftype         yawAng;         // yaw angle measurement (rad)
         ftype         yawAngErr;      // yaw angle 1SD measurement accuracy (rad)
         rotationOrder order;          // type specifiying Euler rotation order used, 0 = 321 (ZYX), 1 = 312 (ZXY)
+        Vector3F      antOffset;      // body-frame antenna offset the yaw measurement was calculated from assuming the
+                                      // vehicle was level, zero when the measurement does not require attitude correction (m)
     };
 
     struct ext_nav_elements : EKF_obs_element_t {
@@ -848,6 +852,21 @@ private:
 
     // align the yaw angle for the quaternion states to the given yaw angle which should be at the fusion horizon
     void alignYawAngle(const yaw_elements &yawAngData);
+
+    // build the body-to-earth rotation matrix at the current state attitude with yaw
+    // set to zero, using the given Euler rotation order. Optionally returns the yaw
+    // angle removed. Returns false if the rotation order is not supported
+    bool buildTbnZeroYaw(rotationOrder order, Matrix3F &Tbn, ftype *yawAng=nullptr) const;
+
+#if EK3_FEATURE_MOVING_BASELINE
+    // correct a yaw measurement calculated from a moving baseline antenna offset for
+    // vehicle attitude using this core's attitude estimate at the fusion time horizon,
+    // inflating yawAngErr by the attitude uncertainty the correction introduces.
+    // returns false when the baseline is too close to vertical at the estimated
+    // attitude for the measurement to contain usable yaw information, or when the
+    // rotation order is not supported
+    bool correctGPSYawForAntennaOffset(yaw_elements &yawAngData) const;
+#endif // EK3_FEATURE_MOVING_BASELINE
 
     // update mag field states and associated variances using magnetomer and declination data
     void resetMagFieldStates();

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -668,8 +668,10 @@ private:
         ftype         yawAng;         // yaw angle measurement (rad)
         ftype         yawAngErr;      // yaw angle 1SD measurement accuracy (rad)
         rotationOrder order;          // type specifiying Euler rotation order used, 0 = 321 (ZYX), 1 = 312 (ZXY)
+#if EK3_FEATURE_MOVING_BASELINE
         Vector3F      antOffset;      // body-frame antenna offset the yaw measurement was calculated from assuming the
                                       // vehicle was level, zero when the measurement does not require attitude correction (m)
+#endif
     };
 
     struct ext_nav_elements : EKF_obs_element_t {

--- a/libraries/AP_NavEKF3/AP_NavEKF3_feature.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_feature.h
@@ -9,6 +9,7 @@
 #include <AP_Beacon/AP_Beacon_config.h>
 #include <AP_AHRS/AP_AHRS_config.h>
 #include <AP_OpticalFlow/AP_OpticalFlow_config.h>
+#include <AP_GPS/AP_GPS_config.h>
 
 // define for when to include all features
 #define EK3_FEATURE_ALL APM_BUILD_TYPE(APM_BUILD_AP_DAL_Standalone) || APM_BUILD_TYPE(APM_BUILD_Replay)
@@ -55,4 +56,14 @@
 // IMU-aided AGL Kalman filter decoupled from the main filter's vertical position state
 #ifndef EK3_FEATURE_OPTFLOW_AGL_KF
 #define EK3_FEATURE_OPTFLOW_AGL_KF EK3_FEATURE_OPTFLOW_FUSION
+#endif
+
+// moving baseline GPS yaw corrected for vehicle attitude, on 2M boards. Requires
+// the moving-baseline GPS path, whose exported antenna offset the correction consumes
+#ifndef EK3_FEATURE_MOVING_BASELINE
+#define EK3_FEATURE_MOVING_BASELINE ((EK3_FEATURE_ALL || HAL_PROGRAM_SIZE_LIMIT_KB > 1024) && (GPS_MOVING_BASELINE))
+#endif
+
+#if EK3_FEATURE_MOVING_BASELINE && !(GPS_MOVING_BASELINE)
+#error "EK3_FEATURE_MOVING_BASELINE requires GPS_MOVING_BASELINE"
 #endif

--- a/libraries/AP_NavEKF3/AP_NavEKF3_feature.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_feature.h
@@ -58,12 +58,13 @@
 #define EK3_FEATURE_OPTFLOW_AGL_KF EK3_FEATURE_OPTFLOW_FUSION
 #endif
 
-// moving baseline GPS yaw corrected for vehicle attitude, on 2M boards. Requires
-// the moving-baseline GPS path, whose exported antenna offset the correction consumes
+// moving baseline GPS yaw corrected for vehicle attitude. The correction consumes
+// the antenna offset exported by the GPS driver, so it follows that switch, which
+// is already limited to the moving baseline GPS path on 2M boards
 #ifndef EK3_FEATURE_MOVING_BASELINE
-#define EK3_FEATURE_MOVING_BASELINE ((EK3_FEATURE_ALL || HAL_PROGRAM_SIZE_LIMIT_KB > 1024) && (GPS_MOVING_BASELINE))
+#define EK3_FEATURE_MOVING_BASELINE AP_GPS_MB_YAW_OFFSET_ENABLED
 #endif
 
-#if EK3_FEATURE_MOVING_BASELINE && !(GPS_MOVING_BASELINE)
-#error "EK3_FEATURE_MOVING_BASELINE requires GPS_MOVING_BASELINE"
+#if EK3_FEATURE_MOVING_BASELINE && !(AP_GPS_MB_YAW_OFFSET_ENABLED)
+#error "EK3_FEATURE_MOVING_BASELINE requires AP_GPS_MB_YAW_OFFSET_ENABLED"
 #endif


### PR DESCRIPTION
Summary
Moving-baseline GPS yaw assumes the vehicle is level; for antenna baselines with a vertical component the recovered yaw is biased when the vehicle rolls or pitches. This PR exports the antenna offset the yaw was calculated from and applies the exact attitude correction inside EKF3, per lane, at the fusion time horizon (gated behind EK3_FEATURE_MOVING_BASELINE, on 2 MB+ boards), with Replay support via a new RGPK DAL message.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

Three new autotests, each verified to fail against the code without its fix (negative control) before being confirmed to pass with it:

- GPSForYawAttitudeCorrection: flies a circle with a large-Z antenna baseline; EKF yaw must track SIMSTATE truth while banked AND the yaw innovation test ratio must stay below 1 (a wrong measurement that is merely gate-rejected leaves the EKF coasting accurately on the gyro, so yaw-vs-truth alone can false-pass).
- GPSForYawVerticalBaseline: a baseline with no horizontal separation carries no yaw information; the driver must reject it rather than publish receiver noise as yaw.
- GPSForYawCompassFallback: with EK3_SRC1_YAW=3, a measurement the EKF rejects geometrically must count as "no usable yaw" so the magnetometer fallback engages after 10 s, even though the GPS is still publishing.

Existing GPSForYaw autotest still passes.

Description
The GPS driver recovers vehicle yaw from the reported baseline heading by subtracting the bearing of the body-frame antenna offset, which is only exact when the vehicle is level. An earlier attempt (#33380) corrected this in AP_GPS using AP::ahrs() attitude, but that creates an EKF->sensor->EKF loop (a bad lane contaminates every lane) and breaks Replay. Instead:

- AP_GPS records the body-frame offset used to calculate each moving-baseline yaw in GPS_State::mb_yaw_offset, exposed via AP_GPS::get_mb_yaw_offset(). The offset is zeroed whenever the published yaw does not come from a moving baseline (solution rejected, AGRICA lost, or a device-reported heading takes over: DroneCAN Heading, NMEA HDT/THS, KSXT) so a stale offset can never be paired with a heading it does not belong to. A shared yaw_source_instance() helper keeps the base->rover redirect identical between the yaw and the offset it accompanies.
- AP_GPS also rejects moving-baseline solutions whose receiver-reported baseline has insufficient horizontal separation (sqrt(dist^2 - D^2) < AP_GPS_MB_MIN_ANTENNA_SEPARATION_M): a baseline close to vertical carries no usable yaw regardless of antenna separation.
- AP_DAL carries the offset in a new low-rate RGPK message (written when changed), so Replay reproduces the fusion bit-exactly. Replaying older logs applies a zero offset, i.e. no correction.
- AP_NavEKF3 buffers the offset with each yaw measurement and correctGPSYawForAntennaOffset() applies the residual correction after storedYawAng.recall(), using this core's own roll/pitch at the fusion horizon (lane-independent, Replay-exact). yawAngErr is inflated by the tilt sensitivity |z|/|xy| of the levelled baseline. A measurement whose baseline is too close to vertical at the estimated attitude is treated exactly like no measurement: not fused, not used for the (innovation-ungated) yaw alignment, and it does not refresh last_gps_yaw_ms — so GPS_COMPASS_FALLBACK still engages and yaw-source health reporting stays truthful while the GPS keeps publishing unusable yaw. The correction is gated behind EK3_FEATURE_MOVING_BASELINE (enabled on 2 MB+ boards and Replay/DAL builds, and only where GPS_MOVING_BASELINE is compiled in); 1 MB boards keep the existing level-assumption behaviour and pay none of the flash.

Split into their own PRs (both found while working on this):

- AP_GPS (Unicore NMEA): UNIHEADINGA reports the 3D baseline length and its elevation angle, so the vertical component is length*sin(pitch); using tan overstated it (11% at 26 deg) and exceeded the baseline length itself beyond 45 deg, which made steep antenna installations unable to ever provide yaw on this backend. → <link PR>
- Replay: MSG_CREATE copied sizeof(msg) from a buffer that only holds the logged offsetof(_end) bytes, reading up to 4 bytes past the record (stack-buffer-overflow under AddressSanitizer for RGPI/RGPJ/RGPK). → <link PR>. This PR adds RGPK, which has tail padding like RGPI/RGPJ, so that Replay fix should land with or before this one for AddressSanitizer-clean replay of RGPK.

Known limitation (pre-existing, unchanged): yaw forwarded over the DroneCAN gnss_Heading message (AP_Periph Heading fallback, FC-as-CAN-GPS) cannot carry the antenna offset, so it remains uncorrected on the consumer; the receiving driver zeroes the offset to make that explicit.