### PR TITLE
AP_HAL_SITL: write watchdog persistent data atomically

### DIFF
--- a/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
+++ b/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
@@ -137,13 +137,16 @@ static char *new_argv[100];
  */
 static bool watchdog_save(const uint32_t *data, uint32_t nwords)
 {
-    int fd = ::open("persistent.dat", O_WRONLY|O_CREAT|O_TRUNC, 0644);
+    int fd = ::open("persistent.dat.tmp", O_WRONLY|O_CREAT|O_TRUNC, 0644);
     bool ret = false;
     if (fd != -1) {
         if (::write(fd, data, nwords*4) == (ssize_t)(nwords*4)) {
             ret = true;
         }
         ::close(fd);
+    }
+    if (ret) {
+        ret = ::rename("persistent.dat.tmp", "persistent.dat") == 0;
     }
     return ret;
 }


### PR DESCRIPTION
### Summary

Fixes flake due to race condition writing persistent.dat file in SITL

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

watchdog_save() rewrote persistent.dat in place with O_TRUNC+write every 100ms.  The simulated watchdog reset (SIGALRM) execv()s from the signal handler, so a reset arriving between the truncate and the write left a short file behind; the re-exec'd process then failed to load its persistent data and booted with home/attitude zeroed, seen in CI as WatchdogHome failing with "Failed to poll home position" and "Restored watchdog attitude 0 0 0".

Write to persistent.dat.tmp and rename() it into place so a complete persistent.dat always exists.
