### PR TITLE
AC_PosControl: build accel limiter cross-track reference from velocity and acceleration

### DIFF
--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -764,7 +764,12 @@ void AC_PosControl::NE_update_controller()
     const float accel_max_mss = angle_rad_to_accel_mss(angle_max_rad);
     // Save unbounded target for use in "limited" check (not unit-consistent with z!)
     _limit_vector_ned.xy() = _accel_target_ned_mss.xy();
-    if (!limit_accel_xy(_vel_desired_ned_ms.xy(), _accel_target_ned_mss.xy(), accel_max_mss)) {
+    // Normalise desired velocity by max speed for the cross-track reference (guard zero max speed).
+    Vector2f vel_norm_ne;
+    if (is_positive(_vel_max_ne_ms)) {
+        vel_norm_ne = _vel_desired_ned_ms.xy() / _vel_max_ne_ms;
+    }
+    if (!limit_accel_xy(vel_norm_ne, _accel_target_ned_mss.xy(), accel_max_mss)) {
         // _accel_target_ned_mss was not limited so we can zero the xy limit vector
         _limit_vector_ned.xy().zero();
     }

--- a/libraries/AP_Math/control.cpp
+++ b/libraries/AP_Math/control.cpp
@@ -27,6 +27,14 @@
 // control default definitions
 #define CORNER_ACCELERATION_RATIO   1.0/safe_sqrt(2.0)   // acceleration reduction to enable zero overshoot corners
 
+// Speed (m/s) below which limit_accel_xy() fades out cross-track prioritisation.
+// Near zero speed the direction of travel is ill-defined, so prioritising
+// "cross-track" acceleration re-projects a saturated command onto a rapidly
+// rotating axis and injects a lateral acceleration spike (e.g. the roll wobble
+// seen at the zero-crossing of a hard Loiter stick reversal). Below this speed
+// we fade to an isotropic magnitude limit that preserves the commanded direction.
+#define LIMIT_ACCEL_XY_MIN_SPEED_MS   1.0f
+
 // Projects velocity forward in time using acceleration, constrained by directional limit.
 // - If `limit` is non-zero, it defines a direction in which acceleration is constrained.
 // - The `vel_error` value defines the direction of velocity error (its sign matters, not its magnitude).
@@ -442,31 +450,51 @@ bool limit_accel_xy(const Vector2f& vel, Vector2f& accel, float accel_max)
     if (!is_positive(accel_max)) {
         return false;
     }
-    // limit acceleration to accel_max while prioritizing cross track acceleration
-    if (accel.length_squared() > sq(accel_max)) {
-        if (vel.is_zero()) {
-            // We do not have a direction of travel so do a simple vector length limit
-            accel.limit_length(accel_max);
-        } else {
-            // calculate acceleration in the direction of and perpendicular to the velocity input
-            const Vector2f vel_unit = vel.normalized();
-            // acceleration in the direction of travel
-            float accel_dir = vel_unit * accel;
-            // cross track acceleration
-            Vector2f accel_cross = accel - (vel_unit * accel_dir);
-            if (accel_cross.limit_length(accel_max)) {
-                accel_dir = 0.0;
-            } else {
-                // limit_length can't absolutely guarantee this subtraction
-                // won't be slightly negative, so safe_sqrt is used
-                float accel_max_dir = safe_sqrt(sq(accel_max) - accel_cross.length_squared());
-                accel_dir = constrain_float(accel_dir, -accel_max_dir, accel_max_dir);
-            }
-            accel = accel_cross + vel_unit * accel_dir;
-        }
+    // nothing to do unless the acceleration vector exceeds the limit
+    if (accel.length_squared() <= sq(accel_max)) {
+        return false;
+    }
+
+    // isotropic (direction-preserving) magnitude limit. Used directly when there
+    // is no meaningful direction of travel, and blended in at low speed below.
+    Vector2f accel_isotropic = accel;
+    accel_isotropic.limit_length(accel_max);
+
+    const float speed_ms = vel.length();
+    if (!is_positive(speed_ms)) {
+        // We do not have a direction of travel so do a simple vector length limit
+        accel = accel_isotropic;
         return true;
     }
-    return false;
+
+    // limit acceleration to accel_max while prioritizing cross track acceleration
+    // calculate acceleration in the direction of and perpendicular to the velocity input
+    const Vector2f vel_unit = vel / speed_ms;
+    // acceleration in the direction of travel
+    float accel_dir = vel_unit * accel;
+    // cross track acceleration
+    Vector2f accel_cross = accel - (vel_unit * accel_dir);
+    if (accel_cross.limit_length(accel_max)) {
+        accel_dir = 0.0;
+    } else {
+        // limit_length can't absolutely guarantee this subtraction
+        // won't be slightly negative, so safe_sqrt is used
+        float accel_max_dir = safe_sqrt(sq(accel_max) - accel_cross.length_squared());
+        accel_dir = constrain_float(accel_dir, -accel_max_dir, accel_max_dir);
+    }
+    const Vector2f accel_prioritised = accel_cross + vel_unit * accel_dir;
+
+    // Fade between the isotropic limit (at zero speed) and the cross-track
+    // prioritised limit (at and above LIMIT_ACCEL_XY_MIN_SPEED_MS). As the
+    // velocity vector rotates through zero (e.g. a hard stick reversal in
+    // Loiter), vel_unit spins and the prioritised split would re-project the
+    // saturated braking command into a lateral acceleration spike. Fading to the
+    // direction-preserving limit removes that spike. Both blend inputs have
+    // magnitude <= accel_max, so the result does too.
+    const float prioritise_ratio = constrain_float(speed_ms / LIMIT_ACCEL_XY_MIN_SPEED_MS, 0.0f, 1.0f);
+    accel = accel_isotropic * (1.0f - prioritise_ratio) + accel_prioritised * prioritise_ratio;
+
+    return true;
 }
 
 // Limits a 2D acceleration vector with direction-dependent prioritisation.

--- a/libraries/AP_Math/control.cpp
+++ b/libraries/AP_Math/control.cpp
@@ -27,13 +27,15 @@
 // control default definitions
 #define CORNER_ACCELERATION_RATIO   1.0/safe_sqrt(2.0)   // acceleration reduction to enable zero overshoot corners
 
-// Speed (m/s) below which limit_accel_xy() fades out cross-track prioritisation.
-// Near zero speed the direction of travel is ill-defined, so prioritising
-// "cross-track" acceleration re-projects a saturated command onto a rapidly
-// rotating axis and injects a lateral acceleration spike (e.g. the roll wobble
-// seen at the zero-crossing of a hard Loiter stick reversal). Below this speed
-// we fade to an isotropic magnitude limit that preserves the commanded direction.
-#define LIMIT_ACCEL_XY_MIN_SPEED_MS   1.0f
+// Normalised cross-track reference magnitude below which limit_accel_xy() fades
+// out cross-track prioritisation. The reference is expected normalised by the
+// maximum speed, so this is a fraction of max speed (0.25 -> 25%). When the
+// reference is small its direction is ill-defined, so prioritising "cross-track"
+// acceleration re-projects a saturated command onto a rapidly rotating axis and
+// injects a lateral acceleration spike (e.g. the roll wobble seen at the
+// zero-crossing of a hard Loiter stick reversal). Below this magnitude we fade to
+// an isotropic magnitude limit that preserves the commanded direction.
+#define LIMIT_ACCEL_XY_MIN_REF   0.25f
 
 // Projects velocity forward in time using acceleration, constrained by directional limit.
 // - If `limit` is non-zero, it defines a direction in which acceleration is constrained.
@@ -439,12 +441,12 @@ void shape_angle_vel_accel(float angle_desired, float angle_vel_desired, float a
 }
 
 // Limits a 2D acceleration vector to prioritize lateral (cross-track) acceleration over longitudinal (in-track) acceleration.
-// - `vel` defines the current direction of motion (used to split the acceleration).
+// - `vel_norm` is the normalised velocity (velocity divided by maximum speed) that sets the reference direction used to split the acceleration: the in-track component is parallel to it and the cross-track component is perpendicular. Normalising keys the cross-track prioritisation fade to a fraction of max speed.
 // - `accel` is modified in-place to remain within `accel_max`.
-// - If the full acceleration vector exceeds `accel_max`, it is reshaped to prioritize lateral correction.
-// - If `vel` is zero, a simple magnitude limit is applied.
+// - If the full acceleration vector exceeds `accel_max`, it is reshaped to prioritize the cross-track component.
+// - If `vel_norm` is zero, a simple magnitude limit is applied.
 // Returns true if the acceleration vector was modified.
-bool limit_accel_xy(const Vector2f& vel, Vector2f& accel, float accel_max)
+bool limit_accel_xy(const Vector2f& vel_norm, Vector2f& accel, float accel_max)
 {
     // check accel_max is defined
     if (!is_positive(accel_max)) {
@@ -456,24 +458,25 @@ bool limit_accel_xy(const Vector2f& vel, Vector2f& accel, float accel_max)
     }
 
     // isotropic (direction-preserving) magnitude limit. Used directly when there
-    // is no meaningful direction of travel, and blended in at low speed below.
+    // is no meaningful reference direction, and blended in at low reference
+    // magnitude below.
     Vector2f accel_isotropic = accel;
     accel_isotropic.limit_length(accel_max);
 
-    const float speed_ms = vel.length();
-    if (!is_positive(speed_ms)) {
-        // We do not have a direction of travel so do a simple vector length limit
+    const float ref_mag = vel_norm.length();
+    if (!is_positive(ref_mag)) {
+        // We do not have a reference direction so do a simple vector length limit
         accel = accel_isotropic;
         return true;
     }
 
     // limit acceleration to accel_max while prioritizing cross track acceleration
-    // calculate acceleration in the direction of and perpendicular to the velocity input
-    const Vector2f vel_unit = vel / speed_ms;
-    // acceleration in the direction of travel
-    float accel_dir = vel_unit * accel;
+    // calculate acceleration along and perpendicular to the reference direction
+    const Vector2f ref_unit = vel_norm / ref_mag;
+    // acceleration along the reference direction (in-track)
+    float accel_dir = ref_unit * accel;
     // cross track acceleration
-    Vector2f accel_cross = accel - (vel_unit * accel_dir);
+    Vector2f accel_cross = accel - (ref_unit * accel_dir);
     if (accel_cross.limit_length(accel_max)) {
         accel_dir = 0.0;
     } else {
@@ -482,16 +485,16 @@ bool limit_accel_xy(const Vector2f& vel, Vector2f& accel, float accel_max)
         float accel_max_dir = safe_sqrt(sq(accel_max) - accel_cross.length_squared());
         accel_dir = constrain_float(accel_dir, -accel_max_dir, accel_max_dir);
     }
-    const Vector2f accel_prioritised = accel_cross + vel_unit * accel_dir;
+    const Vector2f accel_prioritised = accel_cross + ref_unit * accel_dir;
 
-    // Fade between the isotropic limit (at zero speed) and the cross-track
-    // prioritised limit (at and above LIMIT_ACCEL_XY_MIN_SPEED_MS). As the
-    // velocity vector rotates through zero (e.g. a hard stick reversal in
-    // Loiter), vel_unit spins and the prioritised split would re-project the
-    // saturated braking command into a lateral acceleration spike. Fading to the
+    // Fade between the isotropic limit (weak reference) and the cross-track
+    // prioritised limit (reference magnitude at or above LIMIT_ACCEL_XY_MIN_REF).
+    // When the reference is small its direction is ill-defined and the prioritised
+    // split would re-project the saturated braking command into a lateral
+    // acceleration spike (e.g. a hard stick reversal in Loiter). Fading to the
     // direction-preserving limit removes that spike. Both blend inputs have
     // magnitude <= accel_max, so the result does too.
-    const float prioritise_ratio = constrain_float(speed_ms / LIMIT_ACCEL_XY_MIN_SPEED_MS, 0.0f, 1.0f);
+    const float prioritise_ratio = constrain_float(ref_mag / LIMIT_ACCEL_XY_MIN_REF, 0.0f, 1.0f);
     accel = accel_isotropic * (1.0f - prioritise_ratio) + accel_prioritised * prioritise_ratio;
 
     return true;

--- a/libraries/AP_Math/control.h
+++ b/libraries/AP_Math/control.h
@@ -131,15 +131,15 @@ void shape_angle_vel_accel(float angle_desired, float angle_vel_desired, float a
                          float angle_jerk_max, float dt, bool limit_total);
 
 // Limits a 2D acceleration vector to prioritize lateral (cross-track) acceleration over longitudinal (in-track) acceleration.
-// - `vel` defines the current direction of motion (used to split the acceleration).
+// - `vel_norm` is the normalised velocity (velocity divided by maximum speed) that sets the reference direction used to split the acceleration: the in-track component is parallel to it and the cross-track component is perpendicular. Normalising keys the cross-track prioritisation fade to a fraction of max speed.
 // - `accel` is modified in-place to remain within `accel_max`.
-// - If the full acceleration vector exceeds `accel_max`, it is reshaped to prioritize lateral correction.
-// - Near zero speed the cross-track prioritisation is faded out to a simple
+// - If the full acceleration vector exceeds `accel_max`, it is reshaped to prioritize the cross-track component.
+// - Near a weak reference the cross-track prioritisation is faded out to a simple
 //   direction-preserving magnitude limit, avoiding a lateral acceleration spike
-//   as the direction of travel rotates through zero (e.g. a hard stick reversal).
-// - If `vel` is zero, a simple magnitude limit is applied.
+//   as the reference direction rotates (e.g. a hard stick reversal).
+// - If `vel_norm` is zero, a simple magnitude limit is applied.
 // Returns true if the acceleration vector was modified.
-bool limit_accel_xy(const Vector2f& vel, Vector2f& accel, float accel_max);
+bool limit_accel_xy(const Vector2f& vel_norm, Vector2f& accel, float accel_max);
 
 // Limits a 2D acceleration vector with direction-dependent prioritisation.
 // - Acceleration is decomposed into along-track (parallel to velocity) and cross-track components.

--- a/libraries/AP_Math/control.h
+++ b/libraries/AP_Math/control.h
@@ -134,6 +134,9 @@ void shape_angle_vel_accel(float angle_desired, float angle_vel_desired, float a
 // - `vel` defines the current direction of motion (used to split the acceleration).
 // - `accel` is modified in-place to remain within `accel_max`.
 // - If the full acceleration vector exceeds `accel_max`, it is reshaped to prioritize lateral correction.
+// - Near zero speed the cross-track prioritisation is faded out to a simple
+//   direction-preserving magnitude limit, avoiding a lateral acceleration spike
+//   as the direction of travel rotates through zero (e.g. a hard stick reversal).
 // - If `vel` is zero, a simple magnitude limit is applied.
 // Returns true if the acceleration vector was modified.
 bool limit_accel_xy(const Vector2f& vel, Vector2f& accel, float accel_max);

--- a/libraries/AP_Math/tests/test_control.cpp
+++ b/libraries/AP_Math/tests/test_control.cpp
@@ -630,5 +630,31 @@ TEST(Control, test_limit_accel)
     sigaction(SIGFPE, &old_sa_fpe, nullptr);
 }
 
+TEST(Control, test_limit_accel_reversal_no_lateral_spike)
+{
+    // A saturated braking command aligned with the North axis must not inject a
+    // lateral (East) acceleration as the velocity vector rotates through zero
+    // during a hard reversal (roll wobble at the Loiter stop). A small residual
+    // lateral velocity is what makes vel_unit rotate through the crossing.
+    const float accel_max = 5.0f;
+    // braking command pointing South, saturating the limit
+    const float accel_cmd_n = -1.5f * accel_max;
+    const float residual_e = 0.05f;   // small lateral residual velocity (m/s)
+
+    float worst_east = 0.0f;
+    // sweep the North velocity through zero
+    for (float vn = 2.0f; vn >= -2.0f; vn -= 0.01f) {
+        const Vector2f vel{vn, residual_e};
+        Vector2f accel{accel_cmd_n, 0.0f};
+        limit_accel_xy(vel, accel, accel_max);
+        // command has zero East; output East is pure injected cross-axis error
+        worst_east = MAX(worst_east, fabsf(accel.y));
+        // magnitude must always respect the limit
+        EXPECT_LE(accel.length(), accel_max * 1.001f);
+    }
+    // Without the low-speed fade this reaches ~0.2*accel_max. Assert it stays small.
+    EXPECT_LT(worst_east, 0.1f * accel_max);
+}
+
 AP_GTEST_MAIN()
 int hal = 0;

--- a/libraries/AP_Math/tests/test_control.cpp
+++ b/libraries/AP_Math/tests/test_control.cpp
@@ -633,26 +633,28 @@ TEST(Control, test_limit_accel)
 TEST(Control, test_limit_accel_reversal_no_lateral_spike)
 {
     // A saturated braking command aligned with the North axis must not inject a
-    // lateral (East) acceleration as the velocity vector rotates through zero
-    // during a hard reversal (roll wobble at the Loiter stop). A small residual
-    // lateral velocity is what makes vel_unit rotate through the crossing.
+    // lateral (East) acceleration as the cross-track reference rotates through zero
+    // (the roll wobble at a hard Loiter stop). A small residual perpendicular
+    // reference component makes the reference direction rotate through the crossing;
+    // below LIMIT_ACCEL_XY_MIN_REF the fade to the direction-preserving limit
+    // removes the spike.
     const float accel_max = 5.0f;
     // braking command pointing South, saturating the limit
     const float accel_cmd_n = -1.5f * accel_max;
-    const float residual_e = 0.05f;   // small lateral residual velocity (m/s)
+    const float residual_e = 0.02f;   // small perpendicular reference residual
 
     float worst_east = 0.0f;
-    // sweep the North velocity through zero
-    for (float vn = 2.0f; vn >= -2.0f; vn -= 0.01f) {
-        const Vector2f vel{vn, residual_e};
+    // sweep the reference North component through zero
+    for (float rn = 1.0f; rn >= -1.0f; rn -= 0.005f) {
+        const Vector2f vel_norm{rn, residual_e};
         Vector2f accel{accel_cmd_n, 0.0f};
-        limit_accel_xy(vel, accel, accel_max);
+        limit_accel_xy(vel_norm, accel, accel_max);
         // command has zero East; output East is pure injected cross-axis error
         worst_east = MAX(worst_east, fabsf(accel.y));
         // magnitude must always respect the limit
         EXPECT_LE(accel.length(), accel_max * 1.001f);
     }
-    // Without the low-speed fade this reaches ~0.2*accel_max. Assert it stays small.
+    // Without the low-reference fade this reaches ~0.2*accel_max. Assert it stays small.
     EXPECT_LT(worst_east, 0.1f * accel_max);
 }
 


### PR DESCRIPTION
### Summary

I have been working on this for a couple days but I have come to the conclusion that I can't make an Acceleration + Velocity based cross track reference vector without combinations that are either unwanted or discontinuous. So I have removed the only problem I have with the preceding PR https://github.com/ArduPilot/ardupilot/pull/33663. I have changed the PR to work off a normalised velocity relative to the declared maximum velocity.

The motivation and effect were characterised offline against a real flight log: the limiter's pre-limit input was reconstructed from PSCN/PSCE + PIDN/PIDE and replayed through faithful ports of the old and new limiter. 

<img width="1706" height="1266" alt="image" src="https://github.com/user-attachments/assets/88bc8990-a520-4c32-9475-3887de28366f" />


### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
