### PR TITLE
autotest: collect STATUSTEXT before reboot in Sub BackupOrigin

### DIFF
--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -954,8 +954,12 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
             'AHRS_ORIGIN_LAT': 47.607584,
             'AHRS_ORIGIN_LON': -122.343911,
         })
-        self.reboot_sitl()
+        # the origin statustext is emitted early in the boot - with no
+        # GPS configured the EKF does not wait for anything before
+        # adopting the recorded origin - so collection must start
+        # before the reboot or the text can be missed:
         self.context_collect('STATUSTEXT')
+        self.reboot_sitl()
 
         # Wait for the EKF to be happy in constant position mode
         self.wait_ready_to_arm_const_pos()


### PR DESCRIPTION
### Summary

Fixes race condition in Sub BackupOrigin test

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

With no GPS configured the EKF adopts the recorded origin early in the boot, so 'AHRS: using recorded origin' can be emitted while the test framework is still waiting for the reboot to complete - before the test started collecting statustexts - and the wait for it then times out.  Timing changes in the preceding logging tests exposed the race in CI.
