### PR TITLE
Correct constrain function used to constrain integer values

### DIFF
--- a/libraries/AP_OSD/AP_OSD_MAX7456.cpp
+++ b/libraries/AP_OSD/AP_OSD_MAX7456.cpp
@@ -342,8 +342,8 @@ void AP_OSD_MAX7456::reinit()
     _dev->write_register(MAX7456ADD_DMM, DMM_CLEAR_DISPLAY);
 
     //write osd position
-    int8_t hos = constrain_int16(_osd.h_offset, 0, 63);
-    int8_t vos = constrain_int16(_osd.v_offset, 0, 31);
+    const int8_t hos = constrain_int16(_osd.h_offset, 0, 63);
+    const int8_t vos = constrain_int16(_osd.v_offset, 0, 31);
     _dev->write_register(MAX7456ADD_HOS, hos);
     _dev->write_register(MAX7456ADD_VOS, vos);
     last_v_offset = _osd.v_offset;
@@ -363,14 +363,14 @@ void AP_OSD_MAX7456::flush()
 
     // check for offset changes
     if (last_v_offset != _osd.v_offset) {
-        int8_t vos = constrain_int16(_osd.v_offset, 0, 31);
+        const int8_t vos = constrain_int16(_osd.v_offset, 0, 31);
         _dev->get_semaphore()->take_blocking();
         _dev->write_register(MAX7456ADD_VOS, vos);
         _dev->get_semaphore()->give();
         last_v_offset = _osd.v_offset;
     }
     if (last_h_offset != _osd.h_offset) {
-        int8_t hos = constrain_int16(_osd.h_offset, 0, 63);
+        const int8_t hos = constrain_int16(_osd.h_offset, 0, 63);
         _dev->get_semaphore()->take_blocking();
         _dev->write_register(MAX7456ADD_HOS, hos);
         _dev->get_semaphore()->give();


### PR DESCRIPTION
### Summary

Corrects the function used - instead of relying on the implicit cast.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                 *                                                   
Durandal                            *               *      *           *       *                 *      *      *
Hitec-Airspeed           *                                 *                                                   
KakuteH7-bdshot                     *               *      *           *       *                 *      *      *
MatekF405                           *               *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot                  *               *                  *       *                 *      *      *
SITL_x86_64_linux_gnu               *               *                  *       *                 *      *      *
YJUAV_A6SE                          *               *      *           *       *                 *      *      *
f103-QiotekPeriph        *                                 *                                                   
f303-MatekGPS            *                                 *                                                   
f303-Universal           *                                 *                                                   
iomcu                                                                                *                         
revo-mini                           *               *      *           *       *                 *      *      *
skyviper-v2450                                                         *                                       
speedybeef4                         *               *      *           *       *                 *      *      *
```

### Description

This is a subset of the patches in https://github.com/ArduPilot/ardupilot/pull/32059 which produce no compiler output.
