### PR TITLE
SITL: FlightAxis: `interpolate_frame` add check for zero dt

### DIFF
--- a/libraries/SITL/SIM_FlightAxis.cpp
+++ b/libraries/SITL/SIM_FlightAxis.cpp
@@ -718,6 +718,10 @@ struct FlightAxis::state FlightAxis::interpolate_frame(struct state& new_state, 
 {
     struct state intermediate_state = old_state;
     double dt = new_state.m_currentPhysicsTime_SEC - old_state.m_currentPhysicsTime_SEC;
+    if (!is_positive(dt)) {
+        return new_state;
+    }
+
     double interval = new_time - old_state.m_currentPhysicsTime_SEC;
 
 #define INTERPOLATE(name) (intermediate_state.name = (old_state.name + interval * (new_state.name - old_state.name) / dt))


### PR DESCRIPTION
### Summary

Sometimes if when you first connect you get a 0 dt here, I can trigger it reliably by having the realflight menu open, but it seems to happen randomly without the menu open too. I havent seen this until quite recently, posbibly there is some change on the realflight side which make it more likely.

This is a example of the error without this fix:

<img width="879" height="576" alt="image" src="https://github.com/user-attachments/assets/88085d04-f0de-4893-87ac-826ce069ee6b" />


<!-- Put a one or two line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
