### PR TITLE
Tools: add CI check that changed source files keep their trailing newline

### DIFF
--- a/Tools/scripts/check_branch_conventions.py
+++ b/Tools/scripts/check_branch_conventions.py
@@ -9,6 +9,7 @@ Validates:
   - commit messages have a well-formed subsystem prefix before ':'
   - commit subject lines are <= 160 characters
   - changed markdown files pass markdownlint-cli2
+  - changed source files do not lose their trailing newline
 
 (new hwdef board README/image requirements are validated by test_new_boards.py)
 
@@ -41,6 +42,14 @@ BLACKLISTED_PREFIXES = {
 }
 # spaces and quotes allowed to support Revert commits e.g. 'Revert "AP_Periph: ...'
 PREFIX_RE = re.compile(r'^[-A-Za-z0-9._/" ]+$')
+
+# extensions checked for a lost trailing newline
+SOURCE_EXTENSIONS = {
+    ".c", ".cc", ".cpp", ".cxx",
+    ".h", ".hh", ".hpp",
+    ".py",
+    ".lua",
+}
 
 # Enable colour when attached to a terminal or running under GitHub Actions
 _colour = sys.stdout.isatty() or os.environ.get('GITHUB_ACTIONS') == 'true'
@@ -620,6 +629,73 @@ class CheckBranchConventions(build_script_base.BuildScriptBase):
 
         return all_board_ids_are_valid
 
+    def _blob_ends_with_newline(self, rev: str, path: str) -> bool | None:
+        '''return whether the blob rev:path ends with a newline byte;
+           None if the blob is missing or empty'''
+        result = subprocess.run(
+            ["git", "cat-file", "blob", f"{rev}:{path}"],
+            capture_output=True,
+        )
+        if result.returncode != 0:
+            return None
+        data = result.stdout
+        if not data:
+            return None
+        return data[-1:] in (b"\n", b"\r")
+
+    def check_trailing_newlines(self) -> bool:
+        '''check that no changed source file loses its trailing newline;
+           some editors strip the final newline by default, which shows up
+           as "No newline at end of file" noise in GitHub review.
+           Only files the PR adds or modifies are checked, and a modified
+           file is only flagged if the base version did end with a newline,
+           so pre-existing violations do not block unrelated edits.
+        '''
+        merge_base = self.run_git(
+            ["merge-base", self.base_branch, "HEAD"],
+            show_output=False,
+        ).strip()
+        name_status = self.run_git(
+            ["diff", "--name-status", "-M", f"{merge_base}..HEAD"],
+            show_output=False,
+        ).strip()
+
+        ok = True
+        for line in name_status.splitlines():
+            parts = line.split("\t")
+            status = parts[0]
+            if status.startswith("R") and len(parts) == 3:
+                old_path, new_path = parts[1], parts[2]
+            elif status in ("A", "M") and len(parts) == 2:
+                new_path = parts[1]
+                old_path = None if status == "A" else new_path
+            else:
+                # deletions, mode changes etc.
+                continue
+            if pathlib.Path(new_path).suffix.lower() not in SOURCE_EXTENSIONS:
+                continue
+
+            new_ends = self._blob_ends_with_newline("HEAD", new_path)
+            if new_ends is None or new_ends:
+                # empty file, or trailing newline present
+                continue
+
+            if old_path is not None:
+                if not self._blob_ends_with_newline(merge_base, old_path):
+                    # base version already lacked a trailing newline
+                    continue
+                print(f"{FAIL} {new_path} loses its trailing newline in this PR.")
+            else:
+                print(f"{FAIL} {new_path} is added without a trailing newline.")
+            ok = False
+
+        if ok:
+            print(f"{PASS} No changed source files lose their trailing newline.")
+        else:
+            print("       Configure your editor to end files with a newline "
+                  "(e.g. VSCode \"files.insertFinalNewline\": true).")
+        return ok
+
     # NOTE: checks concerning new hwdef boards (README.md presence, README
     # images, defaults.parm contents, and the board build itself) live in
     # test_new_boards.py, not here.  Add new-board-related checks there to keep
@@ -671,6 +747,7 @@ class CheckBranchConventions(build_script_base.BuildScriptBase):
             self.check_submodule_isolation(),
             self.check_submodule_references_exist(),
             self.check_board_ids(),
+            self.check_trailing_newlines(),
             self.check_markdown(),
             self.check_markdown_rst_hyperlinks(),
             self.check_markdown_rst_underlines(),


### PR DESCRIPTION
### Summary

Adds a CI check that trailing newlines are not stripped in a PR

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Example of it failing: https://github.com/peterbarker/ardupilot/actions/runs/29395092124/job/87286676288

### Description

Some editors strip the final newline by default, which shows up as "No newline at end of file" noise in GitHub review.  Fail the branch conventions check when a PR adds a source file without a trailing newline or removes one from a file which had it.  Pre-existing violations do not block unrelated edits.

