### PR TITLE
Fix/throttle nudge guided

### DIFF
--- a/ArduPlane/navigation.cpp
+++ b/ArduPlane/navigation.cpp
@@ -188,7 +188,7 @@ void Plane::calc_airspeed_errors()
                                   get_throttle_input()) + ((int32_t)aparm.airspeed_min * 100);
         }
 #if AP_PLANE_OFFBOARD_GUIDED_SLEW_ENABLED
-    } else if (control_mode == &mode_guided && guided_state.target_airspeed_cm >  0.0) { // if offboard guided speed change cmd not set, then this section is skipped
+    } else if (control_mode == &mode_guided && is_positive(guided_state.target_airspeed_cm)) { // if offboard guided speed change cmd not set, then this section is skipped
         // offboard airspeed demanded
         uint32_t now = AP_HAL::millis();
         float delta = 1e-3f * (now - guided_state.target_airspeed_time_ms);
@@ -275,7 +275,7 @@ void Plane::calc_airspeed_errors()
 
     // when using the special GUIDED mode features for slew control, don't allow airspeed nudging as it doesn't play nicely.
 #if AP_PLANE_OFFBOARD_GUIDED_SLEW_ENABLED
-    if (control_mode == &mode_guided && !is_zero(guided_state.target_airspeed_cm) && (airspeed_nudge_cm != 0)) {
+    if (control_mode == &mode_guided && is_positive(guided_state.target_airspeed_cm) && (airspeed_nudge_cm != 0)) {
         airspeed_nudge_cm = 0; //airspeed_nudge_cm forced to zero
     }
 #endif

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -21,6 +21,7 @@ import vehicle_test_suite
 from pysim import util
 from pysim import vehicleinfo
 from vehicle_test_suite import MAV_POS_TARGET_TYPE_MASK
+from vehicle_test_suite import AltFrame
 from vehicle_test_suite import AutoTestTimeoutException
 from vehicle_test_suite import NotAchievedException
 from vehicle_test_suite import OldpymavlinkException
@@ -887,6 +888,54 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.wait_airspeed(want_airspeed-1, want_airspeed+1, minimum_duration=5, timeout=120)
 
         self.fly_home_land_and_disarm()
+
+    def GuidedThrottleNudge(self):
+        '''ensure THROTTLE_NUDGE nudges target airspeed in GUIDED mode'''
+        # regression test for throttle-nudge being ignored in GUIDED (issue #26094)
+        self.set_parameters({
+            "THROTTLE_NUDGE": 1,
+            "AIRSPEED_CRUISE": 22,
+            "AIRSPEED_MAX": 32,
+            "ARSPD_USE": 1,
+            # keep the vehicle flying near-straight for a stable airspeed
+            # reading while staying bounded near home
+            "WP_LOITER_RAD": 250,
+        })
+        self.takeoff(alt=100, mode="TAKEOFF", timeout=120)
+        self.set_rc(3, 1500)
+        self.change_mode("GUIDED")
+        # hold position near the current location so the vehicle loiters
+        # (auto-throttle active) rather than flying away from home
+        self.send_do_reposition(self.get_location(frame=AltFrame.ABOVE_HOME))
+        self.delay_sim_time(10, reason="vehicle to establish GUIDED position")
+
+        self.start_subtest("Neutral throttle: target airspeed sits at cruise")
+        self.wait_airspeed(20, 24, minimum_duration=5, timeout=60)
+
+        self.start_subtest("Full throttle: nudge raises target airspeed toward AIRSPEED_MAX")
+        self.set_rc(3, 2000)
+        self.wait_airspeed(28, 40, minimum_duration=5, timeout=60)
+
+        self.start_subtest("Neutral throttle: nudge released, back to cruise")
+        self.set_rc(3, 1500)
+        self.wait_airspeed(20, 24, minimum_duration=5, timeout=60)
+
+        self.start_subtest("Offboard guided speed active: throttle nudge stays suppressed")
+        # an active offboard airspeed slew must keep suppressing the nudge
+        self.run_cmd(
+            mavutil.mavlink.MAV_CMD_GUIDED_CHANGE_SPEED,
+            p1=0,   # SPEED_TYPE_AIRSPEED
+            p2=26,  # target airspeed m/s (between cruise and AIRSPEED_MAX)
+            p3=5,   # acceleration m/s/s
+        )
+        self.delay_sim_time(8, reason="offboard airspeed slew to take effect")
+        self.set_rc(3, 2000)
+        # with a slew active the nudge is suppressed, so the target holds at
+        # the commanded 26 m/s and does not climb toward AIRSPEED_MAX (32)
+        self.wait_airspeed(24, 28, minimum_duration=8, timeout=40)
+        self.set_rc(3, 1500)
+
+        self.reboot_sitl(force=True)
 
     def DO_CHANGE_SPEED_mavlink_int(self):
         self.DO_CHANGE_SPEED_mavlink(self.run_cmd_int)
@@ -4659,6 +4708,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.delay_sim_time(1, reason="fence upload to complete")
         self.wait_ready_to_arm()
         self.takeoff(alt=50)
+        self.set_rc(3, 1500)
         self.change_mode("CRUISE")
         self.wait_distance(150, accuracy=20)
 
@@ -4728,6 +4778,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.wait_ready_to_arm()
         home_loc = self.mav.location()
         self.takeoff(alt=50)
+        self.set_rc(3, 1500)
         self.change_mode("CRUISE")
         self.wait_distance(150, accuracy=20)
 
@@ -6490,6 +6541,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.install_terrain_handlers_context()
         self.start_subtest("set home relative altitude")
         self.takeoff(30, relative=True)
+        self.set_rc(3, 1500)
         self.change_mode('GUIDED')
 
         # remember home
@@ -8427,6 +8479,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.SoaringClimbRate,
             self.TestFlaps,
             self.DO_CHANGE_SPEED,
+            self.GuidedThrottleNudge,
             self.DO_REPOSITION,
             self.GuidedRequest,
             self.MainFlight,


### PR DESCRIPTION
### Summary

fix THROTTLE_NUDGE having no effect in GUIDED mode (#26094).

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

new `GuidedThrottleNudge` autotest: fails before and passes after.

### Description

`guided_state.target_airspeed_cm` defaults to -1, so the GUIDED nudge guard `!is_zero(...)` was always true and zeroed the throttle nudge when no offboard speed command was set which madee THROTTLE_NUDGE a no-op in GUIDED. This changed both guards to `is_positive(...)` (unifies all three sites per @IamPete1). still suppressed during an offboard slew. supersedes #26107.

Fixes #26094

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
