### PR TITLE
autotest: resend Sub GuidedWP target until the vehicle accepts it

### DIFF
--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -1377,6 +1377,13 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
 
         self.set_parameter('WP_SPD', speed)
 
+        # the vehicle reports wp_nav's distance-to-destination in
+        # NAV_CONTROLLER_OUTPUT; we use it to confirm our target has been
+        # accepted.  Ask for it before diving; there is no depth hold
+        # between the dive and entering GUIDED, so sim time spent here is
+        # spent floating away from the dived-to depth
+        self.context_set_message_rate_hz('NAV_CONTROLLER_OUTPUT', 10)
+
         self.dive(-15)
 
         # GLOBAL_POSITION_INT will be our clock
@@ -1412,11 +1419,29 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
             current_alt = None
             max_error = 0.0
 
-            # Set the target
-            self.mav.mav.set_position_target_global_int_send(
-                0, 1, 1, run['frame'], pos_mode,
-                int(dest_loc[0] * 1e7), int(dest_loc[1] * 1e7), run['target_alt'],
-                0, 0, 0, 0, 0, 0, 0, 0)
+            # Send the target until the reported distance-to-destination
+            # shows it has become the current destination.  The vehicle
+            # can silently reject the target (e.g. a single bad
+            # rangefinder reading invalidates the terrain frame for an
+            # instant) and there is no acknowledgement to check, so a
+            # single send is not enough.
+            accept_start = self.get_sim_time()
+            accepted = False
+            while not accepted:
+                if self.get_sim_time_cached() - accept_start > 30:
+                    raise NotAchievedException(f'Frame {run["frame"]} target not accepted')
+                self.mav.mav.set_position_target_global_int_send(
+                    0, 1, 1, run['frame'], pos_mode,
+                    int(dest_loc[0] * 1e7), int(dest_loc[1] * 1e7), run['target_alt'],
+                    0, 0, 0, 0, 0, 0, 0, 0)
+                # wait a little for the new distance-to-destination to be
+                # reported before concluding the target was rejected
+                deadline = self.get_sim_time_cached() + 1
+                while self.get_sim_time_cached() < deadline:
+                    msg = self.assert_receive_message('NAV_CONTROLLER_OUTPUT')
+                    if abs(msg.wp_dist - distance) < 5:
+                        accepted = True
+                        break
 
             start_time = self.get_sim_time()
             while True:

--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -1384,7 +1384,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         # spent floating away from the dived-to depth
         self.context_set_message_rate_hz('NAV_CONTROLLER_OUTPUT', 10)
 
-        self.dive(-15)
+        self.dive(-15, mode='ALT_HOLD')
 
         # GLOBAL_POSITION_INT will be our clock
         self.context_set_message_rate_hz('GLOBAL_POSITION_INT', 10)


### PR DESCRIPTION
### Summary

Retries set-position in sub guided terrain test until it succeeds.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

The vehicle can silently reject a SET_POSITION_TARGET_GLOBAL_INT - the synthetic seafloor simulation deliberately injects low-signal-quality rangefinder outliers, and one of those landing in the wrong ~50ms makes the terrain frame momentarily invalid, failing the frame conversion in wp_nav.  There is no acknowledgement for the message, so the test sailed on oblivious and timed out 80 seconds later ("Frame 10 took too long to reach the destination", seen in CI).

Send the target until NAV_CONTROLLER_OUTPUT.wp_dist shows it has become wp_nav's current destination.  The distance report is used rather than the POSITION_TARGET_GLOBAL_INT echo because the latter is never emitted for terrain-altitude destinations on Sub (the alt cannot be converted to AMSL without a terrain database).  Blindly streaming the target is also no good; each resend of an identical target re-initialises the wpnav leg from a stopping point, slowing the vehicle enough to miss the test's timeout.

The leg timer now starts only once the target is accepted, and the message-rate request is made before the dive as there is no depth hold between the dive and GUIDED, so sim time spent there is spent floating back up.


Problem with this approach is that it can happen on a real GCS to a real user if the GCS just sends the command once (mavlink is assumed lossy so there's actually a problem right there.

The Sub code could change to use the SurfaceTrack library which is a little more forgiving of bad measurements.

This test could also change to unconditionally streaming the position target in too, which is more like what a GCS *should* do.  It's not a common assumption to make that you need to do this on the GCS side so would be a significant change in thinking there (vel/accel control assumed to be streaming, pos/vel assumed to be streaming, but "go here" really not.

The test could also change to use `MAV_CMD_DO_REPOSITION` (as well as changing whatever is sending the position in in the real-world use case.

