### PR TITLE
AP_Rangefinder: add power down state and use it for TFMini Plus

### DIFF
--- a/ArduCopter/landing_gear.cpp
+++ b/ArduCopter/landing_gear.cpp
@@ -18,6 +18,7 @@ void Copter::landinggear_update()
     switch (rangefinder.status_orient(ROTATION_PITCH_270)) {
     case RangeFinder::Status::NotConnected:
     case RangeFinder::Status::NoData:
+    case RangeFinder::Status::PoweredDown:
         // use altitude above home for non-functioning rangefinder
         break;
 

--- a/ArduSub/mode_auto.cpp
+++ b/ArduSub/mode_auto.cpp
@@ -439,9 +439,10 @@ bool ModeAuto::auto_terrain_recover_start()
         sub.auto_mode = Auto_TerrainRecover;
         break;
 
-        // Not connected or no data
-    default:
-        return false; // Rangefinder is not connected, or has stopped responding
+    case RangeFinder::Status::NotConnected:
+    case RangeFinder::Status::NoData:
+    case RangeFinder::Status::PoweredDown:
+        return false;
     }
 
     // Initialize recovery timeout time
@@ -526,8 +527,9 @@ void ModeAuto::auto_terrain_recover_run()
         }
         break;
 
-        // Not connected, or no data
-    default:
+    case RangeFinder::Status::NotConnected:
+    case RangeFinder::Status::NoData:
+    case RangeFinder::Status::PoweredDown:
         // Terrain failsafe recovery has failed, terrain data is not available
         // and rangefinder is not connected, or has stopped responding
         gcs().send_text(MAV_SEVERITY_CRITICAL, "Terrain failsafe recovery failure: No Rangefinder!");

--- a/Tools/AP_Periph/rangefinder.cpp
+++ b/Tools/AP_Periph/rangefinder.cpp
@@ -57,10 +57,18 @@ void AP_Periph_FW::can_rangefinder_update(void)
             continue;
         }
 
-        RangeFinder::Status status = backend->status();
-        if (status <= RangeFinder::Status::NoData) {
-            // don't send any data for this instance
-            continue;
+        const RangeFinder::Status status = backend->status();
+        switch (status) {
+            case RangeFinder::Status::NotConnected:
+            case RangeFinder::Status::NoData:
+            case RangeFinder::Status::PoweredDown:
+                // don't send any data for this instance
+                continue;
+
+            case RangeFinder::Status::OutOfRangeLow:
+            case RangeFinder::Status::OutOfRangeHigh:
+            case RangeFinder::Status::Good:
+                break;
         }
 
         const uint32_t sample_ms = backend->last_reading_ms();
@@ -83,7 +91,11 @@ void AP_Periph_FW::can_rangefinder_update(void)
         case RangeFinder::Status::Good:
             pkt.reading_type = UAVCAN_EQUIPMENT_RANGE_SENSOR_MEASUREMENT_READING_TYPE_VALID_RANGE;
             break;
-        default:
+
+        case RangeFinder::Status::NotConnected:
+        case RangeFinder::Status::NoData:
+        case RangeFinder::Status::PoweredDown:
+            // Should never hit this due to continue in switch above
             pkt.reading_type = UAVCAN_EQUIPMENT_RANGE_SENSOR_MEASUREMENT_READING_TYPE_UNDEFINED;
             break;
         }

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -13346,6 +13346,44 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         if not good:
             raise NotAchievedException("Did not see good alt")
 
+    def RangeFinderSITLPowerDown(self):
+        '''Test rangefinder power down by altitude using SITL rangefinder'''
+        pwrrng = 10  # power down above this altitude in metres
+
+        self.set_parameters({
+            "RNGFND1_TYPE": 100,  # SITL
+            "RNGFND1_MAX": 50, # Make sure the it will not unhealty due to max range limit
+            "RNGFND1_PWRRNG": pwrrng,
+        })
+        self.reboot_sitl()
+
+        rf_bit = mavutil.mavlink.MAV_SYS_STATUS_SENSOR_LASER_POSITION
+
+        low_alt = pwrrng - 3   # below threshold
+        high_alt = pwrrng + 5  # above threshold
+
+        self.takeoff(low_alt, mode='GUIDED')
+
+        self.progress("Verify rangefinder healthy below power-down threshold")
+        self.assert_sensor_state(rf_bit, present=True, enabled=True, healthy=True)
+        self.context_set_message_rate_hz('RANGEFINDER', self.sitl_streamrate())
+        self.assert_rangefinder_distance_between(low_alt - 2, low_alt + 2)
+
+        self.progress(f"Climbing above power-down threshold ({pwrrng}m)")
+        self.fly_guided_move_local(0, 0, high_alt)
+
+        self.progress("Verify rangefinder powered down above threshold")
+        self.wait_sensor_state(rf_bit, present=True, enabled=True, healthy=False)
+
+        self.progress("Descending below power-down threshold")
+        self.fly_guided_move_local(0, 0, low_alt)
+
+        self.progress("Verify rangefinder recovers below threshold")
+        self.wait_sensor_state(rf_bit, present=True, enabled=True, healthy=True)
+        self.assert_rangefinder_distance_between(low_alt - 2, low_alt + 2)
+
+        self.land_and_disarm()
+
     def ShipTakeoff(self):
         '''Fly Simulated Ship Takeoff'''
         # test ship takeoff
@@ -15750,6 +15788,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
              self.RangeFinderDriversMaxAlt_AinsteinLRD1_v19,
              self.RangeFinderDriversLongRange,
              self.RangeFinderSITLLongRange,
+             self.RangeFinderSITLPowerDown,
              self.MaxBotixI2CXL,
              self.MAVProximity,
              self.ParameterValidation,

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -13386,6 +13386,54 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         if not good:
             raise NotAchievedException("Did not see good alt")
 
+    def RangeFinderPowerDown(self):
+        '''Test rangefinder power down by altitude for multiple backends'''
+        pwrrng = 10  # power down above this altitude in metres
+
+        backends = [
+            ("SITL", {"RNGFND1_TYPE": 100}),
+            ("TFMiniPlus", {"RNGFND1_TYPE": 25, "RNGFND1_ADDR": 0x09}),
+        ]
+
+        rf_bit = mavutil.mavlink.MAV_SYS_STATUS_SENSOR_LASER_POSITION
+        low_alt = pwrrng - 3   # below threshold
+        high_alt = pwrrng + 5  # above threshold
+
+        for (name, backend_params) in backends:
+            self.start_subtest(f"RangeFinderPowerDown: {name}")
+            self.context_push()
+
+            params = {
+                "RNGFND1_MAX": 50,  # prevent unhealthy due to max range limit
+                "RNGFND1_PWRRNG": pwrrng,
+            }
+            params.update(backend_params)
+            self.set_parameters(params)
+            self.reboot_sitl()
+
+            self.takeoff(low_alt, mode='GUIDED')
+
+            self.progress("Verify rangefinder healthy below power-down threshold")
+            self.assert_sensor_state(rf_bit, present=True, enabled=True, healthy=True)
+            self.context_set_message_rate_hz('RANGEFINDER', self.sitl_streamrate())
+            self.assert_rangefinder_distance_between(low_alt - 2, low_alt + 2)
+
+            self.progress(f"Climbing above power-down threshold ({pwrrng}m)")
+            self.fly_guided_move_local(0, 0, high_alt)
+
+            self.progress("Verify rangefinder powered down above threshold")
+            self.wait_sensor_state(rf_bit, present=True, enabled=True, healthy=False)
+
+            self.progress("Descending below power-down threshold")
+            self.fly_guided_move_local(0, 0, low_alt)
+
+            self.progress("Verify rangefinder recovers below threshold")
+            self.wait_sensor_state(rf_bit, present=True, enabled=True, healthy=True)
+            self.assert_rangefinder_distance_between(low_alt - 2, low_alt + 2)
+
+            self.land_and_disarm()
+            self.context_pop()
+
     def ShipTakeoff(self):
         '''Fly Simulated Ship Takeoff'''
         # test ship takeoff
@@ -15796,6 +15844,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
              self.RangeFinderDriversMaxAlt_AinsteinLRD1_v19,
              self.RangeFinderDriversLongRange,
              self.RangeFinderSITLLongRange,
+             self.RangeFinderPowerDown,
              self.MaxBotixI2CXL,
              self.MAVProximity,
              self.ParameterValidation,

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -2544,7 +2544,7 @@ void AP_OSD_Screen::draw_rngf(uint8_t x, uint8_t y)
     if (rangefinder == nullptr) {
        return;
     }
-    if (rangefinder->status_orient(ROTATION_PITCH_270) < RangeFinder::Status::Good) {
+    if (rangefinder->status_orient(ROTATION_PITCH_270) != RangeFinder::Status::Good) {
         backend->write(x, y, false, "%c---%c", SYMBOL(SYM_RNGFD), u_icon(DISTANCE));
     } else {
         const float distance = rangefinder->distance_orient(ROTATION_PITCH_270);

--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -411,7 +411,7 @@ __INITFUNC__ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial
         // to ease moving from PX4 to ChibiOS we'll lie a little about
         // the backend driver...
         if (AP_RangeFinder_PWM::detect()) {
-            _add_backend(NEW_NOTHROW AP_RangeFinder_PWM(state[instance], params[instance], estimated_terrain_height), instance);
+            _add_backend(NEW_NOTHROW AP_RangeFinder_PWM(state[instance], params[instance]), instance);
         }
         break;
 #endif
@@ -505,7 +505,7 @@ __INITFUNC__ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial
 #if AP_RANGEFINDER_PWM_ENABLED
     case Type::PWM:
         if (AP_RangeFinder_PWM::detect()) {
-            _add_backend(NEW_NOTHROW AP_RangeFinder_PWM(state[instance], params[instance], estimated_terrain_height), instance);
+            _add_backend(NEW_NOTHROW AP_RangeFinder_PWM(state[instance], params[instance]), instance);
         }
         break;
 #endif
@@ -994,6 +994,9 @@ bool RangeFinder::prearm_healthy(char *failure_msg, const uint8_t failure_msg_le
         }
 
         switch (drivers[i]->status()) {
+        case Status::PoweredDown:
+            hal.util->snprintf(failure_msg, failure_msg_len, "Rangefinder %X: Powered Down", i + 1);
+            return false;
         case Status::NoData:
             hal.util->snprintf(failure_msg, failure_msg_len, "Rangefinder %X: No Data", i + 1);
             return false;

--- a/libraries/AP_RangeFinder/AP_RangeFinder.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.h
@@ -215,6 +215,7 @@ public:
         OutOfRangeLow  = 2,
         OutOfRangeHigh = 3,
         Good           = 4,
+        PoweredDown    = 5,
     };
 
     static constexpr int8_t SIGNAL_QUALITY_MIN = 0;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Backend.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Backend.cpp
@@ -51,9 +51,21 @@ RangeFinder::Status AP_RangeFinder_Backend::status() const {
 }
 
 // true if sensor is returning data
-bool AP_RangeFinder_Backend::has_data() const {
-    return ((state.status != RangeFinder::Status::NotConnected) &&
-            (state.status != RangeFinder::Status::NoData));
+bool AP_RangeFinder_Backend::has_data() const
+{
+    switch (state.status) {
+        case RangeFinder::Status::NotConnected:
+        case RangeFinder::Status::NoData:
+        case RangeFinder::Status::PoweredDown:
+            break;
+
+        case RangeFinder::Status::OutOfRangeLow:
+        case RangeFinder::Status::OutOfRangeHigh:
+        case RangeFinder::Status::Good:
+            return true;
+    }
+
+    return false;
 }
 
 // update status based on distance measurement
@@ -95,6 +107,19 @@ bool AP_RangeFinder_Backend::get_temp(float &temp) const
     }
 #endif
     return _get_temp(temp);
+}
+
+// return true if rangefinder should be powered down
+bool AP_RangeFinder_Backend::should_power_down() const
+{
+    // Power saving range must be configured
+    if (params.powersave_range <= 0) {
+        return false;
+    }
+
+    // Must be above configured height
+    RangeFinder &frontend = *AP::rangefinder();
+    return frontend.estimated_terrain_height > params.powersave_range;
 }
 
 #if AP_SCRIPTING_ENABLED

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
@@ -110,6 +110,10 @@ protected:
     // backend-specific temperature reading.  Override in backends that have their
     // own temperature source (e.g. NMEA depth sounders reporting MTW).
     virtual bool _get_temp(float &temp) const { return false; }
+
+    // return true if rangefinder should be powered down
+    bool should_power_down() const;
+
 };
 
 #endif  // AP_RANGEFINDER_ENABLED

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_TFMiniPlus.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_TFMiniPlus.cpp
@@ -36,12 +36,16 @@ extern const AP_HAL::HAL& hal;
  * uint8_t checksum;
  */
 
+#define CMD_SET_DATA_OUT 0x5A, 0x05, 0x07
+#define CMD_ENABLE_DATA_OUT CMD_SET_DATA_OUT, 0x01, 0x67
+#define CMD_DISABLE_DATA_OUT CMD_SET_DATA_OUT, 0x00, 0x66
+
 bool AP_RangeFinder_Benewake_TFMiniPlus::init()
 {
     const uint8_t CMD_FW_VERSION[] =         { 0x5A, 0x04, 0x01, 0x5F };
     const uint8_t CMD_SYSTEM_RESET[] =       { 0x5A, 0x04, 0x04, 0x62 };
     const uint8_t CMD_OUTPUT_FORMAT_CM[] =   { 0x5A, 0x05, 0x05, 0x01, 0x65 };
-    const uint8_t CMD_ENABLE_DATA_OUTPUT[] = { 0x5A, 0x05, 0x07, 0x01, 0x67 };
+    const uint8_t CMD_ENABLE_DATA_OUTPUT[] = { CMD_ENABLE_DATA_OUT };
     const uint8_t CMD_FRAME_RATE_250HZ[] =   { 0x5A, 0x06, 0x03, 0xFA, 0x00, 0x5D };
     const uint8_t CMD_SAVE_SETTINGS[] =      { 0x5A, 0x04, 0x11, 0x6F };
     const uint8_t *cmds[] = {
@@ -106,6 +110,17 @@ void AP_RangeFinder_Benewake_TFMiniPlus::update()
 {
     WITH_SEMAPHORE(_sem);
 
+    // Power down if commanded
+    power_state.commanded_power_down = should_power_down();
+    if (power_state.commanded_power_down || power_state.current_power_down) {
+        set_status(RangeFinder::Status::PoweredDown);
+        // Clear accumulation
+        accum.sum = 0;
+        accum.count = 0;
+        return;
+    }
+
+    // Average samples
     if (accum.count > 0) {
         state.distance_m = (accum.sum * 0.01f) / accum.count;
         state.last_reading_ms = AP_HAL::millis();
@@ -113,6 +128,7 @@ void AP_RangeFinder_Benewake_TFMiniPlus::update()
         accum.count = 0;
         update_status();
     } else if (AP_HAL::millis() - state.last_reading_ms > 200) {
+        // Timeout for bad data
         set_status(RangeFinder::Status::NoData);
     }
 }
@@ -154,6 +170,43 @@ bool AP_RangeFinder_Benewake_TFMiniPlus::check_checksum(uint8_t *arr, int pkt_le
 
 void AP_RangeFinder_Benewake_TFMiniPlus::timer()
 {
+    bool change_power_state;
+    bool power_down;
+    {
+        // Update power flags with semaphore
+        WITH_SEMAPHORE(_sem);
+        change_power_state = power_state.current_power_down != power_state.commanded_power_down;
+        power_down = power_state.commanded_power_down;
+    }
+
+    if (change_power_state) {
+        // Change in power state
+        bool success;
+        if (power_down) {
+            // Send power down command
+            const uint8_t CMD_DISABLE[] = { CMD_DISABLE_DATA_OUT };
+            success = dev.transfer(CMD_DISABLE, sizeof(CMD_DISABLE), nullptr, 0);
+
+        } else {
+            // Send power up command
+            const uint8_t CMD_ENABLE[] = { CMD_ENABLE_DATA_OUT };
+            success = dev.transfer(CMD_ENABLE, sizeof(CMD_ENABLE), nullptr, 0);
+        }
+
+        // Mark state as changed if command was written
+        if (success) {
+            WITH_SEMAPHORE(_sem);
+            power_state.current_power_down = power_down;
+        }
+        // Wait until next call before trying to read data
+        return;
+    }
+    
+    if (power_down) {
+        // Powered down, nothing to do
+        return;
+    }
+
     uint8_t CMD_READ_MEASUREMENT[] = { 0x5A, 0x05, 0x00, 0x07, 0x66 };
     union {
         struct PACKED {

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_TFMiniPlus.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_TFMiniPlus.cpp
@@ -36,12 +36,16 @@ extern const AP_HAL::HAL& hal;
  * uint8_t checksum;
  */
 
+#define CMD_SET_DATA_OUT 0x5A, 0x05, 0x07
+#define CMD_ENABLE_DATA_OUT CMD_SET_DATA_OUT, 0x01, 0x67
+#define CMD_DISABLE_DATA_OUT CMD_SET_DATA_OUT, 0x00, 0x66
+
 bool AP_RangeFinder_Benewake_TFMiniPlus::init()
 {
     const uint8_t CMD_FW_VERSION[] =         { 0x5A, 0x04, 0x01, 0x5F };
     const uint8_t CMD_SYSTEM_RESET[] =       { 0x5A, 0x04, 0x04, 0x62 };
     const uint8_t CMD_OUTPUT_FORMAT_CM[] =   { 0x5A, 0x05, 0x05, 0x01, 0x65 };
-    const uint8_t CMD_ENABLE_DATA_OUTPUT[] = { 0x5A, 0x05, 0x07, 0x01, 0x67 };
+    const uint8_t CMD_ENABLE_DATA_OUTPUT[] = { CMD_ENABLE_DATA_OUT };
     const uint8_t CMD_FRAME_RATE_250HZ[] =   { 0x5A, 0x06, 0x03, 0xFA, 0x00, 0x5D };
     const uint8_t CMD_SAVE_SETTINGS[] =      { 0x5A, 0x04, 0x11, 0x6F };
     const uint8_t *cmds[] = {
@@ -106,6 +110,17 @@ void AP_RangeFinder_Benewake_TFMiniPlus::update()
 {
     WITH_SEMAPHORE(_sem);
 
+    // Power down if commanded
+    power_state.commanded_power_down = should_power_down();
+    if (power_state.commanded_power_down || power_state.current_power_down) {
+        set_status(RangeFinder::Status::PoweredDown);
+        // Clear accumulation
+        accum.sum = 0;
+        accum.count = 0;
+        return;
+    }
+
+    // Average samples
     if (accum.count > 0) {
         state.distance_m = (accum.sum * 0.01f) / accum.count;
         state.last_reading_ms = AP_HAL::millis();
@@ -113,6 +128,7 @@ void AP_RangeFinder_Benewake_TFMiniPlus::update()
         accum.count = 0;
         update_status();
     } else if (AP_HAL::millis() - state.last_reading_ms > 200) {
+        // Timeout for bad data
         set_status(RangeFinder::Status::NoData);
     }
 }
@@ -154,6 +170,41 @@ bool AP_RangeFinder_Benewake_TFMiniPlus::check_checksum(uint8_t *arr, int pkt_le
 
 void AP_RangeFinder_Benewake_TFMiniPlus::timer()
 {
+    bool change_power_state;
+    bool power_down;
+    {
+        // Update power flags with semaphore
+        WITH_SEMAPHORE(_sem);
+        change_power_state = power_state.current_power_down != power_state.commanded_power_down;
+        power_down = power_state.commanded_power_down;
+    }
+
+    if (change_power_state) {
+        // Change in power state
+        bool success;
+        if (power_down) {
+            // Send power down command
+            const uint8_t CMD_DISABLE[] = { CMD_DISABLE_DATA_OUT };
+            success = dev.transfer(CMD_DISABLE, sizeof(CMD_DISABLE), nullptr, 0);
+
+        } else {
+            // Send power up command
+            const uint8_t CMD_ENABLE[] = { CMD_ENABLE_DATA_OUT };
+            success = dev.transfer(CMD_ENABLE, sizeof(CMD_ENABLE), nullptr, 0);
+
+        }
+        // Mark state as changed if command was written
+        if (success) {
+            WITH_SEMAPHORE(_sem);
+            power_state.current_power_down = power_down;
+        }
+        // Wait until next call before trying to read data
+        return;
+    } else if (power_down) {
+        // Powered down, nothing to do
+        return;
+    }
+
     uint8_t CMD_READ_MEASUREMENT[] = { 0x5A, 0x05, 0x00, 0x07, 0x66 };
     union {
         struct PACKED {

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_TFMiniPlus.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Benewake_TFMiniPlus.h
@@ -59,6 +59,12 @@ private:
 
     bool check_checksum(uint8_t *arr, int pkt_len);
 
+    // Track powered down status
+    struct {
+        bool commanded_power_down;
+        bool current_power_down;
+    } power_state;
+
     struct {
         uint32_t sum;
         uint32_t count;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_PWM.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_PWM.cpp
@@ -26,10 +26,8 @@ extern const AP_HAL::HAL& hal;
    The constructor also initialises the rangefinder.
 */
 AP_RangeFinder_PWM::AP_RangeFinder_PWM(RangeFinder::RangeFinder_State &_state,
-                                       AP_RangeFinder_Params &_params,
-                                       float &_estimated_terrain_height) :
-    AP_RangeFinder_Backend(_state, _params),
-    estimated_terrain_height(_estimated_terrain_height)
+                                       AP_RangeFinder_Params &_params) :
+    AP_RangeFinder_Backend(_state, _params)
 {
     // this gives one mm per us
     params.scaling.set_default(1.0);
@@ -93,12 +91,12 @@ void AP_RangeFinder_PWM::update(void)
     }
 
     if (params.stop_pin != -1) {
-        const bool oor = out_of_range();
+        const bool oor = should_power_down();
         if (oor) {
             if (!was_out_of_range) {
                 // we are above the power saving range. Disable the sensor
                 hal.gpio->write(params.stop_pin, false);
-                set_status(RangeFinder::Status::NoData);
+                set_status(RangeFinder::Status::PoweredDown);
                 state.distance_m = 0.0f;
                 state.voltage_mv = 0;
                 was_out_of_range = oor;
@@ -125,12 +123,6 @@ void AP_RangeFinder_PWM::update(void)
     // update range_valid state based on distance measured
     state.last_reading_ms = AP_HAL::millis();
     update_status();
-}
-
-
-// return true if we are beyond the power saving range
-bool AP_RangeFinder_PWM::out_of_range(void) const {
-    return params.powersave_range > 0 && estimated_terrain_height > params.powersave_range;
 }
 
 #endif  // AP_RANGEFINDER_PWM_ENABLED

--- a/libraries/AP_RangeFinder/AP_RangeFinder_PWM.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_PWM.h
@@ -26,8 +26,7 @@ class AP_RangeFinder_PWM : public AP_RangeFinder_Backend
 public:
     // constructor
     AP_RangeFinder_PWM(RangeFinder::RangeFinder_State &_state,
-                       AP_RangeFinder_Params &_params,
-                       float &_estimated_terrain_height);
+                       AP_RangeFinder_Params &_params);
 
     // destructor
     ~AP_RangeFinder_PWM(void) {};
@@ -55,10 +54,7 @@ private:
 
     AP_HAL::PWMSource pwm_source;
 
-    float &estimated_terrain_height;
-
     // return true if we are beyond the power saving range
-    bool out_of_range(void) const;
     bool was_out_of_range = -1; // this odd initialisation ensures we transition to new state
 
 };

--- a/libraries/AP_RangeFinder/AP_RangeFinder_SITL.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_SITL.cpp
@@ -32,11 +32,17 @@ AP_RangeFinder_SITL::AP_RangeFinder_SITL(RangeFinder::RangeFinder_State &_state,
  */
 void AP_RangeFinder_SITL::update(void)
 {
+    // Support the power down state
+    if (should_power_down()) {
+        set_status(RangeFinder::Status::PoweredDown);
+        return;
+    }
+
     const float dist = AP::sitl()->get_rangefinder(_instance);
 
     // nan distance means nothing is connected
     if (isnan(dist) || isinf(dist)) {
-        state.status = RangeFinder::Status::NoData;
+        set_status(RangeFinder::Status::NoData);
         return;
     }
 

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -249,7 +249,7 @@ userdata RangeFinder::RangeFinder_State depends AP_RANGEFINDER_ENABLED
 userdata RangeFinder::RangeFinder_State rename RangeFinder_State
 userdata RangeFinder::RangeFinder_State field last_reading_ms uint32_t'skip_check read write
 userdata RangeFinder::RangeFinder_State field last_reading_ms rename last_reading
-userdata RangeFinder::RangeFinder_State field status RangeFinder::Status'enum read write RangeFinder::Status::NotConnected RangeFinder::Status::Good
+userdata RangeFinder::RangeFinder_State field status RangeFinder::Status'enum read write RangeFinder::Status::NotConnected RangeFinder::Status::PoweredDown
 userdata RangeFinder::RangeFinder_State field range_valid_count uint8_t'skip_check read write
 userdata RangeFinder::RangeFinder_State field distance_m float'skip_check read write
 userdata RangeFinder::RangeFinder_State field distance_m rename distance

--- a/libraries/SITL/SIM_RF_Benewake_TFMiniPlus.cpp
+++ b/libraries/SITL/SIM_RF_Benewake_TFMiniPlus.cpp
@@ -91,6 +91,7 @@ int SITL::Benewake_TFMiniPlus::rdwr(I2C::i2c_rdwr_ioctl_data *&data)
         break;
     case Command::ENABLE_DATA_OUTPUT:
         new_config.data_output_enabled = (msg.buf[3] == 1);
+        running_config.data_output_enabled = new_config.data_output_enabled;
         break;
     case Command::SET_FRAME_RATE:
         new_config.frame_rate = (msg.buf[3] | msg.buf[4]<<8);


### PR DESCRIPTION
### Summary

<!-- Put a one or two line summary of what your PR does here -->

This builds on https://github.com/ArduPilot/ardupilot/pull/33709. It allows the TFMini Plus to be turned off based on the existing max range param `RNGFNDx_PWRRNG`. The TFMini Plus has a operating range of 12m, so you might set it to power off when the vehicle is above 150m for example. The goal here is to save power.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

 
### Description

<!-- Describe the PR's content here -->

Just basing this on height above ground from the vehicle could be quite wrong in some cases. Plane will use the terrain database if available but fall back to home. A better approach might be to use flight phase, but might cause race conditions where for example rangefinder is not on until the landing has stated so there is no good readings until the rangefinder has powered up.

I suspect most of the other rangefinders could implement this, although it is not possible over DroneCAN as far as I can tell.

We could also just remove the functionality, its currently only used by the PWM backend.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
