### PR TITLE
autotest: fix Plane.FenceRetRally

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -1672,7 +1672,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.do_fence_enable()
         self.assert_fence_enabled()
 
-        self.takeoff(alt=50, alt_max=300)
+        self.takeoff(alt=15, alt_max=40)
         # Trigger fence breach, fly to rally location
         self.set_parameters({
             "FENCE_RET_RALLY": 1,

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -1618,7 +1618,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.progress("Testing FENCE_ACTION_RTL with rally point")
 
         self.wait_ready_to_arm()
-        loc = self.home_relative_loc_ne(50, -50)
+        loc = self.home_relative_loc_neu(50, -50, 15)
         self.upload_rally_points_from_locations([loc])
         self.test_fence_breach_circle_at(loc)
 
@@ -1658,7 +1658,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.delay_sim_time(1, reason="fence upload to complete")
 
         # Grab a location for rally point, and upload it.
-        rally_loc = self.home_relative_loc_ne(-50, 50)
+        rally_loc = self.home_relative_loc_neu(-50, 50, 15)
         self.upload_rally_points_from_locations([rally_loc])
 
         return_radius = 100
@@ -8305,7 +8305,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
         self.start_subsubtest("ArmCk: Rally Point must be < ARM_V_RALLY_MAX meters away")
         self.progress("Currently RALLY_LIMIT_KM is %f" % self.get_parameter('RALLY_LIMIT_KM'))
-        loc = self.home_relative_loc_ne(6500, -50)
+        loc = self.home_relative_loc_neu(6500, -50, 100)
         self.upload_rally_points_from_locations([loc])
         self.wait_text("warn: Rally too far", check_context=True)
         self.set_parameter("RALLY_LIMIT_KM", 7)
@@ -8804,6 +8804,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
     def disabled_tests(self):
         return {
             "LandingDrift": "Flapping test. See https://github.com/ArduPilot/ardupilot/issues/20054",
+            "TerrainRally": "Passes vacuously due to helper alt-frame bugs. See https://github.com/ArduPilot/ardupilot/issues/33740",  # noqa
             "InteractTest": "requires user interaction",
             "ClimbThrottleSaturation": "requires https://github.com/ArduPilot/ardupilot/pull/27106 to pass",
             "SoaringClimbRate": "very bad sink rate",

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -12907,7 +12907,7 @@ Also, ignores heartbeats not from our target system'''
             x=int(loc.lat*1e7),
             y=int(loc.lng*1e7),
             z=loc.alt,
-            frame=mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT,
+            frame=mavutil.mavlink.MAV_FRAME_GLOBAL,
             mission_type=mavutil.mavlink.MAV_MISSION_TYPE_RALLY
         )
 


### PR DESCRIPTION
### Summary

Fix two long standing issues with Plane.FenceRetRally that caused it to be flakey.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Bug 1: Alt Frames

The modern rally uploader helper was added in https://github.com/ArduPilot/ardupilot/pull/25168, and uses relative alt frames, but it expects to receive a `mavutil.location`, which is required to report its alt in AMSL. When this was wired up in https://github.com/ArduPilot/ardupilot/pull/27673, the locations were built with AMSL altitudes, but sent to the rally helper that was reinterpreting them as relative.

Original Behavior:
<img width="903" height="677" alt="original_test" src="https://github.com/user-attachments/assets/2cb552aa-5b33-4522-b628-32f6de7a8432" />

Buggy Behavior:
<img width="1149" height="808" alt="master_test" src="https://github.com/user-attachments/assets/455e62a4-b5ec-4861-a1dc-51e4ce413fed" />

The extra climbing/descending sometimes caused the test to time out waiting for altitude.

This PR fixes the helper to correctly use the global frame. The locations were also being built with 0 relative altitude, where they were previously 15m, so I've restored those. For clarity, I've thrown a 100m relative alt to Tim's newer test, which shouldn't make a difference either way, but should help establish the correct pattern for using the rally uploader.

### Bug 2: Takeoff alt margin

The test was designed to take off to 50m (50m-300m), then set the fence floor to 60m to trigger a breach. Sometimes, by the time the param set actually happens, we have managed to just tip over 60m. The breach never occurs (because FBWA max throttle neutral elevator climbs slowly), and it takes off into the sunset in FBWA until it times out.

<img width="1518" height="543" alt="Screenshot 2026-07-15 202756" src="https://github.com/user-attachments/assets/30e09491-13d6-41b8-9a4f-a43b64395e52" />

I've set the takeoff to 15m-40m instead. Plenty of height (we loiter around a 15m rally point), and heaps of margin on the 60m fence floor.

On this one, I couldn't isolate exactly when this margin became a problem. A 3-year-old commit I tested would reliably pass (just by a couple meters), but master doesn't. Nevertheless, it was definitely too narrow before.