### PR TITLE
AP_Bootloader: reserve NewBeeDrone PixNova board ID

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -575,6 +575,9 @@ AP_HW_BrotherHobbyF405v3             5811
 #IDs 5820 ~ 5829 reserved for VimDrones
 AP_HW_VIMDRONES_BMS                  5820
 
+# IDs 5900-5909 reserved for NewBeeDrone PixNova
+AP_HW_NewBeeDrone_PixNova            5900
+
 # IDs 6000-6099 reserved for SpektreWorks
 AP_HW_sw-spar-f407                   6000
 AP_HW_sw-boom-f407                   6001


### PR DESCRIPTION
### Summary

This PR reserves the board ID for the upcoming NewBeeDrone PixNova board in board_types.txt.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

We are planning to support the NewBeeDrone PixNova hardware and need to reserve the board ID to prevent conflicts with other vendors.