### PR TITLE
AP_GPS: correct vertical component of Unicore reported baseline

### DIFF
--- a/libraries/AP_GPS/AP_GPS_NMEA.cpp
+++ b/libraries/AP_GPS/AP_GPS_NMEA.cpp
@@ -493,7 +493,7 @@ bool AP_GPS_NMEA::_term_complete()
                 }
                 const float dist = uh.baseline_length;
                 const float bearing = uh.heading;
-                const float alt_diff = dist*tanf(radians(-uh.pitch));
+                const float alt_diff = dist*sinf(radians(-uh.pitch));
                 state.relPosHeading = bearing;
                 state.relPosLength = dist;
                 state.relPosD = alt_diff;


### PR DESCRIPTION
UNIHEADINGA reports the 3D length of the antenna baseline and the elevation
angle of that baseline (pitch, +/-90 degrees), so the vertical component is
length*sin(pitch). Using tan overstated the vertical component (11% at 26
degrees) and exceeded the baseline length itself from 45 degrees, where the
overstated vertical component falls outside the tolerated vertical-separation
band and all yaw is rejected: steep antenna installations could never provide
yaw on this backend.

### Summary

Fix the Unicore UNIHEADINGA moving-baseline GPS yaw path to compute the
antenna baseline's vertical component as length*sin(pitch) instead of
length*tan(pitch).

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

The Unicore UNIHEADINGA message reports the moving-baseline antenna vector as a
3D baseline length plus an elevation angle (pitch). The down/vertical component
of that vector is therefore length*sin(pitch). The NMEA backend computed it as
length*tan(pitch), which overstates the vertical component by 1/cos(pitch):
about 11% at 26 degrees of pitch, and equal to or greater than the reported
baseline length itself from 45 degrees upward.

That vertical component is passed as `reported_D` into
`AP_GPS_Backend::calculate_moving_base_yaw()`, which rejects the fix when
`reported_D` falls outside a tolerance band built from the configured antenna
offset and the current vehicle attitude. An overstated vertical component pushes
`reported_D` above that band, so any appreciably pitched antenna baseline was
rejected and no GPS yaw was produced on this backend. Installations with a steep
antenna baseline could never obtain yaw.

The fix replaces tanf with sinf for this one term in the UNIHEADINGA handler in
libraries/AP_GPS/AP_GPS_NMEA.cpp. Only the Unicore NMEA backend is affected; the
u-blox, Septentrio and DroneCAN moving-baseline paths compute their own vertical
component and are unchanged.
