### PR TITLE
AP_HAL: correct forward declaration of CANFrame to be struct not class

### DIFF
--- a/libraries/AP_HAL/AP_HAL_Namespace.h
+++ b/libraries/AP_HAL/AP_HAL_Namespace.h
@@ -37,7 +37,7 @@ namespace AP_HAL {
     class WSPIDeviceManager;
 
     class CANIface;
-    class CANFrame;
+    struct CANFrame;
 
     class Util;
     class Flash;


### PR DESCRIPTION
### Summary

Makes forward-declaration and declaration match on this class/struct thing

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<img width="1629" height="769" alt="image" src="https://github.com/user-attachments/assets/600eedb6-3939-488a-965b-499ad003348e" />

```
Board,plane
CubeOrangePlus,*
```

### Description

the implemenation is struct.

we want to do it this way around to avoid adding public: to the struct...
