### PR TITLE
AP_Filesystem: correct fgets for last-line-missing-termination

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem.cpp
@@ -365,8 +365,13 @@ bool AP_Filesystem::fgets(char *buf, uint8_t buflen, int fd)
     }
     buf[i] = '\0';
 
-    // get back to the right offset
-    if (backend.fs.lseek(fd, offset_start+i+1, SEEK_SET) != offset_start+i+1) {
+    // get back to the right offset, consuming the line terminator if
+    // we found one.  If we did not find one we have either filled the
+    // buffer or returned an unterminated final line; in both cases
+    // the seek target must not extend past the data we consumed -
+    // backends such as ROMFS refuse to seek past the end of the file.
+    const int32_t new_offset = offset_start + i + (i < n ? 1 : 0);
+    if (backend.fs.lseek(fd, new_offset, SEEK_SET) != new_offset) {
         // we need to fail if we can't seek back or the caller may loop or get corrupt data
         return false;
     }


### PR DESCRIPTION
### Summary

Corrects `fgets` where a file doesn't have a trailing eol character

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Tested on a partner's defaults.parm.  On master the line is ignored in the hwdef; it is not ignored after this patch is applied.

### Description

It was not the recent clamping which broke this, surprisingly (see below)

Not a regression for 4.7 but we should think about the backport (I'd actually lean towards "not")


```
  When it broke

  c2e52af1e2 — "AP_Filesystem: make fgets() much more efficient" (Andrew 
  Tridgell, 10 July 2024).

  The original fgets (from 2021) read one byte at a time and, on hitting EOF
  with data already in the buffer, broke out and returned the line — an
  unterminated final line worked fine. The 2024 rewrite reads a block, then
  seeks back to just past the line with a strict check: lseek(fd,
  offset_start+i+1, SEEK_SET) != offset_start+i+1 → return false. For an
  unterminated final line that target is one byte past EOF;
  AP_Filesystem_ROMFS::lseek (unchanged since long before) clamps SEEK_SET to
  file size, so the check fails and the already-parsed line is thrown away.

  Release exposure: everything from 4.6.0 onward (all 4.6.x and 4.7 tags, plus
  AP_Periph-1.8.0+). No 4.5.x tag contains it.

  How many defaults files are affected

  I replicated the hwdef @include expansion against committed HEAD for all 229
  defaults.parm files (226 ChibiOS + 3 ESP32). 22 boards ship a final defaults
  line that hardware silently drops:

  ┌───────────────────────┬─────────────────────────────────────────────────┐
  │     lost default      │                     boards                      │
  ├───────────────────────┼─────────────────────────────────────────────────┤
  │                       │ BROTHERHOBBYF405v3, FoxeerF405v2, HEEWING-F405, │
  │ GPS_DRV_OPTIONS 4     │  HEEWING-F405v2 (via include), SkyDroid-S3,     │
  │                       │ SpeedyBeeF405AIO                                │
  ├───────────────────────┼─────────────────────────────────────────────────┤
  │ CAN_P1_DRIVER 1 /     │ KT-FMU-F1, YARIV6X, Aeromind6X                  │
  │ CAN_P2_DRIVER 1       │                                                 │
  ├───────────────────────┼─────────────────────────────────────────────────┤
  │ CAN_TERMINATE 1       │ YARI_GNSS                                       │
  ├───────────────────────┼─────────────────────────────────────────────────┤
  │ OSD_TYPE2 5           │ BlitzMiniF745, HWH7, Morakot                    │
  ├───────────────────────┼─────────────────────────────────────────────────┤
  │ GPS1_TYPE 9           │ SULILGH7-P1-P2, SkyRukh_Surge_H7                │
  ├───────────────────────┼─────────────────────────────────────────────────┤
  │ RELAY2_DEFAULT 1      │ BETAFPV-F405, BETAFPV-F405-I2C                  │
  ├───────────────────────┼─────────────────────────────────────────────────┤
  │ RELAY3_DEFAULT 1      │ DAKEFPVH743_SLIM                                │
  ├───────────────────────┼─────────────────────────────────────────────────┤
  │ SERIAL7_BAUD 115      │ MatekH743-bdshot                                │
  ├───────────────────────┼─────────────────────────────────────────────────┤
  │ NTF_LED_TYPES 257     │ SkySakuraH743                                   │
  ├───────────────────────┼─────────────────────────────────────────────────┤
  │ SERVO9_FUNCTION 120   │ PrincipIoTH7Pi                                  │
  ├───────────────────────┼─────────────────────────────────────────────────┤
  │ SERIAL6_PROTOCOL -1   │ AnyleafH7                                       │
  └───────────────────────┴─────────────────────────────────────────────────┘
```