### PR TITLE
AP_Scripting: add CircuitStatus DroneCAN battery driver

### DIFF
--- a/Tools/AP_Periph/AP_Periph.h
+++ b/Tools/AP_Periph/AP_Periph.h
@@ -99,6 +99,12 @@
 #define AP_PERIPH_SAFETY_SWITCH_ENABLED AP_PERIPH_RC_OUT_ENABLED
 #endif
 
+// send CircuitStatus for each battery backend. SITL-only by default,
+// where it is used to exercise the CircuitStatus lua driver
+#ifndef AP_PERIPH_CAN_CIRCUIT_SENDING_ENABLED
+#define AP_PERIPH_CAN_CIRCUIT_SENDING_ENABLED (AP_PERIPH_BATTERY_ENABLED && CONFIG_HAL_BOARD == HAL_BOARD_SITL)
+#endif
+
 #ifndef HAL_PERIPH_CAN_MIRROR
 #define HAL_PERIPH_CAN_MIRROR 0
 #endif
@@ -193,6 +199,9 @@ public:
 #endif
     void can_battery_update();
     void can_battery_send_cells(uint8_t instance);
+#if AP_PERIPH_CAN_CIRCUIT_SENDING_ENABLED
+    void can_circuit_status_update();
+#endif  // AP_PERIPH_CAN_CIRCUIT_SENDING_ENABLED
     void can_proximity_update();
     void can_buzzer_update(void);
     void can_safety_button_update(void);
@@ -265,6 +274,9 @@ public:
     struct {
         uint32_t last_read_ms;
         uint32_t last_can_send_ms;
+#if AP_PERIPH_CAN_CIRCUIT_SENDING_ENABLED
+        uint32_t last_circuit_send_ms;
+#endif  // AP_PERIPH_CAN_CIRCUIT_SENDING_ENABLED
     } battery;
 #endif
 

--- a/Tools/AP_Periph/battery.cpp
+++ b/Tools/AP_Periph/battery.cpp
@@ -19,6 +19,10 @@ extern const AP_HAL::HAL &hal;
  */
 void AP_Periph_FW::can_battery_update(void)
 {
+#if AP_PERIPH_CAN_CIRCUIT_SENDING_ENABLED
+    can_circuit_status_update();
+#endif  // AP_PERIPH_CAN_CIRCUIT_SENDING_ENABLED
+
     const uint32_t now_ms = AP_HAL::millis();
     if (now_ms - battery.last_can_send_ms < 100) {
         return;
@@ -145,5 +149,45 @@ void AP_Periph_FW::can_battery_send_cells(uint8_t instance)
     delete pkt;
     delete [] buffer;
 }
+
+#if AP_PERIPH_CAN_CIRCUIT_SENDING_ENABLED
+/*
+  send CircuitStatus messages for each battery backend, with circuit_id as the
+  battery instance number plus one
+ */
+void AP_Periph_FW::can_circuit_status_update(void)
+{
+    const uint32_t now_ms = AP_HAL::millis();
+    if (now_ms - battery.last_circuit_send_ms < 100) {
+        return;
+    }
+    battery.last_circuit_send_ms = now_ms;
+
+    const uint8_t battery_instances = battery_lib.num_instances();
+    for (uint8_t i=0; i<battery_instances; i++) {
+        if (!battery_lib.healthy(i)) {
+            continue;
+        }
+        uavcan_equipment_power_CircuitStatus pkt {};
+        pkt.circuit_id = i+1;
+        pkt.voltage = battery_lib.voltage(i);
+        float current;
+        if (battery_lib.current_amps(current, i)) {
+            pkt.current = current;
+        } else {
+            pkt.current = nanf("");
+        }
+
+        uint8_t buffer[UAVCAN_EQUIPMENT_POWER_CIRCUITSTATUS_MAX_SIZE];
+        const uint16_t total_size = uavcan_equipment_power_CircuitStatus_encode(&pkt, buffer, !periph.canfdout());
+
+        canard_broadcast(UAVCAN_EQUIPMENT_POWER_CIRCUITSTATUS_SIGNATURE,
+                         UAVCAN_EQUIPMENT_POWER_CIRCUITSTATUS_ID,
+                         CANARD_TRANSFER_PRIORITY_LOW,
+                         &buffer[0],
+                         total_size);
+    }
+}
+#endif // AP_PERIPH_CAN_CIRCUIT_SENDING_ENABLED
 
 #endif // AP_PERIPH_BATTERY_ENABLED

--- a/Tools/autotest/pysim/vehicleinfo.json
+++ b/Tools/autotest/pysim/vehicleinfo.json
@@ -439,7 +439,8 @@
                 "periph_params_filename": [
                     "default_params/periph.parm",
                     "default_params/quadplane-periph.parm"
-                ]
+                ],
+                "periph_board": "sitl_periph_universal"
             },
             "quadplane-PPP": {
                 "waf_target": "bin/arduplane",

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -3489,6 +3489,59 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
 
         self.do_RTL()
 
+    def CircuitStatusScript(self):
+        '''test CircuitStatus lua driver against a CAN periph'''
+        self.context_collect('STATUSTEXT')
+
+        self.install_driver_script_context("CircuitStatus.lua")
+
+        # CAN_P1_DRIVER=1 is needed so plane publishes the SITL multicast
+        # sim state the periph blocks on at boot. BATT_MONITOR=8
+        # (DroneCAN) gives a reference monitor fed by BatteryInfo from
+        # the same periph battery the CircuitStatus messages come from.
+        self.set_parameters({
+            "SCR_ENABLE": 1,
+            "CAN_P1_DRIVER": 1,
+            "BATT_MONITOR": 8,  # DroneCAN
+            "BATT2_MONITOR": 29,  # scripting
+            "BATT3_MONITOR": 29,  # scripting
+        })
+        self.restart_SITL_frame('quadplane-can', customisations=[])
+
+        # first boot of the script creates DCS_NUM_CIRCUITS; setting it
+        # and rebooting creates the per-circuit parameters
+        self.set_parameters({
+            "DCS_NUM_CIRCUITS": 2,
+        })
+        self.reboot_sitl()
+        self.wait_statustext("CircuitStatus: loaded 2 circuits", check_context=True, timeout=60)
+
+        # per-circuit parameters are polled at runtime, so no further
+        # reboot is needed. The SITL periph sends a circuit per battery
+        # backend with circuit_id of instance+1; map its first battery
+        # to both scripting monitors
+        self.set_parameters({
+            "DCS1_CIRCUIT_ID": 1,
+            "DCS1_BATT_IDX": 2,
+            "DCS2_CIRCUIT_ID": 1,
+            "DCS2_BATT_IDX": 3,
+        })
+
+        # the scripting monitors should match the DroneCAN reference
+        # monitor, with tolerance for float16 quantisation and sampling
+        # time differences. SYS_STATUS gives the pack voltage of the
+        # reference monitor; BATTERY_STATUS voltages[] of the DroneCAN
+        # monitor holds per-cell voltages so is not comparable
+        self.set_message_rate_hz('BATTERY_STATUS', 10)
+        ref = self.assert_receive_message('SYS_STATUS', timeout=10)
+        for instance in 1, 2:
+            self.wait_message_field_values('BATTERY_STATUS', {
+                "voltages[0]": ref.voltage_battery,
+            }, instance=instance, epsilon=100, timeout=60)
+            self.wait_message_field_values('BATTERY_STATUS', {
+                "current_battery": ref.current_battery,
+            }, instance=instance, epsilon=25, timeout=60)
+
     def tests(self):
         '''return list of all tests'''
 
@@ -3575,5 +3628,6 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             self.HighServoFunctionDefault,
             self.WPSpdChange,
             self.TECSThrSpikeOnModeChange,
+            self.CircuitStatusScript,
         ])
         return ret

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -5372,6 +5372,13 @@ class TestSuite(abc.ABC):
         self.install_applet_script(scriptname, **kwargs)
         self.context_get().installed_scripts.append(scriptname)
 
+    def install_driver_script_context(self, scriptname, install_name=None):
+        '''installs a driver script which will be removed when the context goes
+        away'''
+        self.install_driver_script(scriptname, install_name=install_name)
+        installed_name = install_name if install_name is not None else scriptname
+        self.context_get().installed_scripts.append(installed_name)
+
     def rootdir(self):
         this_dir = os.path.dirname(__file__)
         return os.path.realpath(os.path.join(this_dir, "../.."))
@@ -9436,6 +9443,9 @@ Also, ignores heartbeats not from our target system'''
     def script_applet_source_path(self, scriptname):
         return os.path.join(self.rootdir(), "libraries", "AP_Scripting", "applets", scriptname)
 
+    def script_driver_source_path(self, scriptname):
+        return os.path.join(self.rootdir(), "libraries", "AP_Scripting", "drivers", scriptname)
+
     def script_modules_source_path(self, scriptname):
         return os.path.join(self.rootdir(), "libraries", "AP_Scripting", "modules", scriptname)
 
@@ -9499,6 +9509,10 @@ Also, ignores heartbeats not from our target system'''
 
     def install_applet_script(self, scriptname, install_name=None):
         source = self.script_applet_source_path(scriptname)
+        self.install_script(source, scriptname, install_name=install_name)
+
+    def install_driver_script(self, scriptname, install_name=None):
+        source = self.script_driver_source_path(scriptname)
         self.install_script(source, scriptname, install_name=install_name)
 
     def remove_installed_script(self, scriptname):

--- a/libraries/AP_Scripting/drivers/CircuitStatus.lua
+++ b/libraries/AP_Scripting/drivers/CircuitStatus.lua
@@ -1,0 +1,174 @@
+--[[
+   driver for DroneCAN CircuitStatus battery monitors
+
+   listens for uavcan.equipment.power.CircuitStatus messages and maps
+   them onto scripting battery monitor instances
+--]]
+
+local MAV_SEVERITY = {EMERGENCY=0, ALERT=1, CRITICAL=2, ERROR=3, WARNING=4, NOTICE=5, INFO=6, DEBUG=7}
+
+local CIRCUITSTATUS_ID = 1091
+local CIRCUITSTATUS_SIGNATURE = uint64_t(0x8313D33D, 0x0DDDA115)
+
+local MAX_CIRCUITS = 9
+
+local PARAM_TABLE_KEY = 50
+local PARAM_TABLE_PREFIX = "DCS"
+
+-- add a parameter and bind it to a variable
+local function bind_add_param(name, idx, default_value)
+    assert(param:add_param(PARAM_TABLE_KEY, idx, name, default_value), string.format('could not add param %s', name))
+    return Parameter(PARAM_TABLE_PREFIX .. name)
+end
+
+assert(param:add_table(PARAM_TABLE_KEY, PARAM_TABLE_PREFIX, 1+2*MAX_CIRCUITS), 'could not add param table')
+
+--[[
+  // @Param: DCS_NUM_CIRCUITS
+  // @DisplayName: Number of CircuitStatus monitors
+  // @Description: Number of DroneCAN CircuitStatus battery monitor instances. The per-instance DCSx_ parameters are created based on this value.
+  // @Range: 0 9
+  // @RebootRequired: True
+  // @User: Standard
+--]]
+local DCS_NUM_CIRCUITS = bind_add_param('_NUM_CIRCUITS', 1, 0)
+
+local num_circuits = math.floor(DCS_NUM_CIRCUITS:get())
+if num_circuits <= 0 then
+    return
+end
+if num_circuits > MAX_CIRCUITS then
+    num_circuits = MAX_CIRCUITS
+end
+
+--[[
+  // @Param: DCS1_CIRCUIT_ID
+  // @DisplayName: CircuitStatus circuit ID
+  // @Description: circuit_id of the CircuitStatus message to use for this instance. Set to -1 to disable.
+  // @Range: -1 65535
+  // @User: Standard
+--]]
+
+--[[
+  // @Param: DCS1_BATT_IDX
+  // @DisplayName: CircuitStatus battery index
+  // @Description: Battery monitor instance to feed with this circuit. Set to 1 for BATT, 2 for BATT2 etc. The corresponding BATTn_MONITOR must be 29 (scripting). Set to 0 to disable.
+  // @Range: 0 9
+  // @User: Standard
+--]]
+
+local circuit_id_param = {}
+local batt_idx_param = {}
+for i = 1, num_circuits do
+    circuit_id_param[i] = bind_add_param(string.format('%u_CIRCUIT_ID', i), 2*i, -1)
+    batt_idx_param[i] = bind_add_param(string.format('%u_BATT_IDX', i), 2*i+1, 0)
+end
+
+-- receive handles, one per CAN driver
+local handles = {}
+for bus = 0, 1 do
+    local h = DroneCAN_Handle(bus, CIRCUITSTATUS_SIGNATURE, CIRCUITSTATUS_ID)
+    if h and h:subscribe() then
+        table.insert(handles, h)
+    end
+end
+if #handles == 0 then
+    gcs:send_text(MAV_SEVERITY.ERROR, "CircuitStatus: no DroneCAN driver")
+    return
+end
+
+-- last error_flags seen per instance, for change reporting
+local last_error_flags = {}
+local last_idx_warn_ms = uint32_t(0)
+
+--[[
+   unpack a float16 into a floating point number
+--]]
+local function unpackFloat16(v16)
+    local sign     = (v16 >> 15) & 0x1
+    local exponent = (v16 >> 10) & 0x1F
+    local fraction = v16 & 0x3FF
+
+    local value
+    if exponent == 0 then
+        -- zero or subnormal
+        value = (fraction / 1024.0) * 2.0^-14
+    elseif exponent == 0x1F then
+        if fraction == 0 then
+            value = math.huge
+        else
+            value = 0/0
+        end
+    else
+        value = (1 + fraction / 1024.0) * 2.0^(exponent - 15)
+    end
+
+    if sign == 1 then
+        value = -value
+    end
+
+    return value
+end
+
+--[[
+   handle one CircuitStatus message
+--]]
+local function handle_circuit_status(payload)
+    if #payload ~= 7 then
+        return
+    end
+    local circuit_id, voltage16, current16, error_flags = string.unpack("<HHHB", payload)
+    local voltage = unpackFloat16(voltage16)
+    local current = unpackFloat16(current16)
+    if voltage ~= voltage or voltage < 0 or voltage == math.huge then
+        -- reject NaN, negative and infinite voltage
+        return
+    end
+    for i = 1, num_circuits do
+        if circuit_id_param[i]:get() == circuit_id then
+            local batt_idx = math.floor(batt_idx_param[i]:get())
+            if batt_idx >= 1 and batt_idx <= 9 then
+                local state = BattMonitorScript_State()
+                state:healthy(true)
+                state:voltage(voltage)
+                if current == current and current > -math.huge and current < math.huge then
+                    -- leave current unset when not finite
+                    state:current_amps(current)
+                end
+                if not battery:handle_scripting(batt_idx-1, state) then
+                    local now = millis()
+                    if now - last_idx_warn_ms > 10000 then
+                        last_idx_warn_ms = now
+                        local pname = batt_idx == 1 and "BATT" or string.format("BATT%u", batt_idx)
+                        gcs:send_text(MAV_SEVERITY.WARNING, string.format("CircuitStatus: %s_MONITOR must be 29", pname))
+                    end
+                end
+                if error_flags ~= last_error_flags[i] then
+                    last_error_flags[i] = error_flags
+                    if error_flags ~= 0 then
+                        gcs:send_text(MAV_SEVERITY.WARNING, string.format("CircuitStatus: circuit %u error 0x%02x", circuit_id, error_flags))
+                    end
+                end
+            end
+        end
+    end
+end
+
+local function update()
+    for _, h in ipairs(handles) do
+        -- drain all pending messages
+        while true do
+            -- source node_id is discarded, so circuit_id must be unique on the bus
+            local payload, _ = h:check_message()
+            if not payload then
+                break
+            end
+            handle_circuit_status(payload)
+        end
+    end
+    return update, 100
+end
+
+gcs:send_text(MAV_SEVERITY.INFO, string.format("CircuitStatus: loaded %u circuits", num_circuits))
+
+return update, 100

--- a/libraries/AP_Scripting/drivers/CircuitStatus.md
+++ b/libraries/AP_Scripting/drivers/CircuitStatus.md
@@ -1,0 +1,60 @@
+# DroneCAN CircuitStatus Battery Driver
+
+This driver implements support for the DroneCAN
+uavcan.equipment.power.CircuitStatus message, mapping individual
+circuits onto ArduPilot battery monitor instances. This allows
+per-circuit voltage and current from a CAN power distribution board to
+be monitored, logged and reported as batteries.
+
+## Parameters
+
+The script uses the following parameters:
+
+### DCS_NUM_CIRCUITS
+
+The number of CircuitStatus battery monitor instances, up to a maximum
+of 9. The per-instance DCSx parameters are created based on this
+value, so a reboot is needed after changing it. Set to 0 to disable
+the driver.
+
+### DCSx_CIRCUIT_ID
+
+The circuit_id in the CircuitStatus message to use for instance x. Set
+to -1 to disable the instance.
+
+The driver matches on circuit_id alone and ignores which node sent the
+message, so each circuit_id must be unique across the whole CAN bus. If
+two nodes publish the same circuit_id then whichever message arrives
+last wins, and the instance will alternate between the two sources.
+
+### DCSx_BATT_IDX
+
+The battery monitor index to feed with data from this circuit. Set to
+1 for BATT, 2 for BATT2 etc. The corresponding BATTn_MONITOR parameter
+must be set to 29 (scripting). Set to 0 to disable the instance.
+
+## Operation
+
+This driver should be loaded by placing the lua script in the
+APM/SCRIPTS directory on the microSD card or in ROMFS. The following
+key parameters should be set:
+
+- SCR_ENABLE should be set to 1
+- CAN_Px_DRIVER should be set to 1 or 2 to assign the physical CAN
+  port to a CAN driver
+- CAN_Dn_PROTOCOL should be set to 1 (DroneCAN) for that driver
+- BATTn_MONITOR should be set to 29 for each battery instance used
+
+then the flight controller should be rebooted and parameters should be
+refreshed. The DCS_NUM_CIRCUITS parameter will then appear and should
+be set to the number of circuits to monitor, followed by another
+reboot. The DCSx_CIRCUIT_ID and DCSx_BATT_IDX parameters will then
+appear and should be set to map each circuit to a battery monitor.
+Changes to the circuit mappings take effect without a reboot.
+
+Each configured battery instance reports the voltage and current from
+the matching circuit. The current is passed through with the sign sent
+by the device (the DSDL does not define a sign convention). If a
+circuit reports a non-zero error_flags then a warning is sent to the
+GCS. If a circuit stops sending data then the battery monitor will be
+marked unhealthy after 5 seconds.


### PR DESCRIPTION
### Summary

Adds a lua driver for the DroneCAN uavcan.equipment.power.CircuitStatus message, mapping individual circuits onto ArduPilot battery monitor instances, with SITL support and an autotest.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

The new QuadPlane.CircuitStatusScript autotest boots the quadplane-can frame with the driver installed and checks that two scripting monitors fed from CircuitStatus match a DroneCAN reference monitor on the same periph battery for both voltage and current, which also covers the float16 decoding.

### Description

This allows per-circuit voltage and current from a CAN power distribution board to be monitored, logged and reported as batteries.

The number of circuits is set with DCS_NUM_CIRCUITS, which dynamically creates DCSx_CIRCUIT_ID and DCSx_BATT_IDX parameters mapping each circuit_id to a battery monitor instance with BATTn_MONITOR=29 (scripting). Circuit mappings are picked up at runtime, only DCS_NUM_CIRCUITS needs a reboot.

To enable testing, the SITL AP_Periph build now sends a CircuitStatus message per active battery backend, and the quadplane-can frame gained a periph_board entry so restart_SITL_frame() can spawn the periph companion in autotests (sim_vehicle.py already defaulted to sitl_periph_universal for this frame).

Tested in SITL and on a CubeOrangePlus with HFE engine which has 3 CircuitStatus messages