### PR TITLE
ArduSub: fix build error in Guided_PosVel target accessor

### DIFF
--- a/ArduSub/mode_guided.cpp
+++ b/ArduSub/mode_guided.cpp
@@ -304,7 +304,7 @@ bool ModeGuided::get_posvel_target_NEU_cm(Vector3f &pos) const
     if (sub.guided_mode != Guided_PosVel) {
         return false;
     }
-    pos = posvel_pos_target_cm.tofloat();
+    pos = posvel_pos_target_neu_cm.tofloat();
     return true;
 }
 


### PR DESCRIPTION
posvel_pos_target_cm was renamed to posvel_pos_target_neu_cm in #33425 
build broken by #33149

