### PR TITLE
ArduPilot 4.7.0 release

### DIFF
--- a/AntennaTracker/ReleaseNotes.txt
+++ b/AntennaTracker/ReleaseNotes.txt
@@ -1,6 +1,6 @@
 ArduPilot Antenna Tracker Release Notes:
 ------------------------------------------------------------------
-Release 4.7.0-beta8 13-July-2026
+Release 4.7.0 21-July-2026/ 4.7.0-beta8 13-July-2026
 
 Changes from 4.7.0-beta7
 

--- a/AntennaTracker/version.h
+++ b/AntennaTracker/version.h
@@ -6,15 +6,15 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "AntennaTracker V4.7.0-beta8"
+#define THISFIRMWARE "AntennaTracker V4.7.0"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,7,0,FIRMWARE_VERSION_TYPE_BETA+7
+#define FIRMWARE_VERSION 4,7,0,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 7
 #define FW_PATCH 0
-#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA
+#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>
 #include <AP_CheckFirmware/AP_CheckFirmwareDefine.h>

--- a/ArduCopter/ReleaseNotes.txt
+++ b/ArduCopter/ReleaseNotes.txt
@@ -1,6 +1,6 @@
 ArduPilot Copter Release Notes:
 ------------------------------------------------------------------
-Release 4.7.0-beta8 13-July-2026
+Release 4.7.0 21-July-2026/ 4.7.0-beta8 13-July-2026
 
 Changes from 4.7.0-beta7
 

--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -6,15 +6,15 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduCopter V4.7.0-beta8"
+#define THISFIRMWARE "ArduCopter V4.7.0"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,7,0,FIRMWARE_VERSION_TYPE_BETA+7
+#define FIRMWARE_VERSION 4,7,0,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 7
 #define FW_PATCH 0
-#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA
+#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>
 #include <AP_CheckFirmware/AP_CheckFirmwareDefine.h>

--- a/ArduPlane/ReleaseNotes.txt
+++ b/ArduPlane/ReleaseNotes.txt
@@ -1,6 +1,6 @@
 ArduPilot Plane Release Notes:
 ------------------------------------------------------------------
-Release 4.7.0-beta8 13-July-2026
+Release 4.7.0 21-July-2026/ 4.7.0-beta8 13-July-2026
 
 Changes from 4.7.0-beta7
 

--- a/ArduPlane/version.h
+++ b/ArduPlane/version.h
@@ -6,15 +6,15 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduPlane V4.7.0-beta8"
+#define THISFIRMWARE "ArduPlane V4.7.0"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,7,0,FIRMWARE_VERSION_TYPE_BETA+7
+#define FIRMWARE_VERSION 4,7,0,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 7
 #define FW_PATCH 0
-#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA
+#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>
 #include <AP_CheckFirmware/AP_CheckFirmwareDefine.h>

--- a/ArduSub/ReleaseNotes.txt
+++ b/ArduSub/ReleaseNotes.txt
@@ -1,6 +1,6 @@
 ArduPilot Sub Release Notes:
 ------------------------------------------------------------------
-Release 4.7.0-beta8 13-July-2026
+Release 4.7.0 21-July-2026/ 4.7.0-beta8 13-July-2026
 
 Changes from 4.7.0-beta7
 

--- a/ArduSub/version.h
+++ b/ArduSub/version.h
@@ -6,15 +6,15 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduSub V4.7.0-beta8"
+#define THISFIRMWARE "ArduSub V4.7.0"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,7,0,FIRMWARE_VERSION_TYPE_BETA+7
+#define FIRMWARE_VERSION 4,7,0,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 7
 #define FW_PATCH 0
-#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA
+#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>
 #include <AP_CheckFirmware/AP_CheckFirmwareDefine.h>

--- a/Rover/ReleaseNotes.txt
+++ b/Rover/ReleaseNotes.txt
@@ -1,6 +1,6 @@
 ArduPilot Rover Release Notes:
 ------------------------------------------------------------------
-Release 4.7.0-beta8 13-July-2026
+Release 4.7.0 21-July-2026/ 4.7.0-beta8 13-July-2026
 
 Changes from 4.7.0-beta7
 

--- a/Rover/version.h
+++ b/Rover/version.h
@@ -6,15 +6,15 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduRover V4.7.0-beta8"
+#define THISFIRMWARE "ArduRover V4.7.0"
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,7,0,FIRMWARE_VERSION_TYPE_BETA+7
+#define FIRMWARE_VERSION 4,7,0,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 7
 #define FW_PATCH 0
-#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA
+#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>
 #include <AP_CheckFirmware/AP_CheckFirmwareDefine.h>

--- a/Tools/AP_Periph/ReleaseNotes.txt
+++ b/Tools/AP_Periph/ReleaseNotes.txt
@@ -1,6 +1,6 @@
 ArduPilot AP_Periph Release Notes
 ------------------------------------------------------------------
-Release 4.7.0-beta8 13-July-2026
+Release 4.7.0 21-July-2026/ 4.7.0-beta8 13-July-2026
 
 Changes from 4.7.0-beta7
 

--- a/Tools/AP_Periph/version.h
+++ b/Tools/AP_Periph/version.h
@@ -7,7 +7,7 @@
 #include "ap_version.h"
 #include <AP_HAL/AP_HAL.h>
 
-#define THISFIRMWARE "AP_Periph 4.7.0-beta8"
+#define THISFIRMWARE "AP_Periph 4.7.0"
 
 // defines needed due to lack of GCS includes
 #ifndef HAVE_ENUM_FIRMWARE_VERSION_TYPE
@@ -17,12 +17,12 @@
 #endif
 
 // the following line is parsed by the autotest scripts
-#define FIRMWARE_VERSION 4,7,0,FIRMWARE_VERSION_TYPE_BETA+7
+#define FIRMWARE_VERSION 4,7,0,FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #define FW_MAJOR 4
 #define FW_MINOR 7
 #define FW_PATCH 0
-#define FW_TYPE FIRMWARE_VERSION_TYPE_BETA
+#define FW_TYPE FIRMWARE_VERSION_TYPE_OFFICIAL
 
 #include <AP_Common/AP_FWVersionDefine.h>
 #include <AP_CheckFirmware/AP_CheckFirmwareDefine.h>


### PR DESCRIPTION
### Summary

Identical to 4.7.0-beta8. Bumping version numbers and release notes only.
