### PR TITLE
Remove reset values from AHRS outputs

### DIFF
--- a/ArduCopter/ekf_check.cpp
+++ b/ArduCopter/ekf_check.cpp
@@ -248,8 +248,7 @@ void Copter::failsafe_ekf_recheck()
 void Copter::check_ekf_reset()
 {
     // check for yaw reset
-    float yaw_angle_change_rad;
-    const uint16_t new_yaw_reset_count = ahrs.get_yaw_reset_count(yaw_angle_change_rad);
+    const uint16_t new_yaw_reset_count = ahrs.get_yaw_reset_count();
     if (new_yaw_reset_count != ahrs_yaw_reset_count) {
         attitude_control->inertial_frame_reset();
         ahrs_yaw_reset_count = new_yaw_reset_count;

--- a/ArduPlane/Attitude.cpp
+++ b/ArduPlane/Attitude.cpp
@@ -763,8 +763,7 @@ void Plane::check_ahrs_reset()
     bool should_reset = false;
 
     // Check for yaw reset
-    float yaw_angle_change_rad;
-    const uint16_t new_yaw_reset_count = ahrs.get_yaw_reset_count(yaw_angle_change_rad);
+    const uint16_t new_yaw_reset_count = ahrs.get_yaw_reset_count();
     if (ahrs_check.ahrs_yaw_reset_count != new_yaw_reset_count) {
         should_reset = true;
         ahrs_check.ahrs_yaw_reset_count = new_yaw_reset_count;

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2305,8 +2305,7 @@ void QuadPlane::PosControlState::set_state(enum position_control_state s)
             qp.thr_ctrl_land = false;
         } else if (s == QPOS_LAND_FINAL) {
             // remember last pos reset to handle GPS glitch in LAND_FINAL
-            Vector2f rpos;
-            ahrs_position_NE_reset_count = plane.ahrs.get_position_NE_reset_count(rpos);
+            ahrs_position_NE_reset_count = plane.ahrs.get_position_NE_reset_count();
             qp.landing_detect.land_start_ms = 0;
             qp.landing_detect.lower_limit_start_ms = 0;
         }
@@ -2761,8 +2760,7 @@ void QuadPlane::vtol_position_controller(void)
         } else {
             Vector2f zero;
             Vector2f vel_ne_ms = poscontrol.target_vel_ms.xy() + landing_velocity_ne_ms;
-            Vector2f rpos;
-            const uint16_t last_reset_count = plane.ahrs.get_position_NE_reset_count(rpos);
+            const uint16_t last_reset_count = plane.ahrs.get_position_NE_reset_count();
             /* we use velocity control when we may be touching the
               ground or if we've had a position reset from AHRS. This
               helps us handle a GPS glitch in the final land phase,

--- a/ArduSub/Attitude.cpp
+++ b/ArduSub/Attitude.cpp
@@ -43,8 +43,7 @@ float Sub::get_pilot_desired_yaw_rate(int16_t stick_angle) const
 // check for ekf yaw reset and adjust target heading
 void Sub::check_ekf_yaw_reset()
 {
-    float yaw_angle_change_rad;
-    const uint16_t new_ahrs_yaw_reset_count = ahrs.get_yaw_reset_count(yaw_angle_change_rad);
+    const uint16_t new_ahrs_yaw_reset_count = ahrs.get_yaw_reset_count();
     if (new_ahrs_yaw_reset_count != ahrs_yaw_reset_count) {
         attitude_control.inertial_frame_reset();
         ahrs_yaw_reset_count = new_ahrs_yaw_reset_count;

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -3005,9 +3005,15 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         # re-arming is problematic because the GPS is glitching!
         self.reboot_sitl()
 
-    def GPSGlitchLoiter2(self):
-        """test vehicle handles GPS glitch (aka EKF Reset) without twitching"""
+    def gps_glitch_loiter2_for_ekf_type(self, active_type):
+        '''run the GPSGlitchLoiter2 sequence with the given EKF active'''
         self.context_push()
+        self.set_parameters({
+            "AHRS_EKF_TYPE": active_type,
+            "EK2_ENABLE": 1,
+            "EK3_ENABLE": 1,
+        })
+        self.reboot_sitl()
         self.takeoff(10, mode="LOITER")
 
         # wait for vehicle to level
@@ -3026,10 +3032,18 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             if abs(roll_deg) > 2 or abs(pitch_deg) > 2:
                 raise NotAchievedException("fly_gps_glitch_loiter_test2 failed, roll or pitch moved during GPS glitch")
 
-        # RTL, remove glitch and reboot sitl
+        # RTL; the context pop removes the glitch and reboots
         self.do_RTL(alt_max=2)
         self.context_pop()
-        self.reboot_sitl()
+
+    def GPSGlitchLoiter2(self):
+        """test vehicle handles GPS glitch (aka EKF Reset) without twitching"""
+        # both enabled filters see glitch-induced position resets; the
+        # vehicle response only depends on the active filter, so fly
+        # once with each:
+        for active_type in 3, 2:
+            self.start_subtest("active EKF type %u" % active_type)
+            self.gps_glitch_loiter2_for_ekf_type(active_type)
 
     def GPSGlitchAuto(self, timeout=180):
         '''fly mission and test reaction to gps glitch'''
@@ -11948,15 +11962,19 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 raise NotAchievedException("Did not get %s" % want)
             still_want.remove(m.get_type())
 
-    def GSF_reset(self):
-        '''test the Gaussian Sum filter based Emergency reset'''
+    def gsf_reset_for_ekf_type(self, active_type):
+        '''run the GSF emergency-reset sequence with the given EKF active'''
         self.context_push()
         self.set_parameters({
+            "AHRS_EKF_TYPE": active_type,
+            "EK2_ENABLE": 1,
+            "EK3_ENABLE": 1,
             "COMPASS_ORIENT": 4,    # yaw 180
             "COMPASS_USE2": 0,      # disable backup compasses to avoid pre-arm failures
             "COMPASS_USE3": 0,
         })
         self.reboot_sitl()
+        self.context_collect('STATUSTEXT')
         self.change_mode('GUIDED')
         self.wait_ready_to_arm()
 
@@ -11970,7 +11988,8 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.user_takeoff(alt_min=expected_alt)
 
         # watch for emergency yaw reset
-        self.wait_text("EKF3 IMU. emergency yaw reset", timeout=5, regex=True)
+        self.wait_statustext("EKF%u IMU. emergency yaw reset" % active_type,
+                             timeout=10, regex=True, check_context=True)
 
         # record how far vehicle flew off
         endpos = self.assert_receive_message('LOCAL_POSITION_NED')
@@ -11981,12 +12000,22 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.do_RTL()
         self.context_pop()
-        self.reboot_sitl()
 
         # ensure vehicle did not fly too far
         dist_m_max = 8
         if dist_m > dist_m_max:
             raise NotAchievedException("GSF reset failed, vehicle flew too far (%f > %f)" % (dist_m, dist_m_max))
+
+    def GSF_reset(self):
+        '''test the Gaussian Sum filter based Emergency reset'''
+        # the emergency yaw reset request is routed by AHRS to the
+        # active estimator only, so fly once with each filter active;
+        # the other filter remains enabled throughout.  Each iteration
+        # gets its own context so that its statustext collection does
+        # not see the previous iteration's messages.
+        for active_type in 2, 3:
+            self.start_subtest("active EKF type %u" % active_type)
+            self.gsf_reset_for_ekf_type(active_type)
 
     def EKFBootstrapReset(self):
         '''verify EKF reset aux switch is disarmed-only and preserves origin'''
@@ -12276,28 +12305,33 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.assert_ekfs_match_sim_state()
 
-    def EKFYawResetLogged(self):
-        '''in-filter EKF yaw resets must propagate through AHRS and be logged'''
+    def ekf_yaw_reset_logged_for_ekf_type(self, active_type):
+        '''fly an in-filter yaw reset with the given EKF active'''
         self.context_push()
         self.set_parameters({
+            "AHRS_EKF_TYPE": active_type,
+            "EK2_ENABLE": 1,
+            "EK3_ENABLE": 1,
             "COMPASS_ORIENT": 4,    # yaw 180
             "COMPASS_USE2": 0,      # disable backup compasses to avoid pre-arm failures
             "COMPASS_USE3": 0,
         })
         self.reboot_sitl()
+        self.context_collect('STATUSTEXT')
         self.change_mode('GUIDED')
         self.wait_ready_to_arm()
         self.arm_vehicle()
         self.user_takeoff(alt_min=5)
 
-        # the mis-oriented compass causes an in-filter emergency yaw
-        # reset shortly after takeoff:
-        self.wait_text("EKF3 IMU. emergency yaw reset", timeout=5, regex=True)
+        # the mis-oriented compass causes an in-filter emergency
+        # yaw reset shortly after takeoff:
+        self.wait_statustext("EKF%u IMU. emergency yaw reset" % active_type,
+                             timeout=10, regex=True, check_context=True)
         self.delay_sim_time(5, reason="let the event reach the log")
         self.do_RTL()
 
-        # the EKF's internal yaw reset must be noticed by AHRS, which
-        # logs an EKF_YAW_RESET event:
+        # the active EKF's internal yaw reset must be noticed by
+        # AHRS, which logs an EKF_YAW_RESET event:
         dfreader = self.dfreader_for_current_onboard_log()
         armed = False
         while True:
@@ -12311,7 +12345,17 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.progress("Found EKF_YAW_RESET event in log")
 
         self.context_pop()
-        self.reboot_sitl()
+
+    def EKFYawResetLogged(self):
+        '''in-filter EKF yaw resets must propagate through AHRS and be logged'''
+        # the emergency yaw reset request is routed by AHRS to the
+        # active estimator only, so fly once with each filter active;
+        # the other filter remains enabled throughout.  Each iteration
+        # gets its own context so that its statustext collection does
+        # not see the previous iteration's messages.
+        for active_type in 2, 3:
+            self.start_subtest("active EKF type %u" % active_type)
+            self.ekf_yaw_reset_logged_for_ekf_type(active_type)
 
     def FlyRangeFinderMAVlink(self):
         '''fly mavlink-connected rangefinder'''

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -12253,6 +12253,29 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.context_pop()
         self.reboot_sitl()
 
+    def SIMCompare(self):
+        '''compare logged EKF2 and EKF3 estimates against simulator truth'''
+        self.set_parameters({
+            'AHRS_EKF_TYPE': 3,
+            'EK2_ENABLE': 1,
+            'EK3_ENABLE': 1,
+        })
+        self.reboot_sitl()
+
+        # fly a mixture of translation, climb, descent and yaw to give
+        # the estimators something to track:
+        self.change_mode('GUIDED')
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+        self.user_takeoff(alt_min=20)
+        self.guided_achieve_heading(135)
+        self.fly_guided_move_local(30, 40, 15)
+        self.guided_achieve_heading(270)
+        self.fly_guided_move_local(0, 0, 25)
+        self.do_RTL()
+
+        self.assert_ekfs_match_sim_state()
+
     def EKFYawResetLogged(self):
         '''in-filter EKF yaw resets must propagate through AHRS and be logged'''
         self.context_push()
@@ -18543,6 +18566,7 @@ return update, 1000
             self.AHRSSwitchBackendPositionNEReset,
             self.AHRSSwitchBackendYawReset,
             self.EK3SrcSwitchPosDownReset,
+            self.SIMCompare,
             self.EKFYawResetLogged,
             self.AP_Avoidance,
             self.RTL_ALT_FINAL_M,

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -3395,6 +3395,36 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.disarm_vehicle(force=True)
         self.reboot_sitl()
 
+    def SIMCompare(self):
+        '''compare logged EKF2 and EKF3 estimates against simulator truth'''
+        self.set_parameters({
+            'AHRS_EKF_TYPE': 3,
+            'EK2_ENABLE': 1,
+            'EK3_ENABLE': 1,
+        })
+        self.reboot_sitl()
+
+        # a takeoff, some turning flight and a landing gives the
+        # estimators a good range of attitudes and velocities to track:
+        self.takeoff(alt=50)
+        self.change_mode('CIRCLE')
+        # both filters see large transient attitude estimation errors
+        # (over 15 degrees of pitch) during the full-throttle
+        # climb-out, so compare only from established circling flight
+        # onwards:
+        compare_from = self.get_sim_time() + 15
+        self.delay_sim_time(30, reason="turning flight for the estimators to track")
+        self.fly_home_land_and_disarm()
+
+        # EKF2 systematically over-estimates pitch by up to ~15
+        # degrees during the accelerating climb-out (gated out, above)
+        # and remains a few degrees off in manoeuvring flight; EKF3
+        # tracks truth closely throughout:
+        self.assert_ekfs_match_sim_state(
+            ignore_before_time_s=compare_from,
+            max_roll_pitch_err_deg={'XKF1': 3, 'NKF1': 8},
+        )
+
     def Replay(self):
         '''test replay correctness'''
         self.progress("Building Replay")
@@ -3444,6 +3474,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.set_parameters({
             "LOG_REPLAY": 1,
             "LOG_DISARMED": 1,
+            "EK2_ENABLE": 1,
 
             "SIM_WIND_SPD": 5,
             "SIM_WIND_DIR": 45,
@@ -8479,6 +8510,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.TerrainMission,
             self.TerrainMissionInterrupt,
             self.UniversalAutoLandScript,
+            self.SIMCompare,
             self.Replay,
         ])
         return ret

--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -570,6 +570,33 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
             self.set_parameter("MOT_THST_HOVER", value)
             self.AltitudeHold()
 
+    def SIMCompare(self):
+        '''compare logged EKF2 and EKF3 estimates against simulator truth'''
+        self.set_parameters({
+            'AHRS_EKF_TYPE': 3,
+            'EK2_ENABLE': 1,
+            'EK3_ENABLE': 1,
+        })
+        self.reboot_sitl()
+
+        # dive and translate to give the estimators something to track:
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+        self.set_rc(Joystick.Throttle, 1600)
+        self.set_rc(Joystick.Forward, 1600)
+        self.set_rc(Joystick.Lateral, 1550)
+        self.wait_distance(30, accuracy=7, timeout=200)
+        self.set_rc(Joystick.Yaw, 1550)
+        self.wait_heading(0)
+        self.set_rc(Joystick.Yaw, 1500)
+        self.set_rc(Joystick.Forward, 1500)
+        self.set_rc(Joystick.Lateral, 1500)
+        self.set_rc(Joystick.Throttle, 1500)
+        self.delay_sim_time(2, reason="vehicle to settle")
+        self.disarm_vehicle()
+
+        self.assert_ekfs_match_sim_state()
+
     def DiveManual(self):
         '''Dive manual'''
         self.wait_ready_to_arm()
@@ -1649,6 +1676,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
 
         ret.extend([
             self.DiveManual,
+            self.SIMCompare,
             self.GCSFailsafe,
             self.ThrottleFailsafe,
             self.AltitudeHold,

--- a/Tools/autotest/blimp.py
+++ b/Tools/autotest/blimp.py
@@ -169,6 +169,29 @@ class AutoTestBlimp(TestSuite):
 
         self.disarm_vehicle()
 
+    def SIMCompare(self):
+        '''compare logged EKF2 and EKF3 estimates against simulator truth'''
+        self.set_parameters({
+            'AHRS_EKF_TYPE': 3,
+            'EK2_ENABLE': 1,
+            'EK3_ENABLE': 1,
+        })
+        self.reboot_sitl()
+
+        # loiter and translate to give the estimators something to track:
+        self.change_mode('LOITER')
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+        bl = self.get_location()
+        tl = self.offset_location_ne(location=bl, metres_north=5, metres_east=0)
+        self.set_rc(2, 2000)
+        self.wait_distance_to_location(tl, 0, 0.2, timeout=60)
+        self.set_rc(2, 1500)
+        self.delay_sim_time(10, reason="vehicle to settle")
+        self.disarm_vehicle()
+
+        self.assert_ekfs_match_sim_state()
+
     def FlyLoiter(self):
         '''test loiter mode'''
 
@@ -262,6 +285,7 @@ class AutoTestBlimp(TestSuite):
         ret.extend([
             self.FlyManualFinned,
             self.FlyLoiter,
+            self.SIMCompare,
             self.PREFLIGHT_Pressure,
             self.UTMGlobalPosition,
         ])

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -3831,6 +3831,28 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
 
         # MANUAL> usage: wp <changealt|clear|draw|editor|list|load|loop|move|movemulti|noflyadd|param|remove|save|savecsv|savelocal|set|sethome|show|slope|split|status|undo|update>  # noqa
 
+    def SIMCompare(self):
+        '''compare logged EKF2 and EKF3 estimates against simulator truth'''
+        self.set_parameters({
+            'AHRS_EKF_TYPE': 3,
+            'EK2_ENABLE': 1,
+            'EK3_ENABLE': 1,
+        })
+        self.reboot_sitl()
+
+        # drive a triangle to give the estimators some acceleration
+        # and yaw change to track:
+        self.change_mode('GUIDED')
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+        home = self.home_position_as_location()
+        self.drive_to_location(self.offset_location_ne(home, 40, 0), timeout=60)
+        self.drive_to_location(self.offset_location_ne(home, 40, 40), timeout=60)
+        self.drive_to_location(home, timeout=60)
+        self.disarm_vehicle()
+
+        self.assert_ekfs_match_sim_state()
+
     def drive_to_location(self, loc, tolerance=1, timeout=30, target_system=1, target_component=1):
         self.assert_mode('GUIDED')
 
@@ -7446,6 +7468,7 @@ return update()
             self.DriveRTL,
             self.SmartRTL,
             self.DriveSquare,
+            self.SIMCompare,
             self.DriveMission,
             # self.DriveBrake,  # disabled due to frequent failures
             self.MAV_CMD_DO_SEND_BANNER,

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -13296,6 +13296,155 @@ switch value'''
         if dropped != 0:
             raise NotAchievedException("Expected zero dropped log messages in %s, got %d" % (path, dropped))
 
+    def assert_ekfs_match_sim_state(self,
+                                    ekf_message_types=None,
+                                    max_roll_pitch_err_deg=5,
+                                    max_yaw_err_deg=10,
+                                    max_vel_err_ms=1.5,
+                                    max_pos_ne_err_m=5,
+                                    max_pos_d_err_m=3,
+                                    min_samples=100,
+                                    ignore_before_time_s=0,
+                                    max_violation_duration_s=2):
+        '''walk the current onboard log comparing each primary-core EKF
+        estimate message (NKF1 for EKF2, XKF1 for EKF3) against
+        simulator truth (SIM for attitude, SIM2 for velocity and
+        position), linearly interpolated to the estimate timestamps.
+        Only samples logged while armed and after ignore_before_time_s
+        are considered.
+
+        Estimates can briefly diverge from truth during aggressive
+        manoeuvres; only divergence sustained for more than
+        max_violation_duration_s fails.'''
+        import numpy as np
+        if ekf_message_types is None:
+            ekf_message_types = ['NKF1', 'XKF1']
+
+        # tolerances may be supplied as a scalar or as a dict keyed by
+        # message type, allowing per-filter tolerances:
+        def tol(spec, key):
+            if isinstance(spec, dict):
+                return spec[key]
+            return spec
+
+        # gather everything first so truth can be interpolated to the
+        # estimate timestamps:
+        dfreader = self.dfreader_for_current_onboard_log()
+        sim = []
+        sim2 = []
+        est = {}
+        for key in ekf_message_types:
+            est[key] = []
+        armed_spans = []
+        armed_at = None
+        while True:
+            m = dfreader.recv_match(type=ekf_message_types + ['SIM', 'SIM2', 'EV'])
+            if m is None:
+                break
+            m_type = m.get_type()
+            t = m.TimeUS * 1e-6
+            if m_type == 'EV':
+                if m.Id == 10 and armed_at is None:  # armed
+                    armed_at = t
+                elif m.Id == 11 and armed_at is not None:  # disarmed
+                    armed_spans.append((armed_at, t))
+                    armed_at = None
+            elif m_type == 'SIM':
+                sim.append((t, m.Roll, m.Pitch, m.Yaw))
+            elif m_type == 'SIM2':
+                sim2.append((t, m.VN, m.VE, m.VD, m.PN, m.PE, m.PD))
+            elif m.C == 0:
+                # only check each filter's primary core
+                est[m_type].append((t, m.Roll, m.Pitch, m.Yaw, m.VN, m.VE, m.VD, m.PN, m.PE, m.PD))
+        if armed_at is not None:
+            armed_spans.append((armed_at, float('inf')))
+        if len(sim) < 2 or len(sim2) < 2:
+            raise NotAchievedException("Insufficient SIM/SIM2 truth data in log")
+        sim = np.array(sim)
+        sim2 = np.array(sim2)
+        # unwrap yaw so interpolation does not glitch at the 0/360 boundary:
+        sim_yaw_unwrapped = np.degrees(np.unwrap(np.radians(sim[:, 3])))
+
+        for key in ekf_message_types:
+            rows = np.array(est[key])
+            if len(rows) == 0:
+                raise NotAchievedException("No %s messages in log" % key)
+            est_t = rows[:, 0]
+            armed = np.zeros(len(est_t), dtype=bool)
+            for (t0, t1) in armed_spans:
+                armed |= (est_t >= t0) & (est_t <= t1)
+            # restrict to samples bracketed by truth so interpolation
+            # never extrapolates:
+            armed &= (est_t >= max(sim[0, 0], sim2[0, 0])) & (est_t <= min(sim[-1, 0], sim2[-1, 0]))
+            rows = rows[armed]
+            est_t = rows[:, 0]
+            if len(est_t) < min_samples:
+                raise NotAchievedException(
+                    "Insufficient %s/truth samples compared (%u)" % (key, len(est_t)))
+
+            roll_err = np.abs(rows[:, 1] - np.interp(est_t, sim[:, 0], sim[:, 1]))
+            pitch_err = np.abs(rows[:, 2] - np.interp(est_t, sim[:, 0], sim[:, 2]))
+            yaw_err = np.abs((rows[:, 3] - np.interp(est_t, sim[:, 0], sim_yaw_unwrapped) + 180) % 360 - 180)
+            vel_err = np.sqrt(
+                (rows[:, 4] - np.interp(est_t, sim2[:, 0], sim2[:, 1]))**2 +
+                (rows[:, 5] - np.interp(est_t, sim2[:, 0], sim2[:, 2]))**2 +
+                (rows[:, 6] - np.interp(est_t, sim2[:, 0], sim2[:, 3]))**2)
+            # EKF positions are relative to the EKF origin while SIM2
+            # positions are relative to the simulation origin; remove
+            # the constant offset between the two, estimated from the
+            # first few armed samples:
+            pn_err = rows[:, 7] - np.interp(est_t, sim2[:, 0], sim2[:, 4])
+            pe_err = rows[:, 8] - np.interp(est_t, sim2[:, 0], sim2[:, 5])
+            pd_err = rows[:, 9] - np.interp(est_t, sim2[:, 0], sim2[:, 6])
+            nbase = min(10, len(est_t))
+            pn_err -= pn_err[:nbase].mean()
+            pe_err -= pe_err[:nbase].mean()
+            pd_err -= pd_err[:nbase].mean()
+            pos_ne_err = np.sqrt(pn_err**2 + pe_err**2)
+            pos_d_err = np.abs(pd_err)
+
+            att_bad = (roll_err > tol(max_roll_pitch_err_deg, key)) | (pitch_err > tol(max_roll_pitch_err_deg, key))
+            yaw_bad = yaw_err > tol(max_yaw_err_deg, key)
+            vel_bad = vel_err > tol(max_vel_err_ms, key)
+            ne_bad = pos_ne_err > tol(max_pos_ne_err_m, key)
+            d_bad = pos_d_err > tol(max_pos_d_err_m, key)
+            bad = att_bad | yaw_bad | vel_bad | ne_bad | d_bad
+            considered = est_t >= ignore_before_time_s
+            bad &= considered
+
+            # only divergence sustained for max_violation_duration_s fails:
+            run_start = None
+            for i in range(len(est_t)):
+                if not considered[i]:
+                    continue
+                if not bad[i]:
+                    run_start = None
+                    continue
+                desc = []
+                if att_bad[i]:
+                    desc.append("attitude (roll-err=%.1fdeg pitch-err=%.1fdeg)" % (roll_err[i], pitch_err[i]))
+                if yaw_bad[i]:
+                    desc.append("yaw (yaw-err=%.1fdeg)" % yaw_err[i])
+                if vel_bad[i]:
+                    desc.append("velocity (vel-err=%.1fm/s)" % vel_err[i])
+                if ne_bad[i]:
+                    desc.append("position (pos-ne-err=%.1fm)" % pos_ne_err[i])
+                if d_bad[i]:
+                    desc.append("height (pos-d-err=%.1fm)" % pos_d_err[i])
+                if run_start is None:
+                    run_start = est_t[i]
+                    self.progress("%s transient %s divergence at t=%.3f" % (key, " ".join(desc), est_t[i]))
+                elif est_t[i] - run_start > max_violation_duration_s:
+                    raise NotAchievedException(
+                        "%s diverged from truth for more than %.1fs (t=%.3f %s)" %
+                        (key, max_violation_duration_s, est_t[i], " ".join(desc)))
+
+            ncompared = int(considered.sum())
+            if ncompared < min_samples:
+                raise NotAchievedException(
+                    "Insufficient %s/truth samples compared (%u)" % (key, ncompared))
+            self.progress("Compared %u %s samples against simulator truth" % (ncompared, key))
+
     def dfreader_for_current_onboard_log(self):
         return self.dfreader_for_path(self.current_onboard_log_filepath())
 

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -1682,18 +1682,14 @@ float AC_PosControl::calculate_overspeed_gain()
 // Initializes tracking of NE EKF position resets.
 void AC_PosControl::NE_init_ekf_reset()
 {
-    Vector2f pos_shift;
-    _ahrs_position_NE_reset_count = _ahrs.get_position_NE_reset_count(pos_shift);
+    _ahrs_position_NE_reset_count = _ahrs.get_position_NE_reset_count();
 }
 
 // Handles NE position reset detection and response (e.g., clearing accumulated errors).
 void AC_PosControl::NE_handle_ekf_reset()
 {
-    // Check for EKF-reported NE position shift since last update
-    Vector2f pos_shift_ne_m;
-    const uint16_t reset_count = _ahrs.get_position_NE_reset_count(pos_shift_ne_m);
-    // todo: the actual difference in position and velocity estimation.
-    // This will prevent the need to pause error calculation for one cycle.
+    // Check for EKF-reported NE position reset since last update
+    const uint16_t reset_count = _ahrs.get_position_NE_reset_count();
 
     if (reset_count != _ahrs_position_NE_reset_count) {
         // This ensures controller output remains continuous after EKF realigns the origin.
@@ -1725,18 +1721,14 @@ void AC_PosControl::NE_handle_ekf_reset()
 // Initializes tracking of vertical (U) EKF resets.
 void AC_PosControl::D_init_ekf_reset()
 {
-    float alt_shift_d_m;
-    _ahrs_position_D_reset_count = _ahrs.get_position_D_reset_count(alt_shift_d_m);
+    _ahrs_position_D_reset_count = _ahrs.get_position_D_reset_count();
 }
 
 // Handles U EKF reset detection and response.
 void AC_PosControl::D_handle_ekf_reset()
 {
-    // Check for EKF-reported Down-axis shift since last update
-    float pos_shift_d_m;
-    const uint16_t reset_count = _ahrs.get_position_D_reset_count(pos_shift_d_m);
-    // todo: the actual difference in position and velocity estimation.
-    // This will prevent the need to pause error calculation for one cycle.
+    // Check for EKF-reported Down-axis reset since last update
+    const uint16_t reset_count = _ahrs.get_position_D_reset_count();
 
     if (reset_count != _ahrs_position_D_reset_count) {
         // This ensures controller output remains continuous after EKF realigns the origin.

--- a/libraries/APM_Control/AR_PosControl.cpp
+++ b/libraries/APM_Control/AR_PosControl.cpp
@@ -406,16 +406,14 @@ void AR_PosControl::write_log()
 /// initialise ekf xy position reset check
 void AR_PosControl::init_ekf_xy_reset()
 {
-    Vector2f pos_shift;
-    _ekf_xy_reset_count = AP::ahrs().get_position_NE_reset_count(pos_shift);
+    _ekf_xy_reset_count = AP::ahrs().get_position_NE_reset_count();
 }
 
 /// handle_ekf_xy_reset - check for ekf position reset and adjust loiter or brake target position
 void AR_PosControl::handle_ekf_xy_reset()
 {
-    // check for position shift
-    Vector2f pos_shift;
-    const uint16_t reset_count = AP::ahrs().get_position_NE_reset_count(pos_shift);
+    // check for position reset
+    const uint16_t reset_count = AP::ahrs().get_position_NE_reset_count();
     if (reset_count != _ekf_xy_reset_count) {
         Vector2p pos_ne_m;
         if (!AP::ahrs().get_relative_position_NE_origin(pos_ne_m)) {

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -568,13 +568,9 @@ void AP_AHRS::update_reset_counters()
 
         // deltas across the estimator change come from differencing
         // old and new backend estimates; zero if either side invalid
-        float yaw_delta = 0;
         Vector2f pos_ne_delta;
         float pos_d_delta = 0;
         if (last != nullptr) {
-            if (active_estimates->attitude_valid && last->attitude_valid) {
-                yaw_delta = wrap_PI(active_estimates->yaw_rad - last->yaw_rad);
-            }
             if (active_estimates->position_NE_valid && last->position_NE_valid) {
                 pos_ne_delta = (active_estimates->position_NE - last->position_NE).tofloat();
             }
@@ -585,7 +581,7 @@ void AP_AHRS::update_reset_counters()
 
         attitude_reset_count++;
         active_estimates_attitude_reset_count = active_estimates->attitude_reset_count;
-        yaw_reset_tracker.fill(active_estimates->yaw_reset_count, yaw_delta);
+        yaw_reset_tracker.fill(active_estimates->yaw_reset_count);
         position_NE_reset_tracker.fill(active_estimates->position_NE_reset_count, pos_ne_delta);
         position_D_reset_tracker.fill(active_estimates->position_D_reset_count, pos_d_delta);
         LOGGER_WRITE_EVENT(LogEvent::EKF_YAW_RESET);
@@ -596,8 +592,7 @@ void AP_AHRS::update_reset_counters()
         active_estimates_attitude_reset_count = active_estimates->attitude_reset_count;
         attitude_reset_count++;
     }
-    if (yaw_reset_tracker.update(active_estimates->yaw_reset_count,
-                                 active_estimates->yaw_reset_delta)) {
+    if (yaw_reset_tracker.update(active_estimates->yaw_reset_count)) {
         LOGGER_WRITE_EVENT(LogEvent::EKF_YAW_RESET);
     }
     position_NE_reset_tracker.update(active_estimates->position_NE_reset_count,

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -564,25 +564,10 @@ void AP_AHRS::try_set_common_origin(const AP_AHRS_Backend &source_backend, const
 void AP_AHRS::update_reset_counters()
 {
     if (state.active_EKF_type != last_active_ekf_type) {
-        const auto *last = estimates_for_type(last_active_ekf_type);
-
-        // deltas across the estimator change come from differencing
-        // old and new backend estimates; zero if either side invalid
-        Vector2f pos_ne_delta;
-        float pos_d_delta = 0;
-        if (last != nullptr) {
-            if (active_estimates->position_NE_valid && last->position_NE_valid) {
-                pos_ne_delta = (active_estimates->position_NE - last->position_NE).tofloat();
-            }
-            if (active_estimates->position_D_valid && last->position_D_valid) {
-                pos_d_delta = active_estimates->position_D - last->position_D;
-            }
-        }
-
         attitude_reset_tracker.fill(active_estimates->attitude_reset_count);
         yaw_reset_tracker.fill(active_estimates->yaw_reset_count);
-        position_NE_reset_tracker.fill(active_estimates->position_NE_reset_count, pos_ne_delta);
-        position_D_reset_tracker.fill(active_estimates->position_D_reset_count, pos_d_delta);
+        position_NE_reset_tracker.fill(active_estimates->position_NE_reset_count);
+        position_D_reset_tracker.fill(active_estimates->position_D_reset_count);
         LOGGER_WRITE_EVENT(LogEvent::EKF_YAW_RESET);
         return;
     }
@@ -591,10 +576,8 @@ void AP_AHRS::update_reset_counters()
     if (yaw_reset_tracker.update(active_estimates->yaw_reset_count)) {
         LOGGER_WRITE_EVENT(LogEvent::EKF_YAW_RESET);
     }
-    position_NE_reset_tracker.update(active_estimates->position_NE_reset_count,
-                                     active_estimates->position_NE_reset_delta);
-    position_D_reset_tracker.update(active_estimates->position_D_reset_count,
-                                    active_estimates->position_D_reset_delta);
+    position_NE_reset_tracker.update(active_estimates->position_NE_reset_count);
+    position_D_reset_tracker.update(active_estimates->position_D_reset_count);
 }
 
 // update run at loop rate

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -579,8 +579,7 @@ void AP_AHRS::update_reset_counters()
             }
         }
 
-        attitude_reset_count++;
-        active_estimates_attitude_reset_count = active_estimates->attitude_reset_count;
+        attitude_reset_tracker.fill(active_estimates->attitude_reset_count);
         yaw_reset_tracker.fill(active_estimates->yaw_reset_count);
         position_NE_reset_tracker.fill(active_estimates->position_NE_reset_count, pos_ne_delta);
         position_D_reset_tracker.fill(active_estimates->position_D_reset_count, pos_d_delta);
@@ -588,10 +587,7 @@ void AP_AHRS::update_reset_counters()
         return;
     }
 
-    if (active_estimates_attitude_reset_count != active_estimates->attitude_reset_count) {
-        active_estimates_attitude_reset_count = active_estimates->attitude_reset_count;
-        attitude_reset_count++;
-    }
+    attitude_reset_tracker.update(active_estimates->attitude_reset_count);
     if (yaw_reset_tracker.update(active_estimates->yaw_reset_count)) {
         LOGGER_WRITE_EVENT(LogEvent::EKF_YAW_RESET);
     }

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -373,20 +373,6 @@ public:
         return yaw_reset_tracker.count();
     }
 
-    // return the amount of NE position change in meters due to the last reset
-    // returns the number of times position NE has been reset
-    uint16_t get_position_NE_reset_count(Vector2f &pos) const {
-        pos = position_NE_reset_tracker.delta();
-        return position_NE_reset_tracker.count();
-    }
-
-    // return the amount of vertical position change due to the last reset in meters
-    // returns the number of times position-down has been reset
-    uint16_t get_position_D_reset_count(float &posDelta) const {
-        posDelta = position_D_reset_tracker.delta();
-        return position_D_reset_tracker.count();
-    }
-
     // returns the number of times the NE position has been reset
     uint16_t get_position_NE_reset_count(void) const {
         return position_NE_reset_tracker.count();
@@ -1137,8 +1123,8 @@ private:
     // the backend results change (e.g. switching core)
     AP_AHRS_ResetCounter<uint16_t> attitude_reset_tracker;
     AP_AHRS_ResetCounter<uint16_t> yaw_reset_tracker;
-    AP_AHRS_ResetTracker<Vector2f, uint16_t> position_NE_reset_tracker;
-    AP_AHRS_ResetTracker<float, uint16_t> position_D_reset_tracker;
+    AP_AHRS_ResetCounter<uint16_t> position_NE_reset_tracker;
+    AP_AHRS_ResetCounter<uint16_t> position_D_reset_tracker;
 
     // secondary estimates - used for reporting purposes.  If the
     // primary backend fails this is the backend/result pair likely to

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -389,7 +389,7 @@ public:
 
     // returns a counter which is incremented each time the estimator's output resets
     uint16_t get_last_attitude_reset_count() const {
-        return attitude_reset_count;
+        return attitude_reset_tracker.count();
     }
 
     // Resets the baro so that it reads zero at the current height
@@ -1125,9 +1125,7 @@ private:
     void update_reset_counters();
     // reset counters.  These are updated if the backend changes or if
     // the backend results change (e.g. switching core)
-    uint16_t attitude_reset_count;
-    uint16_t active_estimates_attitude_reset_count;
-
+    AP_AHRS_ResetCounter<uint16_t> attitude_reset_tracker;
     AP_AHRS_ResetCounter<uint16_t> yaw_reset_tracker;
     AP_AHRS_ResetTracker<Vector2f, uint16_t> position_NE_reset_tracker;
     AP_AHRS_ResetTracker<float, uint16_t> position_D_reset_tracker;

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -387,6 +387,16 @@ public:
         return position_D_reset_tracker.count();
     }
 
+    // returns the number of times the NE position has been reset
+    uint16_t get_position_NE_reset_count(void) const {
+        return position_NE_reset_tracker.count();
+    }
+
+    // returns the number of times the D position has been reset
+    uint16_t get_position_D_reset_count(void) const {
+        return position_D_reset_tracker.count();
+    }
+
     // returns a counter which is incremented each time the estimator's output resets
     uint16_t get_last_attitude_reset_count() const {
         return attitude_reset_tracker.count();

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -368,13 +368,6 @@ public:
     // true if offsets are valid
     bool getMagOffsets(uint8_t mag_idx, Vector3f &magOffsets) const;
 
-    // return the amount of yaw angle change due to the last yaw angle reset in radians
-    // returns the number of times the yaw angle has been reset
-    uint16_t get_yaw_reset_count(float &yawAng) const {
-        yawAng = yaw_reset_tracker.delta();
-        return yaw_reset_tracker.count();
-    }
-
     // returns the number of times the yaw angle has been reset
     uint16_t get_yaw_reset_count(void) const {
         return yaw_reset_tracker.count();
@@ -1135,7 +1128,7 @@ private:
     uint16_t attitude_reset_count;
     uint16_t active_estimates_attitude_reset_count;
 
-    AP_AHRS_ResetTracker<float, uint16_t> yaw_reset_tracker;
+    AP_AHRS_ResetCounter<uint16_t> yaw_reset_tracker;
     AP_AHRS_ResetTracker<Vector2f, uint16_t> position_NE_reset_tracker;
     AP_AHRS_ResetTracker<float, uint16_t> position_D_reset_tracker;
 

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -375,6 +375,11 @@ public:
         return yaw_reset_tracker.count();
     }
 
+    // returns the number of times the yaw angle has been reset
+    uint16_t get_yaw_reset_count(void) const {
+        return yaw_reset_tracker.count();
+    }
+
     // return the amount of NE position change in meters due to the last reset
     // returns the number of times position NE has been reset
     uint16_t get_position_NE_reset_count(Vector2f &pos) const {

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -160,12 +160,10 @@ public:
         Vector2p position_NE;
         bool position_NE_valid;  // true if position_NE is valid
         uint16_t position_NE_reset_count;  // incremented when a sudden shift happens in position
-        Vector2f position_NE_reset_delta;  // shift amount last time it reset
 
         postype_t position_D;
         bool position_D_valid;   // true if position_D is valid
         uint16_t position_D_reset_count;  // incremented when a sudden shift happens in position (down)
-        float position_D_reset_delta;  // shift amount last time it reset
 
         bool get_hagl(float &height) const WARN_IF_UNUSED {
             height = hagl;
@@ -322,50 +320,8 @@ public:
 };
 
 // Converts an upstream "something changed" key (an EKF reset
-// timestamp, or another tracker's count) into a monotonic local count
-// plus a latched delta.  KeyT is the upstream key type.
-template <typename DeltaT, typename KeyT>
-class AP_AHRS_ResetTracker {
-public:
-    // latch delta and bump count if the upstream key changed.
-    // Returns true if a reset was recorded.
-    bool update(KeyT new_key, const DeltaT &new_delta) {
-        if (new_key == last_key) {
-            return false;
-        }
-        fill(new_key, new_delta);
-        return true;
-    }
-
-    // unconditionally record a reset with an externally computed
-    // delta, re-seating the key so the next update() doesn't
-    // double-count.  Used when the active estimator changes and the
-    // delta comes from differencing old/new backend estimates.
-    void fill(KeyT new_key, const DeltaT &new_delta) {
-        last_key = new_key;
-        reset_delta = new_delta;
-        reset_count++;
-    }
-
-    // copy the current reset count and latched delta out, e.g. into a
-    // backend's published Estimates.  Deliberately not named like the
-    // mutating fill() so the two can't be confused at a call site.
-    void get(uint16_t &count, DeltaT &delta) const {
-        count = reset_count;
-        delta = reset_delta;
-    }
-
-    uint16_t count() const { return reset_count; }
-    const DeltaT &delta() const { return reset_delta; }
-
-private:
-    KeyT last_key;
-    DeltaT reset_delta;
-    uint16_t reset_count;
-};
-
-// as AP_AHRS_ResetTracker, but for consumers which only care that a
-// reset happened, not by how much.  KeyT is the upstream key type.
+// count or timestamp, or another counter's count) into a monotonic
+// local count.  KeyT is the upstream key type.
 template <typename KeyT>
 class AP_AHRS_ResetCounter {
 public:

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -86,7 +86,6 @@ public:
         Quaternion quaternion;
         uint16_t attitude_reset_count;  // counter incremented each time a sudden shift happens in attitude
         uint16_t yaw_reset_count;  // incremented when a sudden shift happens in yaw
-        float yaw_reset_delta;  // shift amount last time yaw reset
 
         // backends must always return the result in the vehicle body
         // frame.  A backend using the autopilot sensors will need to
@@ -362,5 +361,35 @@ public:
 private:
     KeyT last_key;
     DeltaT reset_delta;
+    uint16_t reset_count;
+};
+
+// as AP_AHRS_ResetTracker, but for consumers which only care that a
+// reset happened, not by how much.  KeyT is the upstream key type.
+template <typename KeyT>
+class AP_AHRS_ResetCounter {
+public:
+    // bump count if the upstream key changed.  Returns true if a
+    // reset was recorded.
+    bool update(KeyT new_key) {
+        if (new_key == last_key) {
+            return false;
+        }
+        fill(new_key);
+        return true;
+    }
+
+    // unconditionally record a reset, re-seating the key so the next
+    // update() doesn't double-count.  Used when the active estimator
+    // changes.
+    void fill(KeyT new_key) {
+        last_key = new_key;
+        reset_count++;
+    }
+
+    uint16_t count() const { return reset_count; }
+
+private:
+    KeyT last_key;
     uint16_t reset_count;
 };

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF2.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF2.cpp
@@ -62,8 +62,7 @@ void AP_AHRS_NavEKF2::update()
         GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "EKF2 primary changed:%d", (unsigned)primary_core);
     }
 
-    float yaw_delta;
-    yaw_reset_tracker.update(EKF2.getLastYawResetAngle(yaw_delta), yaw_delta);
+    yaw_reset_tracker.update(EKF2.getYawResetCount());
 
     Vector2f pos_ne_delta;
     position_NE_reset_tracker.update(EKF2.getLastPosNorthEastReset(pos_ne_delta), pos_ne_delta);
@@ -123,8 +122,7 @@ void AP_AHRS_NavEKF2::get_results(AP_AHRS_Backend::Estimates &results)
 
     results.attitude_reset_count = attitude_reset_count;
 
-    // copy results from the yaw reset tracker into results:
-    yaw_reset_tracker.get(results.yaw_reset_count, results.yaw_reset_delta);
+    results.yaw_reset_count = yaw_reset_tracker.count();
 
     /*
      * acceleration estimates

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF2.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF2.cpp
@@ -62,11 +62,9 @@ void AP_AHRS_NavEKF2::update()
 
     yaw_reset_tracker.update(EKF2.getYawResetCount());
 
-    Vector2f pos_ne_delta;
-    position_NE_reset_tracker.update(EKF2.getLastPosNorthEastReset(pos_ne_delta), pos_ne_delta);
+    position_NE_reset_tracker.update(EKF2.getPosNorthEastResetCount());
 
-    float pos_d_delta;
-    position_D_reset_tracker.update(EKF2.getLastPosDownReset(pos_d_delta), pos_d_delta);
+    position_D_reset_tracker.update(EKF2.getPosDownResetCount());
 }
 
 void AP_AHRS_NavEKF2::get_results(AP_AHRS_Backend::Estimates &results)
@@ -165,12 +163,10 @@ void AP_AHRS_NavEKF2::get_results(AP_AHRS_Backend::Estimates &results)
 
     // origin-relative position:
     results.position_NE_valid = EKF2.getPosNE(results.position_NE);
-    // copy results from the position_NE reset tracker into results:
-    position_NE_reset_tracker.get(results.position_NE_reset_count, results.position_NE_reset_delta);
+    results.position_NE_reset_count = position_NE_reset_tracker.count();
 
     results.position_D_valid = EKF2.getPosD(results.position_D);
-    // copy results from the position_D reset tracker into results:
-    position_D_reset_tracker.get(results.position_D_reset_count, results.position_D_reset_delta);
+    results.position_D_reset_count = position_D_reset_tracker.count();
 
     results.hagl_valid = EKF2.getHAGL(results.hagl);
 

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF2.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF2.cpp
@@ -55,9 +55,7 @@ void AP_AHRS_NavEKF2::update()
     // check the current primary core; if it has changed then assume
     // our attitude is reset:
     const int8_t primary_core = EKF2.getPrimaryCoreIndex();
-    if (old_primary_core != primary_core) {
-        old_primary_core = primary_core;
-        attitude_reset_count++;
+    if (attitude_reset_tracker.update(primary_core)) {
         LOGGER_WRITE_ERROR(LogErrorSubsystem::EKF_PRIMARY, LogErrorCode(primary_core));
         GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "EKF2 primary changed:%d", (unsigned)primary_core);
     }
@@ -120,7 +118,7 @@ void AP_AHRS_NavEKF2::get_results(AP_AHRS_Backend::Estimates &results)
 
     results.attitude_valid = started;
 
-    results.attitude_reset_count = attitude_reset_count;
+    results.attitude_reset_count = attitude_reset_tracker.count();
 
     results.yaw_reset_count = yaw_reset_tracker.count();
 

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF2.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF2.h
@@ -92,7 +92,7 @@ public:
     uint16_t attitude_reset_count;
     int8_t old_primary_core;
 
-    AP_AHRS_ResetTracker<float, uint32_t> yaw_reset_tracker;
+    AP_AHRS_ResetCounter<uint16_t> yaw_reset_tracker;
     AP_AHRS_ResetTracker<Vector2f, uint32_t> position_NE_reset_tracker;
     AP_AHRS_ResetTracker<float, uint32_t> position_D_reset_tracker;
 };

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF2.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF2.h
@@ -92,8 +92,8 @@ public:
     AP_AHRS_ResetCounter<int8_t> attitude_reset_tracker;
 
     AP_AHRS_ResetCounter<uint16_t> yaw_reset_tracker;
-    AP_AHRS_ResetTracker<Vector2f, uint32_t> position_NE_reset_tracker;
-    AP_AHRS_ResetTracker<float, uint32_t> position_D_reset_tracker;
+    AP_AHRS_ResetCounter<uint16_t> position_NE_reset_tracker;
+    AP_AHRS_ResetCounter<uint16_t> position_D_reset_tracker;
 };
 
 #endif  // AP_AHRS_NAVEKF2_ENABLED

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF2.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF2.h
@@ -89,8 +89,7 @@ public:
     uint32_t start_time_ms;  // timer used to delay starting the filter
 
     // a counter which is incremented each time the primary core changes:
-    uint16_t attitude_reset_count;
-    int8_t old_primary_core;
+    AP_AHRS_ResetCounter<int8_t> attitude_reset_tracker;
 
     AP_AHRS_ResetCounter<uint16_t> yaw_reset_tracker;
     AP_AHRS_ResetTracker<Vector2f, uint32_t> position_NE_reset_tracker;

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
@@ -62,11 +62,9 @@ void AP_AHRS_NavEKF3::update()
 
     yaw_reset_tracker.update(EKF3.getYawResetCount());
 
-    Vector2f pos_ne_delta;
-    position_NE_reset_tracker.update(EKF3.getLastPosNorthEastReset(pos_ne_delta), pos_ne_delta);
+    position_NE_reset_tracker.update(EKF3.getPosNorthEastResetCount());
 
-    float pos_d_delta;
-    position_D_reset_tracker.update(EKF3.getLastPosDownReset(pos_d_delta), pos_d_delta);
+    position_D_reset_tracker.update(EKF3.getPosDownResetCount());
 }
 
 void AP_AHRS_NavEKF3::get_results(AP_AHRS_Backend::Estimates &results)
@@ -166,12 +164,10 @@ void AP_AHRS_NavEKF3::get_results(AP_AHRS_Backend::Estimates &results)
 
     // origin-relative position:
     results.position_NE_valid = EKF3.getPosNE(results.position_NE);
-    // copy results from the position_NE reset tracker into results:
-    position_NE_reset_tracker.get(results.position_NE_reset_count, results.position_NE_reset_delta);
+    results.position_NE_reset_count = position_NE_reset_tracker.count();
 
     results.position_D_valid = EKF3.getPosD(results.position_D);
-    // copy results from the position_D reset tracker into results:
-    position_D_reset_tracker.get(results.position_D_reset_count, results.position_D_reset_delta);
+    results.position_D_reset_count = position_D_reset_tracker.count();
 
     results.hagl_valid = EKF3.getHAGL(results.hagl);
 

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
@@ -62,8 +62,7 @@ void AP_AHRS_NavEKF3::update()
         GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "EKF3 primary changed:%d", (unsigned)primary_core);
     }
 
-    float yaw_delta;
-    yaw_reset_tracker.update(EKF3.getLastYawResetAngle(yaw_delta), yaw_delta);
+    yaw_reset_tracker.update(EKF3.getYawResetCount());
 
     Vector2f pos_ne_delta;
     position_NE_reset_tracker.update(EKF3.getLastPosNorthEastReset(pos_ne_delta), pos_ne_delta);
@@ -123,8 +122,7 @@ void AP_AHRS_NavEKF3::get_results(AP_AHRS_Backend::Estimates &results)
 
     results.attitude_reset_count = attitude_reset_count;
 
-    // copy results from the yaw reset tracker into results:
-    yaw_reset_tracker.get(results.yaw_reset_count, results.yaw_reset_delta);
+    results.yaw_reset_count = yaw_reset_tracker.count();
 
     /*
      * acceleration estimates

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
@@ -55,9 +55,7 @@ void AP_AHRS_NavEKF3::update()
     // check the current primary core; if it has changed then assume
     // our attitude is reset:
     const int8_t primary_core = EKF3.getPrimaryCoreIndex();
-    if (old_primary_core != primary_core) {
-        old_primary_core = primary_core;
-        attitude_reset_count++;
+    if (attitude_reset_tracker.update(primary_core)) {
         LOGGER_WRITE_ERROR(LogErrorSubsystem::EKF_PRIMARY, LogErrorCode(primary_core));
         GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "EKF3 primary changed:%d", (unsigned)primary_core);
     }
@@ -120,7 +118,7 @@ void AP_AHRS_NavEKF3::get_results(AP_AHRS_Backend::Estimates &results)
 
     results.attitude_valid = started;
 
-    results.attitude_reset_count = attitude_reset_count;
+    results.attitude_reset_count = attitude_reset_tracker.count();
 
     results.yaw_reset_count = yaw_reset_tracker.count();
 

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF3.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF3.h
@@ -88,8 +88,7 @@ public:
     uint32_t start_time_ms;  // timer used to delay starting the filter
 
     // a counter which is incremented each time the primary core changes:
-    uint16_t attitude_reset_count;
-    int8_t old_primary_core;
+    AP_AHRS_ResetCounter<int8_t> attitude_reset_tracker;
 
     AP_AHRS_ResetCounter<uint16_t> yaw_reset_tracker;
     AP_AHRS_ResetTracker<Vector2f, uint32_t> position_NE_reset_tracker;

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF3.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF3.h
@@ -91,7 +91,7 @@ public:
     uint16_t attitude_reset_count;
     int8_t old_primary_core;
 
-    AP_AHRS_ResetTracker<float, uint32_t> yaw_reset_tracker;
+    AP_AHRS_ResetCounter<uint16_t> yaw_reset_tracker;
     AP_AHRS_ResetTracker<Vector2f, uint32_t> position_NE_reset_tracker;
     AP_AHRS_ResetTracker<float, uint32_t> position_D_reset_tracker;
 };

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF3.h
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF3.h
@@ -91,8 +91,8 @@ public:
     AP_AHRS_ResetCounter<int8_t> attitude_reset_tracker;
 
     AP_AHRS_ResetCounter<uint16_t> yaw_reset_tracker;
-    AP_AHRS_ResetTracker<Vector2f, uint32_t> position_NE_reset_tracker;
-    AP_AHRS_ResetTracker<float, uint32_t> position_D_reset_tracker;
+    AP_AHRS_ResetCounter<uint16_t> position_NE_reset_tracker;
+    AP_AHRS_ResetCounter<uint16_t> position_D_reset_tracker;
 };
 
 #endif  // AP_AHRS_NAVEKF3_ENABLED

--- a/libraries/AP_AHRS/AP_AHRS_View.h
+++ b/libraries/AP_AHRS/AP_AHRS_View.h
@@ -157,6 +157,14 @@ public:
         return ahrs.get_position_D_reset_count(posDelta);
     }
 
+    uint16_t get_position_NE_reset_count(void) WARN_IF_UNUSED {
+        return ahrs.get_position_NE_reset_count();
+    }
+
+    uint16_t get_position_D_reset_count(void) WARN_IF_UNUSED {
+        return ahrs.get_position_D_reset_count();
+    }
+
     // rotate a 2D vector from earth frame to body frame
     // in result, x is forward, y is right
     Vector2f earth_to_body2D(const Vector2f &ef_vector) const;

--- a/libraries/AP_AHRS/AP_AHRS_View.h
+++ b/libraries/AP_AHRS/AP_AHRS_View.h
@@ -149,14 +149,6 @@ public:
         return ahrs.get_accel_ef();
     }
 
-    uint16_t get_position_NE_reset_count(Vector2f &pos) WARN_IF_UNUSED {
-        return ahrs.get_position_NE_reset_count(pos);
-    }
-
-    uint16_t get_position_D_reset_count(float &posDelta) WARN_IF_UNUSED {
-        return ahrs.get_position_D_reset_count(posDelta);
-    }
-
     uint16_t get_position_NE_reset_count(void) WARN_IF_UNUSED {
         return ahrs.get_position_NE_reset_count();
     }

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -814,7 +814,7 @@ void NavEKF2::UpdateFilter(void)
         }
         // update the yaw and position reset data to capture changes due to the lane switch
         if (newPrimaryIndex != primary) {
-            updateLaneSwitchYawResetData(newPrimaryIndex, primary);
+            updateLaneSwitchYawResetData(newPrimaryIndex);
             updateLaneSwitchPosResetData(newPrimaryIndex, primary);
             updateLaneSwitchPosDownResetData(newPrimaryIndex, primary);
             primary = newPrimaryIndex;
@@ -863,7 +863,7 @@ void NavEKF2::checkLaneSwitch(void)
 
     // update the yaw and position reset data to capture changes due to the lane switch
     if (newPrimaryIndex != primary) {
-        updateLaneSwitchYawResetData(newPrimaryIndex, primary);
+        updateLaneSwitchYawResetData(newPrimaryIndex);
         updateLaneSwitchPosResetData(newPrimaryIndex, primary);
         updateLaneSwitchPosDownResetData(newPrimaryIndex, primary);
         primary = newPrimaryIndex;
@@ -1329,44 +1329,6 @@ uint16_t NavEKF2::getYawResetCount(void)
     return yaw_reset_data.count;
 }
 
-// Returns the amount of yaw angle change (in radians) due to the last yaw angle reset or core selection switch
-// Returns the time of the last yaw angle reset or 0 if no reset or core switch has ever occurred
-// Where there are multiple consumers, they must access this function on the same frame as each other
-uint32_t NavEKF2::getLastYawResetAngle(float &yawAngDelta)
-{
-    if (!core) {
-        return 0;
-    }
-
-    yawAngDelta = 0.0f;
-
-    // Do the conversion to msec in one place
-    uint32_t now_time_ms = imuSampleTime_us / 1000;
-
-    // The last time we switched to the current primary core is the first reset event
-    uint32_t lastYawReset_ms = yaw_reset_data.last_primary_change;
-
-    // There has been a change notification in the primary core that the controller has not consumed
-    // or this is a repeated access
-    if (yaw_reset_data.core_changed || yaw_reset_data.last_function_call == now_time_ms) {
-        yawAngDelta = yaw_reset_data.core_delta;
-        yaw_reset_data.core_changed = false;
-    }
-
-    // Record last time controller got the yaw reset
-    yaw_reset_data.last_function_call = now_time_ms;
-
-    // There has been a reset inside the core since we switched so update the time and delta
-    float temp_yawAng;
-    uint32_t lastCoreYawReset_ms = core[primary].getLastYawResetAngle(temp_yawAng);
-    if (lastCoreYawReset_ms > lastYawReset_ms) {
-        yawAngDelta = wrap_PI(yawAngDelta + temp_yawAng);
-        lastYawReset_ms = lastCoreYawReset_ms;
-    }
-
-    return lastYawReset_ms;
-}
-
 // Returns the amount of NE position change due to the last position reset or core switch in metres
 // Returns the time of the last reset or 0 if no reset or core switch has ever occurred
 // Where there are multiple consumers, they must access this function on the same frame as each other
@@ -1454,29 +1416,8 @@ uint32_t NavEKF2::getLastPosDownReset(float &posDelta)
 }
 
 // update the yaw reset data to capture changes due to a lane switch
-void NavEKF2::updateLaneSwitchYawResetData(uint8_t new_primary, uint8_t old_primary)
+void NavEKF2::updateLaneSwitchYawResetData(uint8_t new_primary)
 {
-    Vector3f eulers_old_primary, eulers_new_primary;
-    float old_yaw_delta;
-
-    // If core yaw reset data has been consumed reset delta to zero
-    if (!yaw_reset_data.core_changed) {
-        yaw_reset_data.core_delta = 0;
-    }
-
-    // If current primary has reset yaw after controller got it, add it to the delta
-    if (core[old_primary].getLastYawResetAngle(old_yaw_delta) > yaw_reset_data.last_function_call) {
-        yaw_reset_data.core_delta += old_yaw_delta;
-    }
-
-    // Record the yaw delta between current core and new primary core and the timestamp of the core change
-    // Add current delta in case it hasn't been consumed yet
-    core[old_primary].getEulerAngles(eulers_old_primary);
-    core[new_primary].getEulerAngles(eulers_new_primary);
-    yaw_reset_data.core_delta = wrap_PI(eulers_new_primary.z - eulers_old_primary.z + yaw_reset_data.core_delta);
-    yaw_reset_data.last_primary_change = imuSampleTime_us / 1000;
-    yaw_reset_data.core_changed = true;
-
     // the new primary's historic in-core resets are not new events
     // for consumers; re-seat the count and record a single event for
     // the switch itself

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -1314,6 +1314,21 @@ bool NavEKF2::getHeightControlLimit(float &height) const
     return core[primary].getHeightControlLimit(height);
 }
 
+// Returns a count of yaw reset events; incremented when the primary core
+// changes and when the primary core resets its yaw
+uint16_t NavEKF2::getYawResetCount(void)
+{
+    if (!core) {
+        return 0;
+    }
+    const uint16_t core_count = core[primary].getYawResetCount();
+    if (core_count != yaw_reset_data.last_core_count) {
+        yaw_reset_data.last_core_count = core_count;
+        yaw_reset_data.count++;
+    }
+    return yaw_reset_data.count;
+}
+
 // Returns the amount of yaw angle change (in radians) due to the last yaw angle reset or core selection switch
 // Returns the time of the last yaw angle reset or 0 if no reset or core switch has ever occurred
 // Where there are multiple consumers, they must access this function on the same frame as each other
@@ -1462,6 +1477,11 @@ void NavEKF2::updateLaneSwitchYawResetData(uint8_t new_primary, uint8_t old_prim
     yaw_reset_data.last_primary_change = imuSampleTime_us / 1000;
     yaw_reset_data.core_changed = true;
 
+    // the new primary's historic in-core resets are not new events
+    // for consumers; re-seat the count and record a single event for
+    // the switch itself
+    yaw_reset_data.last_core_count = core[new_primary].getYawResetCount();
+    yaw_reset_data.count++;
 }
 
 // update the position reset data to capture changes due to a lane switch

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -1314,6 +1314,36 @@ bool NavEKF2::getHeightControlLimit(float &height) const
     return core[primary].getHeightControlLimit(height);
 }
 
+// Returns a count of NE position reset events; incremented when the primary
+// core changes and when the primary core resets its NE position
+uint16_t NavEKF2::getPosNorthEastResetCount(void)
+{
+    if (!core) {
+        return 0;
+    }
+    const uint16_t core_count = core[primary].getPosNorthEastResetCount();
+    if (core_count != pos_reset_data.last_core_count) {
+        pos_reset_data.last_core_count = core_count;
+        pos_reset_data.count++;
+    }
+    return pos_reset_data.count;
+}
+
+// Returns a count of D position reset events; incremented when the primary
+// core changes and when the primary core resets its D position
+uint16_t NavEKF2::getPosDownResetCount(void)
+{
+    if (!core) {
+        return 0;
+    }
+    const uint16_t core_count = core[primary].getPosDownResetCount();
+    if (core_count != pos_down_reset_data.last_core_count) {
+        pos_down_reset_data.last_core_count = core_count;
+        pos_down_reset_data.count++;
+    }
+    return pos_down_reset_data.count;
+}
+
 // Returns a count of yaw reset events; incremented when the primary core
 // changes and when the primary core resets its yaw
 uint16_t NavEKF2::getYawResetCount(void)
@@ -1449,6 +1479,12 @@ void NavEKF2::updateLaneSwitchPosResetData(uint8_t new_primary, uint8_t old_prim
     pos_reset_data.last_primary_change = imuSampleTime_us / 1000;
     pos_reset_data.core_changed = true;
 
+    // the new primary's historic in-core resets are not new events
+    // for consumers; re-seat the count and record a single event for
+    // the switch itself
+    pos_reset_data.last_core_count = core[new_primary].getPosNorthEastResetCount();
+    pos_reset_data.count++;
+
 }
 
 // Update the vertical position reset data to capture changes due to a core switch
@@ -1476,6 +1512,12 @@ void NavEKF2::updateLaneSwitchPosDownResetData(uint8_t new_primary, uint8_t old_
     pos_down_reset_data.core_delta = posDownNewPrimary - posDownOldPrimary + pos_down_reset_data.core_delta;
     pos_down_reset_data.last_primary_change = imuSampleTime_us / 1000;
     pos_down_reset_data.core_changed = true;
+
+    // the new primary's historic in-core resets are not new events
+    // for consumers; re-seat the count and record a single event for
+    // the switch itself
+    pos_down_reset_data.last_core_count = core[new_primary].getPosDownResetCount();
+    pos_down_reset_data.count++;
 
 }
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.cpp
@@ -815,8 +815,8 @@ void NavEKF2::UpdateFilter(void)
         // update the yaw and position reset data to capture changes due to the lane switch
         if (newPrimaryIndex != primary) {
             updateLaneSwitchYawResetData(newPrimaryIndex);
-            updateLaneSwitchPosResetData(newPrimaryIndex, primary);
-            updateLaneSwitchPosDownResetData(newPrimaryIndex, primary);
+            updateLaneSwitchPosResetData(newPrimaryIndex);
+            updateLaneSwitchPosDownResetData(newPrimaryIndex);
             primary = newPrimaryIndex;
             lastLaneSwitch_ms = AP::dal().millis();
         }
@@ -864,8 +864,8 @@ void NavEKF2::checkLaneSwitch(void)
     // update the yaw and position reset data to capture changes due to the lane switch
     if (newPrimaryIndex != primary) {
         updateLaneSwitchYawResetData(newPrimaryIndex);
-        updateLaneSwitchPosResetData(newPrimaryIndex, primary);
-        updateLaneSwitchPosDownResetData(newPrimaryIndex, primary);
+        updateLaneSwitchPosResetData(newPrimaryIndex);
+        updateLaneSwitchPosDownResetData(newPrimaryIndex);
         primary = newPrimaryIndex;
         lastLaneSwitch_ms = now;
         GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "NavEKF2: lane switch %u", primary);
@@ -1359,92 +1359,6 @@ uint16_t NavEKF2::getYawResetCount(void)
     return yaw_reset_data.count;
 }
 
-// Returns the amount of NE position change due to the last position reset or core switch in metres
-// Returns the time of the last reset or 0 if no reset or core switch has ever occurred
-// Where there are multiple consumers, they must access this function on the same frame as each other
-uint32_t NavEKF2::getLastPosNorthEastReset(Vector2f &posDelta)
-{
-    if (!core) {
-        return 0;
-    }
-
-    posDelta.zero();
-
-    // Do the conversion to msec in one place
-    uint32_t now_time_ms = imuSampleTime_us / 1000;
-
-    // The last time we switched to the current primary core is the first reset event
-    uint32_t lastPosReset_ms = pos_reset_data.last_primary_change;
-
-    // There has been a change in the primary core that the controller has not consumed
-    // allow for multiple consumers on the same frame
-    if (pos_reset_data.core_changed || pos_reset_data.last_function_call == now_time_ms) {
-        posDelta = pos_reset_data.core_delta;
-        pos_reset_data.core_changed = false;
-    }
-
-    // Record last time controller got the position reset
-    pos_reset_data.last_function_call = now_time_ms;
-
-    // There has been a reset inside the core since we switched so update the time and delta
-    Vector2f tempPosDelta;
-    uint32_t lastCorePosReset_ms = core[primary].getLastPosNorthEastReset(tempPosDelta);
-    if (lastCorePosReset_ms > lastPosReset_ms) {
-        posDelta = posDelta + tempPosDelta;
-        lastPosReset_ms = lastCorePosReset_ms;
-    }
-
-    return lastPosReset_ms;
-}
-
-// return the amount of NE velocity change due to the last velocity reset in metres/sec
-// returns the time of the last reset or 0 if no reset has ever occurred
-uint32_t NavEKF2::getLastVelNorthEastReset(Vector2f &vel) const
-{
-    if (!core) {
-        return 0;
-    }
-    return core[primary].getLastVelNorthEastReset(vel);
-}
-
-// Returns the amount of vertical position change due to the last reset or core switch in metres
-// Returns the time of the last reset or 0 if no reset or core switch has ever occurred
-// Where there are multiple consumers, they must access this function on the same frame as each other
-uint32_t NavEKF2::getLastPosDownReset(float &posDelta)
-{
-    if (!core) {
-        return 0;
-    }
-
-    posDelta = 0.0f;
-
-    // Do the conversion to msec in one place
-    uint32_t now_time_ms = imuSampleTime_us / 1000;
-
-    // The last time we switched to the current primary core is the first reset event
-    uint32_t lastPosReset_ms = pos_down_reset_data.last_primary_change;
-
-    // There has been a change in the primary core that the controller has not consumed
-    // allow for multiple consumers on the same frame
-    if (pos_down_reset_data.core_changed || pos_down_reset_data.last_function_call == now_time_ms) {
-        posDelta = pos_down_reset_data.core_delta;
-        pos_down_reset_data.core_changed = false;
-    }
-
-    // Record last time controller got the position reset
-    pos_down_reset_data.last_function_call = now_time_ms;
-
-    // There has been a reset inside the core since we switched so update the time and delta
-    float tempPosDelta;
-    uint32_t lastCorePosReset_ms = core[primary].getLastPosDownReset(tempPosDelta);
-    if (lastCorePosReset_ms > lastPosReset_ms) {
-        posDelta += tempPosDelta;
-        lastPosReset_ms = lastCorePosReset_ms;
-    }
-
-    return lastPosReset_ms;
-}
-
 // update the yaw reset data to capture changes due to a lane switch
 void NavEKF2::updateLaneSwitchYawResetData(uint8_t new_primary)
 {
@@ -1456,29 +1370,8 @@ void NavEKF2::updateLaneSwitchYawResetData(uint8_t new_primary)
 }
 
 // update the position reset data to capture changes due to a lane switch
-void NavEKF2::updateLaneSwitchPosResetData(uint8_t new_primary, uint8_t old_primary)
+void NavEKF2::updateLaneSwitchPosResetData(uint8_t new_primary)
 {
-    Vector2p pos_old_primary, pos_new_primary;
-    Vector2f old_pos_delta;
-
-    // If core position reset data has been consumed reset delta to zero
-    if (!pos_reset_data.core_changed) {
-        pos_reset_data.core_delta.zero();
-    }
-
-    // If current primary has reset position after controller got it, add it to the delta
-    if (core[old_primary].getLastPosNorthEastReset(old_pos_delta) > pos_reset_data.last_function_call) {
-        pos_reset_data.core_delta += old_pos_delta;
-    }
-
-    // Record the position delta between current core and new primary core and the timestamp of the core change
-    // Add current delta in case it hasn't been consumed yet
-    core[old_primary].getPosNE(pos_old_primary);
-    core[new_primary].getPosNE(pos_new_primary);
-    pos_reset_data.core_delta = (pos_new_primary - pos_old_primary).tofloat() + pos_reset_data.core_delta;
-    pos_reset_data.last_primary_change = imuSampleTime_us / 1000;
-    pos_reset_data.core_changed = true;
-
     // the new primary's historic in-core resets are not new events
     // for consumers; re-seat the count and record a single event for
     // the switch itself
@@ -1490,29 +1383,8 @@ void NavEKF2::updateLaneSwitchPosResetData(uint8_t new_primary, uint8_t old_prim
 // Update the vertical position reset data to capture changes due to a core switch
 // This should be called after the decision to switch cores has been made, but before the
 // new primary EKF update has been run
-void NavEKF2::updateLaneSwitchPosDownResetData(uint8_t new_primary, uint8_t old_primary)
+void NavEKF2::updateLaneSwitchPosDownResetData(uint8_t new_primary)
 {
-    postype_t posDownOldPrimary, posDownNewPrimary;
-    float oldPosDownDelta;
-
-    // If core position reset data has been consumed reset delta to zero
-    if (!pos_down_reset_data.core_changed) {
-        pos_down_reset_data.core_delta = 0.0f;
-    }
-
-    // If current primary has reset position after controller got it, add it to the delta
-    if (core[old_primary].getLastPosDownReset(oldPosDownDelta) > pos_down_reset_data.last_function_call) {
-        pos_down_reset_data.core_delta += oldPosDownDelta;
-    }
-
-    // Record the position delta between current core and new primary core and the timestamp of the core change
-    // Add current delta in case it hasn't been consumed yet
-    core[old_primary].getPosD(posDownOldPrimary);
-    core[new_primary].getPosD(posDownNewPrimary);
-    pos_down_reset_data.core_delta = posDownNewPrimary - posDownOldPrimary + pos_down_reset_data.core_delta;
-    pos_down_reset_data.last_primary_change = imuSampleTime_us / 1000;
-    pos_down_reset_data.core_changed = true;
-
     // the new primary's historic in-core resets are not new events
     // for consumers; re-seat the count and record a single event for
     // the switch itself

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -229,6 +229,10 @@ public:
     // returns the time of the last yaw angle reset or 0 if no reset has ever occurred
     uint32_t getLastYawResetAngle(float &yawAngDelta);
 
+    // return a count of yaw reset events; incremented when the
+    // primary core changes and when the primary core resets its yaw
+    uint16_t getYawResetCount(void);
+
     // return the amount of NE position change due to the last position reset in metres
     // returns the time of the last reset or 0 if no reset has ever occurred
     uint32_t getLastPosNorthEastReset(Vector2f &posDelta);
@@ -427,6 +431,8 @@ private:
         bool core_changed;            // true when a core change happened and hasn't been consumed, false otherwise
         uint32_t last_primary_change; // last time a primary has changed
         float core_delta;             // the amount of yaw change between cores when a change happened
+        uint16_t count;               // count of yaw reset events passed to consumers
+        uint16_t last_core_count;     // primary core's yaw reset count when count last changed
     } yaw_reset_data;
 
     struct {

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -229,6 +229,14 @@ public:
     // primary core changes and when the primary core resets its yaw
     uint16_t getYawResetCount(void);
 
+    // return a count of NE position reset events; incremented when the
+    // primary core changes and when the primary core resets its NE position
+    uint16_t getPosNorthEastResetCount(void);
+
+    // return a count of D position reset events; incremented when the
+    // primary core changes and when the primary core resets its D position
+    uint16_t getPosDownResetCount(void);
+
     // return the amount of NE position change due to the last position reset in metres
     // returns the time of the last reset or 0 if no reset has ever occurred
     uint32_t getLastPosNorthEastReset(Vector2f &posDelta);
@@ -432,6 +440,8 @@ private:
         bool core_changed;            // true when a core change happened and hasn't been consumed, false otherwise
         uint32_t last_primary_change; // last time a primary has changed
         Vector2f core_delta;          // the amount of NE position change between cores when a change happened
+        uint16_t count;               // count of NE position reset events passed to consumers
+        uint16_t last_core_count;     // primary core's NE position reset count when count last changed
     } pos_reset_data;
 
     struct {
@@ -439,6 +449,8 @@ private:
         bool core_changed;            // true when a core change happened and hasn't been consumed, false otherwise
         uint32_t last_primary_change; // last time a primary has changed
         float core_delta;             // the amount of D position change between cores when a change happened
+        uint16_t count;               // count of D position reset events passed to consumers
+        uint16_t last_core_count;     // primary core's D position reset count when count last changed
     } pos_down_reset_data;
 
     bool runCoreSelection; // true when the primary core has stabilised and the core selection logic can be started

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -225,10 +225,6 @@ public:
     // this is needed to ensure the vehicle does not fly too high when using optical flow navigation
     bool getHeightControlLimit(float &height) const;
 
-    // return the amount of yaw angle change (in radians) due to the last yaw angle reset or core selection switch
-    // returns the time of the last yaw angle reset or 0 if no reset has ever occurred
-    uint32_t getLastYawResetAngle(float &yawAngDelta);
-
     // return a count of yaw reset events; incremented when the
     // primary core changes and when the primary core resets its yaw
     uint16_t getYawResetCount(void);
@@ -427,10 +423,6 @@ private:
     uint64_t lastLogWrite_us;
     
     struct {
-        uint32_t last_function_call;  // last time getLastYawResetAngle was called
-        bool core_changed;            // true when a core change happened and hasn't been consumed, false otherwise
-        uint32_t last_primary_change; // last time a primary has changed
-        float core_delta;             // the amount of yaw change between cores when a change happened
         uint16_t count;               // count of yaw reset events passed to consumers
         uint16_t last_core_count;     // primary core's yaw reset count when count last changed
     } yaw_reset_data;
@@ -468,7 +460,7 @@ private:
     // update the yaw reset data to capture changes due to a lane switch
     // new_primary - index of the ekf instance that we are about to switch to as the primary
     // old_primary - index of the ekf instance that we are currently using as the primary
-    void updateLaneSwitchYawResetData(uint8_t new_primary, uint8_t old_primary);
+    void updateLaneSwitchYawResetData(uint8_t new_primary);
 
     // update the position reset data to capture changes due to a lane switch
     // new_primary - index of the ekf instance that we are about to switch to as the primary

--- a/libraries/AP_NavEKF2/AP_NavEKF2.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2.h
@@ -237,18 +237,6 @@ public:
     // primary core changes and when the primary core resets its D position
     uint16_t getPosDownResetCount(void);
 
-    // return the amount of NE position change due to the last position reset in metres
-    // returns the time of the last reset or 0 if no reset has ever occurred
-    uint32_t getLastPosNorthEastReset(Vector2f &posDelta);
-
-    // return the amount of NE velocity change due to the last velocity reset in metres/sec
-    // returns the time of the last reset or 0 if no reset has ever occurred
-    uint32_t getLastVelNorthEastReset(Vector2f &vel) const;
-
-    // return the amount of vertical position change due to the last reset in metres
-    // returns the time of the last reset or 0 if no reset has ever occurred
-    uint32_t getLastPosDownReset(float &posDelta);
-
     // set and save the _baroAltNoise parameter
     void set_baro_alt_noise(float noise) { _baroAltNoise.set_and_save(noise); };
 
@@ -436,19 +424,11 @@ private:
     } yaw_reset_data;
 
     struct {
-        uint32_t last_function_call;  // last time getLastPosNorthEastReset was called
-        bool core_changed;            // true when a core change happened and hasn't been consumed, false otherwise
-        uint32_t last_primary_change; // last time a primary has changed
-        Vector2f core_delta;          // the amount of NE position change between cores when a change happened
         uint16_t count;               // count of NE position reset events passed to consumers
         uint16_t last_core_count;     // primary core's NE position reset count when count last changed
     } pos_reset_data;
 
     struct {
-        uint32_t last_function_call;  // last time getLastPosDownReset was called
-        bool core_changed;            // true when a core change happened and hasn't been consumed, false otherwise
-        uint32_t last_primary_change; // last time a primary has changed
-        float core_delta;             // the amount of D position change between cores when a change happened
         uint16_t count;               // count of D position reset events passed to consumers
         uint16_t last_core_count;     // primary core's D position reset count when count last changed
     } pos_down_reset_data;
@@ -477,12 +457,12 @@ private:
     // update the position reset data to capture changes due to a lane switch
     // new_primary - index of the ekf instance that we are about to switch to as the primary
     // old_primary - index of the ekf instance that we are currently using as the primary
-    void updateLaneSwitchPosResetData(uint8_t new_primary, uint8_t old_primary);
+    void updateLaneSwitchPosResetData(uint8_t new_primary);
 
     // update the position down reset data to capture changes due to a lane switch
     // new_primary - index of the ekf instance that we are about to switch to as the primary
     // old_primary - index of the ekf instance that we are currently using as the primary
-    void updateLaneSwitchPosDownResetData(uint8_t new_primary, uint8_t old_primary);
+    void updateLaneSwitchPosDownResetData(uint8_t new_primary);
 
     // return true if a new core has a better score than an existing core, including
     // checks for alignment

--- a/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
@@ -1233,8 +1233,6 @@ void NavEKF2_core::resetQuatStateYawOnly(ftype yaw, ftype yawVariance, bool isDe
     // Update the rotation matrix
     stateStruct.quat.inverse().rotation_matrix(prevTnb);
     
-    ftype deltaYaw = wrap_PI(yaw - eulerAngles.z);
-
     // calculate the change in the quaternion state and apply it to the output history buffer
     QuaternionF quat_delta = stateStruct.quat / quatBeforeReset;
     StoreQuatRotate(quat_delta);
@@ -1259,8 +1257,6 @@ void NavEKF2_core::resetQuatStateYawOnly(ftype yaw, ftype yawVariance, bool isDe
     P[2][2] = bf_variances.z;
 
     // record the yaw reset event
-    yawResetAngle += deltaYaw;
-    lastYawReset_ms = imuSampleTime_ms;
     yawResetCount++;
     recordYawReset();
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_MagFusion.cpp
@@ -1261,6 +1261,7 @@ void NavEKF2_core::resetQuatStateYawOnly(ftype yaw, ftype yawVariance, bool isDe
     // record the yaw reset event
     yawResetAngle += deltaYaw;
     lastYawReset_ms = imuSampleTime_ms;
+    yawResetCount++;
     recordYawReset();
 
     // clear all pending yaw reset requests

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -124,14 +124,6 @@ void NavEKF2_core::getQuaternion(Quaternion& ret) const
     ret = outputDataNew.quat.tofloat();
 }
 
-// return the amount of yaw angle change due to the last yaw angle reset in radians
-// returns the time of the last yaw angle reset or 0 if no reset has ever occurred
-uint32_t NavEKF2_core::getLastYawResetAngle(float &yawAng) const
-{
-    yawAng = yawResetAngle;
-    return lastYawReset_ms;
-}
-
 // return the amount of NE position change due to the last position reset in metres
 // returns the time of the last reset or 0 if no reset has ever occurred
 uint32_t NavEKF2_core::getLastPosNorthEastReset(Vector2f &pos) const

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Outputs.cpp
@@ -124,30 +124,6 @@ void NavEKF2_core::getQuaternion(Quaternion& ret) const
     ret = outputDataNew.quat.tofloat();
 }
 
-// return the amount of NE position change due to the last position reset in metres
-// returns the time of the last reset or 0 if no reset has ever occurred
-uint32_t NavEKF2_core::getLastPosNorthEastReset(Vector2f &pos) const
-{
-    pos = posResetNE.tofloat();
-    return lastPosReset_ms;
-}
-
-// return the amount of vertical position change due to the last vertical position reset in metres
-// returns the time of the last reset or 0 if no reset has ever occurred
-uint32_t NavEKF2_core::getLastPosDownReset(float &posD) const
-{
-    posD = posResetD;
-    return lastPosResetD_ms;
-}
-
-// return the amount of NE velocity change due to the last velocity reset in metres/sec
-// returns the time of the last reset or 0 if no reset has ever occurred
-uint32_t NavEKF2_core::getLastVelNorthEastReset(Vector2f &vel) const
-{
-    vel = velResetNE.tofloat();
-    return lastVelReset_ms;
-}
-
 // return the NED wind speed estimates in m/s (positive is air moving in the direction of the axis)
 void NavEKF2_core::getWind(Vector3f &wind) const
 {

--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -14,10 +14,6 @@ extern const AP_HAL::HAL& hal;
 // Do not reset vertical velocity using GPS as there is baro alt available to constrain drift
 void NavEKF2_core::ResetVelocity(void)
 {
-    // Store the position before the reset so that we can record the reset delta
-    velResetNE.x = stateStruct.velocity.x;
-    velResetNE.y = stateStruct.velocity.y;
-
     // reset the corresponding covariances
     zeroRows(P,3,4);
     zeroCols(P,3,4);
@@ -59,12 +55,6 @@ void NavEKF2_core::ResetVelocity(void)
     outputDataDelayed.velocity.x = stateStruct.velocity.x;
     outputDataDelayed.velocity.y = stateStruct.velocity.y;
 
-    // Calculate the position jump due to the reset
-    velResetNE.x = stateStruct.velocity.x - velResetNE.x;
-    velResetNE.y = stateStruct.velocity.y - velResetNE.y;
-
-    // store the time of the reset
-    lastVelReset_ms = imuSampleTime_ms;
 
 
 }
@@ -135,8 +125,6 @@ void NavEKF2_core::ResetPosition(void)
     posResetNE.x = stateStruct.position.x - posResetNE.x;
     posResetNE.y = stateStruct.position.y - posResetNE.y;
 
-    // store the time of the reset
-    lastPosReset_ms = imuSampleTime_ms;
     posNEResetCount++;
 
 }
@@ -144,7 +132,7 @@ void NavEKF2_core::ResetPosition(void)
 // reset the stateStruct's NE position to the specified position
 //    posResetNE is updated to hold the change in position
 //    storedOutput, outputDataNew and outputDataDelayed are updated with the change in position
-//    lastPosReset_ms is updated with the time of the reset
+//    posNEResetCount is incremented to record the reset
 void NavEKF2_core::ResetPositionNE(ftype posN, ftype posE)
 {
     // Store the position before the reset so that we can record the reset delta
@@ -168,8 +156,6 @@ void NavEKF2_core::ResetPositionNE(ftype posN, ftype posE)
     outputDataDelayed.position.x += posResetNE.x;
     outputDataDelayed.position.y += posResetNE.y;
 
-    // store the time of the reset
-    lastPosReset_ms = imuSampleTime_ms;
     posNEResetCount++;
 }
 
@@ -200,8 +186,6 @@ void NavEKF2_core::ResetHeight(void)
     // Calculate the position jump due to the reset
     posResetD = stateStruct.position.z - posResetD;
 
-    // store the time of the reset
-    lastPosResetD_ms = imuSampleTime_ms;
     posDResetCount++;
 
     // clear the timeout flags and counters
@@ -247,7 +231,7 @@ void NavEKF2_core::ResetHeight(void)
 // reset the stateStruct's D position
 //    posResetD is updated to hold the change in position
 //    storedOutput, outputDataNew and outputDataDelayed are updated with the change in position
-//    lastPosResetD_ms is updated with the time of the reset
+//    posDResetCount is incremented to record the reset
 void NavEKF2_core::ResetPositionD(ftype posD)
 {
     // Store the position before the reset so that we can record the reset delta
@@ -267,8 +251,6 @@ void NavEKF2_core::ResetPositionD(ftype posD)
         storedOutput[i].position.z += posResetD;
     }
 
-    // store the time of the reset
-    lastPosResetD_ms = imuSampleTime_ms;
     posDResetCount++;
 }
 
@@ -505,8 +487,6 @@ void NavEKF2_core::SelectVelPosFusion()
         outputDataDelayed.position.x += posResetNE.x;
         outputDataDelayed.position.y += posResetNE.y;
 
-        // store the time of the reset
-        lastPosReset_ms = imuSampleTime_ms;
         posNEResetCount++;
 
         // If we are also using GPS as the height reference, reset the height
@@ -528,8 +508,6 @@ void NavEKF2_core::SelectVelPosFusion()
                 storedOutput[i].position.z += posResetD;
             }
 
-            // store the time of the reset
-            lastPosResetD_ms = imuSampleTime_ms;
             posDResetCount++;
         }
     }

--- a/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_PosVelFusion.cpp
@@ -137,6 +137,7 @@ void NavEKF2_core::ResetPosition(void)
 
     // store the time of the reset
     lastPosReset_ms = imuSampleTime_ms;
+    posNEResetCount++;
 
 }
 
@@ -169,6 +170,7 @@ void NavEKF2_core::ResetPositionNE(ftype posN, ftype posE)
 
     // store the time of the reset
     lastPosReset_ms = imuSampleTime_ms;
+    posNEResetCount++;
 }
 
 // reset the vertical position state using the last height measurement
@@ -200,6 +202,7 @@ void NavEKF2_core::ResetHeight(void)
 
     // store the time of the reset
     lastPosResetD_ms = imuSampleTime_ms;
+    posDResetCount++;
 
     // clear the timeout flags and counters
     hgtTimeout = false;
@@ -266,6 +269,7 @@ void NavEKF2_core::ResetPositionD(ftype posD)
 
     // store the time of the reset
     lastPosResetD_ms = imuSampleTime_ms;
+    posDResetCount++;
 }
 
 // Zero the EKF height datum
@@ -503,6 +507,7 @@ void NavEKF2_core::SelectVelPosFusion()
 
         // store the time of the reset
         lastPosReset_ms = imuSampleTime_ms;
+        posNEResetCount++;
 
         // If we are also using GPS as the height reference, reset the height
         if (activeHgtSource == HGT_SOURCE_GPS) {
@@ -525,6 +530,7 @@ void NavEKF2_core::SelectVelPosFusion()
 
             // store the time of the reset
             lastPosResetD_ms = imuSampleTime_ms;
+            posDResetCount++;
         }
     }
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -200,8 +200,6 @@ void NavEKF2_core::InitialiseVariables()
     gpsHgtAccuracy = 0.0f;
     baroHgtOffset = 0.0f;
     rngOnGnd = 0.05f;
-    yawResetAngle = 0.0f;
-    lastYawReset_ms = 0;
     yawResetCount = 0;
     tiltErrFilt = 1.0f;
     tiltAlignComplete = false;
@@ -1619,15 +1617,7 @@ QuaternionF NavEKF2_core::calcQuatAndFieldStates(ftype roll, ftype pitch)
         yaw = magDecAng - magHeading;
 
         // calculate initial filter quaternion states using yaw from magnetometer
-        // store the yaw change so that it can be retrieved externally for use by the control loops to prevent yaw disturbances following a reset
-        Vector3F tempEuler;
-        stateStruct.quat.to_euler(tempEuler.x, tempEuler.y, tempEuler.z);
-        // this check ensures we accumulate the resets that occur within a single iteration of the EKF
-        if (imuSampleTime_ms != lastYawReset_ms) {
-            yawResetAngle = 0.0f;
-        }
-        yawResetAngle += wrap_PI(yaw - tempEuler.z);
-        lastYawReset_ms = imuSampleTime_ms;
+        // record the reset so that it can be detected externally for use by the control loops to prevent yaw disturbances following a reset
         yawResetCount++;
         // calculate an initial quaternion using the new yaw value
         initQuat.from_euler(roll, pitch, yaw);

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -153,6 +153,8 @@ void NavEKF2_core::InitialiseVariables()
     lastPosReset_ms = 0;
     lastVelReset_ms = 0;
     lastPosResetD_ms = 0;
+    posNEResetCount = 0;
+    posDResetCount = 0;
     lastRngMeasTime_ms = 0;
 
     // initialise other variables

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -150,9 +150,6 @@ void NavEKF2_core::InitialiseVariables()
     lastGpsAidBadTime_ms = 0;
     timeTasReceived_ms = 0;
     lastPreAlignGpsCheckTime_ms = imuSampleTime_ms;
-    lastPosReset_ms = 0;
-    lastVelReset_ms = 0;
-    lastPosResetD_ms = 0;
     posNEResetCount = 0;
     posDResetCount = 0;
     lastRngMeasTime_ms = 0;
@@ -233,7 +230,6 @@ void NavEKF2_core::InitialiseVariables()
     airSpdFusionDelayed = false;
     sideSlipFusionDelayed = false;
     posResetNE.zero();
-    velResetNE.zero();
     posResetD = 0.0f;
     hgtInnovFiltState = 0.0f;
 

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.cpp
@@ -202,6 +202,7 @@ void NavEKF2_core::InitialiseVariables()
     rngOnGnd = 0.05f;
     yawResetAngle = 0.0f;
     lastYawReset_ms = 0;
+    yawResetCount = 0;
     tiltErrFilt = 1.0f;
     tiltAlignComplete = false;
     stateIndexLim = 23;
@@ -1627,6 +1628,7 @@ QuaternionF NavEKF2_core::calcQuatAndFieldStates(ftype roll, ftype pitch)
         }
         yawResetAngle += wrap_PI(yaw - tempEuler.z);
         lastYawReset_ms = imuSampleTime_ms;
+        yawResetCount++;
         // calculate an initial quaternion using the new yaw value
         initQuat.from_euler(roll, pitch, yaw);
         // zero the attitude covariances because the corelations will now be invalid

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -268,6 +268,9 @@ public:
     // returns the time of the last yaw angle reset or 0 if no reset has ever occurred
     uint32_t getLastYawResetAngle(float &yawAng) const;
 
+    // return the number of yaw resets performed by this core
+    uint16_t getYawResetCount(void) const { return yawResetCount; }
+
     // return the amount of NE position change due to the last position reset in metres
     // returns the time of the last reset or 0 if no reset has ever occurred
     uint32_t getLastPosNorthEastReset(Vector2f &pos) const;
@@ -881,6 +884,7 @@ private:
     bool useGpsVertVel;             // true if GPS vertical velocity should be used
     ftype yawResetAngle;            // Change in yaw angle due to last in-flight yaw reset in radians. A positive value means the yaw angle has increased.
     uint32_t lastYawReset_ms;       // System time at which the last yaw reset occurred. Returned by getLastYawResetAngle
+    uint16_t yawResetCount;         // number of yaw resets performed by this core
     Vector3F tiltErrVec;            // Vector of most recent attitude error correction from Vel,Pos fusion
     ftype tiltErrFilt;              // Filtered tilt error metric
     bool tiltAlignComplete;         // true when tilt alignment is complete

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -267,6 +267,12 @@ public:
     // return the number of yaw resets performed by this core
     uint16_t getYawResetCount(void) const { return yawResetCount; }
 
+    // return the number of NE position resets performed by this core
+    uint16_t getPosNorthEastResetCount(void) const { return posNEResetCount; }
+
+    // return the number of D position resets performed by this core
+    uint16_t getPosDownResetCount(void) const { return posDResetCount; }
+
     // return the amount of NE position change due to the last position reset in metres
     // returns the time of the last reset or 0 if no reset has ever occurred
     uint32_t getLastPosNorthEastReset(Vector2f &pos) const;
@@ -922,6 +928,8 @@ private:
     uint32_t lastVelReset_ms;       // System time at which the last velocity reset occurred. Returned by getLastVelNorthEastReset
     ftype posResetD;                // Change in Down position due to last in-flight reset in metres. Returned by getLastPosDowntReset
     uint32_t lastPosResetD_ms;      // System time at which the last position reset occurred. Returned by getLastPosDownReset
+    uint16_t posNEResetCount;       // number of NE position resets performed by this core
+    uint16_t posDResetCount;        // number of D position resets performed by this core
     ftype yawTestRatio;             // square of magnetometer yaw angle innovation divided by fail threshold
     QuaternionF prevQuatMagReset;    // Quaternion from the last time the magnetic field state reset condition test was performed
     ftype hgtInnovFiltState;        // state used for fitering of the height innovations used for pre-flight checks

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -273,18 +273,6 @@ public:
     // return the number of D position resets performed by this core
     uint16_t getPosDownResetCount(void) const { return posDResetCount; }
 
-    // return the amount of NE position change due to the last position reset in metres
-    // returns the time of the last reset or 0 if no reset has ever occurred
-    uint32_t getLastPosNorthEastReset(Vector2f &pos) const;
-
-    // return the amount of D position change due to the last position reset in metres
-    // returns the time of the last reset or 0 if no reset has ever occurred
-    uint32_t getLastPosDownReset(float &posD) const;
-
-    // return the amount of NE velocity change due to the last velocity reset in metres/sec
-    // returns the time of the last reset or 0 if no reset has ever occurred
-    uint32_t getLastVelNorthEastReset(Vector2f &vel) const;
-
     // report any reason for why the backend is refusing to initialise
     const char *prearm_failure_reason(void) const;
 
@@ -922,12 +910,8 @@ private:
     bool sideSlipFusionDelayed;     // true when the sideslip fusion has been delayed
     Vector3F lastMagOffsets;        // Last magnetometer offsets from COMPASS_ parameters. Used to detect parameter changes.
     bool lastMagOffsetsValid;       // True when lastMagOffsets has been initialized
-    Vector2F posResetNE;            // Change in North/East position due to last in-flight reset in metres. Returned by getLastPosNorthEastReset
-    uint32_t lastPosReset_ms;       // System time at which the last position reset occurred. Returned by getLastPosNorthEastReset
-    Vector2F velResetNE;            // Change in North/East velocity due to last in-flight reset in metres/sec. Returned by getLastVelNorthEastReset
-    uint32_t lastVelReset_ms;       // System time at which the last velocity reset occurred. Returned by getLastVelNorthEastReset
-    ftype posResetD;                // Change in Down position due to last in-flight reset in metres. Returned by getLastPosDowntReset
-    uint32_t lastPosResetD_ms;      // System time at which the last position reset occurred. Returned by getLastPosDownReset
+    Vector2F posResetNE;            // Change in North/East position due to last in-flight reset in metres
+    ftype posResetD;                // Change in Down position due to last in-flight reset in metres
     uint16_t posNEResetCount;       // number of NE position resets performed by this core
     uint16_t posDResetCount;        // number of D position resets performed by this core
     ftype yawTestRatio;             // square of magnetometer yaw angle innovation divided by fail threshold

--- a/libraries/AP_NavEKF2/AP_NavEKF2_core.h
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_core.h
@@ -264,10 +264,6 @@ public:
     // this is needed to ensure the vehicle does not fly too high when using optical flow navigation
     bool getHeightControlLimit(float &height) const;
 
-    // return the amount of yaw angle change due to the last yaw angle reset in radians
-    // returns the time of the last yaw angle reset or 0 if no reset has ever occurred
-    uint32_t getLastYawResetAngle(float &yawAng) const;
-
     // return the number of yaw resets performed by this core
     uint16_t getYawResetCount(void) const { return yawResetCount; }
 
@@ -882,8 +878,6 @@ private:
     uint32_t lastGpsAidBadTime_ms;  // time in msec gps aiding was last detected to be bad
     ftype posDownAtTakeoff;         // flight vehicle vertical position sampled at transition from on-ground to in-air and used as a reference (m)
     bool useGpsVertVel;             // true if GPS vertical velocity should be used
-    ftype yawResetAngle;            // Change in yaw angle due to last in-flight yaw reset in radians. A positive value means the yaw angle has increased.
-    uint32_t lastYawReset_ms;       // System time at which the last yaw reset occurred. Returned by getLastYawResetAngle
     uint16_t yawResetCount;         // number of yaw resets performed by this core
     Vector3F tiltErrVec;            // Vector of most recent attitude error correction from Vel,Pos fusion
     ftype tiltErrFilt;              // Filtered tilt error metric

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -1094,7 +1094,7 @@ void NavEKF3::switchLane(uint8_t new_lane_index)
     }
 
     if (new_lane_index != primary) {
-        updateLaneSwitchYawResetData(new_lane_index, primary);
+        updateLaneSwitchYawResetData(new_lane_index);
         updateLaneSwitchPosResetData(new_lane_index, primary);
         updateLaneSwitchPosDownResetData(new_lane_index, primary);
         primary = new_lane_index;
@@ -1977,44 +1977,6 @@ uint16_t NavEKF3::getYawResetCount(void)
     return yaw_reset_data.count;
 }
 
-// Returns the amount of yaw angle change (in radians) due to the last yaw angle reset or core selection switch
-// Returns the time of the last yaw angle reset or 0 if no reset or core switch has ever occurred
-// Where there are multiple consumers, they must access this function on the same frame as each other
-uint32_t NavEKF3::getLastYawResetAngle(float &yawAngDelta)
-{
-    if (!core) {
-        return 0;
-    }
-
-    yawAngDelta = 0.0f;
-
-    // Do the conversion to msec in one place
-    uint32_t now_time_ms = imuSampleTime_us / 1000;
-
-    // The last time we switched to the current primary core is the first reset event
-    uint32_t lastYawReset_ms = yaw_reset_data.last_primary_change;
-
-    // There has been a change notification in the primary core that the controller has not consumed
-    // or this is a repeated access
-    if (yaw_reset_data.core_changed || yaw_reset_data.last_function_call == now_time_ms) {
-        yawAngDelta = yaw_reset_data.core_delta;
-        yaw_reset_data.core_changed = false;
-    }
-
-    // Record last time controller got the yaw reset
-    yaw_reset_data.last_function_call = now_time_ms;
-
-    // There has been a reset inside the core since we switched so update the time and delta
-    float temp_yawAng;
-    uint32_t lastCoreYawReset_ms = core[primary].getLastYawResetAngle(temp_yawAng);
-    if (lastCoreYawReset_ms > lastYawReset_ms) {
-        yawAngDelta = wrap_PI(yawAngDelta + temp_yawAng);
-        lastYawReset_ms = lastCoreYawReset_ms;
-    }
-
-    return lastYawReset_ms;
-}
-
 // Returns the amount of NE position change due to the last position reset or core switch in metres
 // Returns the time of the last reset or 0 if no reset or core switch has ever occurred
 // Where there are multiple consumers, they must access this function on the same frame as each other
@@ -2102,29 +2064,8 @@ uint32_t NavEKF3::getLastPosDownReset(float &posDelta)
 }
 
 // update the yaw reset data to capture changes due to a lane switch
-void NavEKF3::updateLaneSwitchYawResetData(uint8_t new_primary, uint8_t old_primary)
+void NavEKF3::updateLaneSwitchYawResetData(uint8_t new_primary)
 {
-    Vector3f eulers_old_primary, eulers_new_primary;
-    float old_yaw_delta;
-
-    // If core yaw reset data has been consumed reset delta to zero
-    if (!yaw_reset_data.core_changed) {
-        yaw_reset_data.core_delta = 0;
-    }
-
-    // If current primary has reset yaw after controller got it, add it to the delta
-    if (core[old_primary].getLastYawResetAngle(old_yaw_delta) > yaw_reset_data.last_function_call) {
-        yaw_reset_data.core_delta += old_yaw_delta;
-    }
-
-    // Record the yaw delta between current core and new primary core and the timestamp of the core change
-    // Add current delta in case it hasn't been consumed yet
-    core[old_primary].getEulerAngles(eulers_old_primary);
-    core[new_primary].getEulerAngles(eulers_new_primary);
-    yaw_reset_data.core_delta = wrap_PI(eulers_new_primary.z - eulers_old_primary.z + yaw_reset_data.core_delta);
-    yaw_reset_data.last_primary_change = imuSampleTime_us / 1000;
-    yaw_reset_data.core_changed = true;
-
     // the new primary's historic in-core resets are not new events
     // for consumers; re-seat the count and record a single event for
     // the switch itself

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -1962,6 +1962,36 @@ bool NavEKF3::getHeightControlLimit(float &height) const
     return core[primary].getHeightControlLimit(height);
 }
 
+// Returns a count of NE position reset events; incremented when the primary
+// core changes and when the primary core resets its NE position
+uint16_t NavEKF3::getPosNorthEastResetCount(void)
+{
+    if (!core) {
+        return 0;
+    }
+    const uint16_t core_count = core[primary].getPosNorthEastResetCount();
+    if (core_count != pos_reset_data.last_core_count) {
+        pos_reset_data.last_core_count = core_count;
+        pos_reset_data.count++;
+    }
+    return pos_reset_data.count;
+}
+
+// Returns a count of D position reset events; incremented when the primary
+// core changes and when the primary core resets its D position
+uint16_t NavEKF3::getPosDownResetCount(void)
+{
+    if (!core) {
+        return 0;
+    }
+    const uint16_t core_count = core[primary].getPosDownResetCount();
+    if (core_count != pos_down_reset_data.last_core_count) {
+        pos_down_reset_data.last_core_count = core_count;
+        pos_down_reset_data.count++;
+    }
+    return pos_down_reset_data.count;
+}
+
 // Returns a count of yaw reset events; incremented when the primary core
 // changes and when the primary core resets its yaw
 uint16_t NavEKF3::getYawResetCount(void)
@@ -2097,6 +2127,12 @@ void NavEKF3::updateLaneSwitchPosResetData(uint8_t new_primary, uint8_t old_prim
     pos_reset_data.last_primary_change = imuSampleTime_us / 1000;
     pos_reset_data.core_changed = true;
 
+    // the new primary's historic in-core resets are not new events
+    // for consumers; re-seat the count and record a single event for
+    // the switch itself
+    pos_reset_data.last_core_count = core[new_primary].getPosNorthEastResetCount();
+    pos_reset_data.count++;
+
 }
 
 // Update the vertical position reset data to capture changes due to a core switch
@@ -2124,6 +2160,12 @@ void NavEKF3::updateLaneSwitchPosDownResetData(uint8_t new_primary, uint8_t old_
     pos_down_reset_data.core_delta = posDownNewPrimary - posDownOldPrimary + pos_down_reset_data.core_delta;
     pos_down_reset_data.last_primary_change = imuSampleTime_us / 1000;
     pos_down_reset_data.core_changed = true;
+
+    // the new primary's historic in-core resets are not new events
+    // for consumers; re-seat the count and record a single event for
+    // the switch itself
+    pos_down_reset_data.last_core_count = core[new_primary].getPosDownResetCount();
+    pos_down_reset_data.count++;
 
 }
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -1095,8 +1095,8 @@ void NavEKF3::switchLane(uint8_t new_lane_index)
 
     if (new_lane_index != primary) {
         updateLaneSwitchYawResetData(new_lane_index);
-        updateLaneSwitchPosResetData(new_lane_index, primary);
-        updateLaneSwitchPosDownResetData(new_lane_index, primary);
+        updateLaneSwitchPosResetData(new_lane_index);
+        updateLaneSwitchPosDownResetData(new_lane_index);
         primary = new_lane_index;
         lastLaneSwitch_ms = dal.millis();
         GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "EKF3 lane switch %u", primary);
@@ -2007,92 +2007,6 @@ uint16_t NavEKF3::getYawResetCount(void)
     return yaw_reset_data.count;
 }
 
-// Returns the amount of NE position change due to the last position reset or core switch in metres
-// Returns the time of the last reset or 0 if no reset or core switch has ever occurred
-// Where there are multiple consumers, they must access this function on the same frame as each other
-uint32_t NavEKF3::getLastPosNorthEastReset(Vector2f &posDelta)
-{
-    if (!core) {
-        return 0;
-    }
-
-    posDelta.zero();
-
-    // Do the conversion to msec in one place
-    uint32_t now_time_ms = imuSampleTime_us / 1000;
-
-    // The last time we switched to the current primary core is the first reset event
-    uint32_t lastPosReset_ms = pos_reset_data.last_primary_change;
-
-    // There has been a change in the primary core that the controller has not consumed
-    // allow for multiple consumers on the same frame
-    if (pos_reset_data.core_changed || pos_reset_data.last_function_call == now_time_ms) {
-        posDelta = pos_reset_data.core_delta;
-        pos_reset_data.core_changed = false;
-    }
-
-    // Record last time controller got the position reset
-    pos_reset_data.last_function_call = now_time_ms;
-
-    // There has been a reset inside the core since we switched so update the time and delta
-    Vector2f tempPosDelta;
-    uint32_t lastCorePosReset_ms = core[primary].getLastPosNorthEastReset(tempPosDelta);
-    if (lastCorePosReset_ms > lastPosReset_ms) {
-        posDelta = posDelta + tempPosDelta;
-        lastPosReset_ms = lastCorePosReset_ms;
-    }
-
-    return lastPosReset_ms;
-}
-
-// return the amount of NE velocity change due to the last velocity reset in metres/sec
-// returns the time of the last reset or 0 if no reset has ever occurred
-uint32_t NavEKF3::getLastVelNorthEastReset(Vector2f &vel) const
-{
-    if (!core) {
-        return 0;
-    }
-    return core[primary].getLastVelNorthEastReset(vel);
-}
-
-// Returns the amount of vertical position change due to the last reset or core switch in metres
-// Returns the time of the last reset or 0 if no reset or core switch has ever occurred
-// Where there are multiple consumers, they must access this function on the same frame as each other
-uint32_t NavEKF3::getLastPosDownReset(float &posDelta)
-{
-    if (!core) {
-        return 0;
-    }
-
-    posDelta = 0.0f;
-
-    // Do the conversion to msec in one place
-    uint32_t now_time_ms = imuSampleTime_us / 1000;
-
-    // The last time we switched to the current primary core is the first reset event
-    uint32_t lastPosReset_ms = pos_down_reset_data.last_primary_change;
-
-    // There has been a change in the primary core that the controller has not consumed
-    // allow for multiple consumers on the same frame
-    if (pos_down_reset_data.core_changed || pos_down_reset_data.last_function_call == now_time_ms) {
-        posDelta = pos_down_reset_data.core_delta;
-        pos_down_reset_data.core_changed = false;
-    }
-
-    // Record last time controller got the position reset
-    pos_down_reset_data.last_function_call = now_time_ms;
-
-    // There has been a reset inside the core since we switched so update the time and delta
-    float tempPosDelta;
-    uint32_t lastCorePosReset_ms = core[primary].getLastPosDownReset(tempPosDelta);
-    if (lastCorePosReset_ms > lastPosReset_ms) {
-        posDelta += tempPosDelta;
-        lastPosReset_ms = lastCorePosReset_ms;
-    }
-
-    return lastPosReset_ms;
-}
-
 // update the yaw reset data to capture changes due to a lane switch
 void NavEKF3::updateLaneSwitchYawResetData(uint8_t new_primary)
 {
@@ -2104,29 +2018,8 @@ void NavEKF3::updateLaneSwitchYawResetData(uint8_t new_primary)
 }
 
 // update the position reset data to capture changes due to a lane switch
-void NavEKF3::updateLaneSwitchPosResetData(uint8_t new_primary, uint8_t old_primary)
+void NavEKF3::updateLaneSwitchPosResetData(uint8_t new_primary)
 {
-    Vector2p pos_old_primary, pos_new_primary;
-    Vector2f old_pos_delta;
-
-    // If core position reset data has been consumed reset delta to zero
-    if (!pos_reset_data.core_changed) {
-        pos_reset_data.core_delta.zero();
-    }
-
-    // If current primary has reset position after controller got it, add it to the delta
-    if (core[old_primary].getLastPosNorthEastReset(old_pos_delta) > pos_reset_data.last_function_call) {
-        pos_reset_data.core_delta += old_pos_delta;
-    }
-
-    // Record the position delta between current core and new primary core and the timestamp of the core change
-    // Add current delta in case it hasn't been consumed yet
-    core[old_primary].getPosNE(pos_old_primary);
-    core[new_primary].getPosNE(pos_new_primary);
-    pos_reset_data.core_delta = (pos_new_primary - pos_old_primary).tofloat() + pos_reset_data.core_delta;
-    pos_reset_data.last_primary_change = imuSampleTime_us / 1000;
-    pos_reset_data.core_changed = true;
-
     // the new primary's historic in-core resets are not new events
     // for consumers; re-seat the count and record a single event for
     // the switch itself
@@ -2138,29 +2031,8 @@ void NavEKF3::updateLaneSwitchPosResetData(uint8_t new_primary, uint8_t old_prim
 // Update the vertical position reset data to capture changes due to a core switch
 // This should be called after the decision to switch cores has been made, but before the
 // new primary EKF update has been run
-void NavEKF3::updateLaneSwitchPosDownResetData(uint8_t new_primary, uint8_t old_primary)
+void NavEKF3::updateLaneSwitchPosDownResetData(uint8_t new_primary)
 {
-    postype_t posDownOldPrimary, posDownNewPrimary;
-    float oldPosDownDelta;
-
-    // If core position reset data has been consumed reset delta to zero
-    if (!pos_down_reset_data.core_changed) {
-        pos_down_reset_data.core_delta = 0.0f;
-    }
-
-    // If current primary has reset position after controller got it, add it to the delta
-    if (core[old_primary].getLastPosDownReset(oldPosDownDelta) > pos_down_reset_data.last_function_call) {
-        pos_down_reset_data.core_delta += oldPosDownDelta;
-    }
-
-    // Record the position delta between current core and new primary core and the timestamp of the core change
-    // Add current delta in case it hasn't been consumed yet
-    core[old_primary].getPosD_local(posDownOldPrimary);
-    core[new_primary].getPosD_local(posDownNewPrimary);
-    pos_down_reset_data.core_delta = posDownNewPrimary - posDownOldPrimary + pos_down_reset_data.core_delta;
-    pos_down_reset_data.last_primary_change = imuSampleTime_us / 1000;
-    pos_down_reset_data.core_changed = true;
-
     // the new primary's historic in-core resets are not new events
     // for consumers; re-seat the count and record a single event for
     // the switch itself

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -1962,6 +1962,21 @@ bool NavEKF3::getHeightControlLimit(float &height) const
     return core[primary].getHeightControlLimit(height);
 }
 
+// Returns a count of yaw reset events; incremented when the primary core
+// changes and when the primary core resets its yaw
+uint16_t NavEKF3::getYawResetCount(void)
+{
+    if (!core) {
+        return 0;
+    }
+    const uint16_t core_count = core[primary].getYawResetCount();
+    if (core_count != yaw_reset_data.last_core_count) {
+        yaw_reset_data.last_core_count = core_count;
+        yaw_reset_data.count++;
+    }
+    return yaw_reset_data.count;
+}
+
 // Returns the amount of yaw angle change (in radians) due to the last yaw angle reset or core selection switch
 // Returns the time of the last yaw angle reset or 0 if no reset or core switch has ever occurred
 // Where there are multiple consumers, they must access this function on the same frame as each other
@@ -2110,6 +2125,11 @@ void NavEKF3::updateLaneSwitchYawResetData(uint8_t new_primary, uint8_t old_prim
     yaw_reset_data.last_primary_change = imuSampleTime_us / 1000;
     yaw_reset_data.core_changed = true;
 
+    // the new primary's historic in-core resets are not new events
+    // for consumers; re-seat the count and record a single event for
+    // the switch itself
+    yaw_reset_data.last_core_count = core[new_primary].getYawResetCount();
+    yaw_reset_data.count++;
 }
 
 // update the position reset data to capture changes due to a lane switch

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -308,6 +308,14 @@ public:
     // primary core changes and when the primary core resets its yaw
     uint16_t getYawResetCount(void);
 
+    // return a count of NE position reset events; incremented when the
+    // primary core changes and when the primary core resets its NE position
+    uint16_t getPosNorthEastResetCount(void);
+
+    // return a count of D position reset events; incremented when the
+    // primary core changes and when the primary core resets its D position
+    uint16_t getPosDownResetCount(void);
+
     // return the amount of NE position change due to the last position reset in metres
     // returns the time of the last reset or 0 if no reset has ever occurred
     uint32_t getLastPosNorthEastReset(Vector2f &posDelta);
@@ -544,6 +552,8 @@ private:
         bool core_changed;            // true when a core change happened and hasn't been consumed, false otherwise
         uint32_t last_primary_change; // last time a primary has changed
         Vector2f core_delta;          // the amount of NE position change between cores when a change happened
+        uint16_t count;               // count of NE position reset events passed to consumers
+        uint16_t last_core_count;     // primary core's NE position reset count when count last changed
     } pos_reset_data;
 
     struct {
@@ -551,6 +561,8 @@ private:
         bool core_changed;            // true when a core change happened and hasn't been consumed, false otherwise
         uint32_t last_primary_change; // last time a primary has changed
         float core_delta;             // the amount of D position change between cores when a change happened
+        uint16_t count;               // count of D position reset events passed to consumers
+        uint16_t last_core_count;     // primary core's D position reset count when count last changed
     } pos_down_reset_data;
 
 #define CORE_ERR_LIM      1 // -LIM to LIM relative error range for a core

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -304,10 +304,6 @@ public:
     // this is needed to ensure the vehicle does not fly too high when using optical flow navigation
     bool getHeightControlLimit(float &height) const;
 
-    // return the amount of yaw angle change (in radians) due to the last yaw angle reset or core selection switch
-    // returns the time of the last yaw angle reset or 0 if no reset has ever occurred
-    uint32_t getLastYawResetAngle(float &yawAngDelta);
-
     // return a count of yaw reset events; incremented when the
     // primary core changes and when the primary core resets its yaw
     uint16_t getYawResetCount(void);
@@ -539,10 +535,6 @@ private:
     uint64_t lastLogWrite_us;
 
     struct {
-        uint32_t last_function_call;  // last time getLastYawResetAngle was called
-        bool core_changed;            // true when a core change happened and hasn't been consumed, false otherwise
-        uint32_t last_primary_change; // last time a primary has changed
-        float core_delta;             // the amount of yaw change between cores when a change happened
         uint16_t count;               // count of yaw reset events passed to consumers
         uint16_t last_core_count;     // primary core's yaw reset count when count last changed
     } yaw_reset_data;
@@ -578,7 +570,7 @@ private:
     // update the yaw reset data to capture changes due to a lane switch
     // new_primary - index of the ekf instance that we are about to switch to as the primary
     // old_primary - index of the ekf instance that we are currently using as the primary
-    void updateLaneSwitchYawResetData(uint8_t new_primary, uint8_t old_primary);
+    void updateLaneSwitchYawResetData(uint8_t new_primary);
 
     // update the position reset data to capture changes due to a lane switch
     // new_primary - index of the ekf instance that we are about to switch to as the primary

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -316,18 +316,6 @@ public:
     // primary core changes and when the primary core resets its D position
     uint16_t getPosDownResetCount(void);
 
-    // return the amount of NE position change due to the last position reset in metres
-    // returns the time of the last reset or 0 if no reset has ever occurred
-    uint32_t getLastPosNorthEastReset(Vector2f &posDelta);
-
-    // return the amount of NE velocity change due to the last velocity reset in metres/sec
-    // returns the time of the last reset or 0 if no reset has ever occurred
-    uint32_t getLastVelNorthEastReset(Vector2f &vel) const;
-
-    // return the amount of vertical position change due to the last reset in metres
-    // returns the time of the last reset or 0 if no reset has ever occurred
-    uint32_t getLastPosDownReset(float &posDelta);
-
     // set and save the _baroAltNoise parameter
     void set_baro_alt_noise(float noise) { _baroAltNoise.set_and_save(noise); };
 
@@ -548,19 +536,11 @@ private:
     } yaw_reset_data;
 
     struct {
-        uint32_t last_function_call;  // last time getLastPosNorthEastReset was called
-        bool core_changed;            // true when a core change happened and hasn't been consumed, false otherwise
-        uint32_t last_primary_change; // last time a primary has changed
-        Vector2f core_delta;          // the amount of NE position change between cores when a change happened
         uint16_t count;               // count of NE position reset events passed to consumers
         uint16_t last_core_count;     // primary core's NE position reset count when count last changed
     } pos_reset_data;
 
     struct {
-        uint32_t last_function_call;  // last time getLastPosDownReset was called
-        bool core_changed;            // true when a core change happened and hasn't been consumed, false otherwise
-        uint32_t last_primary_change; // last time a primary has changed
-        float core_delta;             // the amount of D position change between cores when a change happened
         uint16_t count;               // count of D position reset events passed to consumers
         uint16_t last_core_count;     // primary core's D position reset count when count last changed
     } pos_down_reset_data;
@@ -587,12 +567,12 @@ private:
     // update the position reset data to capture changes due to a lane switch
     // new_primary - index of the ekf instance that we are about to switch to as the primary
     // old_primary - index of the ekf instance that we are currently using as the primary
-    void updateLaneSwitchPosResetData(uint8_t new_primary, uint8_t old_primary);
+    void updateLaneSwitchPosResetData(uint8_t new_primary);
 
     // update the position down reset data to capture changes due to a lane switch
     // new_primary - index of the ekf instance that we are about to switch to as the primary
     // old_primary - index of the ekf instance that we are currently using as the primary
-    void updateLaneSwitchPosDownResetData(uint8_t new_primary, uint8_t old_primary);
+    void updateLaneSwitchPosDownResetData(uint8_t new_primary);
 
     // Update instance error scores for all available cores 
     float updateCoreErrorScores(void);

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -308,6 +308,10 @@ public:
     // returns the time of the last yaw angle reset or 0 if no reset has ever occurred
     uint32_t getLastYawResetAngle(float &yawAngDelta);
 
+    // return a count of yaw reset events; incremented when the
+    // primary core changes and when the primary core resets its yaw
+    uint16_t getYawResetCount(void);
+
     // return the amount of NE position change due to the last position reset in metres
     // returns the time of the last reset or 0 if no reset has ever occurred
     uint32_t getLastPosNorthEastReset(Vector2f &posDelta);
@@ -539,6 +543,8 @@ private:
         bool core_changed;            // true when a core change happened and hasn't been consumed, false otherwise
         uint32_t last_primary_change; // last time a primary has changed
         float core_delta;             // the amount of yaw change between cores when a change happened
+        uint16_t count;               // count of yaw reset events passed to consumers
+        uint16_t last_core_count;     // primary core's yaw reset count when count last changed
     } yaw_reset_data;
 
     struct {

--- a/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
@@ -1455,6 +1455,7 @@ void NavEKF3_core::resetQuatStateYawOnly(ftype yaw, ftype yawVariance, rotationO
     // record the yaw reset event
     yawResetAngle += deltaYaw;
     lastYawReset_ms = imuSampleTime_ms;
+    yawResetCount++;
 
     // record the yaw reset event
     recordYawResetsCompleted();

--- a/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
@@ -1442,8 +1442,6 @@ void NavEKF3_core::resetQuatStateYawOnly(ftype yaw, ftype yawVariance, rotationO
     // Update the rotation matrix
     stateStruct.quat.inverse().rotation_matrix(prevTnb);
     
-    ftype deltaYaw = wrap_PI(yaw - eulerAngles.z);
-
     // calculate the change in the quaternion state and apply it to the output history buffer
     QuaternionF quat_delta = stateStruct.quat / quatBeforeReset;
     StoreQuatRotate(quat_delta);
@@ -1453,8 +1451,6 @@ void NavEKF3_core::resetQuatStateYawOnly(ftype yaw, ftype yawVariance, rotationO
     CovariancePrediction(&angleErrVarVec);
 
     // record the yaw reset event
-    yawResetAngle += deltaYaw;
-    lastYawReset_ms = imuSampleTime_ms;
     yawResetCount++;
 
     // record the yaw reset event

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
@@ -162,14 +162,6 @@ void NavEKF3_core::getQuaternion(Quaternion& ret) const
     ret = outputDataNew.quat.tofloat();
 }
 
-// return the amount of yaw angle change due to the last yaw angle reset in radians
-// returns the time of the last yaw angle reset or 0 if no reset has ever occurred
-uint32_t NavEKF3_core::getLastYawResetAngle(float &yawAng) const
-{
-    yawAng = yawResetAngle;
-    return lastYawReset_ms;
-}
-
 // return the amount of NE position change due to the last position reset in metres
 // returns the time of the last reset or 0 if no reset has ever occurred
 uint32_t NavEKF3_core::getLastPosNorthEastReset(Vector2f &pos) const

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
@@ -162,30 +162,6 @@ void NavEKF3_core::getQuaternion(Quaternion& ret) const
     ret = outputDataNew.quat.tofloat();
 }
 
-// return the amount of NE position change due to the last position reset in metres
-// returns the time of the last reset or 0 if no reset has ever occurred
-uint32_t NavEKF3_core::getLastPosNorthEastReset(Vector2f &pos) const
-{
-    pos = posResetNE.tofloat();
-    return lastPosReset_ms;
-}
-
-// return the amount of vertical position change due to the last vertical position reset in metres
-// returns the time of the last reset or 0 if no reset has ever occurred
-uint32_t NavEKF3_core::getLastPosDownReset(float &posD) const
-{
-    posD = posResetD;
-    return lastPosResetD_ms;
-}
-
-// return the amount of NE velocity change due to the last velocity reset in metres/sec
-// returns the time of the last reset or 0 if no reset has ever occurred
-uint32_t NavEKF3_core::getLastVelNorthEastReset(Vector2f &vel) const
-{
-    vel = velResetNE.tofloat();
-    return lastVelReset_ms;
-}
-
 // return the NED wind speed estimates in m/s (positive is air moving in the direction of the axis)
 // returns true if wind state estimation is active
 bool NavEKF3_core::getWind(Vector3f &wind) const

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -176,6 +176,7 @@ void NavEKF3_core::ResetPosition(resetDataSource posResetSource)
 
     // store the time of the reset
     lastPosReset_ms = imuSampleTime_ms;
+    posNEResetCount++;
 
     // clear the timeout flags and counters
     posTimeout = false;
@@ -251,6 +252,7 @@ void NavEKF3_core::ResetPositionNE(ftype posN, ftype posE)
 
     // store the time of the reset
     lastPosReset_ms = imuSampleTime_ms;
+    posNEResetCount++;
 }
 
 // reset the stateStruct's D position
@@ -278,6 +280,7 @@ void NavEKF3_core::ResetPositionD(ftype posD)
 
     // store the time of the reset
     lastPosResetD_ms = imuSampleTime_ms;
+    posDResetCount++;
 }
 
 // reset the vertical position state using the last height measurement
@@ -309,6 +312,7 @@ void NavEKF3_core::ResetHeight(void)
 
     // store the time of the reset
     lastPosResetD_ms = imuSampleTime_ms;
+    posDResetCount++;
 
     // clear the timeout flags and counters
     hgtTimeout = false;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_PosVelFusion.cpp
@@ -33,10 +33,6 @@ void NavEKF3_core::ResetVelocity(resetDataSource velResetSource)
         }
     }
 
-    // Store the velocity before the reset so that we can record the reset delta
-    velResetNE.x = stateStruct.velocity.x;
-    velResetNE.y = stateStruct.velocity.y;
-
     // reset the corresponding covariances
     zeroStatesVarCov(4, 5);
 
@@ -81,12 +77,6 @@ void NavEKF3_core::ResetVelocity(resetDataSource velResetSource)
     outputDataDelayed.velocity.x = stateStruct.velocity.x;
     outputDataDelayed.velocity.y = stateStruct.velocity.y;
 
-    // Calculate the velocity jump due to the reset
-    velResetNE.x = stateStruct.velocity.x - velResetNE.x;
-    velResetNE.y = stateStruct.velocity.y - velResetNE.y;
-
-    // store the time of the reset
-    lastVelReset_ms = imuSampleTime_ms;
 }
 
 // resets position states to last GPS measurement or to zero if in constant position mode
@@ -174,8 +164,6 @@ void NavEKF3_core::ResetPosition(resetDataSource posResetSource)
     posResetNE.x = stateStruct.position.x - posResetNE.x;
     posResetNE.y = stateStruct.position.y - posResetNE.y;
 
-    // store the time of the reset
-    lastPosReset_ms = imuSampleTime_ms;
     posNEResetCount++;
 
     // clear the timeout flags and counters
@@ -226,7 +214,7 @@ bool NavEKF3_core::setLatLng(const Location &loc, float posAccuracy, uint32_t ti
 // reset the stateStruct's NE position to the specified position
 //    posResetNE is updated to hold the change in position
 //    storedOutput, outputDataNew and outputDataDelayed are updated with the change in position
-//    lastPosReset_ms is updated with the time of the reset
+//    posNEResetCount is incremented to record the reset
 void NavEKF3_core::ResetPositionNE(ftype posN, ftype posE)
 {
     // Store the position before the reset so that we can record the reset delta
@@ -250,15 +238,13 @@ void NavEKF3_core::ResetPositionNE(ftype posN, ftype posE)
     outputDataDelayed.position.x += posResetNE.x;
     outputDataDelayed.position.y += posResetNE.y;
 
-    // store the time of the reset
-    lastPosReset_ms = imuSampleTime_ms;
     posNEResetCount++;
 }
 
 // reset the stateStruct's D position
 //    posResetD is updated to hold the change in position
 //    storedOutput, outputDataNew and outputDataDelayed are updated with the change in position
-//    lastPosResetD_ms is updated with the time of the reset
+//    posDResetCount is incremented to record the reset
 void NavEKF3_core::ResetPositionD(ftype posD)
 {
     // Store the position before the reset so that we can record the reset delta
@@ -278,8 +264,6 @@ void NavEKF3_core::ResetPositionD(ftype posD)
         storedOutput[i].position.z += posResetD;
     }
 
-    // store the time of the reset
-    lastPosResetD_ms = imuSampleTime_ms;
     posDResetCount++;
 }
 
@@ -310,8 +294,6 @@ void NavEKF3_core::ResetHeight(void)
     // Calculate the position jump due to the reset
     posResetD = stateStruct.position.z - posResetD;
 
-    // store the time of the reset
-    lastPosResetD_ms = imuSampleTime_ms;
     posDResetCount++;
 
     // clear the timeout flags and counters

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -219,9 +219,6 @@ void NavEKF3_core::InitialiseVariables()
     lastGpsAidBadTime_ms = 0;
     timeTasReceived_ms = 0;
     lastPreAlignGpsCheckTime_ms = imuSampleTime_ms;
-    lastPosReset_ms = 0;
-    lastVelReset_ms = 0;
-    lastPosResetD_ms = 0;
     posNEResetCount = 0;
     posDResetCount = 0;
     lastRngMeasTime_ms = 0;
@@ -340,7 +337,6 @@ void NavEKF3_core::InitialiseVariables()
     sideSlipFusionDelayed = false;
     airDataFusionWindOnly = false;
     posResetNE.zero();
-    velResetNE.zero();
     posResetD = 0.0f;
     hgtInnovFiltState = 0.0f;
     imuDataDownSampledNew.delAng.zero();

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -296,8 +296,6 @@ void NavEKF3_core::InitialiseVariables()
     aglKfValid = false;
     lastAglRngFuseTime_ms = 0;
 #endif
-    yawResetAngle = 0.0f;
-    lastYawReset_ms = 0;
     yawResetCount = 0;
     tiltErrorVariance = sq(M_2PI);
     tiltAlignComplete = false;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -222,6 +222,8 @@ void NavEKF3_core::InitialiseVariables()
     lastPosReset_ms = 0;
     lastVelReset_ms = 0;
     lastPosResetD_ms = 0;
+    posNEResetCount = 0;
+    posDResetCount = 0;
     lastRngMeasTime_ms = 0;
 
     // initialise other variables

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -298,6 +298,7 @@ void NavEKF3_core::InitialiseVariables()
 #endif
     yawResetAngle = 0.0f;
     lastYawReset_ms = 0;
+    yawResetCount = 0;
     tiltErrorVariance = sq(M_2PI);
     tiltAlignComplete = false;
     yawAlignComplete = false;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -410,18 +410,6 @@ public:
     // return the number of D position resets performed by this core
     uint16_t getPosDownResetCount(void) const { return posDResetCount; }
 
-    // return the amount of NE position change due to the last position reset in metres
-    // returns the time of the last reset or 0 if no reset has ever occurred
-    uint32_t getLastPosNorthEastReset(Vector2f &pos) const;
-
-    // return the amount of D position change due to the last position reset in metres
-    // returns the time of the last reset or 0 if no reset has ever occurred
-    uint32_t getLastPosDownReset(float &posD) const;
-
-    // return the amount of NE velocity change due to the last velocity reset in metres/sec
-    // returns the time of the last reset or 0 if no reset has ever occurred
-    uint32_t getLastVelNorthEastReset(Vector2f &vel) const;
-
     // report any reason for why the backend is refusing to initialise
     const char *prearm_failure_reason(void) const;
 
@@ -1231,12 +1219,8 @@ private:
     bool airDataFusionWindOnly;     // true when  sideslip and airspeed fusion is only allowed to modify the wind states
     Vector3F lastMagOffsets;        // Last magnetometer offsets from COMPASS_ parameters. Used to detect parameter changes.
     bool lastMagOffsetsValid;       // True when lastMagOffsets has been initialized
-    Vector2F posResetNE;            // Change in North/East position due to last in-flight reset in metres. Returned by getLastPosNorthEastReset
-    uint32_t lastPosReset_ms;       // System time at which the last position reset occurred. Returned by getLastPosNorthEastReset
-    Vector2F velResetNE;            // Change in North/East velocity due to last in-flight reset in metres/sec. Returned by getLastVelNorthEastReset
-    uint32_t lastVelReset_ms;       // System time at which the last velocity reset occurred. Returned by getLastVelNorthEastReset
-    ftype posResetD;                // Change in Down position due to last in-flight reset in metres. Returned by getLastPosDowntReset
-    uint32_t lastPosResetD_ms;      // System time at which the last position reset occurred. Returned by getLastPosDownReset
+    Vector2F posResetNE;            // Change in North/East position due to last in-flight reset in metres
+    ftype posResetD;                // Change in Down position due to last in-flight reset in metres
     uint16_t posNEResetCount;       // number of NE position resets performed by this core
     uint16_t posDResetCount;        // number of D position resets performed by this core
     ftype yawTestRatio;             // square of magnetometer yaw angle innovation divided by fail threshold

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -404,6 +404,12 @@ public:
     // return the number of yaw resets performed by this core
     uint16_t getYawResetCount(void) const { return yawResetCount; }
 
+    // return the number of NE position resets performed by this core
+    uint16_t getPosNorthEastResetCount(void) const { return posNEResetCount; }
+
+    // return the number of D position resets performed by this core
+    uint16_t getPosDownResetCount(void) const { return posDResetCount; }
+
     // return the amount of NE position change due to the last position reset in metres
     // returns the time of the last reset or 0 if no reset has ever occurred
     uint32_t getLastPosNorthEastReset(Vector2f &pos) const;
@@ -1231,6 +1237,8 @@ private:
     uint32_t lastVelReset_ms;       // System time at which the last velocity reset occurred. Returned by getLastVelNorthEastReset
     ftype posResetD;                // Change in Down position due to last in-flight reset in metres. Returned by getLastPosDowntReset
     uint32_t lastPosResetD_ms;      // System time at which the last position reset occurred. Returned by getLastPosDownReset
+    uint16_t posNEResetCount;       // number of NE position resets performed by this core
+    uint16_t posDResetCount;        // number of D position resets performed by this core
     ftype yawTestRatio;             // square of magnetometer yaw angle innovation divided by fail threshold
     QuaternionF prevQuatMagReset;    // Quaternion from the last time the magnetic field state reset condition test was performed
     ftype hgtInnovFiltState;        // state used for fitering of the height innovations used for pre-flight checks

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -405,6 +405,9 @@ public:
     // returns the time of the last yaw angle reset or 0 if no reset has ever occurred
     uint32_t getLastYawResetAngle(float &yawAng) const;
 
+    // return the number of yaw resets performed by this core
+    uint16_t getYawResetCount(void) const { return yawResetCount; }
+
     // return the amount of NE position change due to the last position reset in metres
     // returns the time of the last reset or 0 if no reset has ever occurred
     uint32_t getLastPosNorthEastReset(Vector2f &pos) const;
@@ -1186,6 +1189,7 @@ private:
     bool useGpsVertVel;             // true if GPS vertical velocity should be used
     ftype yawResetAngle;            // Change in yaw angle due to last in-flight yaw reset in radians. A positive value means the yaw angle has increased.
     uint32_t lastYawReset_ms;       // System time at which the last yaw reset occurred. Returned by getLastYawResetAngle
+    uint16_t yawResetCount;         // number of yaw resets performed by this core
     bool tiltAlignComplete;         // true when tilt alignment is complete
     bool yawAlignComplete;          // true when yaw alignment is complete
     uint8_t yawAlignGpsValidCount;  // number of continuous good GPS velocity samples used for in flight yaw alignment

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -401,10 +401,6 @@ public:
     // this is needed to ensure the vehicle does not fly too high when using optical flow navigation
     bool getHeightControlLimit(float &height) const;
 
-    // return the amount of yaw angle change due to the last yaw angle reset in radians
-    // returns the time of the last yaw angle reset or 0 if no reset has ever occurred
-    uint32_t getLastYawResetAngle(float &yawAng) const;
-
     // return the number of yaw resets performed by this core
     uint16_t getYawResetCount(void) const { return yawResetCount; }
 
@@ -1187,8 +1183,6 @@ private:
     uint32_t lastGpsAidBadTime_ms;  // time in msec gps aiding was last detected to be bad
     ftype posDownAtTakeoff;         // flight vehicle vertical position sampled at transition from on-ground to in-air and used as a reference (m)
     bool useGpsVertVel;             // true if GPS vertical velocity should be used
-    ftype yawResetAngle;            // Change in yaw angle due to last in-flight yaw reset in radians. A positive value means the yaw angle has increased.
-    uint32_t lastYawReset_ms;       // System time at which the last yaw reset occurred. Returned by getLastYawResetAngle
     uint16_t yawResetCount;         // number of yaw resets performed by this core
     bool tiltAlignComplete;         // true when tilt alignment is complete
     bool yawAlignComplete;          // true when yaw alignment is complete


### PR DESCRIPTION
### Summary

Removes the values supplied when handling resets from the AP_AHRS library.  These were unused.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli   iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                 *                                                    
Durandal                            -1144           -1136  *           -1160   -1144              -1168  -1152  -1280
Hitec-Airspeed           *                                 *                                                    
KakuteH7-bdshot                     -1120           -1144  *           -1120   -1136              -1344  -1208  -1024
MatekF405                           -1432           -1344  *           -1296   -1288              -1384  -1360  -1352
Pixhawk1-1M-bdshot                  -1320           -1328              -1352   -1336              -1176  -1336  -1368
SITL_x86_64_linux_gnu               -4952           -9048              -4952   -4960              -4952  -4952  -4960
YJUAV_A6SE                          -1192           -1208  *           -1200   -1184              -1336  -1144  -1384
f103-QiotekPeriph        *                                 *                                                    
f303-MatekGPS            *                                 *                                                    
f303-Universal           *                                 *                                                    
iomcu                                                                                 *                         
revo-mini                           -1376           -1368  *           -1320   -1328              -296   -1296  -1384
skyviper-v2450                                                         -1384                                    
speedybeef4                         -1480           -1368  *           -1456   -1448              -1800  -1256  -1368
```

### Description

ArduPilot used to take the reset values and use it in its calculations.  It not longer uses any of these, so just remove them from the results we track.

These were fragile anyway.  Two resets in a row would lose the information about the previous reset.  A caller could track the information it last acted on and the new value coming from the estimator easily enough, but a single, "this is the last reset value" is non-sensical.

Note that I don't need to chase this down into the EKF, the `AP_AHRS_NavEKFx` shims could translate.  But this is a lot of wasted flash at the moment!
