### PR TITLE
AP_FW_Controller: add ticks check to make sure there are no duplicate or missed calls

### DIFF
--- a/ArduPlane/mode_training.cpp
+++ b/ArduPlane/mode_training.cpp
@@ -42,6 +42,7 @@ void ModeTraining::run()
     const float pexpo = plane.pitch_in_expo(false);
     if (plane.training_manual_roll) {
         SRV_Channels::set_output_scaled(SRV_Channel::k_aileron, rexpo);
+        plane.rollController.reset();
     } else {
         // calculate what is needed to hold
         plane.stabilize_roll();
@@ -54,6 +55,7 @@ void ModeTraining::run()
 
     if (plane.training_manual_pitch) {
         SRV_Channels::set_output_scaled(SRV_Channel::k_elevator, pexpo);
+        plane.pitchController.reset();
     } else {
         plane.stabilize_pitch();
         if ((plane.nav_pitch_cd > 0 && pexpo < SRV_Channels::get_output_scaled(SRV_Channel::k_elevator)) ||

--- a/libraries/APM_Control/AP_FW_Controller.cpp
+++ b/libraries/APM_Control/AP_FW_Controller.cpp
@@ -131,6 +131,20 @@ float AP_FW_Controller::run_angle_control(int32_t desired_angle_cd, float scaler
 */
 float AP_FW_Controller::run_rate_control(float desired_rate_degs, float scaler, bool disable_integrator, bool ground_mode)
 {
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    // Check that the controller is called once per loop and no more
+    const uint32_t ticks = AP::scheduler().ticks32();
+    if (last_run_ticks != 0) {
+        if (last_run_ticks == ticks) {
+            AP_HAL::panic("FW rate control must be run only once per loop");
+        }
+        if ((last_run_ticks + 1) != ticks) {
+            AP_HAL::panic("FW rate control must be run or reset every loop");
+        }
+    }
+    last_run_ticks = ticks;
+#endif // CONFIG_HAL_BOARD == HAL_BOARD_SITL
+
     const float dt = AP::scheduler().get_loop_period_s();
 
     const float eas2tas = AP::ahrs().get_EAS2TAS();
@@ -301,6 +315,11 @@ float AP_FW_Controller::get_airspeed() const
 // Reset controller
 void AP_FW_Controller::reset()
 {
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    // Reset tick tracking
+    last_run_ticks = 0;
+#endif // CONFIG_HAL_BOARD == HAL_BOARD_SITL
+
     // Reset PID
     rate_pid.reset_I();
     rate_pid.reset_filter();

--- a/libraries/APM_Control/AP_FW_Controller.h
+++ b/libraries/APM_Control/AP_FW_Controller.h
@@ -121,4 +121,9 @@ protected:
     AP_Float angle_p;
 
     const AP_AutoTune::ATType autotune_type;
+
+private:
+
+    // Ticks tracking to check that the controller is called once per loop and no more
+    uint32_t last_run_ticks;
 };


### PR DESCRIPTION
### Summary

This SITL only check ensures that the new input shaping continues working. It relies on being called continuously and being re-set correctly. In order to get it to pass this needed some new reset calls in training mode.

<!-- Put a one or two line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->

I have tested this with some tailsitters in realflight to make sure there are no issues in transitions. 

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
