### PR TITLE
AP_RangeFinder: TFMiniPlus: add small delay to improve read reliability

### DIFF
--- a/libraries/AP_HAL_SITL/I2CDevice.cpp
+++ b/libraries/AP_HAL_SITL/I2CDevice.cpp
@@ -87,8 +87,8 @@ void I2CBus::_timer_tick()
     for (struct callback_info *ci = callbacks; ci != nullptr; ci = ci->next) {
         if (ci->next_usec < now) {
             WITH_SEMAPHORE(sem);
-            ci->cb();
             ci->next_usec += ci->period_usec;
+            ci->cb();
         }
     }
 }

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_TFMiniPlus.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_TFMiniPlus.cpp
@@ -79,13 +79,13 @@ bool AP_RangeFinder_Benewake_TFMiniPlus::init()
         return false;
     }
 
-    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "TFMiniPlus: found fw version %u.%u.%u\n",
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "TFMiniPlus: found fw version %u.%u.%u",
                         val[5], val[4], val[3]);
 
     for (i = 0; i < ARRAY_SIZE(cmds); i++) {
         ret = dev.transfer(cmds[i], cmds[i][1], nullptr, 0);
         if (!ret) {
-            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "TFMiniPlus: Unable to set configuration register %u\n",
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "TFMiniPlus: Unable to set configuration register %u",
                                 cmds[i][2]);
             return false;
         }
@@ -166,16 +166,24 @@ void AP_RangeFinder_Benewake_TFMiniPlus::timer()
         } val;
         uint8_t arr[11];
     } u;
-    bool ret;
     uint16_t distance;
 
-    ret = dev.transfer(CMD_READ_MEASUREMENT, sizeof(CMD_READ_MEASUREMENT), nullptr, 0);
-    if (!ret || !dev.transfer(nullptr, 0, (uint8_t *)&u, sizeof(u))) {
+    if (!dev.transfer(CMD_READ_MEASUREMENT, sizeof(CMD_READ_MEASUREMENT), nullptr, 0)) {
+        // Failed write
         return;
     }
 
-    if (u.val.header1 != 0x59 || u.val.header2 != 0x59 || !check_checksum(u.arr, sizeof(u)))
+    // Short delay helps avoid bad data, despite datasheet saying its not needed
+    hal.scheduler->delay_microseconds(10);
+
+    if (!dev.transfer(nullptr, 0, (uint8_t *)&u, sizeof(u))) {
+        // Failed read
         return;
+    }
+
+    if (u.val.header1 != 0x59 || u.val.header2 != 0x59 || !check_checksum(u.arr, sizeof(u))) {
+        return;
+    }
 
     process_raw_measure(u.val.distance, u.val.strength, distance);
 


### PR DESCRIPTION
### Summary

The current driver sometimes gets bad data, this fixes it by adding a short delay.

<!-- Put a one or two line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->

Master status switches between good (4) and no-data (1):

<img width="1068" height="507" alt="image" src="https://github.com/user-attachments/assets/2e933668-71e3-4b7c-ac61-2273ca8df098" />

no-data is caused by corrupt i2c header reading 0x16 when it should be 0x59.

<img width="1554" height="770" alt="image" src="https://github.com/user-attachments/assets/ff82c6cd-ca4a-43d8-a89b-a521e684d396" />

This PR all good (4):

<img width="1068" height="507" alt="image" src="https://github.com/user-attachments/assets/3f76e3f0-aff8-4c5f-92af-6c0c45904525" />

Now with the small delay we get the correct 0x59 header:

<img width="2330" height="762" alt="image" src="https://github.com/user-attachments/assets/2f91e802-5188-4cdf-b847-5d244d7c6d9a" />

