### PR TITLE
autotest: raise Soaring throttle-down timeout to 5 seconds

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -2771,7 +2771,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.set_rc(rc_chan, 1500)
 
         # Make sure this causes throttle down.
-        self.wait_servo_channel_value(3, 1200, timeout=3, comparator=operator.lt)
+        self.wait_servo_channel_value(3, 1200, timeout=5, comparator=operator.lt)
 
         self.progress("Waiting for next WP with no thermalling")
         self.wait_waypoint(4, 4, timeout=1200, max_dist_to_final_wp_m=120)


### PR DESCRIPTION
### Summary

This was marginal/flakey on autotest due to Python/C++ interaction issues.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

The throttle deterministically takes 2.4-2.6s of sim time to slew down from its saturated 2000us (THR_SLEWRATE 100%/s) after soaring is re-enabled, so the 3s timeout left almost no margin and flaked on loaded CI machines.

