### PR TITLE
AP_HAL_SITL: fix double-EAS2TAS in pitot model

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -7814,6 +7814,90 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         if airspeed_active != [False, True]:
             raise NotAchievedException("Not using expected airspeed sensors %s" % str(airspeed_active))
 
+    def AirspeedEAS2TAS(self):
+        '''check the SITL pitot applies EAS2TAS correctly'''
+
+        self.set_parameters({
+            "SIM_WIND_SPD": 0,      # groundspeed must equal true airspeed
+            "SIM_WIND_TURB": 0,
+        })
+
+        def sample_level_flight(duration=25):
+            '''average groundspeed, airspeed and altitude over level flight'''
+            sum_gs = 0.0
+            sum_as = 0.0
+            sum_alt = 0.0
+            count = 0
+            last_airspeed_message = None
+            tstart = self.get_sim_time()
+            while self.get_sim_time_cached() - tstart < duration:
+                m = self.assert_receive_message('VFR_HUD')
+                if abs(m.climb) > 1.0:
+                    continue        # only sample steady, level flight
+                # pair with the most recent raw airspeed sensor reading,
+                # skipping if it hasn't updated since the last sample
+                a = self.mav.messages.get('AIRSPEED', None)
+                if a is None or a is last_airspeed_message or a.id != 0 or a.airspeed < 1:
+                    continue
+                last_airspeed_message = a
+                sum_gs += m.groundspeed
+                sum_as += a.airspeed
+                sum_alt += m.alt
+                count += 1
+            if count < 15:
+                raise NotAchievedException("Too few level-flight samples (%u)" % count)
+            return sum_gs / count, sum_as / count, sum_alt / count
+
+        def guided_hold_alt(alt_rel_m, timeout=600):
+            # loiter at the current position and climb/hold the target altitude
+            loc = self.mav.location()
+            self.run_cmd_int(
+                mavutil.mavlink.MAV_CMD_DO_REPOSITION,
+                p5=int(loc.lat * 1e7),
+                p6=int(loc.lng * 1e7),
+                p7=alt_rel_m,
+                frame=mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT,
+            )
+            self.wait_altitude(alt_rel_m - 5, alt_rel_m + 5, relative=True, timeout=timeout)
+            self.delay_sim_time(10, reason="settle into level flight")
+
+        low_alt_rel = 100
+        high_alt_rel = 2100
+        # Expected change in E2T for a 2000m climb
+        e2t_ratio_expected = 1.10
+        e2t_ratio_tolerance = 0.03
+
+        self.takeoff(alt=low_alt_rel, mode="TAKEOFF")
+        self.change_mode("GUIDED")
+
+        guided_hold_alt(low_alt_rel)
+        gs_lo, as_lo, alt_lo = sample_level_flight()
+
+        guided_hold_alt(high_alt_rel)
+        gs_hi, as_hi, alt_hi = sample_level_flight()
+
+        e2t_lo = gs_lo / as_lo
+        e2t_hi = gs_hi / as_hi
+        e2t_ratio = e2t_hi / e2t_lo
+        e2t_ratio_min = e2t_ratio_expected - e2t_ratio_tolerance
+        e2t_ratio_max = e2t_ratio_expected + e2t_ratio_tolerance
+
+        self.progress("EAS2TAS low:  alt=%.0f gs=%.2f as=%.2f e2t=%.4f" %
+                      (alt_lo, gs_lo, as_lo, e2t_lo))
+        self.progress("EAS2TAS high: alt=%.0f gs=%.2f as=%.2f e2t=%.4f" %
+                      (alt_hi, gs_hi, as_hi, e2t_hi))
+        self.progress("EAS2TAS ratio observed=%.4f want=[%.2f, %.2f]" %
+                      (e2t_ratio, e2t_ratio_min, e2t_ratio_max))
+
+        if e2t_ratio < e2t_ratio_min or e2t_ratio > e2t_ratio_max:
+            raise NotAchievedException(
+                f"groundspeed/airspeed ratio {e2t_ratio:.4f} outside "
+                f"[{e2t_ratio_min:.2f}, {e2t_ratio_max:.2f}]")
+
+        # force-disarm and reset SITL rather than descending all the way back down
+        self.disarm_vehicle(force=True)
+        self.reboot_sitl()
+
     def RudderArmingWithArmingChecksSkipped(self):
         '''check we can't arm with rudder even if all checks are skipped'''
         self.set_parameters({
@@ -8584,6 +8668,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.BadRollChannelDefined,
             self.VolzMission,
             self.mavlink_AIRSPEED,
+            self.AirspeedEAS2TAS,
             self.Volz,
             self.LoggedNamedValueFloat,
             self.LoggedNamedValueInt,

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -4965,6 +4965,12 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
     def AUTOTUNE(self):
         '''Test AutoTune mode'''
+
+        # Prior to 2026-07-15, the SITL airspeed sensor was reading about 5%
+        # slower than actual during this test. We bump the scaling airspeed by
+        # that same amount to get the same tune results as before.
+        self.set_parameter("SCALING_SPEED", 15.8)
+
         self.run_autotune()
 
         # Values that are set to constants

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -961,7 +961,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.change_mode('MANUAL')
         self.context_push()
         self.context_set_speedup(1)
-        self.set_rc(2, 1550)
+        self.set_rc(2, 1600)
         self.wait_pitch(lim_pitch_up_deg+5, accuracy=5)
         self.context_pop()
         self.progress("Killing elevator servo output to force qassist to help")

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -882,6 +882,12 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
                                       comparator=operator.eq)
         self.set_rc(3, 1300)
 
+        # Disable speed assist and alt assist during angle assist tests
+        self.set_parameters({
+            "Q_ASSIST_SPEED": 1,
+            "Q_ASSIST_ALT": 0,
+        })
+
         self.start_subtest("Test angle assist (roll)")
         self.context_push()
         self.context_collect('STATUSTEXT')
@@ -902,7 +908,8 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.set_rc(1, 1500)
         self.progress("Checking qassist stops")
         # we must push RC3 here or the translational drag from the
-        # motors keeps us at ~17m/s, below the airspeed assist speed!
+        # motors keeps our airspeed below AIRSPEED_MIN, and the
+        # transition back to pure fixed-wing never completes
         self.set_rc(3, 1800)
         self.wait_servo_channel_value(
             5,
@@ -934,7 +941,8 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.context_pop()
         self.progress("Checking qassist stops")
         # we must push RC3 here or the translational drag from the
-        # motors keeps us at ~17m/s, below the airspeed assist speed!
+        # motors keeps our airspeed below AIRSPEED_MIN, and the
+        # transition back to pure fixed-wing never completes
         self.set_rc(3, 1800)
         self.wait_servo_channel_value(
             5,
@@ -974,7 +982,8 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.context_pop()
         self.progress("Checking qassist stops")
         # we must push RC3 here or the translational drag from the
-        # motors keeps us at ~17m/s, below the airspeed assist speed!
+        # motors keeps our airspeed below AIRSPEED_MIN, and the
+        # transition back to pure fixed-wing never completes
         self.set_rc(3, 1800)
         self.wait_servo_channel_value(
             5,

--- a/libraries/AP_HAL_SITL/SITL_State.h
+++ b/libraries/AP_HAL_SITL/SITL_State.h
@@ -74,7 +74,7 @@ private:
     void _update_rangefinder();
     void _set_signal_handlers(void) const;
 
-    void _update_airspeed(float airspeed);
+    void _update_airspeed(float eas);
     void _fdm_input_local(void);
     void _output_to_flightgear(void);
     void _simulator_servos(struct sitl_input &input);

--- a/libraries/AP_HAL_SITL/sitl_airspeed.cpp
+++ b/libraries/AP_HAL_SITL/sitl_airspeed.cpp
@@ -25,13 +25,13 @@ using namespace HALSITL;
 #define PASCAL_TO_VOLTS(_p) (_p/VOLTS_TO_PASCAL)
 
 /*
-  convert airspeed in m/s to an airspeed sensor value
+  convert equivalent airspeed (EAS) in m/s to an airspeed sensor value
  */
-void SITL_State::_update_airspeed(float true_airspeed)
+void SITL_State::_update_airspeed(float eas)
 {
     for (uint8_t i=0; i<AIRSPEED_MAX_SENSORS; i++) {
         const auto &arspd = _sitl->airspeed[i];
-        float airspeed = true_airspeed / AP_Baro::get_EAS2TAS_for_alt_amsl(_sitl->state.altitude);
+        float airspeed = eas;
         const float diff_pressure = sq(airspeed) / arspd.ratio;
         float airspeed_raw;
     


### PR DESCRIPTION
### Summary

Simulated airspeed values were slightly wrong; SITL was applying the EAS2TAS conversion twice when generating them.

### Classification & Testing

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [x] Logs attached
- [ ] Logs available on request

Tested that my [AirspeedFit WebTool](https://github.com/ArduPilot/WebTools/pull/330) returns the exact same ratio as `SIM_ARSPD_RATIO` on a SITL log

### Description

`SITL_State::_update_airspeed` was designed to take a true airspeed which it was first converting to equivalent airspeed (EAS). It has one caller, and it passes `_sitl->state.airspeed`, which by [documentation](https://github.com/ArduPilot/ardupilot/blob/6d578b4ff48b589ef009aecf13da8a5f45dd0b3e/libraries/SITL/SITL.h#L73) and by [implementation](https://github.com/ArduPilot/ardupilot/blob/6d578b4ff48b589ef009aecf13da8a5f45dd0b3e/libraries/SITL/SIM_Aircraft.cpp#L1405-L1412) is already EAS (`airspeed_pitot` [directly feeds](https://github.com/ArduPilot/ardupilot/blob/6d578b4ff48b589ef009aecf13da8a5f45dd0b3e/libraries/SITL/SIM_Aircraft.cpp#L427) `fdm.airspeed`)

[before-eas-bugfix.zip](https://github.com/user-attachments/files/29993819/before-eas-bugfix.zip)
[after-eas-bugfix.zip](https://github.com/user-attachments/files/29993822/after-eas-bugfix.zip)