### PR TITLE
feat: add ATTITUDE_QUATERNION_COV message

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -488,6 +488,7 @@ void AP_AHRS::update_state(void)
     update_trig();
 
     state.quat_ok = active_estimates->get_quaternion(state.quat);
+    state.attitude_covariance_ok = active_estimates->get_attitude_covariance(state.attitude_covariance);
     state.location_ok = _get_location(state.location);
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     if (state.location_ok && !state.location.initialised()) {
@@ -2410,6 +2411,13 @@ bool AP_AHRS::get_quaternion(Quaternion &quat) const
 {
     quat = state.quat;
     return state.quat_ok;
+}
+
+// return the 3x3 covariance of the (roll, pitch, yaw) Euler angles in rad^2
+bool AP_AHRS::get_attitude_covariance(Matrix3f &cov) const
+{
+    cov = state.attitude_covariance;
+    return state.attitude_covariance_ok;
 }
 
 // returns the inertial navigation origin in lat/lon/alt

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -212,6 +212,10 @@ public:
     // return the quaternion defining the rotation from NED to XYZ (body) axes
     bool get_quaternion(Quaternion &quat) const WARN_IF_UNUSED;
 
+    // return the 3x3 covariance of the (roll, pitch, yaw) Euler angles in rad^2.
+    // Only available from the EKF3 backend; returns false otherwise.
+    bool get_attitude_covariance(Matrix3f &cov) const WARN_IF_UNUSED;
+
     // return secondary estimates; note that this may return nullptr!
     const AP_AHRS_Backend::Estimates *get_secondary_estimates() const {
         return secondary_estimates;
@@ -1013,6 +1017,8 @@ private:
         bool airspeed_TAS_vec_ok;
         Quaternion quat;
         bool quat_ok;
+        Matrix3f attitude_covariance;
+        bool attitude_covariance_ok;
         Location location;
         bool location_ok;
         Vector2f ground_speed_vec;

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -97,6 +97,18 @@ public:
             return attitude_valid;
         }
 
+        // 3x3 covariance of the (roll, pitch, yaw) Euler angles in rad^2.
+        // Only EKF3 populates this; other backends leave _valid false.
+        Matrix3f attitude_covariance;
+        bool attitude_covariance_valid;
+        bool get_attitude_covariance(Matrix3f &cov) const {
+            if (!attitude_covariance_valid) {
+                return false;
+            }
+            cov = attitude_covariance;
+            return true;
+        }
+
         Vector3f gyro_estimate;
         Vector3f gyro_drift;
 

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
@@ -119,6 +119,8 @@ void AP_AHRS_NavEKF3::get_results(AP_AHRS_Backend::Estimates &results)
     EKF3.getQuaternion(results.quaternion);
     results.quaternion.rotate(-AP::ahrs().get_trim());
 
+    results.attitude_covariance_valid = EKF3.getEulerCovariance(results.attitude_covariance);
+
     results.attitude_valid = started;
 
     results.attitude_reset_count = attitude_reset_count;

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -1574,6 +1574,15 @@ bool NavEKF3::getPosVelUncertainty(float &pos_horiz_m, float &pos_vert_m, float 
     return core[primary].getPosVelUncertainty(pos_horiz_m, pos_vert_m, vel_m_s);
 }
 
+// return the 3x3 covariance of the (roll, pitch, yaw) Euler angles in rad^2
+bool NavEKF3::getEulerCovariance(Matrix3f &cov) const
+{
+    if (core == nullptr) {
+        return false;
+    }
+    return core[primary].getEulerCovariance(cov);
+}
+
 // get a source's velocity innovations
 // returns true on success and results are placed in innovations and variances arguments
 bool NavEKF3::getVelInnovationsAndVariancesForSource(AP_NavEKF_Source::SourceXY source, Vector3f &innovations, Vector3f &variances) const

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -182,6 +182,9 @@ public:
     // return 1-sigma position and velocity uncertainty from the EKF state error covariance matrix P
     bool getPosVelUncertainty(float &pos_horiz_m, float &pos_vert_m, float &vel_m_s) const;
 
+    // return the 3x3 covariance of the (roll, pitch, yaw) Euler angles in rad^2
+    bool getEulerCovariance(Matrix3f &cov) const WARN_IF_UNUSED;
+
     // get a source's velocity innovations
     // returns true on success and results are placed in innovations and variances arguments
     bool getVelInnovationsAndVariancesForSource(AP_NavEKF_Source::SourceXY source, Vector3f &innovations, Vector3f &variances) const WARN_IF_UNUSED;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Outputs.cpp
@@ -162,6 +162,81 @@ void NavEKF3_core::getQuaternion(Quaternion& ret) const
     ret = outputDataNew.quat.tofloat();
 }
 
+bool NavEKF3_core::getEulerCovariance(Matrix3f &cov) const
+{
+    if (!statesInitialised) {
+        return false;
+    }
+
+    // (w,x,y,z); formulas below mirror QuaternionT::get_euler_*()
+    const ftype w = stateStruct.quat[0];
+    const ftype x = stateStruct.quat[1];
+    const ftype y = stateStruct.quat[2];
+    const ftype z = stateStruct.quat[3];
+
+    // roll  = atan2(a, b),  a = 2(wx + yz),  b = 1 - 2(x^2 + y^2)
+    const ftype a = 2*(w*x + y*z);
+    const ftype b = 1 - 2*(x*x + y*y);
+    const ftype denom_r = a*a + b*b;
+
+    // pitch = asin(s),  s = 2(wy - zx)
+    const ftype s = 2*(w*y - z*x);
+
+    // yaw   = atan2(e, f),  e = 2(wz + xy),  f = 1 - 2(y^2 + z^2)
+    const ftype e = 2*(w*z + x*y);
+    const ftype f = 1 - 2*(y*y + z*z);
+    const ftype denom_y = e*e + f*f;
+
+    // reject near gimbal lock (pitch -> +-90 deg) where the asin derivative diverges,
+    // and degenerate atan2 denominators
+    const ftype c = 1 - s*s;
+    if (c < 1e-6f || denom_r < 1e-9f || denom_y < 1e-9f) {
+        return false;
+    }
+    const ftype sc = 1.0f / sqrtF(c);
+
+    // J = d(roll,pitch,yaw) / d(w,x,y,z)
+    ftype J[3][4];
+    J[0][0] = 2*x*b / denom_r;
+    J[0][1] = (2*w*b + 4*a*x) / denom_r;
+    J[0][2] = (2*z*b + 4*a*y) / denom_r;
+    J[0][3] = 2*y*b / denom_r;
+
+    J[1][0] =  2*y * sc;
+    J[1][1] = -2*z * sc;
+    J[1][2] =  2*w * sc;
+    J[1][3] = -2*x * sc;
+
+    J[2][0] = 2*z*f / denom_y;
+    J[2][1] = 2*y*f / denom_y;
+    J[2][2] = (2*x*f + 4*e*y) / denom_y;
+    J[2][3] = (2*w*f + 4*e*z) / denom_y;
+
+    // C = J * Pq * J^T; Pq is the quaternion covariance block P[0..3][0..3]
+    ftype M[3][4];  // M = J * Pq
+    for (uint8_t i=0; i<3; i++) {
+        for (uint8_t k=0; k<4; k++) {
+            ftype sum = 0;
+            for (uint8_t j=0; j<4; j++) {
+                sum += J[i][j] * P[j][k];
+            }
+            M[i][k] = sum;
+        }
+    }
+    // C = M * J^T
+    for (uint8_t i=0; i<3; i++) {
+        for (uint8_t j=0; j<3; j++) {
+            ftype sum = 0;
+            for (uint8_t k=0; k<4; k++) {
+                sum += M[i][k] * J[j][k];
+            }
+            cov[i][j] = sum;
+        }
+    }
+
+    return true;
+}
+
 // return the amount of yaw angle change due to the last yaw angle reset in radians
 // returns the time of the last yaw angle reset or 0 if no reset has ever occurred
 uint32_t NavEKF3_core::getLastYawResetAngle(float &yawAng) const

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -264,6 +264,10 @@ public:
     // returns false if EKF is not yet initialised
     bool getPosVelUncertainty(float &pos_horiz_m, float &pos_vert_m, float &vel_m_s) const;
 
+    // return the 3x3 covariance of the (roll, pitch, yaw) Euler angles in rad^2
+    // returns false if not initialised or near gimbal lock
+    bool getEulerCovariance(Matrix3f &cov) const WARN_IF_UNUSED;
+
     // get a particular source's velocity innovations
     // returns true on success and results are placed in innovations and variances arguments
     bool getVelInnovationsAndVariancesForSource(AP_NavEKF_Source::SourceXY source, Vector3f &innovations, Vector3f &variances) const WARN_IF_UNUSED;

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -369,6 +369,7 @@ public:
     void send_opticalflow();
     virtual void send_attitude() const;
     virtual void send_attitude_quaternion() const;
+    void send_attitude_quaternion_cov() const;
     void send_autopilot_version() const;
     void send_extended_sys_state() const;
     void send_local_position() const;

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -1094,6 +1094,9 @@ ap_message GCS_MAVLINK::mavlink_id_to_ap_message_id(const uint32_t mavlink_id) c
         { MAVLINK_MSG_ID_AHRS,                  MSG_AHRS},
         { MAVLINK_MSG_ID_ATTITUDE,              MSG_ATTITUDE},
         { MAVLINK_MSG_ID_ATTITUDE_QUATERNION,   MSG_ATTITUDE_QUATERNION},
+#if AP_AHRS_ENABLED
+        { MAVLINK_MSG_ID_ATTITUDE_QUATERNION_COV, MSG_ATTITUDE_QUATERNION_COV},
+#endif
         { MAVLINK_MSG_ID_GLOBAL_POSITION_INT,   MSG_LOCATION},
 #if AP_AHRS_ENABLED
         { MAVLINK_MSG_ID_LOCAL_POSITION_NED,    MSG_LOCAL_POSITION},
@@ -6128,6 +6131,43 @@ void GCS_MAVLINK::send_attitude_quaternion() const
 #endif
 }
 
+void GCS_MAVLINK::send_attitude_quaternion_cov() const
+{
+#if AP_AHRS_ENABLED
+    const AP_AHRS &ahrs = AP::ahrs();
+    Quaternion quat;
+    if (!ahrs.get_quaternion(quat)) {
+        return;
+    }
+    const Vector3f omega = ahrs.get_gyro();
+    const float q[4] { quat.q1, quat.q2, quat.q3, quat.q4 };
+
+    // row-major 3x3 (roll, pitch, yaw) covariance; per the MAVLink spec the
+    // first element is set to NaN when the covariance is unavailable
+    float covariance[9];
+    Matrix3f cov;
+    if (ahrs.get_attitude_covariance(cov)) {
+        for (uint8_t i=0; i<3; i++) {
+            for (uint8_t j=0; j<3; j++) {
+                covariance[i*3+j] = cov[i][j];
+            }
+        }
+    } else {
+        covariance[0] = nanf("");
+    }
+
+    mavlink_msg_attitude_quaternion_cov_send(
+        chan,
+        AP_HAL::micros64(),
+        q,
+        omega.x, // rollspeed
+        omega.y, // pitchspeed
+        omega.z, // yawspeed
+        covariance
+        );
+#endif
+}
+
 int32_t GCS_MAVLINK::global_position_int_alt() const {
     return global_position_current_loc.alt * 10UL;
 }
@@ -6622,6 +6662,11 @@ bool GCS_MAVLINK::try_send_message(const enum ap_message id)
     case MSG_ATTITUDE_QUATERNION:
         CHECK_PAYLOAD_SIZE(ATTITUDE_QUATERNION);
         send_attitude_quaternion();
+        break;
+
+    case MSG_ATTITUDE_QUATERNION_COV:
+        CHECK_PAYLOAD_SIZE(ATTITUDE_QUATERNION_COV);
+        send_attitude_quaternion_cov();
         break;
 #endif
 

--- a/libraries/GCS_MAVLink/ap_message.h
+++ b/libraries/GCS_MAVLink/ap_message.h
@@ -116,5 +116,8 @@ enum ap_message : uint8_t {
 #if AP_MAVLINK_UTM_GLOBAL_POSITION_SENDING_ENABLED
     MSG_UTM_GLOBAL_POSITION            = 101,
 #endif  // AP_MAVLINK_UTM_GLOBAL_POSITION_SENDING_ENABLED
+#if AP_AHRS_ENABLED
+    MSG_ATTITUDE_QUATERNION_COV        = 102,
+#endif
     MSG_LAST // MSG_LAST must be the last entry in this enum
 };


### PR DESCRIPTION
### Summary

Enables sending of the `ATTITUDE_QUATERNION_COV` mavlink message ([docs](https://mavlink.io/en/messages/common.html#ATTITUDE_QUATERNION_COV))

### Classification & Testing (check all that apply and add your own)

- [ ] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
