### PR TITLE
Do not fuse synthetic airspeed for fly-forward without airspeed sensor when dead-reckoning

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -767,10 +767,11 @@ void  NavEKF3_core::updateFilterStatus(void)
     status.value = 0;
     bool doingBodyVelNav = (PV_AidingMode != AID_NONE) && (imuSampleTime_ms - prevBodyVelFuseTime_ms < 5000);
     bool doingFlowNav = (PV_AidingMode != AID_NONE) && flowDataValid;
-    bool doingWindRelNav = (!tasTimeout && assume_zero_sideslip()) || !dragTimeout;
+    bool sideSlipTimeout = imuSampleTime_ms - prevBetaDragStep_ms >= 5000;
+    bool doingWindRelNav = (!(tasTimeout && sideSlipTimeout) && assume_zero_sideslip()) || !dragTimeout;
     bool doingNormalGpsNav = !posTimeout && (PV_AidingMode == AID_ABSOLUTE);
     bool someVertRefData = (!velTimeout && (useGpsVertVel || useExtNavVel)) || !hgtTimeout;
-    bool someHorizRefData = !(velTimeout && posTimeout && tasTimeout && dragTimeout) || doingFlowNav || doingBodyVelNav;
+    bool someHorizRefData = !(velTimeout && posTimeout && tasTimeout && dragTimeout && sideSlipTimeout) || doingFlowNav || doingBodyVelNav;
     bool filterHealthy = healthy() && tiltAlignComplete && (yawAlignComplete || (!use_compass() && (PV_AidingMode != AID_ABSOLUTE)));
 
     // If GPS height usage is specified, height is considered to be inaccurate until the GPS passes all checks

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -328,6 +328,9 @@ void NavEKF3_core::setAidingMode()
             // check if drag data is being used
             bool dragUsed = (imuSampleTime_ms - lastDragPassTime_ms <= minTestTime_ms);
 
+            // Check if sideslip data is being used
+            bool sideSlipUsed = (imuSampleTime_ms - prevBetaDragStep_ms <= minTestTime_ms);
+
 #if EK3_FEATURE_BEACON_FUSION
             // Check if range beacon data is being used
             const bool rngBcnUsed = (imuSampleTime_ms - rngBcn.lastPassTime_ms <= minTestTime_ms);
@@ -340,16 +343,16 @@ void NavEKF3_core::setAidingMode()
             bool gpsVelUsed = (imuSampleTime_ms - lastVelPassTime_ms <= minTestTime_ms);
 
             // Check if attitude drift has been constrained by a measurement source
-            bool attAiding = posUsed || gpsVelUsed || optFlowUsed || airSpdUsed || dragUsed || rngBcnUsed || bodyOdmUsed;
+            bool attAiding = posUsed || gpsVelUsed || optFlowUsed || airSpdUsed || dragUsed || sideSlipUsed || rngBcnUsed || bodyOdmUsed;
 
             // Check if velocity drift has been constrained by a measurement source
             // Currently these are all the same source as will stabilise attitude because we do not currently have
             // a sensor that only observes attitude
-            velAiding = posUsed || gpsVelUsed || optFlowUsed || airSpdUsed || dragUsed || rngBcnUsed || bodyOdmUsed;
+            velAiding = posUsed || gpsVelUsed || optFlowUsed || airSpdUsed || dragUsed || sideSlipUsed || rngBcnUsed || bodyOdmUsed;
 
             // Store the last valid airspeed estimate
             windStateIsObservable = !inhibitWindStates && (posUsed || gpsVelUsed || optFlowUsed || rngBcnUsed || bodyOdmUsed);
-            if (windStateIsObservable) {
+            if (windStateIsObservable && (airSpdUsed || dragUsed)) {
                 lastAirspeedEstimate = (stateStruct.velocity - Vector3F(stateStruct.wind_vel.x, stateStruct.wind_vel.y, 0.0F)).length();
                 lastAspdEstIsValid = true;
             }

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -880,7 +880,9 @@ void NavEKF3_core::readAirSpdData()
         }
         // Check the buffer for measurements that have been overtaken by the fusion time horizon and need to be fused
         tasDataToFuse = storedTAS.recall(tasDataDelayed,imuDataDelayed.time_ms);
-    } else if (assume_zero_sideslip()) {
+        return;
+    }
+    if (assume_zero_sideslip()) {
         // synthetic airspeed is only valid for 'fly forward' vehicles that
         // do not sideslip; fusing it on a multicopter corrupts the attitude
         // and velocity states when dead reckoning (see issue #33451)
@@ -892,9 +894,7 @@ void NavEKF3_core::readAirSpdData()
                 tasDataToFuse = true;
                 tasDataDelayed.allowFusion = true;
                 tasDataDelayed.time_ms = imuDataDelayed.time_ms;
-            } else {
-                tasDataToFuse = false;
-                tasDataDelayed.allowFusion = false;
+                return;
             }
         } else if (lastAspdEstIsValid && !windStateIsObservable) {
             // this uses the last airspeed estimated before dead reckoning started and
@@ -906,15 +906,12 @@ void NavEKF3_core::readAirSpdData()
                 tasDataToFuse = true;
                 tasDataDelayed.allowFusion = true;
                 tasDataDelayed.time_ms = imuDataDelayed.time_ms;
-            } else {
-                tasDataToFuse = false;
-                tasDataDelayed.allowFusion = false;
+                return;
             }
         }
-    } else {
-        tasDataToFuse = false;
-        tasDataDelayed.allowFusion = false;
     }
+    tasDataToFuse = false;
+    tasDataDelayed.allowFusion = false;
 }
 
 #if EK3_FEATURE_BEACON_FUSION


### PR DESCRIPTION
### Summary

Prevents fusing synthetic airspeed when dead-reckoning if no airspeed sensor is available.

Closes https://github.com/ArduPilot/ardupilot/issues/33720

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Testing was done in SITL with standard plane that has airspeed sensor disabled:
`ARSPD_USE=0`
Simulation wind was set to 5m/s from North, with no vertical profile:
`SIM_WIND_DIR=0`
`SIM_WIND_SPD=5`
`SIM_WIND_T=1`
Plane was taken off with GPS in `TAKEOFF` mode, left for few revolutions for wind estimation to set up, and then GPS was disabled. Drift from real position was estimated during 1min of flight wo GPS.
Both versions (original and fixed) had similar drift & behavior.

Then GPS was enabled, and process noise checked through debugger.
Fixed version correctly scaled it by 10.

### Description

Actually, with this PR, synthetic airspeed fusion is not used anymore in any case, at least in SITL - with failed airspeed sensor it continues to pass inside this if:
https://github.com/ArduPilot/ardupilot/blob/996a50e9fb0acf113699cfbadbdfb9832822b5a6/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp#L865-L866
Not sure if this `if` passes with physical setup.