### PR TITLE
Improve test coverage of AP_HAL/utility functions

### DIFF
--- a/libraries/AP_HAL/utility/tests/test_better_stream.cpp
+++ b/libraries/AP_HAL/utility/tests/test_better_stream.cpp
@@ -1,0 +1,229 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <AP_gtest.h>
+
+#include <string.h>
+#include <cmath>
+
+#include <AP_HAL/utility/BetterStream.h>
+
+/*
+  minimal BetterStream implementation capturing all output and
+  feeding reads from a caller-supplied buffer.  Used to exercise both
+  the non-pure BetterStream methods and print_vprintf behind them.
+ */
+class CaptureStream : public AP_HAL::BetterStream {
+public:
+    size_t write(uint8_t b) override {
+        if (output_len < sizeof(output)-1) {
+            output[output_len++] = b;
+            output[output_len] = 0;
+        }
+        return 1;
+    }
+    size_t write(const uint8_t *buffer, size_t size) override {
+        for (size_t i=0; i<size; i++) {
+            write(buffer[i]);
+        }
+        return size;
+    }
+    using AP_HAL::BetterStream::write;
+
+    uint32_t available() override { return input_len - input_ofs; }
+    bool read(uint8_t &b) override {
+        if (input_ofs >= input_len) {
+            return false;
+        }
+        b = input[input_ofs++];
+        return true;
+    }
+    using AP_HAL::BetterStream::read;
+
+    bool discard_input() override {
+        input_ofs = input_len;
+        return true;
+    }
+    uint32_t txspace() override { return sizeof(output) - output_len; }
+
+    void set_input(const char *str) {
+        strncpy(input, str, sizeof(input)-1);
+        input_len = strlen(str);
+        input_ofs = 0;
+    }
+    void reset() {
+        output_len = 0;
+        output[0] = 0;
+        input_len = 0;
+        input_ofs = 0;
+    }
+
+    char output[512] {};
+    size_t output_len;
+    char input[64] {};
+    size_t input_len;
+    size_t input_ofs;
+};
+
+static CaptureStream stream;
+
+// printf to a fresh stream and return the captured output
+static const char *fmt_result(const char *fmt, ...) FMT_PRINTF(1, 2);
+static const char *fmt_result(const char *fmt, ...)
+{
+    stream.reset();
+    va_list ap;
+    va_start(ap, fmt);
+    stream.vprintf(fmt, ap);
+    va_end(ap);
+    return stream.output;
+}
+
+TEST(BetterStream, PrintfStrings)
+{
+    EXPECT_STREQ(fmt_result("hello, world"), "hello, world");
+    EXPECT_STREQ(fmt_result("%s", "hello"), "hello");
+    EXPECT_STREQ(fmt_result("[%10s]", "hello"), "[     hello]");
+    EXPECT_STREQ(fmt_result("[%-10s]", "hello"), "[hello     ]");
+    EXPECT_STREQ(fmt_result("%.3s", "hello"), "hel");
+    EXPECT_STREQ(fmt_result("%c", 'A'), "A");
+    EXPECT_STREQ(fmt_result("[%5c]", 'A'), "[    A]");
+    EXPECT_STREQ(fmt_result("100%%"), "100%");
+}
+
+TEST(BetterStream, PrintfIntegers)
+{
+    EXPECT_STREQ(fmt_result("%d", 0), "0");
+    EXPECT_STREQ(fmt_result("%d", 123), "123");
+    EXPECT_STREQ(fmt_result("%d", -123), "-123");
+    EXPECT_STREQ(fmt_result("%i", 45), "45");
+    EXPECT_STREQ(fmt_result("%+d", 42), "+42");
+    EXPECT_STREQ(fmt_result("% d", 42), " 42");
+    EXPECT_STREQ(fmt_result("[%5d]", 42), "[   42]");
+    EXPECT_STREQ(fmt_result("[%-5d]", 42), "[42   ]");
+    EXPECT_STREQ(fmt_result("%05d", 42), "00042");
+    EXPECT_STREQ(fmt_result("%.5d", 42), "00042");
+    EXPECT_STREQ(fmt_result("%u", 4294967295U), "4294967295");
+    EXPECT_STREQ(fmt_result("%ld", -1234567890L), "-1234567890");
+    EXPECT_STREQ(fmt_result("%lu", 4000000000LU), "4000000000");
+    EXPECT_STREQ(fmt_result("%lld", -1234567890123LL), "-1234567890123");
+    // values much beyond INT64_MAX overflow ulltoa_invert's decimal
+    // conversion (acknowledged in a comment there), so stick to this:
+    EXPECT_STREQ(fmt_result("%llu", 9223372036854775807ULL), "9223372036854775807");
+}
+
+TEST(BetterStream, PrintfBases)
+{
+    // this printf deviates from the standard: hex is always
+    // upper-case, whether via %x or %X (XTOA_UPPER is set at compile
+    // time in ultoa_invert, and doesn't fit in its uint8_t base
+    // parameter anyway)
+    EXPECT_STREQ(fmt_result("%x", 0xdeadbeefU), "DEADBEEF");
+    EXPECT_STREQ(fmt_result("%X", 0xdeadbeefU), "DEADBEEF");
+    EXPECT_STREQ(fmt_result("%#x", 0xbeefU), "0xBEEF");
+    EXPECT_STREQ(fmt_result("%#X", 0xbeefU), "0XBEEF");
+    EXPECT_STREQ(fmt_result("%o", 8U), "10");
+    EXPECT_STREQ(fmt_result("%#o", 8U), "010");
+    EXPECT_STREQ(fmt_result("%08x", 0x1fU), "0000001F");
+    EXPECT_STREQ(fmt_result("%llx", 0x123456789abcdefULL), "123456789ABCDEF");
+    EXPECT_STREQ(fmt_result("%p", (void*)0x1234), "0x1234");
+}
+
+TEST(BetterStream, PrintfFloats)
+{
+    EXPECT_STREQ(fmt_result("%f", 1.5), "1.500000");
+    EXPECT_STREQ(fmt_result("%f", 0.0), "0.000000");
+    EXPECT_STREQ(fmt_result("%.2f", 3.14159), "3.14");
+    EXPECT_STREQ(fmt_result("%.2f", -0.5), "-0.50");
+    EXPECT_STREQ(fmt_result("%.0f", 3.0), "3");
+    EXPECT_STREQ(fmt_result("%+.1f", 2.5), "+2.5");
+    EXPECT_STREQ(fmt_result("[%8.2f]", 3.5), "[    3.50]");
+    EXPECT_STREQ(fmt_result("[%-8.2f]", 3.5), "[3.50    ]");
+    EXPECT_STREQ(fmt_result("%08.2f", 3.5), "00003.50");
+    EXPECT_STREQ(fmt_result("%.3f", 0.125), "0.125");
+}
+
+TEST(BetterStream, PrintfFloatExponent)
+{
+    EXPECT_STREQ(fmt_result("%e", 1234.5), "1.234500e+03");
+    EXPECT_STREQ(fmt_result("%E", 1234.5), "1.234500E+03");
+    EXPECT_STREQ(fmt_result("%.2e", 0.00012345), "1.23e-04");
+    EXPECT_STREQ(fmt_result("%g", 0.0001), "0.0001");
+    EXPECT_STREQ(fmt_result("%g", 1234.5), "1234.5");
+    EXPECT_STREQ(fmt_result("%g", 100000.0), "100000");
+    EXPECT_STREQ(fmt_result("%g", 10000000.0), "1e+07");
+    EXPECT_STREQ(fmt_result("%G", 10000000.0), "1E+07");
+
+    // this printf deviates from the standard: %f of anything larger
+    // than 9999999 falls back to exponent notation
+    EXPECT_STREQ(fmt_result("%f", 100000000.0), "1.000000e+08");
+}
+
+TEST(BetterStream, PrintfFloatSpecials)
+{
+    EXPECT_STREQ(fmt_result("%f", (double)INFINITY), "inf");
+    EXPECT_STREQ(fmt_result("%f", (double)-INFINITY), "-inf");
+    EXPECT_STREQ(fmt_result("%F", (double)INFINITY), "INF");
+    EXPECT_STREQ(fmt_result("%f", (double)NAN), "nan");
+    EXPECT_STREQ(fmt_result("%F", (double)NAN), "NAN");
+    EXPECT_STREQ(fmt_result("[%6f]", (double)INFINITY), "[   inf]");
+    EXPECT_STREQ(fmt_result("%+f", (double)INFINITY), "+inf");
+}
+
+TEST(BetterStream, Write)
+{
+    stream.reset();
+    // write(const char*) is implemented in terms of the buffer write
+    EXPECT_EQ(stream.write("hello"), 5U);
+    EXPECT_STREQ(stream.output, "hello");
+
+    stream.reset();
+    stream.print("abc");
+    EXPECT_STREQ(stream.output, "abc");
+
+    stream.reset();
+    stream.println("abc");
+    EXPECT_STREQ(stream.output, "abc\r\n");
+}
+
+TEST(BetterStream, Read)
+{
+    stream.reset();
+    // read of an empty stream fails
+    EXPECT_EQ(stream.read(), -1);
+
+    stream.set_input("abcde");
+    EXPECT_EQ(stream.available(), 5U);
+    // single-byte read
+    EXPECT_EQ(stream.read(), 'a');
+
+    // multi-byte read
+    uint8_t buf[16] {};
+    EXPECT_EQ(stream.read(buf, 2), 2);
+    EXPECT_EQ(buf[0], 'b');
+    EXPECT_EQ(buf[1], 'c');
+
+    // a read larger than available returns only what is there
+    EXPECT_EQ(stream.read(buf, sizeof(buf)), 2);
+    EXPECT_EQ(buf[0], 'd');
+    EXPECT_EQ(buf[1], 'e');
+    EXPECT_EQ(stream.available(), 0U);
+
+    stream.set_input("xyz");
+    EXPECT_TRUE(stream.discard_input());
+    EXPECT_EQ(stream.available(), 0U);
+    EXPECT_EQ(stream.read(), -1);
+}
+
+AP_GTEST_MAIN()

--- a/libraries/AP_HAL/utility/tests/test_data_rate_limit.cpp
+++ b/libraries/AP_HAL/utility/tests/test_data_rate_limit.cpp
@@ -1,0 +1,99 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <AP_gtest.h>
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_HAL/utility/DataRateLimit.h>
+
+const AP_HAL::HAL& hal = AP_HAL::get_HAL();
+
+/*
+  DataRateLimit uses AP_HAL::micros() internally; stopping the SITL
+  scheduler clock makes time - and thus these tests - deterministic
+ */
+static uint64_t now_us = 1000000;
+
+static void set_time(uint64_t t_us)
+{
+    now_us = t_us;
+    hal.scheduler->stop_clock(now_us);
+}
+
+static void advance_time(uint64_t dt_us)
+{
+    set_time(now_us + dt_us);
+}
+
+TEST(DataRateLimit, Basic)
+{
+    set_time(1000000);
+    DataRateLimit limit {};
+
+    // first call has seen 1 second elapse since construction (time
+    // zero), so a 1000 byte/s limit yields 1000 bytes
+    EXPECT_EQ(limit.max_bytes(1000.0f), 1000U);
+
+    // no time elapsed, no bytes allowed
+    EXPECT_EQ(limit.max_bytes(1000.0f), 0U);
+
+    // half a second at 1000 bytes/s
+    advance_time(500000);
+    EXPECT_EQ(limit.max_bytes(1000.0f), 500U);
+
+    // 1ms at 1000 bytes/s is a single byte
+    advance_time(1000);
+    EXPECT_EQ(limit.max_bytes(1000.0f), 1U);
+}
+
+TEST(DataRateLimit, ZeroRate)
+{
+    set_time(2000000);
+    DataRateLimit limit {};
+
+    EXPECT_EQ(limit.max_bytes(0.0f), 0U);
+    advance_time(1000000);
+    EXPECT_EQ(limit.max_bytes(0.0f), 0U);
+}
+
+TEST(DataRateLimit, RemainderAccumulates)
+{
+    set_time(3000000);
+    DataRateLimit limit {};
+    // flush the time since construction
+    limit.max_bytes(5.0f);
+
+    // 5 bytes/s polled every 100ms is 0.5 bytes per call; the
+    // fractional part must carry over rather than being lost
+    uint32_t total = 0;
+    for (uint8_t i=0; i<10; i++) {
+        advance_time(100000);
+        const uint32_t n = limit.max_bytes(5.0f);
+        EXPECT_LE(n, 1U);
+        total += n;
+    }
+    EXPECT_EQ(total, 5U);
+}
+
+TEST(DataRateLimit, HighRate)
+{
+    set_time(5000000);
+    DataRateLimit limit {};
+    limit.max_bytes(1.0e6f);
+
+    advance_time(1000000);
+    EXPECT_EQ(limit.max_bytes(1.0e6f), 1000000U);
+}
+
+AP_GTEST_MAIN()

--- a/libraries/AP_HAL/utility/tests/test_dsm.cpp
+++ b/libraries/AP_HAL/utility/tests/test_dsm.cpp
@@ -1,0 +1,231 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <AP_gtest.h>
+
+#include <string.h>
+
+#include <AP_Common/AP_Common.h>
+#include <AP_HAL/utility/dsm.h>
+
+/*
+  dsm_decode keeps static state for its 10/11-bit format guessing; a
+  gap of more than one second between frames resets that state.  Each
+  test uses advance_time() to get a fresh decoder state.
+ */
+static uint64_t frame_time_us;
+
+static void advance_time(void)
+{
+    frame_time_us += 2000000;
+}
+
+// number of consecutive frames the format-guesser must see before it
+// locks on (5 samples, then decoding starts on the next frame)
+static const uint8_t GUESS_FRAMES = 6;
+
+// build a frame of 7 channels in 11-bit format; channel numbers
+// 0..6, all with the given raw value
+static void build_11bit_frame(uint8_t frame[16], const uint16_t raw_value)
+{
+    frame[0] = 0;
+    frame[1] = 0;
+    for (uint8_t ch=0; ch<7; ch++) {
+        const uint16_t raw = (ch << 11) | (raw_value & 0x7ff);
+        frame[2 + 2*ch] = raw >> 8;
+        frame[2 + 2*ch + 1] = raw & 0xff;
+    }
+}
+
+// build a frame of 7 channels in 10-bit format
+static void build_10bit_frame(uint8_t frame[16], const uint16_t raw_value)
+{
+    frame[0] = 0;
+    frame[1] = 0;
+    for (uint8_t ch=0; ch<7; ch++) {
+        const uint16_t raw = (ch << 10) | (raw_value & 0x3ff);
+        frame[2 + 2*ch] = raw >> 8;
+        frame[2 + 2*ch + 1] = raw & 0xff;
+    }
+}
+
+// feed the same frame until the format guesser locks on, then decode
+static bool train_and_decode(const uint8_t frame[16],
+                             uint16_t *values,
+                             uint16_t *num_values,
+                             uint16_t max_values)
+{
+    bool ret = false;
+    for (uint8_t i=0; i<GUESS_FRAMES+1; i++) {
+        frame_time_us += 11000;
+        ret = dsm_decode(frame_time_us, frame, values, num_values, max_values);
+    }
+    return ret;
+}
+
+// the DSM value scaling used by dsm_decode for 11-bit data
+static uint16_t expected_value_11bit(uint16_t raw)
+{
+    return ((((int)raw - 1024) * 1000) / 1700) + 1500;
+}
+
+TEST(DSMTest, Decode11Bit)
+{
+    advance_time();
+
+    uint8_t frame[16];
+    const uint16_t raw = 1024;  // mid-point
+    build_11bit_frame(frame, raw);
+
+    uint16_t values[16] {};
+    uint16_t num_values = 0;
+
+    EXPECT_TRUE(train_and_decode(frame, values, &num_values, ARRAY_SIZE(values)));
+    EXPECT_EQ(num_values, 7);
+
+    // 1024 scales to exactly the centered mid-point
+    for (uint8_t ch=0; ch<7; ch++) {
+        EXPECT_EQ(values[ch], 1500) << "channel " << (unsigned)ch;
+    }
+}
+
+TEST(DSMTest, GuessingReturnsFalse)
+{
+    advance_time();
+
+    uint8_t frame[16];
+    build_11bit_frame(frame, 1024);
+
+    uint16_t values[16] {};
+    uint16_t num_values = 0;
+
+    // while the format guesser has not locked on, no frame decodes
+    for (uint8_t i=0; i<GUESS_FRAMES; i++) {
+        frame_time_us += 11000;
+        EXPECT_FALSE(dsm_decode(frame_time_us, frame, values, &num_values, ARRAY_SIZE(values)));
+    }
+    // ... and the next frame does
+    frame_time_us += 11000;
+    EXPECT_TRUE(dsm_decode(frame_time_us, frame, values, &num_values, ARRAY_SIZE(values)));
+}
+
+TEST(DSMTest, ChannelMapping)
+{
+    advance_time();
+
+    // give each channel a distinct value so the AETR reordering is visible
+    uint8_t frame[16];
+    frame[0] = 0;
+    frame[1] = 0;
+    const uint16_t raws[7] { 1024, 1124, 1224, 1324, 1424, 1524, 1624 };
+    for (uint8_t ch=0; ch<7; ch++) {
+        const uint16_t raw = (ch << 11) | raws[ch];
+        frame[2 + 2*ch] = raw >> 8;
+        frame[2 + 2*ch + 1] = raw & 0xff;
+    }
+
+    uint16_t values[16] {};
+    uint16_t num_values = 0;
+    EXPECT_TRUE(train_and_decode(frame, values, &num_values, ARRAY_SIZE(values)));
+    EXPECT_EQ(num_values, 7);
+
+    // DSM channel order is TAER; ArduPilot buffer order is AETR:
+    // DSM channel 0 (throttle) lands in slot 2, 1 in slot 0, 2 in slot 1
+    EXPECT_EQ(values[2], expected_value_11bit(raws[0]));
+    EXPECT_EQ(values[0], expected_value_11bit(raws[1]));
+    EXPECT_EQ(values[1], expected_value_11bit(raws[2]));
+    // channels 3 and up are not remapped
+    for (uint8_t ch=3; ch<7; ch++) {
+        EXPECT_EQ(values[ch], expected_value_11bit(raws[ch])) << "channel " << (unsigned)ch;
+    }
+}
+
+TEST(DSMTest, Decode10Bit)
+{
+    advance_time();
+
+    uint8_t frame[16];
+    const uint16_t raw = 512;  // 10-bit mid-point
+    build_10bit_frame(frame, raw);
+
+    uint16_t values[16] {};
+    uint16_t num_values = 0;
+
+    EXPECT_TRUE(train_and_decode(frame, values, &num_values, ARRAY_SIZE(values)));
+    EXPECT_EQ(num_values, 7);
+
+    // 10-bit values are doubled before scaling, so 512 -> 1024 -> 1500
+    for (uint8_t ch=0; ch<7; ch++) {
+        EXPECT_EQ(values[ch], 1500) << "channel " << (unsigned)ch;
+    }
+}
+
+TEST(DSMTest, ChannelsBeyondMaxValuesIgnored)
+{
+    advance_time();
+
+    uint8_t frame[16];
+    build_11bit_frame(frame, 1024);
+
+    // only 4 slots available; channels 4..6 must be dropped rather
+    // than written out-of-bounds
+    uint16_t values[4] {};
+    uint16_t num_values = 0;
+
+    EXPECT_TRUE(train_and_decode(frame, values, &num_values, ARRAY_SIZE(values)));
+    EXPECT_EQ(num_values, 4);
+    for (uint8_t ch=0; ch<4; ch++) {
+        EXPECT_EQ(values[ch], 1500) << "channel " << (unsigned)ch;
+    }
+}
+
+TEST(DSMTest, AllOnesChannelsSkipped)
+{
+    advance_time();
+
+    // 0xffff raw channel data must not decode
+    uint8_t frame[16];
+    memset(frame, 0xff, sizeof(frame));
+
+    uint16_t values[16] {};
+    uint16_t num_values = 0;
+
+    // the format guesser can never lock onto all-0xffff frames, so
+    // decoding never succeeds
+    for (uint8_t i=0; i<GUESS_FRAMES*3; i++) {
+        frame_time_us += 11000;
+        EXPECT_FALSE(dsm_decode(frame_time_us, frame, values, &num_values, ARRAY_SIZE(values)));
+    }
+    EXPECT_EQ(num_values, 0);
+}
+
+TEST(DSMTest, SignalLossResetsFormatGuess)
+{
+    advance_time();
+
+    uint8_t frame[16];
+    build_11bit_frame(frame, 1024);
+
+    uint16_t values[16] {};
+    uint16_t num_values = 0;
+    EXPECT_TRUE(train_and_decode(frame, values, &num_values, ARRAY_SIZE(values)));
+
+    // more than 1s of signal loss must reset the format guess, so
+    // the next frame goes back to training
+    advance_time();
+    frame_time_us += 11000;
+    EXPECT_FALSE(dsm_decode(frame_time_us, frame, values, &num_values, ARRAY_SIZE(values)));
+}
+
+AP_GTEST_MAIN()

--- a/libraries/AP_HAL/utility/tests/test_getopt.cpp
+++ b/libraries/AP_HAL/utility/tests/test_getopt.cpp
@@ -1,0 +1,168 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <AP_gtest.h>
+
+#include <AP_Common/AP_Common.h>
+#include <AP_HAL/utility/getopt_cpp.h>
+
+static int flag_value;
+
+static const GetOptLong::option longopts[] = {
+    {"help",    false, nullptr,     'h'},
+    {"level",   true,  nullptr,     'L'},
+    {"setflag", false, &flag_value, 42},
+    {nullptr,   false, nullptr,     0},
+};
+
+static const char *optstring = "hvL:";
+
+#define MAKE_ARGS(...) \
+    const char *argv[] { "prog", __VA_ARGS__ }; \
+    GetOptLong gopt(ARRAY_SIZE(argv), (char* const*)argv, optstring, longopts)
+
+TEST(GetOptLong, ShortOption)
+{
+    MAKE_ARGS("-h");
+    EXPECT_EQ(gopt.getoption(), 'h');
+    EXPECT_EQ(gopt.getoption(), -1);
+    EXPECT_EQ(gopt.optind, 2);
+}
+
+TEST(GetOptLong, ShortOptionArgAttached)
+{
+    MAKE_ARGS("-Lfive");
+    EXPECT_EQ(gopt.getoption(), 'L');
+    EXPECT_STREQ(gopt.optarg, "five");
+    EXPECT_EQ(gopt.getoption(), -1);
+}
+
+TEST(GetOptLong, ShortOptionArgSeparate)
+{
+    MAKE_ARGS("-L", "five");
+    EXPECT_EQ(gopt.getoption(), 'L');
+    EXPECT_STREQ(gopt.optarg, "five");
+    EXPECT_EQ(gopt.optind, 3);
+    EXPECT_EQ(gopt.getoption(), -1);
+}
+
+TEST(GetOptLong, CombinedShortOptions)
+{
+    MAKE_ARGS("-hv");
+    EXPECT_EQ(gopt.getoption(), 'h');
+    EXPECT_EQ(gopt.getoption(), 'v');
+    EXPECT_EQ(gopt.getoption(), -1);
+}
+
+TEST(GetOptLong, UnknownShortOption)
+{
+    MAKE_ARGS("-z");
+    EXPECT_EQ(gopt.getoption(), GetOptLong::BADCH);
+    EXPECT_EQ(gopt.optopt, 'z');
+}
+
+TEST(GetOptLong, ShortOptionMissingArg)
+{
+    MAKE_ARGS("-L");
+    EXPECT_EQ(gopt.getoption(), GetOptLong::BADCH);
+}
+
+TEST(GetOptLong, ShortOptionMissingArgColon)
+{
+    const char *argv[] { "prog", "-L" };
+    GetOptLong gopt(ARRAY_SIZE(argv), (char* const*)argv, ":hL:", longopts);
+    EXPECT_EQ(gopt.getoption(), GetOptLong::BADARG);
+}
+
+TEST(GetOptLong, LongOption)
+{
+    MAKE_ARGS("--help");
+    EXPECT_EQ(gopt.getoption(), 'h');
+    EXPECT_EQ(gopt.longindex, 0);
+    EXPECT_EQ(gopt.getoption(), -1);
+}
+
+TEST(GetOptLong, LongOptionArgEquals)
+{
+    MAKE_ARGS("--level=5");
+    EXPECT_EQ(gopt.getoption(), 'L');
+    EXPECT_STREQ(gopt.optarg, "5");
+    EXPECT_EQ(gopt.longindex, 1);
+    EXPECT_EQ(gopt.getoption(), -1);
+}
+
+TEST(GetOptLong, LongOptionArgSeparate)
+{
+    MAKE_ARGS("--level", "5");
+    EXPECT_EQ(gopt.getoption(), 'L');
+    EXPECT_STREQ(gopt.optarg, "5");
+    EXPECT_EQ(gopt.getoption(), -1);
+}
+
+TEST(GetOptLong, LongOptionFlag)
+{
+    flag_value = 0;
+    MAKE_ARGS("--setflag");
+    EXPECT_EQ(gopt.getoption(), 0);
+    EXPECT_EQ(flag_value, 42);
+}
+
+TEST(GetOptLong, UnknownLongOption)
+{
+    MAKE_ARGS("--bogus");
+    EXPECT_EQ(gopt.getoption(), GetOptLong::BADCH);
+    EXPECT_EQ(gopt.optind, 2);
+}
+
+TEST(GetOptLong, LongOptionMissingArg)
+{
+    MAKE_ARGS("--level");
+    EXPECT_EQ(gopt.getoption(), GetOptLong::BADCH);
+}
+
+TEST(GetOptLong, LongOptionMissingArgColon)
+{
+    const char *argv[] { "prog", "--level" };
+    GetOptLong gopt(ARRAY_SIZE(argv), (char* const*)argv, ":hL:", longopts);
+    EXPECT_EQ(gopt.getoption(), GetOptLong::BADARG);
+}
+
+TEST(GetOptLong, DoubleDashTerminates)
+{
+    MAKE_ARGS("--", "-h");
+    EXPECT_EQ(gopt.getoption(), -1);
+    // "--" itself is consumed, leaving optind at the first operand
+    EXPECT_EQ(gopt.optind, 2);
+}
+
+TEST(GetOptLong, NonOptionStopsParsing)
+{
+    MAKE_ARGS("foo", "-h");
+    EXPECT_EQ(gopt.getoption(), -1);
+    EXPECT_EQ(gopt.optind, 1);
+}
+
+TEST(GetOptLong, MixedOptions)
+{
+    MAKE_ARGS("-h", "--level=3", "-L", "x", "rest");
+    EXPECT_EQ(gopt.getoption(), 'h');
+    EXPECT_EQ(gopt.getoption(), 'L');
+    EXPECT_STREQ(gopt.optarg, "3");
+    EXPECT_EQ(gopt.getoption(), 'L');
+    EXPECT_STREQ(gopt.optarg, "x");
+    EXPECT_EQ(gopt.getoption(), -1);
+    EXPECT_EQ(gopt.optind, 5);
+}
+
+AP_GTEST_MAIN()

--- a/libraries/AP_HAL/utility/tests/test_replace.cpp
+++ b/libraries/AP_HAL/utility/tests/test_replace.cpp
@@ -1,0 +1,79 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <AP_gtest.h>
+
+#include <AP_HAL/AP_HAL.h>
+
+#ifdef HAVE_MEMRCHR
+// this build's libc provides memrchr, so replace.cpp compiles to
+// nothing; compile the replacement here so it can be tested
+#undef HAVE_MEMRCHR
+#include <AP_HAL/utility/replace.cpp>
+#else
+#include <AP_HAL/utility/replace.h>
+#endif
+
+TEST(ReplaceMemrchr, LastOccurrence)
+{
+    char buf[] = "abcabc";
+    void *ret = replace_memrchr(buf, 'b', 6);
+    EXPECT_EQ(ret, &buf[4]);
+}
+
+TEST(ReplaceMemrchr, SingleOccurrence)
+{
+    char buf[] = "abcdef";
+    void *ret = replace_memrchr(buf, 'c', 6);
+    EXPECT_EQ(ret, &buf[2]);
+}
+
+TEST(ReplaceMemrchr, FirstByte)
+{
+    char buf[] = "abcdef";
+    void *ret = replace_memrchr(buf, 'a', 6);
+    EXPECT_EQ(ret, &buf[0]);
+}
+
+TEST(ReplaceMemrchr, NotFound)
+{
+    char buf[] = "abcdef";
+    EXPECT_EQ(replace_memrchr(buf, 'z', 6), nullptr);
+}
+
+TEST(ReplaceMemrchr, ZeroLength)
+{
+    char buf[] = "abcdef";
+    EXPECT_EQ(replace_memrchr(buf, 'a', 0), nullptr);
+}
+
+TEST(ReplaceMemrchr, RespectsLength)
+{
+    // 'e' is present, but beyond the searched length
+    char buf[] = "abcdef";
+    EXPECT_EQ(replace_memrchr(buf, 'e', 3), nullptr);
+    // last occurrence within the searched length is found
+    char buf2[] = "aabaa";
+    EXPECT_EQ(replace_memrchr(buf2, 'a', 2), &buf2[1]);
+}
+
+TEST(ReplaceMemrchr, CharConversion)
+{
+    // the int argument must be converted to unsigned char for comparison
+    uint8_t buf[] = { 0x00, 0xff, 0x00 };
+    EXPECT_EQ(replace_memrchr(buf, 0xff, 3), &buf[1]);
+    EXPECT_EQ(replace_memrchr(buf, (int)0xffffffff, 3), &buf[1]);
+}
+
+AP_GTEST_MAIN()

--- a/libraries/AP_HAL/utility/tests/test_ringbuffer.cpp
+++ b/libraries/AP_HAL/utility/tests/test_ringbuffer.cpp
@@ -16,6 +16,7 @@
  */
 #include <AP_gtest.h>
 
+#include <string.h>
 #include <utility>
 #include <AP_HAL/utility/RingBuffer.h>
 
@@ -100,6 +101,68 @@ TEST(ObjectBufferTest, SetSize)
     EXPECT_EQ(x.get_size(), unsigned(size));
     EXPECT_EQ(x.space(), unsigned(size));
     EXPECT_TRUE(x.is_empty());
+}
+
+TEST(ByteBufferTest, ReadByte)
+{
+    ByteBuffer x{32};
+    uint8_t b = 0;
+
+    // read of an empty buffer fails
+    EXPECT_FALSE(x.read_byte(&b));
+    // as does a read into nullptr
+    EXPECT_FALSE(x.read_byte(nullptr));
+
+    EXPECT_EQ(x.write((const uint8_t *)"ab", 2), 2U);
+    EXPECT_TRUE(x.read_byte(&b));
+    EXPECT_EQ(b, 'a');
+    EXPECT_TRUE(x.read_byte(&b));
+    EXPECT_EQ(b, 'b');
+    EXPECT_TRUE(x.is_empty());
+}
+
+TEST(ByteBufferTest, Update)
+{
+    ByteBuffer x{8};
+
+    EXPECT_EQ(x.write((const uint8_t *)"abcd", 4), 4U);
+
+    // can't update more bytes than are stored
+    EXPECT_FALSE(x.update((const uint8_t *)"WXYZ!", 5));
+
+    // update the head of the buffer without popping
+    EXPECT_TRUE(x.update((const uint8_t *)"XY", 2));
+    uint8_t buf[8] {};
+    EXPECT_EQ(x.peekbytes(buf, 4), 4U);
+    EXPECT_STREQ((char*)buf, "XYcd");
+
+    // move the read pointer near the end of the 8-byte backing
+    // buffer, then write and update data wrapping around the end
+    EXPECT_EQ(x.read(buf, 4), 4U);
+    EXPECT_EQ(x.write((const uint8_t *)"efghij", 6), 6U);
+    EXPECT_TRUE(x.update((const uint8_t *)"EFGHIJ", 6));
+    memset(buf, 0, sizeof(buf));
+    EXPECT_EQ(x.read(buf, 6), 6U);
+    EXPECT_STREQ((char*)buf, "EFGHIJ");
+}
+
+TEST(ByteBufferTest, SetSizeBest)
+{
+    ByteBuffer x{32};
+    EXPECT_TRUE(x.set_size_best(64));
+    EXPECT_EQ(x.get_size(), 64U);
+
+    // an external buffer can't be resized, so every candidate size
+    // is refused
+    uint8_t backing[16];
+    ByteBuffer ext{backing, sizeof(backing)};
+    EXPECT_FALSE(ext.set_size_best(64));
+
+    // ... but reads and writes work as normal
+    EXPECT_EQ(ext.write((const uint8_t *)"abc", 3), 3U);
+    uint8_t buf[4] {};
+    EXPECT_EQ(ext.read(buf, sizeof(buf)), 3U);
+    EXPECT_STREQ((char*)buf, "abc");
 }
 
 TEST(ObjectBufferTest, PeekTest)

--- a/libraries/AP_HAL/utility/utoa_invert.cpp
+++ b/libraries/AP_HAL/utility/utoa_invert.cpp
@@ -34,7 +34,7 @@
 char * ultoa_invert (uint32_t val, char *s, uint8_t base) {
 	if (base == 8) {
 		do {
-			*s = '0' + (val & 0x7);
+			*s++ = '0' + (val & 0x7);
 			val >>= 3;
 		} while(val);
 		return s;
@@ -79,7 +79,7 @@ char * ultoa_invert (uint32_t val, char *s, uint8_t base) {
 char * ulltoa_invert (uint64_t val, char *s, uint8_t base) {
 	if (base == 8) {
 		do {
-			*s = '0' + (val & 0x7);
+			*s++ = '0' + (val & 0x7);
 			val >>= 3;
 		} while(val);
 		return s;


### PR DESCRIPTION
### Summary

Adds unit tests for more utility functions and improves coverage where we already have some

Also fixes a bug when formatting octal numbers.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

More unit tests.

One bug fix.  Nothing in-tree crosses the octal path (but it's format string stuff so a user could try to use it in a debug printf or whatever).    Bug has been in-tree since 2013.
