### PR TITLE
autotest: adjust flakey RotorRunup test

### DIFF
--- a/Tools/autotest/helicopter.py
+++ b/Tools/autotest/helicopter.py
@@ -68,7 +68,6 @@ class AutoTestHelicopter(AutoTestCopter):
         '''Test rotor runup'''
         # Takeoff and landing in Loiter
         TARGET_RUNUP_TIME = 10
-        self.zero_throttle()
         self.change_mode('LOITER')
         self.wait_ready_to_arm()
         self.arm_vehicle()
@@ -77,10 +76,10 @@ class AutoTestHelicopter(AutoTestCopter):
         coll = coll + 50
         self.set_parameter("H_RSC_RUNUP_TIME", TARGET_RUNUP_TIME)
         self.progress("Initiate Runup by putting some throttle")
+        tstart = self.get_sim_time()
         self.set_rc(8, 2000)
         self.set_rc(3, 1700)
         self.progress("Collective threshold PWM %u" % coll)
-        tstart = self.get_sim_time()
         self.progress("Wait that collective PWM pass threshold value")
         servo = self.assert_receive_message(
             "SERVO_OUTPUT_RAW",
@@ -98,7 +97,6 @@ class AutoTestHelicopter(AutoTestCopter):
         self.progress("Runup time %u" % runup_time)
         self.zero_throttle()
         self.land_and_disarm()
-        self.mav.wait_heartbeat()
 
     # fly_avc_test - fly AVC mission
     def AVCMission(self):


### PR DESCRIPTION
### Summary

Moves where we initialise a timer so we don't finish the runup before the timer is large enough

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

need to take runup timestamp before we send the interlock change otherwise we really can go before the timer has run for long enough to pass the TARGET_RUNUP_TIME