### PR TITLE
autotest: fix alt unit in WaitAndMaintainLocation

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -14311,7 +14311,8 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.user_takeoff(alt_min=30)
 
         # send vehicle to global position target
-        location = self.home_relative_loc_ne(n=300, e=0)
+        target_alt = 30
+        location = self.home_relative_loc_neu(300, 0, target_alt)
         target_typemask = MAV_POS_TARGET_TYPE_MASK.POS_ONLY
         self.mav.mav.set_position_target_global_int_send(
             0, # timestamp
@@ -14321,7 +14322,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             target_typemask | MAV_POS_TARGET_TYPE_MASK.LAST_BYTE, # target typemask as pos only
             int(location.lat * 1e7), # lat
             int(location.lng * 1e7), # lon
-            30, # alt
+            target_alt, # alt
             0, # vx
             0, # vy
             0, # vz
@@ -14745,8 +14746,8 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
     def RTL_TO_RALLY(self, target_system=1, target_component=1):
         '''Check RTL to rally point'''
         self.wait_ready_to_arm()
-        rally_loc = self.home_relative_loc_ne(50, -25)
         rally_alt = 37
+        rally_loc = self.home_relative_loc_neu(50, -25, rally_alt)
         items = [
             self.mav.mav.mission_item_int_encode(
                 target_system,
@@ -14774,7 +14775,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         })
         self.takeoff(10)
         self.change_mode('RTL')
-        self.wait_location(rally_loc)
+        self.wait_location(rally_loc, height_accuracy=None)
         self.assert_altitude(rally_alt, relative=True)
         self.progress("Ensuring we're descending")
         self.wait_altitude(20, 25, relative=True)
@@ -14806,8 +14807,8 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         '''test that AHRS applies accel bias correctly'''
         self.change_mode('LOITER')
         self.wait_ready_to_arm()
-        here = self.mav.location(relative_alt=True)
-        hereabs = self.mav.location()
+        takeoff_alt = 10
+        target = self.home_relative_loc_neu(0, 0, takeoff_alt)
         self.set_parameters({
             "AHRS_EKF_TYPE": 10,
 
@@ -14816,8 +14817,8 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             "SIM_ACC3_BIAS_X": 1,
 
             "PLND_ENABLED": 1,
-            "SIM_PLD_LAT": here.lat,
-            "SIM_PLD_LON": here.lng,
+            "SIM_PLD_LAT": target.lat,
+            "SIM_PLD_LON": target.lng,
             "SIM_PLD_HEIGHT": 0,
             "SIM_PLD_ALT_LMT": 15,
             "SIM_PLD_DIST_LMT": 10,
@@ -14827,12 +14828,13 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.set_parameter("SIM_SONAR_SCALE", 12)
         self.reboot_sitl()
 
-        self.takeoff(10, mode='LOITER')
+        self.takeoff(takeoff_alt, mode='LOITER')
 
         self.run_auxfunc(39, 2)  # enable precision loiter
         WaitAndMaintainLocation(
             self,
-            hereabs,
+            target,
+            height_accuracy=5,  # takeoff only promises alt_min-1..alt_min+max_err(=5)
             fn=lambda : self.precision_loiter_to_pos(0, 0, 10, True),
             fn_interval=0.1,
             minimum_duration=10,

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -2040,19 +2040,19 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             if disable_airspeed_sensor:
                 self.set_parameter("ARSPD_USE", 0)
 
+            target_alt = 100
+            loc = self.home_relative_loc_neu(500, 500, target_alt)
             self.takeoff(50)
-            loc = self.mav.location()
-            self.location_offset_ne(loc, 500, 500)
             self.run_cmd_int(
                 mavutil.mavlink.MAV_CMD_DO_REPOSITION,
                 p1=0,
                 p2=mavutil.mavlink.MAV_DO_REPOSITION_FLAGS_CHANGE_MODE,
                 p5=int(loc.lat * 1e7),
                 p6=int(loc.lng * 1e7),
-                p7=100,    # alt
+                p7=target_alt,    # alt
                 frame=mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT_INT,
             )
-            self.wait_location(loc, accuracy=100)
+            self.wait_location(loc, accuracy=100, height_accuracy=10)
             self.progress("Orbit with GPS and learn wind")
             # allow longer to learn wind if there is no airspeed sensor
             if disable_airspeed_sensor:
@@ -2449,9 +2449,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.set_rc(3, 1500)
         self.start_subtest("Ensure command bounced outside guided mode")
         desired_relative_alt = 33
-        loc = self.mav.location()
-        self.location_offset_ne(loc, 300, 300)
-        loc.alt += desired_relative_alt
+        loc = self.home_relative_loc_neu(300, 300, desired_relative_alt)
         self.mav.mav.mission_item_int_send(
             target_system,
             target_component,
@@ -2493,7 +2491,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         m = self.assert_receive_message('MISSION_ACK', timeout=5)
         if m.type != mavutil.mavlink.MAV_MISSION_ACCEPTED:
             raise NotAchievedException("Did not get accepted response")
-        self.wait_location(loc, accuracy=100) # based on loiter radius
+        self.wait_location(loc, accuracy=100, height_accuracy=None) # based on loiter radius
         self.wait_altitude(altitude_min=desired_relative_alt-3,
                            altitude_max=desired_relative_alt+3,
                            relative=True,
@@ -3029,9 +3027,10 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.wait_waypoint(3, 3, max_dist_to_final_wp_m=3150, timeout=600)
         self.progress("Entering guided and flying somewhere constant")
         self.change_mode("GUIDED")
+        new_alt = 280
         loc = self.mav.location()
         self.location_offset_ne(loc, 350, 0)
-        new_alt = 280
+        loc.alt = self.home_position_as_mav_location().alt + new_alt
         self.run_cmd_int(
             mavutil.mavlink.MAV_CMD_DO_REPOSITION,
             p5=int(loc.lat * 1e7),
@@ -3041,7 +3040,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         )
 
         # Resume auto when we are close to the GUIDED waypoint and start tracking maximum terrain alt.
-        self.wait_location(loc, accuracy=100)  # based on loiter radius
+        self.wait_location(loc, accuracy=100, height_accuracy=10)  # based on loiter radius
         self.change_mode('AUTO')
         self.install_message_hook_context(record_maxalt)
 
@@ -6606,7 +6605,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             dest,
             accuracy=200,
             timeout=600,
-            height_accuracy=10,
+            height_accuracy=None,  # dest.alt is relative; alt checked below
         )
         self.wait_altitude(
             dest.alt-5,
@@ -6644,7 +6643,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             dest,
             accuracy=200,
             timeout=600,
-            height_accuracy=10,
+            height_accuracy=None,  # dest.alt is above-terrain; alt checked below
         )
         self.wait_altitude(
             dest.alt-10,

--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -862,11 +862,18 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.send_do_reposition(loc, frame=mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT)
         self.wait_location(loc, timeout=120)
 
-        # Reposition, alt relative to seafloor
-        loc = self.offset_location_ne(loc, 10, 10)
-        loc.alt = -start_altitude
-        self.send_do_reposition(loc, frame=mavutil.mavlink.MAV_FRAME_GLOBAL_TERRAIN_ALT)
-        self.wait_location(loc, timeout=120)
+        # Reposition, alt relative to seafloor.  The SITL seafloor is
+        # ~50m deep here, so holding 25m above it is ~-25m AMSL.
+        # target_terrain abuses the location's alt field to carry a
+        # terrain-frame altitude, as send_do_reposition requires
+        seafloor_depth = 50
+        alt_above_seafloor = 25
+        target_terrain = self.offset_location_ne(loc, 10, 10)
+        target_terrain.alt = alt_above_seafloor
+        target_global = self.offset_location_ne(loc, 10, 10)
+        target_global.alt = alt_above_seafloor - seafloor_depth
+        self.send_do_reposition(target_terrain, frame=mavutil.mavlink.MAV_FRAME_GLOBAL_TERRAIN_ALT)
+        self.wait_location(target_global, timeout=120, height_accuracy=5)
 
         self.disarm_vehicle()
 

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -1054,7 +1054,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             timeout=60,
             relative=True,
             minimum_duration=10)
-        self.wait_location(loc, timeout=120, accuracy=100)
+        self.wait_location(loc, timeout=120, accuracy=100, height_accuracy=None)
         self.progress("Triggering failsafe")
         self.set_parameter('BATT_LOW_VOLT', 50)
         self.wait_mode(25)  # LoiterAltQLand
@@ -1115,7 +1115,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             relative=True,
             minimum_duration=10)
 
-        self.wait_location(loc, timeout=500, accuracy=100)
+        self.wait_location(loc, timeout=500, accuracy=100, height_accuracy=None)
 
         self.progress("Triggering failsafe")
         self.set_parameter('BATT_LOW_VOLT', 50)
@@ -2012,8 +2012,8 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.run_cmd(mavutil.mavlink.MAV_CMD_NAV_TAKEOFF, p7=15)
         self.wait_altitude(14, 16, relative=True)
 
-        loc = self.mav.location()
-        self.location_offset_ne(loc, 50, 50)
+        target_alt = 30
+        loc = self.home_relative_loc_neu(50, 50, target_alt)
 
         # set position target
         self.run_cmd_int(
@@ -2024,10 +2024,10 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             0,
             int(loc.lat * 1e7),
             int(loc.lng * 1e7),
-            30,    # alt
+            target_alt,    # alt
             frame=mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT_INT,
         )
-        self.wait_location(loc, timeout=120)
+        self.wait_location(loc, timeout=120, height_accuracy=2)
 
         self.fly_home_land_and_disarm()
 
@@ -2127,6 +2127,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             accuracy=accuracy,
             minimum_duration=20,
             timeout=120,
+            height_accuracy=None,  # loiter altitude behaviour is not under test
         )
 
     def AHRSFlyForwardFlag(self):
@@ -2683,7 +2684,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             dest,
             accuracy=200,
             timeout=600,
-            height_accuracy=10,
+            height_accuracy=None,  # dest.alt is above-terrain; alt checked below
         )
         self.delay_sim_time(20, reason="terrain altitude to settle")
 
@@ -2746,7 +2747,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
                 loc,
                 accuracy=10,
                 timeout=600,
-                height_accuracy=10,
+                height_accuracy=None,  # loc.alt is above-terrain; alt checked below
             )
             self.delay_sim_time(10, reason="terrain altitude to settle")
             self.wait_altitude(
@@ -2843,7 +2844,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
                 loc,
                 accuracy=10,
                 timeout=600,
-                height_accuracy=10,
+                height_accuracy=None,  # loc.alt is above-terrain; alt checked below
             )
             self.delay_sim_time(10, reason="terrain altitude to settle")
             self.wait_altitude(

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -586,7 +586,7 @@ class WaitAndMaintainLocation(WaitAndMaintain):
         t = self.target
         if self.height_accuracy is not None:
             return ("Waiting for distance to Location (%.4f, %.4f, %.2f) (h_err<%f, v_err<%.2f " %
-                    (t.lat, t.lng, t.alt*0.01, self.accuracy, self.height_accuracy))
+                    (t.lat, t.lng, t.alt, self.accuracy, self.height_accuracy))
         return ("Waiting for distance to Location (%.4f, %.4f) (h_err<%f" %
                 (t.lat, t.lng, self.accuracy))
 
@@ -602,7 +602,7 @@ class WaitAndMaintainLocation(WaitAndMaintain):
         return self.test_suite.get_distance(value, self.target)
 
     def vertical_error(self, value):
-        return math.fabs(value.alt*0.01 - self.target.alt*0.01)
+        return math.fabs(value.alt - self.target.alt)
 
     def validate_value(self, value):
         if self.horizontal_error(value) > self.accuracy:
@@ -12155,10 +12155,10 @@ Also, ignores heartbeats not from our target system'''
 
     def SetpointGlobalPos(self, timeout=100):
         """Test set position message in guided mode."""
-        # Disable heading and yaw test on rover type
+        # Disable heading, yaw, and altitude tests on rover type
 
         if self.is_rover():
-            test_alt = True
+            test_alt = False
             test_heading = False
             test_yaw_rate = False
         else:


### PR DESCRIPTION
### Summary

Fix altitude units in WaitAndMaintainLocation.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

WaitAndMaintainLocation was assuming cm altitude, not meter. All altitudes tolerances were 100x larger than intended. Fixing that broke several tests, which needed their target location altitudes specified correctly or the altitude check disabled.
