### PR TITLE
SITL: NAK unknown commands in simulated TSYS01

### DIFF
--- a/libraries/SITL/SIM_Temperature_TSYS01.cpp
+++ b/libraries/SITL/SIM_Temperature_TSYS01.cpp
@@ -75,6 +75,12 @@ int SITL::TSYS01::rdwr(I2C::i2c_rdwr_ioctl_data *&data)
             }
             break;
         }
+        default:
+            // NAK commands we do not understand.  The MS5611 probe
+            // sends us prom reads for words 6 and 7 (0xAC and 0xAE);
+            // failing the transfer here ensures the response buffer
+            // is not returned uninitialised.
+            return -1;
         }
         return 0;
     }
@@ -106,6 +112,9 @@ int SITL::TSYS01::rdwr(I2C::i2c_rdwr_ioctl_data *&data)
             break;
         case Command::READ_ADC:
             AP_HAL::panic("bad READ_ADC");
+        default:
+            // NAK commands we do not understand
+            return -1;
         }
         return 0;
     }


### PR DESCRIPTION
### Summary

Stop returning success while not initialising a buffer in simulated baro driver

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

ArduSub sets BARO_EXT_BUS 1, so AP_Baro::init probes for an MS5611 at address 0x77 on bus 1 - where the SITL I2C bus places the simulated TSYS01.  The MS5611 driver reads eight PROM words (commands 0xA0..0xAE) but the simulator only understands 0xA0..0xAA; commands 0xAC and 0xAE fell through the switch without filling the response buffer and the transfer was reported as successful, so the driver ran its PROM CRC check over uninitialised stack bytes.  Valgrind reports this and fails any --valgrind autotest run; worse, roughly one boot in sixteen the garbage passes the CRC-4 check and a phantom MS5611 barometer is registered using TSYS01 PROM data as calibration.

Fail the transfer instead, as a real device would NAK.  The driver then sees zeroes for words 6 and 7 and the CRC check fails deterministically, so the MS5611 probe is always cleanly rejected.

