### PR TITLE
Avoid use of uninitialised values in m/cm conversion code

### DIFF
--- a/libraries/AC_WPNav/AC_Circle.cpp
+++ b/libraries/AC_WPNav/AC_Circle.cpp
@@ -289,9 +289,10 @@ bool AC_Circle::update_ms(float climb_rate_ms)
 // See get_closest_point_on_circle_NED_m() for full details.
 void AC_Circle::get_closest_point_on_circle_NEU_cm(Vector3f& result_neu_cm, float& dist_cm) const
 {
-    // Convert input arguments from neu cm to ned meters
-    Vector3p result_ned_m = Vector3p{result_neu_cm.x, result_neu_cm.y, -result_neu_cm.z} * 0.01;
-    float dist_m = dist_cm * 0.01;
+    // result_neu_cm and dist_cm are outputs only; do not read the caller's
+    // values here, callers may pass them in uninitialised
+    Vector3p result_ned_m;
+    float dist_m;
 
     // Compute closest point in meters
     get_closest_point_on_circle_NED_m(result_ned_m, dist_m);

--- a/libraries/AC_WPNav/AC_Circle.cpp
+++ b/libraries/AC_WPNav/AC_Circle.cpp
@@ -289,8 +289,6 @@ bool AC_Circle::update_ms(float climb_rate_ms)
 // See get_closest_point_on_circle_NED_m() for full details.
 void AC_Circle::get_closest_point_on_circle_NEU_cm(Vector3f& result_neu_cm, float& dist_cm) const
 {
-    // result_neu_cm and dist_cm are outputs only; do not read the caller's
-    // values here, callers may pass them in uninitialised
     Vector3p result_ned_m;
     float dist_m;
 

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -487,8 +487,7 @@ bool AC_WPNav::set_wp_destination_next_NED_m(const Vector3p& destination_ned_m, 
 // See get_wp_stopping_point_NE_m() for full details.
 void AC_WPNav::get_wp_stopping_point_NE_cm(Vector2f& stopping_point_ne_cm) const
 {
-    // convert input/output to meters to match internal representation
-    Vector2p stopping_point_ne_m = stopping_point_ne_cm.topostype() * 0.01;
+    Vector2p stopping_point_ne_m;
     get_wp_stopping_point_NE_m(stopping_point_ne_m);
     stopping_point_ne_cm = stopping_point_ne_m.tofloat() * 100.0;
 }
@@ -505,8 +504,7 @@ void AC_WPNav::get_wp_stopping_point_NE_m(Vector2p& stopping_point_ne_m) const
 // See get_wp_stopping_point_NED_m() for full details.
 void AC_WPNav::get_wp_stopping_point_NEU_cm(Vector3f& stopping_point_neu_cm) const
 {
-    // convert input from cm to m for internal calculation
-    Vector3p stopping_point_ned_m = Vector3p(stopping_point_neu_cm.x, stopping_point_neu_cm.y, -stopping_point_neu_cm.z) * 0.01;
+    Vector3p stopping_point_ned_m;
     // compute stopping point using meters
     get_wp_stopping_point_NED_m(stopping_point_ned_m);
     // convert result back to centimeters


### PR DESCRIPTION
### Summary

Avoids a SIGFPE problem in SITL if a passed-in uninitialised value happens to be NaN

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

`dist_cm` can come in off the stack with whatever value, including NaN.  Multiplying by that as part of initialialisation can then cause an FPE.

Also removes similar conversion code on parameters which are, in fact, only output parameters, not input parameters!
