### PR TITLE
MAVLink: support mavlink 2.1 32 bit system IDs

### DIFF
--- a/AntennaTracker/GCS_MAVLink_Tracker.cpp
+++ b/AntennaTracker/GCS_MAVLink_Tracker.cpp
@@ -254,7 +254,7 @@ void GCS_MAVLINK_Tracker::packetReceived(const mavlink_status_t &status,
                                          const mavlink_message_t &msg)
 {
     // return immediately if sysid doesn't match our target sysid
-    if ((tracker.g.sysid_target != 0) && (tracker.g.sysid_target != msg.sysid)) {
+    if ((tracker.g.sysid_target != 0) && (uint32_t(tracker.g.sysid_target.get()) != msg.sysid)) {
         GCS_MAVLINK::packetReceived(status, msg);
         return;
     }

--- a/AntennaTracker/GCS_Tracker.cpp
+++ b/AntennaTracker/GCS_Tracker.cpp
@@ -1,7 +1,7 @@
 #include "GCS_Tracker.h"
 #include "Tracker.h"
 
-void GCS_Tracker::request_datastream_position(const uint8_t _sysid, const uint8_t compid)
+void GCS_Tracker::request_datastream_position(const uint32_t _sysid, const uint8_t compid)
 {
     for (uint8_t i=0; i < num_gcs(); i++) {
             // request position
@@ -17,7 +17,7 @@ void GCS_Tracker::request_datastream_position(const uint8_t _sysid, const uint8_
     }
 }
 
-void GCS_Tracker::request_datastream_airpressure(const uint8_t _sysid, const uint8_t compid)
+void GCS_Tracker::request_datastream_airpressure(const uint32_t _sysid, const uint8_t compid)
 {
     for (uint8_t i=0; i < num_gcs(); i++) {
             // request air pressure

--- a/AntennaTracker/GCS_Tracker.h
+++ b/AntennaTracker/GCS_Tracker.h
@@ -30,7 +30,7 @@ protected:
 
 private:
 
-    void request_datastream_position(uint8_t sysid, uint8_t compid);
-    void request_datastream_airpressure(uint8_t sysid, uint8_t compid);
+    void request_datastream_position(uint32_t sysid, uint8_t compid);
+    void request_datastream_airpressure(uint32_t sysid, uint8_t compid);
 
 };

--- a/AntennaTracker/Parameters.cpp
+++ b/AntennaTracker/Parameters.cpp
@@ -19,7 +19,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: SYSID_TARGET
     // @DisplayName: Target vehicle's MAVLink system ID
     // @Description: The identifier of the vehicle being tracked. This should be zero (to auto detect) or be the same as the MAV_SYSID parameter of the vehicle being tracked.
-    // @Range: 1 255
+    // @Range: 1 16777215
     // @User: Advanced
     GSCALAR(sysid_target,           "SYSID_TARGET",    0),
 

--- a/AntennaTracker/Parameters.h
+++ b/AntennaTracker/Parameters.h
@@ -140,7 +140,7 @@ public:
 
     // Telemetry control
     //
-    AP_Int16 sysid_target;
+    AP_Int32 sysid_target;
 
     AP_Float yaw_slew_time;
     AP_Float pitch_slew_time;

--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -5,6 +5,9 @@ static const StorageAccess wp_storage(StorageManager::StorageMission);
 
 void Tracker::init_ardupilot()
 {
+    // PARAMETER_CONVERSION - Added: Jul-2026 for 32 bit sysids
+    g.sysid_target.convert_parameter_width(AP_PARAM_INT16);
+
     // initialise notify
     notify.init();
     AP_Notify::flags.pre_arm_check = true;

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1337,6 +1337,11 @@ void Copter::load_parameters(void)
     copter.avoid.convert_params();
 #endif
 
+#if MODE_FOLLOW_ENABLED
+    // convert Follow parameters
+    copter.g2.follow.convert_params();
+#endif
+
     // convert PILOT vertical speed and acceleration parameters
     // PARAMETER_CONVERSION - Added: Feb 2026 for ardupilot-4.7
     {

--- a/ArduPlane/GCS_MAVLink_Plane.cpp
+++ b/ArduPlane/GCS_MAVLink_Plane.cpp
@@ -746,13 +746,15 @@ MAV_RESULT GCS_MAVLINK_Plane::handle_command_int_packet(const mavlink_command_in
 #endif
 
 #if AP_SCRIPTING_ENABLED && AP_FOLLOW_ENABLED
-    case MAV_CMD_DO_FOLLOW:
+    case MAV_CMD_DO_FOLLOW: {
         // param1: sysid of target to follow
-        if ((packet.param1 > 0) && (packet.param1 <= 255)) {
-            plane.g2.follow.set_target_sysid((uint8_t)packet.param1);
+        const int64_t sysid = (int64_t)packet.param1;
+        if (sysid > 0 && sysid <= (int64_t)0xFFFFFFFF) {
+            plane.g2.follow.set_target_sysid((uint32_t)sysid);
             return MAV_RESULT_ACCEPTED;
         }
         return MAV_RESULT_DENIED;
+    }
 #endif
 
 #if AP_ICENGINE_ENABLED

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1478,6 +1478,11 @@ void Plane::load_parameters(void)
 
     g.use_reverse_thrust.convert_parameter_width(AP_PARAM_INT16);
 
+#if AP_SCRIPTING_ENABLED && AP_FOLLOW_ENABLED
+    // convert Follow parameters
+    g2.follow.convert_params();
+#endif
+
     // PARAMETER_CONVERSION - Added: Jun-2026 for FBWB_CLIMB_RATE width change
     g.flybywire_climb_rate.convert_parameter_width(AP_PARAM_INT8);
 

--- a/Rover/Parameters.cpp
+++ b/Rover/Parameters.cpp
@@ -842,6 +842,11 @@ void Rover::load_parameters(void)
     };
     AP_Param::convert_old_parameters(&ff_and_filt_conversion_info[0], ARRAY_SIZE(ff_and_filt_conversion_info));
 
+#if AP_FOLLOW_ENABLED
+    // convert Follow parameters
+    g2.follow.convert_params();
+#endif
+
     // configure safety switch to allow stopping the motors while armed
 #if HAL_HAVE_SAFETY_SWITCH
     AP_Param::set_default_by_name("BRD_SAFETYOPTION", AP_BoardConfig::BOARD_SAFETY_OPTION_BUTTON_ACTIVE_SAFETY_OFF|

--- a/Rover/mode_auto.cpp
+++ b/Rover/mode_auto.cpp
@@ -497,7 +497,7 @@ void ModeAuto::send_guided_position_target()
         guided_target.last_sent_ms = now_ms;
 
         // get system id and component id of offboard navigation system
-        uint8_t sysid;
+        uint32_t sysid;
         uint8_t compid;
         mavlink_channel_t chan;
         if (GCS_MAVLINK::find_by_mavtype(MAV_TYPE_ONBOARD_CONTROLLER, sysid, compid, chan)) {

--- a/Tools/AP_Periph/adsb.cpp
+++ b/Tools/AP_Periph/adsb.cpp
@@ -86,7 +86,11 @@ void AP_Periph_FW::adsb_update(void)
                                                        &adsb.status,
                                                        &msg, &heartbeat);
 
-        uart->write((uint8_t*)&msg.magic, len);
+        uint8_t msgbuf[len];
+        len = mavlink_msg_to_send_buffer(msgbuf, &msg);
+        if (len > 0) {
+            uart->write(msgbuf, len);
+        }
     }
 }
 

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -6663,6 +6663,70 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
 
         self.progress("WebServer tests OK")
 
+    def MAV_SYSID_32bit(self):
+        '''test 32 bit MAV_SYSID'''
+        if not hasattr(mavutil.mavlink, "MAVLINK_IFLAG_SYSID32"):
+            raise NotAchievedException("pymavlink is too old for 32 bit system IDs")
+
+        # sysid values must round-trip losslessly through the float32
+        # parameter transport, so stay below 2^24 for now
+        sysid = 100000
+        self.set_parameter("MAV_SYSID", sysid)
+
+        # the sysid changes across the reboot so we can't use
+        # reboot_sitl(); send the reboot at the old sysid and re-point
+        # the connection at the new one
+        self.send_reboot_command()
+        self.mav.target_system = sysid
+        self.sysid_thismav = lambda: sysid
+        try:
+            self.wait_heartbeat(timeout=60)
+            m = self.wait_heartbeat()
+            if m.get_srcSystem() != sysid:
+                raise NotAchievedException("Did not get 32 bit sysid, got %u" % m.get_srcSystem())
+            hdr = m.get_header()
+            if not (hdr.incompat_flags & mavutil.mavlink.MAVLINK_IFLAG_SYSID32):
+                raise NotAchievedException("expected MAVLINK_IFLAG_SYSID32 to be set")
+
+            # parameter fetch at the new sysid
+            if int(self.get_parameter("MAV_SYSID")) != sysid:
+                raise NotAchievedException("MAV_SYSID readback failed")
+
+            # our own GCS with a 32 bit source system, and a targeted
+            # message each way
+            mav2 = mavutil.mavlink_connection(
+                "tcp:localhost:%u" % self.adjust_ardupilot_port(5763),
+                robust_parsing=True,
+                source_system=70000,
+                source_component=7,
+            )
+            mav2.mav.param_request_read_send(sysid, 1, b"MAV_SYSID", -1)
+            m = mav2.recv_match(type='PARAM_VALUE', blocking=True, timeout=10)
+            if m is None:
+                raise NotAchievedException("no PARAM_VALUE for 32 bit source system")
+            if m.param_id != "MAV_SYSID" or int(m.param_value) != sysid:
+                raise NotAchievedException("bad PARAM_VALUE %s" % str(m))
+            mav2.close()
+
+            # targeted mission-protocol round trip (the mission upload
+            # helpers hard-code target system 1, so do this by hand)
+            self.mav.mav.mission_request_list_send(sysid, 1, mavutil.mavlink.MAV_MISSION_TYPE_MISSION)
+            m = self.assert_receive_message('MISSION_COUNT', timeout=10)
+            if m.mission_type != mavutil.mavlink.MAV_MISSION_TYPE_MISSION:
+                raise NotAchievedException("bad MISSION_COUNT")
+
+            self.wait_ready_to_arm()
+            self.arm_vehicle()
+            self.disarm_vehicle()
+        finally:
+            # restore the old sysid
+            self.set_parameter("MAV_SYSID", 1)
+            self.send_reboot_command()
+            del self.sysid_thismav
+            self.mav.target_system = 1
+            self.wait_heartbeat(timeout=60)
+            self.wait_heartbeat()
+
     def NetworkingWebServer(self):
         '''web server'''
         applet_script = "net_webserver.lua"
@@ -7553,6 +7617,7 @@ return update()
             self.MAV_CMD_BATTERY_RESET,
             self.GPSForYaw,
             self.NetworkingWebServer,
+            self.MAV_SYSID_32bit,
             self.NetworkingWebServerPPP,
             self.RTL_SPEED,
             self.ScriptingLocationBindings,

--- a/libraries/AP_AccelCal/AP_AccelCal.cpp
+++ b/libraries/AP_AccelCal/AP_AccelCal.cpp
@@ -183,7 +183,7 @@ void AP_AccelCal::update()
     }
 }
 
-void AP_AccelCal::start(GCS_MAVLINK *gcs, uint8_t sysid, uint8_t compid)
+void AP_AccelCal::start(GCS_MAVLINK *gcs, uint32_t sysid, uint8_t compid)
 {
     if (gcs == nullptr || _started) {
         return;
@@ -364,7 +364,7 @@ bool AP_AccelCal::client_active(uint8_t client_num)
 }
 
 #if HAL_GCS_ENABLED
-void AP_AccelCal::handle_command_ack(const mavlink_command_ack_t &packet, uint8_t src_sysid, uint8_t src_compid)
+void AP_AccelCal::handle_command_ack(const mavlink_command_ack_t &packet, uint32_t src_sysid, uint8_t src_compid)
 {
     if(_sysid != src_sysid || _compid != src_compid) {
         return;

--- a/libraries/AP_AccelCal/AP_AccelCal.h
+++ b/libraries/AP_AccelCal/AP_AccelCal.h
@@ -28,7 +28,7 @@ public:
     { update_status(); }
 
     // start all the registered calibrations
-    void start(GCS_MAVLINK *gcs, uint8_t sysid, uint8_t compid);
+    void start(GCS_MAVLINK *gcs, uint32_t sysid, uint8_t compid);
 
     // called on calibration cancellation
     void cancel();
@@ -46,7 +46,7 @@ public:
     static void register_client(AP_AccelCal_Client* client);
 
 #if HAL_GCS_ENABLED
-    void handle_command_ack(const mavlink_command_ack_t &packet, uint8_t src_sysid, uint8_t src_compid);
+    void handle_command_ack(const mavlink_command_ack_t &packet, uint32_t src_sysid, uint8_t src_compid);
 #endif
 
     // true if we are in a calibration process
@@ -54,7 +54,7 @@ public:
 
 private:
     class GCS_MAVLINK *_gcs;
-    uint8_t _sysid;
+    uint32_t _sysid;
     uint8_t _compid;
     bool _use_gcs_snoop;
     bool _waiting_for_mavlink_ack = false;

--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -1148,7 +1148,7 @@ void AP_BattMonitor::checkPoweringOff(void)
             cmd_msg.command = MAV_CMD_POWER_OFF_INITIATED;
             cmd_msg.param1 = i+1;
             GCS_MAVLINK::send_to_components(MAVLINK_MSG_ID_COMMAND_LONG, (char*)&cmd_msg, sizeof(cmd_msg));
-            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Vehicle %d battery %d is powering off", mavlink_system.sysid, i+1);
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Vehicle %u battery %d is powering off", (unsigned)mavlink_system.sysid, i+1);
 #endif
 
             // only send this once

--- a/libraries/AP_CANManager/AP_MAVLinkCAN.cpp
+++ b/libraries/AP_CANManager/AP_MAVLinkCAN.cpp
@@ -295,7 +295,7 @@ void AP_MAVLinkCAN::_handle_can_filter_modify(const mavlink_message_t &msg)
 void AP_MAVLinkCAN::can_frame_callback(uint8_t bus, const AP_HAL::CANFrame &frame, AP_HAL::CANIface::CanIOFlags flags)
 {
     mavlink_channel_t chan;
-    uint8_t system_id;
+    uint32_t system_id;
     uint8_t component_id;
     {
         WITH_SEMAPHORE(can_forward.sem);

--- a/libraries/AP_CANManager/AP_MAVLinkCAN.h
+++ b/libraries/AP_CANManager/AP_MAVLinkCAN.h
@@ -48,7 +48,7 @@ private:
      */
     struct {
         mavlink_channel_t chan;
-        uint8_t system_id;
+        uint32_t system_id;
         uint8_t component_id;
         uint8_t frame_counter;
         uint32_t last_callback_enable_ms;

--- a/libraries/AP_Camera/AP_Camera_MAVLinkCamV2.cpp
+++ b/libraries/AP_Camera/AP_Camera_MAVLinkCamV2.cpp
@@ -29,13 +29,13 @@ bool AP_Camera_MAVLinkCamV2::trigger_pic()
 
     // prepare and send message
     mavlink_command_long_t pkt {};
-    pkt.target_system = _sysid;
+    pkt.target_system = _sysid>255?0:_sysid;  // targets > 255 travel in the extended header
     pkt.target_component = _compid;
     pkt.command = MAV_CMD_IMAGE_START_CAPTURE;
     pkt.param3 = 1;             // number of images to take
     pkt.param4 = image_index+1; // starting sequence number
 
-    _link->send_message(MAVLINK_MSG_ID_COMMAND_LONG, (const char*)&pkt);
+    _link->send_message_target(MAVLINK_MSG_ID_COMMAND_LONG, (const char*)&pkt, _sysid, _compid);
 
     return true;
 }
@@ -51,7 +51,7 @@ bool AP_Camera_MAVLinkCamV2::record_video(bool start_recording)
 
     // prepare and send message
     mavlink_command_long_t pkt {};
-    pkt.target_system = _sysid;
+    pkt.target_system = _sysid>255?0:_sysid;  // targets > 255 travel in the extended header
     pkt.target_component = _compid;
 
     if (start_recording) {
@@ -63,7 +63,7 @@ bool AP_Camera_MAVLinkCamV2::record_video(bool start_recording)
         // param1 = 0, video stream id. 0 for all streams
     }
 
-    _link->send_message(MAVLINK_MSG_ID_COMMAND_LONG, (const char*)&pkt);
+    _link->send_message_target(MAVLINK_MSG_ID_COMMAND_LONG, (const char*)&pkt, _sysid, _compid);
 
     return true;
 }
@@ -78,7 +78,7 @@ bool AP_Camera_MAVLinkCamV2::set_zoom(ZoomType zoom_type, float zoom_value)
 
     // prepare and send message
     mavlink_command_long_t pkt {};
-    pkt.target_system = _sysid;
+    pkt.target_system = _sysid>255?0:_sysid;  // targets > 255 travel in the extended header
     pkt.target_component = _compid;
     pkt.command = MAV_CMD_SET_CAMERA_ZOOM;
     switch (zoom_type) {
@@ -91,7 +91,7 @@ bool AP_Camera_MAVLinkCamV2::set_zoom(ZoomType zoom_type, float zoom_value)
     }
     pkt.param2 = zoom_value;            // Zoom Value
 
-    _link->send_message(MAVLINK_MSG_ID_COMMAND_LONG, (const char*)&pkt);
+    _link->send_message_target(MAVLINK_MSG_ID_COMMAND_LONG, (const char*)&pkt, _sysid, _compid);
 
     return true;
 }
@@ -107,7 +107,7 @@ SetFocusResult AP_Camera_MAVLinkCamV2::set_focus(FocusType focus_type, float foc
 
     // prepare and send message
     mavlink_command_long_t pkt {};
-    pkt.target_system = _sysid;
+    pkt.target_system = _sysid>255?0:_sysid;  // targets > 255 travel in the extended header
     pkt.target_component = _compid;
     pkt.command = MAV_CMD_SET_CAMERA_FOCUS;
     switch (focus_type) {
@@ -126,7 +126,7 @@ SetFocusResult AP_Camera_MAVLinkCamV2::set_focus(FocusType focus_type, float foc
     }
     pkt.param2 = focus_value;
 
-    _link->send_message(MAVLINK_MSG_ID_COMMAND_LONG, (const char*)&pkt);
+    _link->send_message_target(MAVLINK_MSG_ID_COMMAND_LONG, (const char*)&pkt, _sysid, _compid);
 
     return SetFocusResult::ACCEPTED;
 }
@@ -242,12 +242,12 @@ void AP_Camera_MAVLinkCamV2::request_camera_information() const
         0,  // param6
         0,  // param7
         MAV_CMD_REQUEST_MESSAGE,
-        _sysid,
+        uint8_t(_sysid>255?0:_sysid),  // targets > 255 travel in the extended header
         _compid,
         0  // confirmation
     };
 
-    _link->send_message(MAVLINK_MSG_ID_COMMAND_LONG, (const char*)&pkt);
+    _link->send_message_target(MAVLINK_MSG_ID_COMMAND_LONG, (const char*)&pkt, _sysid, _compid);
 }
 
 #endif // AP_CAMERA_MAVLINKCAMV2_ENABLED

--- a/libraries/AP_Camera/AP_Camera_MAVLinkCamV2.h
+++ b/libraries/AP_Camera/AP_Camera_MAVLinkCamV2.h
@@ -70,7 +70,7 @@ private:
     mavlink_camera_information_t _cam_info {}; // latest camera information received from camera
     uint32_t _last_caminfo_req_ms;  // system time that CAMERA_INFORMATION was last requested (used to throttle requests)
     class GCS_MAVLINK *_link;   // link we have found the camera on. nullptr if not seen yet
-    uint8_t _sysid;             // sysid of camera
+    uint32_t _sysid;            // sysid of camera
     uint8_t _compid;            // component id of gimbal
 };
 

--- a/libraries/AP_DDS/AP_DDS_Client.cpp
+++ b/libraries/AP_DDS/AP_DDS_Client.cpp
@@ -1437,10 +1437,10 @@ bool AP_DDS_Client::init_session()
     return true;
 }
 
-void AP_DDS_Client::dds_format_name(char* buf, const char* dds_prefix, const uint8_t sysid, const char* name, bool use_sysid_ns)
+void AP_DDS_Client::dds_format_name(char* buf, const char* dds_prefix, const uint32_t sysid, const char* name, bool use_sysid_ns)
 {
     if (use_sysid_ns) {
-        snprintf(buf, AP_DDS_MAX_NAME_LEN, "%s/%s/v%u/%s", dds_prefix, participant_name_prefix, sysid, name);
+        snprintf(buf, AP_DDS_MAX_NAME_LEN, "%s/%s/v%u/%s", dds_prefix, participant_name_prefix, (unsigned)sysid, name);
     } else {
         snprintf(buf, AP_DDS_MAX_NAME_LEN, "%s/%s/%s", dds_prefix, participant_name_prefix, name);
     }
@@ -1450,7 +1450,7 @@ bool AP_DDS_Client::create()
 {
     WITH_SEMAPHORE(csem);
 
-    const uint8_t sysid = gcs().sysid_this_mav();
+    const uint32_t sysid = gcs().sysid_this_mav();
     const bool use_sysid_ns = use_ns.get() != 0;
 
     // Participant
@@ -1460,7 +1460,7 @@ bool AP_DDS_Client::create()
     };
     char participant_name[AP_DDS_MAX_NAME_LEN];
     if (use_sysid_ns) {
-        snprintf(participant_name, sizeof(participant_name), "%s_v%u", participant_name_prefix, sysid);
+        snprintf(participant_name, sizeof(participant_name), "%s_v%u", participant_name_prefix, (unsigned)sysid);
     } else {
         snprintf(participant_name, sizeof(participant_name), "%s", participant_name_prefix);
     }

--- a/libraries/AP_DDS/AP_DDS_Client.h
+++ b/libraries/AP_DDS/AP_DDS_Client.h
@@ -323,7 +323,7 @@ private:
     static constexpr const char *dds_service_reply_prefix = "rr";
     static constexpr const char *participant_name_prefix = "ap";
 
-    static void dds_format_name(char* buf, const char* dds_prefix, uint8_t sysid, const char* name, bool use_sysid_ns);
+    static void dds_format_name(char* buf, const char* dds_prefix, uint32_t sysid, const char* name, bool use_sysid_ns);
 
 
 public:

--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -83,7 +83,7 @@ const AP_Param::GroupInfo AP_Follow::var_info[] = {
     // @Param: _SYSID
     // @DisplayName: Follow target's mavlink system id
     // @Description: Follow target's mavlink system id
-    // @Range: 0 255
+    // @Range: 0 16777215
     // @User: Standard
     AP_GROUPINFO("_SYSID", 3, AP_Follow, _sysid, 0),
 
@@ -226,6 +226,15 @@ AP_Follow::AP_Follow() :
 {
     _singleton = this;
     AP_Param::setup_object_defaults(this, var_info);
+}
+
+// convert parameters. Must be called before anything reads FOLL_SYSID,
+// which includes mode entry at startup, so this is done from the vehicle's
+// load_parameters() rather than lazily on first use
+void AP_Follow::convert_params()
+{
+    // PARAMETER_CONVERSION - Added: Jul-2026 for 32 bit sysids
+    _sysid.convert_parameter_width(AP_PARAM_INT16);
 }
 
 
@@ -558,7 +567,7 @@ bool AP_Follow::should_handle_message(const mavlink_message_t &msg) const
     }
 
     // skip message if not from our target
-    if (_sysid != 0 && msg.sysid != _sysid) {
+    if (_sysid != 0 && msg.sysid != uint32_t(_sysid.get())) {
         return false;
     }
 

--- a/libraries/AP_Follow/AP_Follow.h
+++ b/libraries/AP_Follow/AP_Follow.h
@@ -68,7 +68,7 @@ public:
     bool enabled() const { return _enabled; }
 
     // set which target to follow
-    void set_target_sysid(uint8_t sysid) { _sysid.set(sysid); }
+    void set_target_sysid(uint32_t sysid) { _sysid.set(sysid); }
 
     // Resets the follow mode offsets to zero if they were automatically initialized. Should be called when exiting Follow mode.
     void clear_offsets_if_required();
@@ -82,6 +82,9 @@ public:
 
     // Projects the target’s position, velocity, and heading forward using the latest updates, smoothing with input shaping if necessary 
     void update_estimates();
+
+    // convert parameters, called from the vehicle's load_parameters()
+    void convert_params();
 
     // Retrieves the estimated target position, velocity, and acceleration in the NED frame relative to the origin (units: meters and meters/second).
     bool get_target_pos_vel_accel_NED_m(Vector3p &pos_ned_m, Vector3f &vel_ned_ms, Vector3f &accel_ned_mss) const;
@@ -115,7 +118,6 @@ public:
     // Accessor Methods
     //==========================================================================
 
-    // get target sysid as a 32 bit number to allow for future expansion of MAV_SYSID
     uint32_t get_target_sysid() const { return (uint32_t)_sysid.get(); }
 
     // get position controller.  this controller is not used within this library but it is convenient to hold it here
@@ -194,7 +196,7 @@ private:
     //==========================================================================
 
     AP_Int8     _enabled;           // 1 = Follow mode is enabled; 0 = disabled
-    AP_Int16    _sysid;             // MAVLink system ID of the target (0 = auto-select first sender)
+    AP_Int32    _sysid;             // MAVLink system ID of the target (0 = auto-select first sender)
     AP_Float    _dist_max_m;        // Maximum allowed distance to target in meters; if exceeded, estimation is rejected
     AP_Int8     _offset_type;       // Offset frame type: 0 = NED, 1 = relative to lead vehicle heading
     AP_Vector3f _offset_m;          // Offset from lead vehicle (meters), in NED or FRD frame depending on _offset_type
@@ -237,7 +239,7 @@ private:
     Vector3f    _ofs_estimate_accel_ned_mss;    // Estimated acceleration with offsets applied (NED frame)
 
     bool        _automatic_sysid;               // True if target sysid was automatically selected
-    int16_t     _sysid_used;                    // Currently active sysid used for updates
+    int64_t     _sysid_used;                    // Currently active sysid used for updates, -1 when none
     float       _dist_to_target_m;              // Horizontal distance to target, for reporting (meters)
     float       _bearing_to_target_deg;         // Bearing to target from vehicle (degrees, 0 = North)
     bool        _offsets_were_zero;             // True if initial offset was zero before being initialized

--- a/libraries/AP_Generator/AP_Generator_Loweheiser.cpp
+++ b/libraries/AP_Generator/AP_Generator_Loweheiser.cpp
@@ -504,7 +504,7 @@ void AP_Generator_Loweheiser::command_generator()
             "TimeUS," "SI," "CI," "C," "I," "ES," "GS," "Thr," "Strtr",
             "s"       "-"   "-"   "-"  "#"  "-"   "-"   "-"    "-"     ,
             "F"       "-"   "-"   "-"  "-"  "-"   "-"   "-"    "-"     ,
-            "Q"       "B"   "B"   "I"  "B"  "B"   "B"   "f"    "B"     ,
+            "Q"       "I"   "B"   "I"  "B"  "B"   "B"   "f"    "B"     ,
             AP_HAL::micros64(),
             sysid,
             compid,

--- a/libraries/AP_Generator/AP_Generator_Loweheiser.h
+++ b/libraries/AP_Generator/AP_Generator_Loweheiser.h
@@ -103,7 +103,7 @@ private:
     // only process from one source:
     bool seen_good_message;
     const class GCS_MAVLINK *mavlink_channel;
-    uint8_t sysid;
+    uint32_t sysid;
     uint8_t compid;
     uint8_t efi_index;
 

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -277,8 +277,11 @@ public:
     void Write_Mode(uint8_t mode, const ModeReason reason);
 
     void Write_EntireMission();
+    // target_system must come from the message header, not the packet;
+    // the payload byte is zero when the target is in the extended header
     void Write_Command(const mavlink_command_int_t &packet,
-                       uint8_t source_system,
+                       uint32_t target_system,
+                       uint32_t source_system,
                        uint8_t source_component,
                        MAV_RESULT result,
                        bool was_command_long=false);

--- a/libraries/AP_Logger/AP_Logger_MAVLink.cpp
+++ b/libraries/AP_Logger/AP_Logger_MAVLink.cpp
@@ -254,7 +254,7 @@ void AP_Logger_MAVLink::handle_ack(const GCS_MAVLINK &link,
             _next_seq_num = 0;
             start_new_log_reset_variables();
             _last_response_time = AP_HAL::millis();
-            Debug("Target: (%u/%u)", _target_system_id, _target_component_id);
+            Debug("Target: (%u/%u)", (unsigned)_target_system_id, _target_component_id);
         }
         return;
     }

--- a/libraries/AP_Logger/AP_Logger_MAVLink.h
+++ b/libraries/AP_Logger/AP_Logger_MAVLink.h
@@ -119,7 +119,7 @@ private:
 
     const GCS_MAVLINK *_link;
 
-    uint8_t _target_system_id;
+    uint32_t _target_system_id;
     uint8_t _target_component_id;
 
     // this controls the maximum number of blocks we will push from

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -277,7 +277,8 @@ void AP_Logger::Write_RSSI()
 #endif
 
 void AP_Logger::Write_Command(const mavlink_command_int_t &packet,
-                              uint8_t source_system,
+                              uint32_t target_system,
+                              uint32_t source_system,
                               uint8_t source_component,
                               const MAV_RESULT result,
                               bool was_command_long)
@@ -285,7 +286,7 @@ void AP_Logger::Write_Command(const mavlink_command_int_t &packet,
     const struct log_MAVLink_Command pkt{
         LOG_PACKET_HEADER_INIT(LOG_MAVLINK_COMMAND_MSG),
         time_us         : AP_HAL::micros64(),
-        target_system   : packet.target_system,
+        target_system   : target_system,
         target_component: packet.target_component,
         source_system   : source_system,
         source_component: source_component,

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -365,9 +365,9 @@ struct PACKED log_MCU {
 struct PACKED log_MAVLink_Command {
     LOG_PACKET_HEADER;
     uint64_t time_us;
-    uint8_t target_system;
+    uint32_t target_system;
     uint8_t target_component;
-    uint8_t source_system;
+    uint32_t source_system;
     uint8_t source_component;
     uint8_t frame;
     uint16_t command;
@@ -1187,7 +1187,7 @@ LOG_STRUCTURE_FROM_PRECLAND \
       "MCU","Qffff","TimeUS,MTemp,MVolt,MVmin,MVmax", "sOvvv", "F0000", true }, \
 LOG_STRUCTURE_FROM_MISSION \
     { LOG_MAVLINK_COMMAND_MSG, sizeof(log_MAVLink_Command), \
-      "MAVC", "QBBBBBHffffiifBB","TimeUS,TS,TC,SS,SC,Fr,Cmd,P1,P2,P3,P4,X,Y,Z,Res,WL", "s---------------", "F---------------" }, \
+      "MAVC", "QIBIBBHffffiifBB","TimeUS,TS,TC,SS,SC,Fr,Cmd,P1,P2,P3,P4,X,Y,Z,Res,WL", "s---------------", "F---------------" }, \
     { LOG_RADIO_MSG, sizeof(log_Radio), \
       "RAD", "QBBBBBHH", "TimeUS,RSSI,RemRSSI,TxBuf,Noise,RemNoise,RxErrors,Fixed", "s-------", "F-------", true }, \
 LOG_STRUCTURE_FROM_CAMERA \

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -64,6 +64,11 @@ void AP_Mount::init()
     // perform any required parameter conversion
     convert_params();
 
+    // PARAMETER_CONVERSION - Added: Jul-2026 for 32 bit sysids
+    for (uint8_t instance=0; instance<AP_MOUNT_MAX_INSTANCES; instance++) {
+        _params[instance].sysid_default.convert_parameter_width(AP_PARAM_INT8);
+    }
+
     // primary is reset to the first instantiated mount
     bool primary_set = false;
 
@@ -548,7 +553,7 @@ void AP_Mount::handle_gimbal_manager_set_pitchyaw(const mavlink_message_t &msg)
 
 MAV_RESULT AP_Mount::handle_command_do_set_roi_sysid(const mavlink_command_int_t &packet)
 {
-    set_target_sysid((uint8_t)packet.param1);
+    set_target_sysid((uint32_t)packet.param1);
     return MAV_RESULT_ACCEPTED;
 }
 
@@ -804,7 +809,7 @@ void AP_Mount::write_log(uint8_t instance, uint64_t timestamp_us)
 #endif
 
 // point at system ID sysid
-void AP_Mount::set_target_sysid(uint8_t instance, uint8_t sysid)
+void AP_Mount::set_target_sysid(uint8_t instance, uint32_t sysid)
 {
     auto *backend = get_instance(instance);
     if (backend == nullptr) {

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -208,8 +208,8 @@ public:
     void clear_roi_target(uint8_t instance);
 
     // point at system ID sysid
-    void set_target_sysid(uint8_t sysid) { set_target_sysid(_primary, sysid); }
-    void set_target_sysid(uint8_t instance, uint8_t sysid);
+    void set_target_sysid(uint32_t sysid) { set_target_sysid(_primary, sysid); }
+    void set_target_sysid(uint8_t instance, uint32_t sysid);
 
     // handling of set_roi_sysid message
     MAV_RESULT handle_command_do_set_roi_sysid(const mavlink_command_int_t &packet);

--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -394,7 +394,7 @@ void AP_Mount_Backend::set_roi_target_wpnext_offset(const Vector3f &rpy)
 #endif  // AP_MOUNT_ROI_WPNEXT_OFFSET_ENABLED
 
 // set_sys_target - sets system that mount should attempt to point towards
-void AP_Mount_Backend::set_target_sysid(uint8_t sysid)
+void AP_Mount_Backend::set_target_sysid(uint32_t sysid)
 {
     _target_sysid = sysid;
 
@@ -536,7 +536,7 @@ void AP_Mount_Backend::send_gimbal_manager_status(mavlink_channel_t chan)
                                            AP_HAL::millis(),    // autopilot system time
                                            flags,               // bitmap of gimbal manager flags
                                            _instance + 1,       // gimbal device id
-                                           mavlink_control_id.sysid,    // primary control system id
+                                           mavlink_control_id.sysid>255?0:mavlink_control_id.sysid,    // primary control system id (8 bit only in this message)
                                            mavlink_control_id.compid,   // primary control component id
                                            0,                           // secondary control system id
                                            0);                          // secondary control component id
@@ -606,8 +606,10 @@ MAV_RESULT AP_Mount_Backend::handle_command_do_mount_control(const mavlink_comma
 // requires original message in order to extract caller's sysid and compid
 MAV_RESULT AP_Mount_Backend::handle_command_do_gimbal_manager_configure(const mavlink_command_int_t &packet, const mavlink_message_t &msg)
 {
-    // sanity check param1 and param2 values
-    if ((packet.param1 < -3) || (packet.param1 > UINT8_MAX) || (packet.param2 < -3) || (packet.param2 > UINT8_MAX)) {
+    // sanity check param1 and param2 values. param1 is a system ID, which a
+    // float parameter can only carry exactly up to 2^24-1; param2 is a compid
+    if ((packet.param1 < -3) || (packet.param1 > float((1U<<24)-1)) ||
+        (packet.param2 < -3) || (packet.param2 > UINT8_MAX)) {
         return MAV_RESULT_FAILED;
     }
 
@@ -615,7 +617,7 @@ MAV_RESULT AP_Mount_Backend::handle_command_do_gimbal_manager_configure(const ma
     mavlink_control_id_t prev_control_id = mavlink_control_id;
 
     // convert negative packet1 and packet2 values
-    int16_t new_sysid = packet.param1;
+    int64_t new_sysid = packet.param1;
     switch (new_sysid) {
         case -1:
             // leave unchanged
@@ -647,7 +649,7 @@ MAV_RESULT AP_Mount_Backend::handle_command_do_gimbal_manager_configure(const ma
 }
 
 // handle a GLOBAL_POSITION_INT message
-bool AP_Mount_Backend::handle_global_position_int(uint8_t msg_sysid, const mavlink_global_position_int_t &packet)
+bool AP_Mount_Backend::handle_global_position_int(uint32_t msg_sysid, const mavlink_global_position_int_t &packet)
 {
     if (_target_sysid != msg_sysid) {
         return false;

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -119,7 +119,7 @@ public:
     void clear_roi_target();
 
     // set_sys_target - sets system that mount should attempt to point towards
-    void set_target_sysid(uint8_t sysid);
+    void set_target_sysid(uint32_t sysid);
 
 #if AP_MOUNT_ROI_WPNEXT_OFFSET_ENABLED
     // set_roi_target_wpnext_offset - point to next waypoint, with offsets
@@ -152,7 +152,7 @@ public:
     virtual void handle_param_value(const mavlink_message_t &msg) {}
 
     // handle a GLOBAL_POSITION_INT message
-    bool handle_global_position_int(uint8_t msg_sysid, const mavlink_global_position_int_t &packet);
+    bool handle_global_position_int(uint32_t msg_sysid, const mavlink_global_position_int_t &packet);
 
     // handle GIMBAL_DEVICE_INFORMATION message
     virtual void handle_gimbal_device_information(const mavlink_message_t &msg) {}
@@ -483,7 +483,7 @@ private:
     Vector3f _roi_wpnext_rpy;       // angular offsets for pointing-at-waypoint
 #endif  // AP_MOUNT_ROI_WPNEXT_OFFSET_ENABLED
 
-    uint8_t _target_sysid;          // sysid to track
+    uint32_t _target_sysid;         // sysid to track
     Location _target_sysid_location;// sysid target location
 
     uint32_t _last_warning_ms;      // system time of last warning sent to GCS
@@ -499,7 +499,7 @@ private:
     // structure holding mavlink sysid and compid of controller of this gimbal
     // see MAV_CMD_DO_GIMBAL_MANAGER_CONFIGURE and GIMBAL_MANAGER_STATUS
     struct mavlink_control_id_t {
-        uint8_t sysid;
+        uint32_t sysid;
         uint8_t compid;
 
         // equality operators

--- a/libraries/AP_Mount/AP_Mount_MAVLink.cpp
+++ b/libraries/AP_Mount/AP_Mount_MAVLink.cpp
@@ -183,12 +183,12 @@ void AP_Mount_MAVLink::request_gimbal_device_information() const
         0,  // param6
         0,  // param7
         MAV_CMD_REQUEST_MESSAGE,
-        _sysid,
+        uint8_t(_sysid>255?0:_sysid),  // targets > 255 travel in the extended header
         _compid,
         0  // confirmation
     };
 
-    _link->send_message(MAVLINK_MSG_ID_COMMAND_LONG, (const char*)&pkt);
+    _link->send_message_target(MAVLINK_MSG_ID_COMMAND_LONG, (const char*)&pkt, _sysid, _compid);
 }
 
 // start sending ATTITUDE and AUTOPILOT_STATE_FOR_GIMBAL_DEVICE to gimbal
@@ -219,11 +219,11 @@ void AP_Mount_MAVLink::send_target_retracted()
         0,  // angular velocity y
         0,    // angular velocity z
         GIMBAL_DEVICE_FLAGS_RETRACT,  // flags
-        _sysid,
+        uint8_t(_sysid>255?0:_sysid),  // targets > 255 travel in the extended header
         _compid
     };
 
-    _link->send_message(MAVLINK_MSG_ID_GIMBAL_DEVICE_SET_ATTITUDE, (const char*)&pkt);
+    _link->send_message_target(MAVLINK_MSG_ID_GIMBAL_DEVICE_SET_ATTITUDE, (const char*)&pkt, _sysid, _compid);
 }
 
 // send GIMBAL_DEVICE_SET_ATTITUDE to gimbal to control rate
@@ -243,11 +243,11 @@ void AP_Mount_MAVLink::send_target_rates(const MountRateTarget &rate_rads)
         pitch_rads,  // angular velocity y
         yaw_rads,    // angular velocity z
         flags,
-        _sysid,
+        uint8_t(_sysid>255?0:_sysid),  // targets > 255 travel in the extended header
         _compid
     };
 
-    _link->send_message(MAVLINK_MSG_ID_GIMBAL_DEVICE_SET_ATTITUDE, (const char*)&pkt);
+    _link->send_message_target(MAVLINK_MSG_ID_GIMBAL_DEVICE_SET_ATTITUDE, (const char*)&pkt, _sysid, _compid);
 }
 
 // send GIMBAL_DEVICE_SET_ATTITUDE to gimbal to control attitude
@@ -276,11 +276,11 @@ void AP_Mount_MAVLink::send_target_angles(const MountAngleTarget &angle_rad)
         NAN,  // angular velocity y
         NAN,  // angular velocity z
         flags,
-        _sysid,
+        uint8_t(_sysid>255?0:_sysid),  // targets > 255 travel in the extended header
         _compid
     };
 
-    _link->send_message(MAVLINK_MSG_ID_GIMBAL_DEVICE_SET_ATTITUDE, (const char*)&pkt);
+    _link->send_message_target(MAVLINK_MSG_ID_GIMBAL_DEVICE_SET_ATTITUDE, (const char*)&pkt, _sysid, _compid);
 }
 
 // Send MAV_CMD_DO_SET_ROI_LOCATION  to gimbal
@@ -291,7 +291,7 @@ void AP_Mount_MAVLink::send_target_location(const Location &roi_loc)
     }
 
     mavlink_command_int_t pkt {};
-    pkt.target_system = _sysid;
+    pkt.target_system = _sysid>255?0:_sysid;  // targets > 255 travel in the extended header
     pkt.target_component = _compid;
 
     if (roi_loc.initialised()) {
@@ -304,7 +304,7 @@ void AP_Mount_MAVLink::send_target_location(const Location &roi_loc)
         pkt.command = MAV_CMD_DO_SET_ROI_NONE;
     }
 
-    _link->send_message(MAVLINK_MSG_ID_COMMAND_INT, (const char*)&pkt);
+    _link->send_message_target(MAVLINK_MSG_ID_COMMAND_INT, (const char*)&pkt, _sysid, _compid);
 }
 
 #endif // HAL_MOUNT_MAVLINK_ENABLED

--- a/libraries/AP_Mount/AP_Mount_MAVLink.h
+++ b/libraries/AP_Mount/AP_Mount_MAVLink.h
@@ -98,7 +98,7 @@ private:
     bool _initialised;              // true once the gimbal has provided a GIMBAL_DEVICE_INFORMATION
     uint32_t _last_devinfo_req_ms;  // system time that GIMBAL_DEVICE_INFORMATION was last requested (used to throttle requests)
     class GCS_MAVLINK *_link;       // link we have found gimbal on; nullptr if not seen yet
-    uint8_t _sysid;                 // sysid of gimbal
+    uint32_t _sysid;                // sysid of gimbal
     uint8_t _compid;                // component id of gimbal
     mavlink_gimbal_device_attitude_status_t _gimbal_device_attitude_status;  // copy of most recently received gimbal status
     uint32_t _last_attitude_status_ms;  // system time last attitude status was received (used for health reporting)

--- a/libraries/AP_Mount/AP_Mount_Params.h
+++ b/libraries/AP_Mount/AP_Mount_Params.h
@@ -29,7 +29,7 @@ public:
 
     AP_Float    roll_stb_lead;      // roll lead control gain (only used by servo backend)
     AP_Float    pitch_stb_lead;     // pitch lead control gain (only used by servo backend)
-    AP_Int8     sysid_default;      // target sysid for mount to follow
+    AP_Int32    sysid_default;      // target sysid for mount to follow
     AP_Int32    dev_id;             // Device id taking into account bus
     AP_Int8     options;            // mount options bitmask
 };

--- a/libraries/AP_Mount/AP_Mount_SToRM32.h
+++ b/libraries/AP_Mount/AP_Mount_SToRM32.h
@@ -50,7 +50,7 @@ private:
 
     // internal variables
     bool _initialised;              // true once the driver has been initialised
-    uint8_t _sysid;                 // sysid of gimbal
+    uint32_t _sysid;                // sysid of gimbal
     uint8_t _compid;                // component id of gimbal
     mavlink_channel_t _chan = MAVLINK_COMM_0;        // mavlink channel used to communicate with gimbal
 };

--- a/libraries/AP_OpenDroneID/AP_OpenDroneID.cpp
+++ b/libraries/AP_OpenDroneID/AP_OpenDroneID.cpp
@@ -135,8 +135,10 @@ void AP_OpenDroneID::set_basic_id() {
     }
     if (id_len > 0) {
         // prepare basic id pkt
-        uint8_t val = gcs().sysid_this_mav();
-        pkt_basic_id.target_system = val;
+        // this packet is sent as a raw struct, so has no extended header
+        // for a target sysid over 255
+        const uint32_t val = gcs().sysid_this_mav();
+        pkt_basic_id.target_system = val>255?0:val;
         pkt_basic_id.target_component = MAV_COMP_ID_ODID_TXRX_1;
         pkt_basic_id.id_type = atoi(id_type);
         pkt_basic_id.ua_type = atoi(ua_type);

--- a/libraries/AP_Scripting/applets/param-lockdown.lua
+++ b/libraries/AP_Scripting/applets/param-lockdown.lua
@@ -211,12 +211,26 @@ local function update()
             break
         end
 
-        local param_value, _, _, param_id, _ = string.unpack("<fBBc16B", string.sub(msg, 13, 36))
+        -- newer firmware passes a structure with a 4 byte sysid (299
+        -- bytes); older firmware uses a 1 byte sysid (291 bytes)
+        local sysid32_layout = #msg >= 299
+        local payload_ofs = sysid32_layout and 16 or 13
+        local param_value, _, _, param_id, _ = string.unpack("<fBBc16B", string.sub(msg, payload_ofs, payload_ofs + 23))
         param_id = string.gsub(param_id, string.char(0), "")
 
         param_error = handle_param_set(param_id, param_value)
         if param_error ~= 0 then
-           sysid, compid = string.unpack("<BBB", msg, 8)
+           if sysid32_layout then
+              sysid = string.unpack("<I4", msg, 8)
+              if sysid > 255 then
+                 -- scripting cannot send the extended target header yet, and
+                 -- the payload target byte cannot hold a 32 bit sysid
+                 sysid = 0
+              end
+              compid = string.unpack("<B", msg, 12)
+           else
+              sysid, compid = string.unpack("<BB", msg, 8)
+           end
            send_param_error_response(chan, sysid, compid, param_id, param_error)
         end
     end

--- a/libraries/AP_Scripting/examples/config_profiles.lua
+++ b/libraries/AP_Scripting/examples/config_profiles.lua
@@ -718,7 +718,10 @@ local function handle_param_setting()
       end
 
       if gcs_allow_set == false then -- we are in change of param setting
-         local param_value, _, _, param_id, _ = string.unpack("<fBBc16B", string.sub(msg, 13, 36))
+         -- newer firmware passes a structure with a 4 byte sysid (299
+         -- bytes); older firmware uses a 1 byte sysid (291 bytes)
+         local payload_ofs = (#msg >= 299) and 16 or 13
+         local param_value, _, _, param_id, _ = string.unpack("<fBBc16B", string.sub(msg, payload_ofs, payload_ofs + 23))
          param_id = string.gsub(param_id, string.char(0), "")
 
          handle_param_set(param_id, param_value)

--- a/libraries/AP_Scripting/modules/MAVLink/mavlink_msgs.lua
+++ b/libraries/AP_Scripting/modules/MAVLink/mavlink_msgs.lua
@@ -12,9 +12,20 @@ function mavlink_msgs.get_msgid(msgname)
   return message_map.id
 end
 
+---True when this firmware passes messages with the MAVLink2.1 32 bit
+---sysid mavlink_message_t layout. Older firmware uses a 1 byte sysid and
+---has no trailing extended target fields, giving a 291 byte structure
+---instead of 299, so the same script can work on both
+---@param message any -- encoded message
+---@return boolean
+function mavlink_msgs.sysid32_layout(message)
+  return #message >= 299
+end
+
 ---Return a object containing everything that is not the payload
 ---@param message any -- encoded message
 ---@return table
+---@return integer -- offset of the payload in the message
 function mavlink_msgs.decode_header(message)
   -- build up a map of the result
   local result = {}
@@ -37,13 +48,29 @@ function mavlink_msgs.decode_header(message)
   -- fetch the incompat/compat flags
   result.incompat_flags, result.compat_flags = string.unpack("<BB", message, 5)
 
-  -- fetch seq/sysid/compid
-  result.seq, result.sysid, result.compid = string.unpack("<BBB", message, 7)
+  if not mavlink_msgs.sysid32_layout(message) then
+    -- older firmware with a 1 byte sysid in the structure
+    result.seq, result.sysid, result.compid = string.unpack("<BBB", message, 7)
+    result.msgid = string.unpack("<I3", message, 10)
+    return result, 13
+  end
+
+  -- fetch seq/sysid/compid, sysid is 32 bits to support MAVLink2.1
+  result.seq = string.unpack("<B", message, 7)
+  result.sysid = string.unpack("<I4", message, 8)
+  result.compid = string.unpack("<B", message, 12)
 
   -- fetch the message id
-  result.msgid = string.unpack("<I3", message, 10)
+  result.msgid = string.unpack("<I3", message, 13)
 
-  return result
+  -- extended target from the MAVLink2.1 TARGETTED header, stored at the
+  -- end of the C structure
+  if (result.incompat_flags & 0x04) ~= 0 then
+    result.target_sysid = string.unpack("<I4", message, 295)
+    result.target_compid = string.unpack("<B", message, 299)
+  end
+
+  return result, 16
 end
 
 -- generate the x25crc for a given buffer
@@ -67,7 +94,7 @@ end
 ---@param msg_map table -- table containing message objects with keys of the message ID
 ---@return table|nil -- a table representing the contents of the message, or nill if decode failed
 function mavlink_msgs.decode(message, msg_map)
-  local result = mavlink_msgs.decode_header(message)
+  local result, payload_ofs = mavlink_msgs.decode_header(message)
   local message_map = require("MAVLink/mavlink_msg_" .. msg_map[result.msgid])
   if not message_map then
     -- we don't know how to decode this message, bail on it
@@ -80,7 +107,24 @@ function mavlink_msgs.decode(message, msg_map)
     -- crc of payload and header values
     local crc_buffer
     if result.protocol_version == 2 then
-      crc_buffer = string.sub(message, 4, 12 + result.payload_length)
+      if not mavlink_msgs.sysid32_layout(message) then
+        -- older firmware: structure matches the wire header directly
+        crc_buffer = string.sub(message, 4, 12 + result.payload_length)
+      else
+        -- reconstruct the wire header; the structure holds a 4 byte sysid
+        -- but the wire form is 1 byte unless MAVLINK_IFLAG_SYSID32 is set
+        crc_buffer = string.sub(message, 4, 7)
+        if (result.incompat_flags & 0x02) ~= 0 then
+          crc_buffer = crc_buffer .. string.sub(message, 8, 11)
+        else
+          crc_buffer = crc_buffer .. string.sub(message, 8, 8)
+        end
+        crc_buffer = crc_buffer .. string.sub(message, 12, 15)
+        if (result.incompat_flags & 0x04) ~= 0 then
+          crc_buffer = crc_buffer .. string.sub(message, 295, 299)
+        end
+        crc_buffer = crc_buffer .. string.sub(message, payload_ofs, payload_ofs - 1 + result.payload_length)
+      end
 
     else
       -- V1 does not include all fields on the wire
@@ -90,7 +134,7 @@ function mavlink_msgs.decode(message, msg_map)
       crc_buffer = crc_buffer .. string.char(result.compid)
       crc_buffer = crc_buffer .. string.char(result.msgid)
       if result.payload_length > 0 then
-        crc_buffer = crc_buffer .. string.sub(message, 13, 12 + result.payload_length)
+        crc_buffer = crc_buffer .. string.sub(message, payload_ofs, payload_ofs - 1 + result.payload_length)
       end
 
     end
@@ -104,7 +148,7 @@ function mavlink_msgs.decode(message, msg_map)
   end
 
   -- map all the fields out
-  local offset = 13
+  local offset = payload_ofs
   for _,v in ipairs(message_map.fields) do
     if v[3] then
       result[v[1]] = {}

--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -38,14 +38,14 @@ const AP_Param::GroupInfo GCS::var_info[] {
     // @Param: _SYSID
     // @DisplayName: MAVLink system ID of this vehicle
     // @Description: Allows setting an individual MAVLink system id for this vehicle to distinguish it from others on the same network.
-    // @Range: 1 255
+    // @Range: 1 16777215
     // @User: Advanced
     AP_GROUPINFO("_SYSID",    1,     GCS,  sysid,  MAV_SYSID_DEFAULT),
 
     // @Param: _GCS_SYSID
     // @DisplayName: My ground station number
     // @Description: This sets what MAVLink source system IDs are accepted for GCS failsafe handling, RC overrides and manual control. When MAV_GCS_SYSID_HI is less than MAV_GCS_SYSID then only this value is considered to be a GCS. When MAV_GCS_SYSID_HI is greater than or equal to MAV_GCS_SYSID then the range of values between MAV_GCS_SYSID and MAV_GCS_SYSID_HI (inclusive) are all treated as valid GCS MAVLink system IDs
-    // @Range: 1 255
+    // @Range: 1 16777215
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("_GCS_SYSID",    2,      GCS, mav_gcs_sysid, 255),
@@ -53,7 +53,7 @@ const AP_Param::GroupInfo GCS::var_info[] {
     // @Param: _GCS_SYSID_HI
     // @DisplayName: ground station system ID, maximum
     // @Description: Upper limit of MAVLink source system IDs considered to be from the GCS. When this is less than MAV_GCS_SYSID then only MAV_GCS_SYSID is used as GCS ID. When this is greater than or equal to MAV_GCS_SYSID then the range of values from MAV_GCS_SYSID to MAV_GCS_SYSID_HI (inclusive) is treated as a GCS ID.
-    // @Range: 0 255
+    // @Range: 0 16777215
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("_GCS_SYSID_HI",    5,   GCS, mav_gcs_sysid_high, 0),
@@ -261,6 +261,11 @@ MissionItemProtocol *GCS::missionitemprotocols[3];
 
 void GCS::init()
 {
+    // sysid parameters widened for 32 bit system IDs
+    sysid.convert_parameter_width(AP_PARAM_INT16);
+    mav_gcs_sysid.convert_parameter_width(AP_PARAM_INT16);
+    mav_gcs_sysid_high.convert_parameter_width(AP_PARAM_INT16);
+
     mavlink_system.sysid = sysid_this_mav();
 }
 
@@ -724,12 +729,12 @@ MAV_RESULT GCS::lua_command_int_packet(const mavlink_command_int_t &packet)
 /*
   return true if a MAVLink system ID is a GCS for this vehicle
 */
-bool GCS::sysid_is_gcs(uint8_t _sysid) const
+bool GCS::sysid_is_gcs(uint32_t _sysid) const
 {
     if (mav_gcs_sysid_high <= mav_gcs_sysid) {
-        return mav_gcs_sysid == _sysid;
+        return uint32_t(mav_gcs_sysid.get()) == _sysid;
     }
-    return _sysid >= mav_gcs_sysid && _sysid <= mav_gcs_sysid_high;
+    return _sysid >= uint32_t(mav_gcs_sysid.get()) && _sysid <= uint32_t(mav_gcs_sysid_high.get());
 }
 
 #endif  // HAL_GCS_ENABLED

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -149,13 +149,13 @@ public:
     Type task;
     MAV_CMD mav_cmd;
 
-    static class GCS_MAVLINK_InProgress *get_task(MAV_CMD cmd, Type t, uint8_t sysid, uint8_t compid, mavlink_channel_t chan);
+    static class GCS_MAVLINK_InProgress *get_task(MAV_CMD cmd, Type t, uint32_t sysid, uint8_t compid, mavlink_channel_t chan);
 
     static void check_tasks();
 
 private:
 
-    uint8_t requesting_sysid;
+    uint32_t requesting_sysid;
     uint8_t requesting_compid;
     mavlink_channel_t chan;
 
@@ -259,6 +259,26 @@ public:
                                         entry->min_msg_len,
                                         entry->max_msg_len,
                                         entry->crc_extra);
+    }
+    // variant for raw payload structs with a target sysid over 255; the
+    // caller must have written the payload target_system byte as
+    // (target_sysid > 255 ? 0 : target_sysid)
+    void send_message_target(uint32_t msgid, const char *pkt, uint32_t target_sysid, uint8_t target_compid) {
+        const mavlink_msg_entry_t *entry = mavlink_get_msg_entry(msgid);
+        if (entry == nullptr) {
+            return;
+        }
+        if (!check_payload_size(entry->max_msg_len)) {
+            return;
+        }
+        _mav_finalize_message_chan_send_target(chan,
+                                               entry->msgid,
+                                               pkt,
+                                               entry->min_msg_len,
+                                               entry->max_msg_len,
+                                               entry->crc_extra,
+                                               target_sysid,
+                                               target_compid);
     }
 
     // accessor for uart
@@ -391,7 +411,7 @@ public:
     void send_accelcal_vehicle_position(uint32_t position);
     void send_scaled_imu(uint8_t instance, void (*send_fn)(mavlink_channel_t chan, uint32_t time_ms, int16_t xacc, int16_t yacc, int16_t zacc, int16_t xgyro, int16_t ygyro, int16_t zgyro, int16_t xmag, int16_t ymag, int16_t zmag, int16_t temperature));
     void send_sys_status();
-    void send_set_position_target_global_int(uint8_t target_system, uint8_t target_component, const Location& loc);
+    void send_set_position_target_global_int(uint32_t target_system, uint8_t target_component, const Location& loc);
     void send_rpm() const;
     void send_generator_status() const;
 #if AP_WINCH_ENABLED
@@ -469,16 +489,16 @@ public:
       search for a component in the routing table with given mav_type and retrieve it's sysid, compid and channel
       returns if a matching component is found
      */
-    static bool find_by_mavtype(uint8_t mav_type, uint8_t &sysid, uint8_t &compid, mavlink_channel_t &channel) { return routing.find_by_mavtype(mav_type, sysid, compid, channel); }
+    static bool find_by_mavtype(uint8_t mav_type, uint32_t &sysid, uint8_t &compid, mavlink_channel_t &channel) { return routing.find_by_mavtype(mav_type, sysid, compid, channel); }
 
     /*
       search for the first vehicle or component in the routing table with given mav_type and component id and retrieve its sysid and channel
       returns true if a match is found
      */
-    static bool find_by_mavtype_and_compid(uint8_t mav_type, uint8_t compid, uint8_t &sysid, mavlink_channel_t &channel) { return routing.find_by_mavtype_and_compid(mav_type, compid, sysid, channel); }
+    static bool find_by_mavtype_and_compid(uint8_t mav_type, uint8_t compid, uint32_t &sysid, mavlink_channel_t &channel) { return routing.find_by_mavtype_and_compid(mav_type, compid, sysid, channel); }
     // same as above, but returns a pointer to the GCS_MAVLINK object
     // corresponding to the channel
-    static GCS_MAVLINK *find_by_mavtype_and_compid(uint8_t mav_type, uint8_t compid, uint8_t &sysid);
+    static GCS_MAVLINK *find_by_mavtype_and_compid(uint8_t mav_type, uint8_t compid, uint32_t &sysid);
 
 #if AP_MAVLINK_SIGNING_ENABLED
     // update signing timestamp on GPS lock
@@ -681,7 +701,7 @@ protected:
 
     void handle_statustext(const mavlink_message_t &msg);
     struct {
-        uint8_t last_src_system;
+        uint32_t last_src_system;
         uint8_t last_src_component;
         uint8_t last_id; // ID from the mavlink packet
         uint8_t msg_id;  // ID used in our logs
@@ -983,7 +1003,7 @@ private:
         mavlink_channel_t chan;
         int16_t param_index;
         char param_name[AP_MAX_NAME_SIZE+1];
-        uint8_t src_system_id;
+        uint32_t src_system_id;
         uint8_t src_component_id;
     };
 
@@ -994,7 +1014,7 @@ private:
         int16_t param_index;
         uint16_t count;
         char param_name[AP_MAX_NAME_SIZE+1];
-        uint8_t src_system_id;
+        uint32_t src_system_id;
         uint8_t src_component_id;
         MAV_PARAM_ERROR param_error;
     };
@@ -1176,7 +1196,7 @@ public:
     /*
       return true if a MAVLink system ID is a GCS
      */
-    bool sysid_is_gcs(uint8_t sysid) const;
+    bool sysid_is_gcs(uint32_t sysid) const;
 
     // last time traffic was seen from my designated GCS.  traffic
     // includes heartbeats and some manual control messages.
@@ -1302,7 +1322,7 @@ public:
     bool get_high_latency_status();
 #endif // HAL_HIGH_LATENCY2_ENABLED
 
-    uint8_t sysid_this_mav() const { return sysid; }
+    uint32_t sysid_this_mav() const { return sysid; }
     uint32_t telem_delay() const { return mav_telem_delay; }
 
 #if AP_SCRIPTING_ENABLED
@@ -1330,9 +1350,9 @@ protected:
     GCS_MAVLINK *_chan[MAVLINK_COMM_NUM_BUFFERS];
 
     // parameters
-    AP_Int16                 sysid;
-    AP_Int16                 mav_gcs_sysid;
-    AP_Int16                 mav_gcs_sysid_high;
+    AP_Int32                 sysid;
+    AP_Int32                 mav_gcs_sysid;
+    AP_Int32                 mav_gcs_sysid_high;
     AP_Enum16<Option>        mav_options;
     AP_Int8                  mav_telem_delay;
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3856,7 +3856,7 @@ void GCS_MAVLINK::handle_statustext(const mavlink_message_t &msg)
     const uint8_t max_prefix_len = 14;
     const uint8_t text_len = MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1+max_prefix_len;
     if (msg.sysid != statustext_chunking.last_src_system ||
-        msg.compid != statustext_chunking.last_src_system ||
+        msg.compid != statustext_chunking.last_src_component ||
         packet.id != statustext_chunking.last_id) {
         statustext_chunking.last_src_system = msg.sysid;
         statustext_chunking.last_src_component = msg.compid;

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1470,7 +1470,7 @@ bool GCS_MAVLINK_InProgress::conclude(MAV_RESULT result)
     return true;
 }
 
-GCS_MAVLINK_InProgress *GCS_MAVLINK_InProgress::get_task(MAV_CMD mav_cmd, GCS_MAVLINK_InProgress::Type t, uint8_t sysid, uint8_t compid, mavlink_channel_t chan)
+GCS_MAVLINK_InProgress *GCS_MAVLINK_InProgress::get_task(MAV_CMD mav_cmd, GCS_MAVLINK_InProgress::Type t, uint32_t sysid, uint8_t compid, mavlink_channel_t chan)
 {
     // we can't have two outstanding tasks for the same command from
     // the same mavlink node or the result is ambiguous:
@@ -3799,7 +3799,7 @@ void GCS_MAVLINK::handle_timesync(const mavlink_message_t &msg)
                 "TimeUS,SysID,RTT",
                 "s-s",
                 "F-F",
-                "QBQ",
+                "QIQ",
                 AP_HAL::micros64(),
                 msg.sysid,
                 round_trip_time_us
@@ -3875,7 +3875,7 @@ void GCS_MAVLINK::handle_statustext(const mavlink_message_t &msg)
             offset = hal.util->snprintf(text,
                                         max_prefix_len,
                                         "SRC=%u/%u:",
-                                        msg.sysid,
+                                        (unsigned)msg.sysid,
                                         msg.compid);
             offset = MIN(offset, max_prefix_len);
         }
@@ -3902,7 +3902,7 @@ void GCS_MAVLINK::handle_named_value(const mavlink_message_t &msg) const
     mavlink_msg_named_value_float_decode(&msg, &p);
     char s[11] {};
     strncpy(s, p.name, sizeof(s)-1);
-    logger->Write("NVAL", "TimeUS,TimeBootMS,Name,Value,SSys,SCom", "ss#---", "FC----", "QINfBB",
+    logger->Write("NVAL", "TimeUS,TimeBootMS,Name,Value,SSys,SCom", "ss#---", "FC----", "QINfIB",
                   AP_HAL::micros64(),
                   p.time_boot_ms,
                   s,
@@ -5441,7 +5441,8 @@ void GCS_MAVLINK::handle_command_long(const mavlink_message_t &msg)
     // log the packet:
     mavlink_command_int_t packet_int;
     convert_COMMAND_LONG_to_COMMAND_INT(packet, packet_int);
-    AP::logger().Write_Command(packet_int, msg.sysid, msg.compid, result, true);
+    AP::logger().Write_Command(packet_int, mavlink_msg_command_long_get_target_system(&msg),
+                               msg.sysid, msg.compid, result, true);
 #endif
 
     hal.util->persistent_data.last_mavlink_cmd = 0;
@@ -5660,8 +5661,9 @@ MAV_RESULT GCS_MAVLINK::handle_command_do_follow(const mavlink_command_int_t &pa
     }
 
     // param1: sysid of target to follow
-    if ((packet.param1 > 0) && (packet.param1 <= 255)) {
-        follow->set_target_sysid((uint8_t)packet.param1);
+    const int64_t sysid = (int64_t)packet.param1;
+    if (sysid > 0 && sysid <= (int64_t)0xFFFFFFFF) {
+        follow->set_target_sysid((uint32_t)sysid);
         return MAV_RESULT_ACCEPTED;
     }
     return MAV_RESULT_DENIED;
@@ -5931,7 +5933,8 @@ void GCS_MAVLINK::handle_command_int(const mavlink_message_t &msg)
                                  msg.compid);
 
 #if HAL_LOGGING_ENABLED
-    AP::logger().Write_Command(packet, msg.sysid, msg.compid, result);
+    AP::logger().Write_Command(packet, mavlink_msg_command_int_get_target_system(&msg),
+                               msg.sysid, msg.compid, result);
 #endif
 
     hal.util->persistent_data.last_mavlink_cmd = 0;
@@ -6342,7 +6345,7 @@ void GCS_MAVLINK::send_gimbal_manager_status() const
 }
 #endif
 
-void GCS_MAVLINK::send_set_position_target_global_int(uint8_t target_system, uint8_t target_component, const Location& loc)
+void GCS_MAVLINK::send_set_position_target_global_int(uint32_t target_system, uint8_t target_component, const Location& loc)
 {
 
     const uint16_t type_mask = POSITION_TARGET_TYPEMASK_VX_IGNORE | POSITION_TARGET_TYPEMASK_VY_IGNORE | POSITION_TARGET_TYPEMASK_VZ_IGNORE | \
@@ -7642,7 +7645,8 @@ void GCS_MAVLINK::handle_manual_control(const mavlink_message_t &msg)
     mavlink_manual_control_t packet;
     mavlink_msg_manual_control_decode(&msg, &packet);
 
-    if (packet.target != gcs().sysid_this_mav()) {
+    // use the getter as the target may be in the extended header
+    if (mavlink_msg_manual_control_get_target(&msg) != gcs().sysid_this_mav()) {
         return; // only accept control aimed at us
     }
 

--- a/libraries/GCS_MAVLink/GCS_FTP.cpp
+++ b/libraries/GCS_MAVLink/GCS_FTP.cpp
@@ -110,7 +110,8 @@ bool GCS_FTP::send_reply(const Transaction &reply)
     }
     mavlink_file_transfer_protocol_t pkt {};
     pkt.target_network = 0;
-    pkt.target_system = reply.sysid;
+    // targets > 255 travel in the extended header
+    pkt.target_system = reply.sysid>255?0:reply.sysid;
     pkt.target_component = reply.compid;
     uint8_t *payload = pkt.payload;
     put_le16_ptr(payload, reply.seq_number);
@@ -121,7 +122,7 @@ bool GCS_FTP::send_reply(const Transaction &reply)
     payload[6] = reply.burst_complete ? 1 : 0;
     put_le32_ptr(&payload[8], reply.offset);
     memcpy(&pkt.payload[12], reply.data, sizeof(reply.data));
-    mavlink_msg_file_transfer_protocol_send_struct(reply.chan, &pkt);
+    mavlink_msg_file_transfer_protocol_send(reply.chan, pkt.target_network, reply.sysid, reply.compid, pkt.payload);
     return true;
 }
 

--- a/libraries/GCS_MAVLink/GCS_FTP.h
+++ b/libraries/GCS_MAVLink/GCS_FTP.h
@@ -64,7 +64,7 @@ private:
         bool  burst_complete;
         uint8_t size;
         uint8_t session;
-        uint8_t sysid;
+        uint32_t sysid;
         uint8_t compid;
         uint8_t data[239];
     };
@@ -86,7 +86,7 @@ private:
         int16_t session_id;
         FTP_FILE_MODE mode; // work around AP_Filesystem not supporting file modes
         mavlink_channel_t chan;
-        uint8_t sysid;
+        uint32_t sysid;
         uint8_t compid;
 
         bool check_name_len(const Transaction &request);

--- a/libraries/GCS_MAVLink/GCS_MAVLink.cpp
+++ b/libraries/GCS_MAVLink/GCS_MAVLink.cpp
@@ -81,7 +81,7 @@ mavlink_system_t mavlink_system = {7,1};
 // routing table
 MAVLink_routing GCS_MAVLINK::routing;
 
-GCS_MAVLINK *GCS_MAVLINK::find_by_mavtype_and_compid(uint8_t mav_type, uint8_t compid, uint8_t &sysid) {
+GCS_MAVLINK *GCS_MAVLINK::find_by_mavtype_and_compid(uint8_t mav_type, uint8_t compid, uint32_t &sysid) {
     mavlink_channel_t channel;
     if (!routing.find_by_mavtype_and_compid(mav_type, compid, sysid, channel)) {
         return nullptr;

--- a/libraries/GCS_MAVLink/GCS_Signing.cpp
+++ b/libraries/GCS_MAVLink/GCS_Signing.cpp
@@ -260,10 +260,22 @@ uint8_t GCS_MAVLINK::packet_overhead_chan(mavlink_channel_t chan)
     }
     
     const mavlink_status_t *status = mavlink_get_channel_status(chan);
-    if ((status != nullptr) && status->signing && (status->signing->flags & MAVLINK_SIGNING_FLAG_SIGN_OUTGOING)) {
-        return MAVLINK_NUM_NON_PAYLOAD_BYTES + MAVLINK_SIGNATURE_BLOCK_LEN + reserved_space;
+
+    // allow for the sysid32 extended header when our sysid is over
+    // 255, and conservatively for an extended target on any message.
+    // MAVLink1 channels never have extended headers
+    uint8_t ext_header_space = 0;
+    if (status == nullptr || !(status->flags & MAVLINK_STATUS_FLAG_OUT_MAVLINK1)) {
+        ext_header_space = MAVLINK_TARGETTED_HEADER_EXTRA;
+        if (mavlink_system.sysid > 255) {
+            ext_header_space += MAVLINK_SYSID32_HEADER_EXTRA;
+        }
     }
-    return MAVLINK_NUM_NON_PAYLOAD_BYTES + reserved_space;
+
+    if ((status != nullptr) && status->signing && (status->signing->flags & MAVLINK_SIGNING_FLAG_SIGN_OUTGOING)) {
+        return MAVLINK_NUM_NON_PAYLOAD_BYTES + ext_header_space + MAVLINK_SIGNATURE_BLOCK_LEN + reserved_space;
+    }
+    return MAVLINK_NUM_NON_PAYLOAD_BYTES + ext_header_space + reserved_space;
 }
 
 #if !AP_MAVLINK_SIGNING_ENABLED

--- a/libraries/GCS_MAVLink/MAVLink_routing.cpp
+++ b/libraries/GCS_MAVLink/MAVLink_routing.cpp
@@ -175,7 +175,7 @@ bool MAVLink_routing::forward(GCS_MAVLINK &in_link,
                               const mavlink_message_t &msg)
 {
     // extract the targets for this packet
-    int16_t target_system = -1;
+    int64_t target_system = -1;
     int16_t target_component = -1;
     get_targets(msg, target_system, target_component);
 
@@ -230,11 +230,11 @@ bool MAVLink_routing::forward(GCS_MAVLINK &in_link,
             if (&in_link != out_link && !sent_to_chan[routes[i].channel]) {
                 if (out_link->check_payload_size(msg.len)) {
 #if ROUTING_DEBUG
-                    ::printf("fwd msg %u from chan %u on chan %u sysid=%d compid=%d\n",
+                    ::printf("fwd msg %u from chan %u on chan %u sysid=%lld compid=%d\n",
                              msg.msgid,
                              (unsigned)in_link.get_chan(),
                              (unsigned)routes[i].channel,
-                             (int)target_system,
+                             (long long)target_system,
                              (int)target_component);
 #endif
                     _mavlink_resend_uart(routes[i].channel, &msg);
@@ -299,12 +299,20 @@ void MAVLink_routing::send_to_components(const char *pkt, const mavlink_msg_entr
                           entry->max_msg_len, pkt_len);
         }
 #endif
-        _mav_finalize_message_chan_send(routes[i].channel,
+        // the target is a component of this system; pass our (possibly
+        // 32 bit) sysid so it can go in the extended header if needed
+        uint8_t target_compid = 0;
+        if (entry->flags & MAV_MSG_ENTRY_FLAG_HAVE_TARGET_COMPONENT) {
+            target_compid = pkt[entry->target_component_ofs];
+        }
+        _mav_finalize_message_chan_send_target(routes[i].channel,
                                         entry->msgid,
                                         pkt,
                                         entry->min_msg_len,
                                         MIN(entry->max_msg_len, pkt_len),
-                                        entry->crc_extra);
+                                        entry->crc_extra,
+                                        mavlink_system.sysid,
+                                        target_compid);
         sent_to_chan[routes[i].channel] = true;
     }
 }
@@ -313,7 +321,7 @@ void MAVLink_routing::send_to_components(const char *pkt, const mavlink_msg_entr
   search for the first vehicle or component in the routing table with given mav_type and retrieve it's sysid, compid and channel
   returns true if a match is found
  */
-bool MAVLink_routing::find_by_mavtype(uint8_t mavtype, uint8_t &sysid, uint8_t &compid, mavlink_channel_t &channel)
+bool MAVLink_routing::find_by_mavtype(uint8_t mavtype, uint32_t &sysid, uint8_t &compid, mavlink_channel_t &channel)
 {
     // check learned routes
     for (uint8_t i=0; i<num_routes; i++) {
@@ -333,7 +341,7 @@ bool MAVLink_routing::find_by_mavtype(uint8_t mavtype, uint8_t &sysid, uint8_t &
   search for the first vehicle or component in the routing table with given mav_type and component id and retrieve its sysid and channel
   returns true if a match is found
  */
-bool MAVLink_routing::find_by_mavtype_and_compid(uint8_t mavtype, uint8_t compid, uint8_t &sysid, mavlink_channel_t &channel) const
+bool MAVLink_routing::find_by_mavtype_and_compid(uint8_t mavtype, uint8_t compid, uint32_t &sysid, mavlink_channel_t &channel) const
 {
     for (uint8_t i=0; i<num_routes; i++) {
         if ((routes[i].mavtype == mavtype) && (routes[i].compid == compid)) {
@@ -451,17 +459,20 @@ void MAVLink_routing::handle_heartbeat(GCS_MAVLINK &link, const mavlink_message_
   that the caller can set them to -1 and know when a sysid or compid
   target is found in the message
 */
-void MAVLink_routing::get_targets(const mavlink_message_t &msg, int16_t &sysid, int16_t &compid)
+void MAVLink_routing::get_targets(const mavlink_message_t &msg, int64_t &sysid, int16_t &compid)
 {
     const mavlink_msg_entry_t *msg_entry = mavlink_get_msg_entry(msg.msgid);
-    if (msg_entry == nullptr) {
+    const bool targetted = (msg.incompat_flags & MAVLINK_IFLAG_TARGETTED) != 0;
+    if (msg_entry == nullptr && !targetted) {
         return;
     }
-    if (msg_entry->flags & MAV_MSG_ENTRY_FLAG_HAVE_TARGET_SYSTEM) {
-        sysid = _MAV_RETURN_uint8_t(&msg,  msg_entry->target_system_ofs);
+    if (targetted ||
+        (msg_entry != nullptr && (msg_entry->flags & MAV_MSG_ENTRY_FLAG_HAVE_TARGET_SYSTEM))) {
+        sysid = mavlink_msg_get_target_sysid(&msg, msg_entry);
     }
-    if (msg_entry->flags & MAV_MSG_ENTRY_FLAG_HAVE_TARGET_COMPONENT) {
-        compid = _MAV_RETURN_uint8_t(&msg,  msg_entry->target_component_ofs);
+    if (targetted ||
+        (msg_entry != nullptr && (msg_entry->flags & MAV_MSG_ENTRY_FLAG_HAVE_TARGET_COMPONENT))) {
+        compid = mavlink_msg_get_target_compid(&msg, msg_entry);
     }
 }
 

--- a/libraries/GCS_MAVLink/MAVLink_routing.h
+++ b/libraries/GCS_MAVLink/MAVLink_routing.h
@@ -43,20 +43,20 @@ public:
       search for the first vehicle or component in the routing table with given mav_type and retrieve it's sysid, compid and channel
       returns true if a match is found
      */
-    bool find_by_mavtype(uint8_t mavtype, uint8_t &sysid, uint8_t &compid, mavlink_channel_t &channel);
+    bool find_by_mavtype(uint8_t mavtype, uint32_t &sysid, uint8_t &compid, mavlink_channel_t &channel);
 
     /*
       search for the first vehicle or component in the routing table with given mav_type and component id and retrieve its sysid and channel
       returns true if a match is found
      */
-    bool find_by_mavtype_and_compid(uint8_t mavtype, uint8_t compid, uint8_t &sysid, mavlink_channel_t &channel) const;
+    bool find_by_mavtype_and_compid(uint8_t mavtype, uint8_t compid, uint32_t &sysid, mavlink_channel_t &channel) const;
 
 private:
     // a simple linear routing table. We don't expect to have a lot of
     // routes, so a scalable structure isn't worthwhile yet.
     uint8_t num_routes;
     struct route {
-        uint8_t sysid;
+        uint32_t sysid;
         uint8_t compid;
         mavlink_channel_t channel;
         uint8_t mavtype;
@@ -69,7 +69,7 @@ private:
     void learn_route(GCS_MAVLINK &link, const mavlink_message_t &msg);
 
     // extract target sysid and compid from a message
-    void get_targets(const mavlink_message_t &msg, int16_t &sysid, int16_t &compid);
+    void get_targets(const mavlink_message_t &msg, int64_t &sysid, int16_t &compid);
 
     // special handling for heartbeat messages
     void handle_heartbeat(GCS_MAVLINK &link, const mavlink_message_t &msg);

--- a/libraries/GCS_MAVLink/MissionItemProtocol.cpp
+++ b/libraries/GCS_MAVLink/MissionItemProtocol.cpp
@@ -173,10 +173,11 @@ void MissionItemProtocol::handle_mission_request_int(GCS_MAVLINK &_link,
         return;
     }
 
-    ret_packet.target_system = msg.sysid;
+    // targets > 255 travel in the extended header
+    ret_packet.target_system = msg.sysid>255?0:msg.sysid;
     ret_packet.target_component = msg.compid;
 
-    _link.send_message(MAVLINK_MSG_ID_MISSION_ITEM_INT, (const char*)&ret_packet);
+    _link.send_message_target(MAVLINK_MSG_ID_MISSION_ITEM_INT, (const char*)&ret_packet, msg.sysid, msg.compid);
 }
 
 #if AP_MAVLINK_MSG_MISSION_REQUEST_ENABLED
@@ -196,7 +197,8 @@ void MissionItemProtocol::handle_mission_request(GCS_MAVLINK &_link,
         return;
     }
 
-    item_int.target_system = msg.sysid;
+    // targets > 255 travel in the extended header
+    item_int.target_system = msg.sysid>255?0:msg.sysid;
     item_int.target_component = msg.compid;
 
     mavlink_mission_item_t ret_packet{};
@@ -212,7 +214,7 @@ void MissionItemProtocol::handle_mission_request(GCS_MAVLINK &_link,
     }
 
     // buffer space is checked by send_message
-    _link.send_message(MAVLINK_MSG_ID_MISSION_ITEM, (const char*)&ret_packet);
+    _link.send_message_target(MAVLINK_MSG_ID_MISSION_ITEM, (const char*)&ret_packet, msg.sysid, msg.compid);
 }
 #endif  // AP_MAVLINK_MSG_MISSION_REQUEST_ENABLED
 

--- a/libraries/GCS_MAVLink/MissionItemProtocol.h
+++ b/libraries/GCS_MAVLink/MissionItemProtocol.h
@@ -88,7 +88,7 @@ private:
     uint16_t        request_i; // request index
 
     // waypoints
-    uint8_t         dest_sysid;  // where to send requests
+    uint32_t        dest_sysid;  // where to send requests
     uint8_t         dest_compid; // "
     uint32_t        timelast_receive_ms;
     uint32_t        timelast_request_ms;

--- a/libraries/SITL/SIM_ADSB.cpp
+++ b/libraries/SITL/SIM_ADSB.cpp
@@ -216,7 +216,11 @@ void ADSB::send_report(const class Aircraft &aircraft)
                                                   &mavlink.status,
                                                   &msg, &heartbeat);
 
-        write_to_autopilot((char*)&msg.magic, len);
+        uint8_t msgbuf[len];
+        len = mavlink_msg_to_send_buffer(msgbuf, &msg);
+        if (len > 0) {
+            write_to_autopilot((char*)msgbuf, len);
+        }
 
         last_heartbeat_ms = now;
     }

--- a/libraries/SITL/SIM_ADSB.h
+++ b/libraries/SITL/SIM_ADSB.h
@@ -76,7 +76,7 @@ private:
     
     uint32_t last_heartbeat_ms;
     bool seen_heartbeat = false;
-    uint8_t vehicle_system_id;
+    uint32_t vehicle_system_id;
     uint8_t vehicle_component_id;
 
     struct {

--- a/libraries/SITL/SIM_AVT_CM62.h
+++ b/libraries/SITL/SIM_AVT_CM62.h
@@ -57,7 +57,7 @@ private:
     void camera_send_mavlink_message(const mavlink_message_t &msg) override {
         send_mavlink_message(msg);
     }
-    uint8_t camera_vehicle_sysid() const override { return vehicle_sysid(); }
+    uint32_t camera_vehicle_sysid() const override { return vehicle_sysid(); }
     mavlink_status_t &camera_mav_status() override { return gimbal_mav_status(); }
 };
 

--- a/libraries/SITL/SIM_MAVLinkCamV2.cpp
+++ b/libraries/SITL/SIM_MAVLinkCamV2.cpp
@@ -36,7 +36,9 @@ void MAVLinkCamV2::handle_message(const mavlink_message_t &msg)
     }
     mavlink_command_long_t cmd;
     mavlink_msg_command_long_decode(&msg, &cmd);
-    if (cmd.target_system    != camera_vehicle_sysid() ||
+    // use the header-aware getter: the payload byte is zero for a target
+    // over 255
+    if (mavlink_msg_command_long_get_target_system(&msg) != camera_vehicle_sysid() ||
         cmd.target_component != _camera_compid) {
         return;
     }
@@ -110,7 +112,7 @@ void MAVLinkCamV2::send_camera_heartbeat()
     camera_send_mavlink_message(msg);
 }
 
-void MAVLinkCamV2::send_camera_information(uint8_t target_sysid, uint8_t target_compid)
+void MAVLinkCamV2::send_camera_information(uint32_t target_sysid, uint8_t target_compid)
 {
     mavlink_camera_information_t info {};
     info.time_boot_ms     = AP_HAL::millis();
@@ -144,20 +146,19 @@ void MAVLinkCamV2::send_camera_settings()
     camera_send_mavlink_message(msg);
 }
 
-void MAVLinkCamV2::send_camera_command_ack(uint8_t target_sysid, uint8_t target_compid,
+void MAVLinkCamV2::send_camera_command_ack(uint32_t target_sysid, uint8_t target_compid,
                                             MAV_CMD cmd, MAV_RESULT result)
 {
-    mavlink_command_ack_t ack {};
-    ack.command          = (uint16_t)cmd;
-    ack.result           = (uint8_t)result;
-    ack.progress         = 255;
-    ack.target_system    = target_sysid;
-    ack.target_component = target_compid;
-
+    // pack rather than encode so a target over 255 goes in the extended
+    // header rather than being truncated in the payload
     mavlink_message_t msg;
-    mavlink_msg_command_ack_encode_status(
+    mavlink_msg_command_ack_pack_status(
         camera_vehicle_sysid(), _camera_compid,
-        &camera_mav_status(), &msg, &ack);
+        &camera_mav_status(), &msg,
+        (uint16_t)cmd, (uint8_t)result,
+        255,                // progress
+        0,                  // result_param2
+        target_sysid, target_compid);
     camera_send_mavlink_message(msg);
 }
 

--- a/libraries/SITL/SIM_MAVLinkCamV2.h
+++ b/libraries/SITL/SIM_MAVLinkCamV2.h
@@ -38,14 +38,14 @@ protected:
 
     // transport — combined device class wires these to the shared serial link
     virtual void camera_send_mavlink_message(const mavlink_message_t &msg) = 0;
-    virtual uint8_t camera_vehicle_sysid() const = 0;
+    virtual uint32_t camera_vehicle_sysid() const = 0;
     virtual mavlink_status_t &camera_mav_status() = 0;
 
 private:
     void send_camera_heartbeat();
-    void send_camera_information(uint8_t target_sysid, uint8_t target_compid);
+    void send_camera_information(uint32_t target_sysid, uint8_t target_compid);
     void send_camera_settings();
-    void send_camera_command_ack(uint8_t target_sysid, uint8_t target_compid,
+    void send_camera_command_ack(uint32_t target_sysid, uint8_t target_compid,
                                   MAV_CMD cmd, MAV_RESULT result);
 
     uint8_t  _camera_compid {MAV_COMP_ID_CAMERA};

--- a/libraries/SITL/SIM_MAVLinkGimbalv2.cpp
+++ b/libraries/SITL/SIM_MAVLinkGimbalv2.cpp
@@ -70,8 +70,9 @@ void MAVLinkGimbalv2::handle_message(const mavlink_message_t &msg)
     case MAVLINK_MSG_ID_COMMAND_LONG: {
         mavlink_command_long_t cmd;
         mavlink_msg_command_long_decode(&msg, &cmd);
-        // only handle messages addressed to this gimbal
-        if (cmd.target_system != _vehicle_system_id ||
+        // only handle messages addressed to this gimbal. Use the header-aware
+        // getter: the payload byte is zero for a target over 255
+        if (mavlink_msg_command_long_get_target_system(&msg) != _vehicle_system_id ||
             cmd.target_component != _compid) {
             break;
         }
@@ -88,7 +89,7 @@ void MAVLinkGimbalv2::handle_message(const mavlink_message_t &msg)
     case MAVLINK_MSG_ID_COMMAND_INT: {
         mavlink_command_int_t cmd;
         mavlink_msg_command_int_decode(&msg, &cmd);
-        if (cmd.target_system != _vehicle_system_id ||
+        if (mavlink_msg_command_int_get_target_system(&msg) != _vehicle_system_id ||
             cmd.target_component != _compid) {
             break;
         }
@@ -105,7 +106,7 @@ void MAVLinkGimbalv2::handle_message(const mavlink_message_t &msg)
     case MAVLINK_MSG_ID_GIMBAL_DEVICE_SET_ATTITUDE: {
         mavlink_gimbal_device_set_attitude_t cmd;
         mavlink_msg_gimbal_device_set_attitude_decode(&msg, &cmd);
-        if (cmd.target_system != _vehicle_system_id ||
+        if (mavlink_msg_gimbal_device_set_attitude_get_target_system(&msg) != _vehicle_system_id ||
             cmd.target_component != _compid) {
             break;
         }
@@ -292,42 +293,36 @@ void MAVLinkGimbalv2::send_attitude_status()
         q.from_rotation_matrix(body_to_gimbal);
     }
 
-    mavlink_gimbal_device_attitude_status_t status {};
-    status.target_system    = _vehicle_system_id;
-    status.target_component = _vehicle_component_id;
-    status.time_boot_ms     = AP_HAL::millis();
-    status.flags = flags;
-    status.q[0] = q.q1;  // w
-    status.q[1] = q.q2;  // x
-    status.q[2] = q.q3;  // y
-    status.q[3] = q.q4;  // z
-    status.angular_velocity_x = 0.0f;
-    status.angular_velocity_y = 0.0f;
-    status.angular_velocity_z = 0.0f;
-    status.failure_flags = 0;
+    const float qarr[4] { q.q1, q.q2, q.q3, q.q4 };  // w, x, y, z
 
+    // pack rather than encode so a target over 255 goes in the extended
+    // header rather than being truncated in the payload
     mavlink_message_t msg;
-    mavlink_msg_gimbal_device_attitude_status_encode_status(
+    mavlink_msg_gimbal_device_attitude_status_pack_status(
         _vehicle_system_id, _compid,
-        &mav.status, &msg, &status);
+        &mav.status, &msg,
+        _vehicle_system_id, _vehicle_component_id,
+        AP_HAL::millis(), flags, qarr,
+        0.0f, 0.0f, 0.0f,   // angular velocity x, y, z
+        0,                  // failure_flags
+        0.0f, 0.0f,         // delta_yaw, delta_yaw_velocity
+        0);                 // gimbal_device_id
     send_mavlink_message(msg);
 }
 
-void MAVLinkGimbalv2::send_command_ack(uint8_t target_sysid, uint8_t target_compid,
+void MAVLinkGimbalv2::send_command_ack(uint32_t target_sysid, uint8_t target_compid,
                                         MAV_CMD command, MAV_RESULT result)
 {
-    mavlink_command_ack_t ack {};
-    ack.command          = (uint16_t)command;
-    ack.result           = (uint8_t)result;
-    ack.progress         = 255;
-    ack.result_param2    = 0;
-    ack.target_system    = target_sysid;
-    ack.target_component = target_compid;
-
+    // pack rather than encode so a target over 255 goes in the extended
+    // header rather than being truncated in the payload
     mavlink_message_t msg;
-    mavlink_msg_command_ack_encode_status(
+    mavlink_msg_command_ack_pack_status(
         _vehicle_system_id, _compid,
-        &mav.status, &msg, &ack);
+        &mav.status, &msg,
+        (uint16_t)command, (uint8_t)result,
+        255,                // progress
+        0,                  // result_param2
+        target_sysid, target_compid);
     send_mavlink_message(msg);
 }
 

--- a/libraries/SITL/SIM_MAVLinkGimbalv2.h
+++ b/libraries/SITL/SIM_MAVLinkGimbalv2.h
@@ -54,7 +54,7 @@ protected:
     // available to combined classes (e.g. gimbal+camera) for sending messages
     // and accessing transport state
     void send_mavlink_message(const mavlink_message_t &msg);
-    uint8_t vehicle_sysid()  const { return _vehicle_system_id; }
+    uint32_t vehicle_sysid() const { return _vehicle_system_id; }
     uint8_t vehicle_compid() const { return _vehicle_component_id; }
     mavlink_status_t &gimbal_mav_status() { return mav.status; }
 
@@ -68,13 +68,13 @@ private:
     void send_heartbeat();
     void send_gimbal_device_information();
     void send_attitude_status();
-    void send_command_ack(uint8_t target_sysid, uint8_t target_compid,
+    void send_command_ack(uint32_t target_sysid, uint8_t target_compid,
                           MAV_CMD command, MAV_RESULT result);
 
     uint8_t _compid {MAV_COMP_ID_GIMBAL};
 
     bool     _seen_autopilot_heartbeat;
-    uint8_t  _vehicle_system_id;
+    uint32_t _vehicle_system_id;
     uint8_t  _vehicle_component_id;
 
     uint32_t _last_heartbeat_ms;

--- a/libraries/SITL/SIM_SoloGimbal.cpp
+++ b/libraries/SITL/SIM_SoloGimbal.cpp
@@ -191,7 +191,10 @@ void SoloGimbal::send_report(void)
                 case MAVLINK_MSG_ID_PARAM_REQUEST_LIST: {
                     mavlink_param_request_list_t pkt;
                     mavlink_msg_param_request_list_decode(&msg, &pkt);
-                    if (pkt.target_system == 0 && pkt.target_component == MAV_COMP_ID_GIMBAL) {
+                    // use the header-aware getter: the payload byte is zero
+                    // for a target over 255, which would look like a broadcast
+                    if (mavlink_msg_param_request_list_get_target_system(&msg) == 0 &&
+                        pkt.target_component == MAV_COMP_ID_GIMBAL) {
                         // start param send
                         param_send_idx = 0;
                         param_send_last_ms = AP_HAL::millis();
@@ -227,7 +230,11 @@ void SoloGimbal::send_report(void)
                                                   &mavlink.status,
                                                   &msg, &heartbeat);
 
-        mav_socket.send(&msg.magic, len);
+        uint8_t msgbuf[len];
+        len = mavlink_msg_to_send_buffer(msgbuf, &msg);
+        if (len > 0) {
+            mav_socket.send(msgbuf, len);
+        }
         last_heartbeat_ms = now;
     }
 
@@ -246,24 +253,24 @@ void SoloGimbal::send_report(void)
         Vector3f joint_angles;
         gimbal.get_joint_angles(joint_angles);
 
-        mavlink_gimbal_report_t gimbal_report;
-        gimbal_report.target_system = vehicle_system_id;
-        gimbal_report.target_component = vehicle_component_id;
-        gimbal_report.delta_time = delta_time_us * 1e-6;
-        gimbal_report.delta_angle_x = delta_angle.x;
-        gimbal_report.delta_angle_y = delta_angle.y;
-        gimbal_report.delta_angle_z = delta_angle.z;
-        gimbal_report.delta_velocity_x = delta_velocity.x;
-        gimbal_report.delta_velocity_y = delta_velocity.y;
-        gimbal_report.delta_velocity_z = delta_velocity.z;
-        gimbal_report.joint_roll = joint_angles.x;
-        gimbal_report.joint_el = joint_angles.y;
-        gimbal_report.joint_az = joint_angles.z;
-
-        len = mavlink_msg_gimbal_report_encode_status(vehicle_system_id,
-                                                      gimbal_component_id,
-                                                      &mavlink.status,
-                                                      &msg, &gimbal_report);
+        // pack rather than encode so a target over 255 goes in the
+        // extended header rather than being truncated in the payload
+        len = mavlink_msg_gimbal_report_pack_status(vehicle_system_id,
+                                                    gimbal_component_id,
+                                                    &mavlink.status,
+                                                    &msg,
+                                                    vehicle_system_id,
+                                                    vehicle_component_id,
+                                                    delta_time_us * 1e-6,
+                                                    delta_angle.x,
+                                                    delta_angle.y,
+                                                    delta_angle.z,
+                                                    delta_velocity.x,
+                                                    delta_velocity.y,
+                                                    delta_velocity.z,
+                                                    joint_angles.x,
+                                                    joint_angles.y,
+                                                    joint_angles.z);
 
         uint8_t msgbuf[len];
         len = mavlink_msg_to_send_buffer(msgbuf, &msg);

--- a/libraries/SITL/SIM_SoloGimbal.h
+++ b/libraries/SITL/SIM_SoloGimbal.h
@@ -62,7 +62,7 @@ private:
     uint32_t last_heartbeat_ms;
     bool seen_heartbeat;
     bool seen_gimbal_control;
-    uint8_t vehicle_system_id;
+    uint32_t vehicle_system_id;
     uint8_t vehicle_component_id;
 
     SocketAPM_native mav_socket{false};


### PR DESCRIPTION
### Summary

Implements 32 bit system IDs

See also:
 - https://github.com/ArduPilot/pymavlink/pull/1229
 - https://github.com/ArduPilot/MAVProxy/pull/1704
 - https://github.com/ArduPilot/mavlink/pull/515
 - https://github.com/mavlink/rfcs/pull/20

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

This implements https://github.com/mavlink/rfcs/pull/20 but with 32 bit system IDs to allow for IPv4 addresses to be used for system IDs. This should make large drone light shows easier. 
I also plan on making full 32 bit integers work with mavlink parameters to make this more practical for real IPv4 addresses. That will be a separate effort. For now this PR is really 24 bit sysid support, but once we get the mavlink param change in it will work with 32 bit

Some open questions:
 - should we put target_system&0xff in the uint8_t target_system field in messages or should we put in 0? This PR uses 0
 - the lua script changes are tricky as the mavlink receiver gets the raw C structure which is now 3 bytes larger. Should we add compatibility code so the new lua script handles both forms? UPDATE: I've added compat code

Testing done both in SITL and on a fixed wing (bixler) at Spring Valley

### Note on MAVLink peripherals

Setting `MAV_SYSID` above 255 means all packets are incompatible with older mavlink2 implementations. That means all packets to older peripherals will be dropped. We could add pre-arm checks in the future if this turns out to be an issue.
