### PR TITLE
AP_NavEKF3: invalidate parameter count when EKF3 disables itself

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -840,6 +840,7 @@ bool NavEKF3::InitialiseFilter(void)
         if (dal.available_memory() < sizeof(NavEKF3_core)*num_cores + 4096) {
             GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "EKF3 not enough memory");
             _enable.set(0);
+            AP_Param::invalidate_count();
             num_cores = 0;
             return false;
         }
@@ -848,6 +849,7 @@ bool NavEKF3::InitialiseFilter(void)
         core = (NavEKF3_core*)dal.malloc_type(sizeof(NavEKF3_core)*num_cores, AP_DAL::MemoryType::FAST);
         if (core == nullptr) {
             _enable.set(0);
+            AP_Param::invalidate_count();
             num_cores = 0;
             GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "EKF3 allocation failed");
             return false;


### PR DESCRIPTION
InitialiseFilter() clears EK3_ENABLE via _enable.set(0) when it can't allocate the EKF3 cores, whether from insufficient free memory or a failed core allocation (e.g. zero usable IMUs, so num_cores is zero and the resulting zero-byte allocation fails).

Disabling EK3_ENABLE hides the entire EK3_* parameter group from AP_Param's parameter walk, but neither failure path invalidated the cached parameter count afterwards, unlike every other subsystem that hides a parameter group this way (AP_RangeFinder, AP_BattMonitor, AP_Camera, AP_Generator, AP_TemperatureSensor, AP_Filter and AP_DDS all call AP_Param::invalidate_count() when they do this).

AP_Param::count_parameters() caches its result and only recomputes on invalidate_count(). Without it here, a GCS is handed the larger, stale parameter count captured before EKF3 disabled itself, then can only ever receive the smaller, live parameter set - leaving it waiting indefinitely for parameters it was told to expect but will never receive. This reproduces as a QGroundControl being unable to complete a full parameter list download on any board where EKF3 fails to allocate its cores after the parameter count was already cached.

Add the missing invalidate_count() call at both self-disable sites so the next parameter count reflects reality before it is handed to a GCS.