### PR TITLE
AP_Bootloader: reserve board IDs for CoreWing boards

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -612,6 +612,10 @@ AP_HW_Accton_Godwit_GA1              7120
 AP_HW_Accton_Godwit_GFF4             7121
 AP_HW_Accton_Godwit_GFH7             7122
 
+# IDs 7130-7139 reserved for CoreWing
+AP_HW_CoreWingF405WingV2             7130
+AP_HW_CoreWingF405WMiniV2            7131
+
 # please fill gaps in the above ranges rather than adding past ID #7199
 
 


### PR DESCRIPTION
### Summary

Reserve board IDs 7130-7139 for CoreWing and add `AP_HW_CoreWingF405WingV2` (7130) and `AP_HW_CoreWingF405WMiniV2` (7131).

### Classification & Testing (check all that apply and add your own)

- [x] Non-functional change

### Description

Board ID reservation split out of #33717 as requested by @Hwurzburg so the IDs can be reserved while the board support PR is reviewed. #33717 currently carries the same commit and will be rebased once this is merged.