### PR TITLE
AP_Bootloader: prevent strlen self-reference

### DIFF
--- a/Tools/AP_Bootloader/support.cpp
+++ b/Tools/AP_Bootloader/support.cpp
@@ -426,7 +426,8 @@ int strcmp(const char *s1, const char *s2)
 }
 
 //simple variant of std c function to reduce used flash space
-size_t strlen(const char *s1)
+// GCC 13.2 recognizes this loop as strlen and emits a self-reference.
+size_t __attribute__((optimize("no-tree-loop-distribute-patterns"))) strlen(const char *s1)
 {
     size_t ret = 0;
     while (*s1++) ret++;


### PR DESCRIPTION

### Summary

Prevent GCC 13.2 from compiling AP_Bootloader's local `strlen()` implementation into an unconditional branch to itself.

Fixes #33559.

### Classification & Testing

* [x] Checked by a human programmer
* [ ] Non-functional change
* [ ] No-binary change
* [ ] Infrastructure change (e.g. unit tests, helper scripts)
* [ ] Automated test(s) verify changes (e.g. unit test, autotest)
* [x] Tested manually, description below (e.g. SITL)
* [ ] Tested on hardware
* [ ] Logs attached
* [ ] Logs available on request

### Testing

Built the MatekH743 bootloader with both supported and affected compiler versions.

#### Arm GNU Toolchain 13.2.Rel1

Before the change, GCC 13.2.1 compiled `strlen()` as an unconditional branch to itself:

```asm
08001b20 <strlen>:
 8001b20:       f7ff bffe       b.w     8001b20 <strlen>
```

After applying the function-scoped optimization attribute, GCC 13.2.1 generates a normal character-loading loop:

```asm
08001b20 <strlen>:
 8001b20:       4603            mov     r3, r0
 8001b22:       461a            mov     r2, r3
 8001b24:       f913 1b01       ldrsb.w r1, [r3], #1
 8001b28:       2900            cmp     r1, #0
 8001b2a:       d1fa            bne.n   8001b22 <strlen+0x2>
 8001b2c:       1a10            subs    r0, r2, r0
 8001b2e:       4770            bx      lr
```

The MatekH743 bootloader completed successfully. The corrected build increased text by 12 bytes, reduced BSS by 12 bytes, and left the overall `arm-none-eabi-size` total unchanged.

#### GNU Arm Embedded Toolchain 10-2020-q4-major

The bootloader also builds successfully with ArduPilot's standard GCC 10.2.1 toolchain. The generated `strlen()` remains a normal loop with no self-reference.

Additional validation:

* `git diff --check`
* `Tools/scripts/check_branch_conventions.py`
* Confirmed only `Tools/AP_Bootloader/support.cpp` changed
* Confirmed the optimization attribute applies only to `strlen()`

### Description

The bootloader provides a small local `strlen()` implementation to avoid linking the standard C library. GCC 13.2 recognizes the implementation loop as the standard `strlen` pattern and replaces it with a call to `strlen`. Because the local function has the same symbol name, the call resolves back to itself and is reduced to an infinite self-branch.

Disable `tree-loop-distribute-patterns` only for this function. This prevents the unsafe transformation while leaving the implementation and all other compiler optimizations unchanged.

This contribution was AI-assisted. Claude was used to analyze the compiler behavior, propose the narrowly scoped fix, and review the generated assembly and validation results. I reviewed the code and test output and take responsibility for the submitted change.
