### PR TITLE
waf: detect 64-bit Linux targets for DroneCAN

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -1463,6 +1463,24 @@ class LinuxBoard(Board):
         if self.with_can:
             env.DEFINES.update(CANARD_MULTI_IFACE=1,
                                CANARD_IFACE_ALL = 0x3)
+            # libcanard infers pointer width from glibc's __WORDSIZE, which
+            # musl does not provide, so probe the target compiler's pointer
+            # width and define CANARD_64_BIT explicitly on 64-bit targets.
+            is_64bit = cfg.check(
+                compiler='c',
+                features='c',
+                fragment='''
+                typedef char canard_64_bit_pointer_check[
+                    sizeof(void *) == 8 ? 1 : -1
+                ];
+                ''',
+                msg='Checking for 64-bit pointers',
+                okmsg='yes',
+                errmsg='no',
+                mandatory=False,
+            )
+            if is_64bit:
+                env.DEFINES.update(CANARD_64_BIT=1)
 
         if cfg.options.apstatedir:
             cfg.define('AP_STATEDIR', cfg.options.apstatedir)


### PR DESCRIPTION
### Summary

Detect the configured Linux target's pointer width and define `CANARD_64_BIT` explicitly for 64-bit DroneCAN builds.

Fixes #33721.

### Classification & Testing

* [x] Checked by a human programmer
* [ ] Non-functional change
* [ ] No-binary change
* [ ] Infrastructure change
* [ ] Automated test(s) verify changes
* [x] Tested manually, description below
* [ ] Tested on hardware
* [ ] Logs attached
* [x] Logs available on request

### Description

Libcanard determines whether it is compiling for a 64-bit target using glibc's `__WORDSIZE` macro. Musl does not provide that macro through the headers included by libcanard, so an AArch64 musl build incorrectly selects the 32-bit libcanard data layout and fails its compile-time structure-layout assertion.

Add a compile-only Waf check that uses the configured target C compiler to determine whether pointers are eight bytes. When the check succeeds, `CANARD_64_BIT=1` is added to the common build definitions, including the generated DroneCAN C sources.

The check is limited to Linux boards with CAN enabled and does not rely on the build host architecture or an architecture-name list.

### Testing

#### AArch64 Alpine/musl baseline

Before the change, the static Linux Rover build failed in generated DroneCAN C sources with:

```text
modules/DroneCAN/libcanard/canard.h:371:
static assertion failed: "Invalid memory layout"
```

#### AArch64 Alpine/musl after the change

* `Checking for 64-bit pointers: yes`
* Full Linux Rover build completed successfully
* Generated DroneCAN C compile commands contained `CANARD_64_BIT=1`
* The result was an ELF 64-bit ARM AArch64 statically linked executable
* The libcanard memory-layout failure was no longer present

#### ARMHF/musl regression build

Using the existing `navigator` ARMHF/musl CI-style build:

* `Checking for 64-bit pointers: no`
* The Sub build completed successfully
* `CANARD_64_BIT=1` was absent from `compile_commands.json`
* The resulting executable was a 32-bit ARM ELF

Additional checks:

* `git diff --check`
* `python3 -m py_compile Tools/ardupilotwaf/boards.py`
* `Tools/scripts/check_branch_conventions.py`
* Confirmed only `Tools/ardupilotwaf/boards.py` changed

### AI Assistance

This contribution was AI-assisted. Claude and ChatGPT were used to analyze the Waf and libcanard behavior, develop the validation plan, and review the proposed change and test results. I reproduced the failure, reviewed the code, ran the listed builds and checks, and take responsibility for the submitted change.
