### PR TITLE
.github: annotations for test_location_ratchet

### DIFF
--- a/.github/workflows/test_location_ratchet.yml
+++ b/.github/workflows/test_location_ratchet.yml
@@ -17,20 +17,20 @@ jobs:
     runs-on: ubuntu-slim
 
     steps:
-      - name: Checkout PR branch
+      # the default (merge-ref) checkout is deliberate: it tests the PR as
+      # merged into the current base branch, and guarantees the latest ratchet
+      # script is present even for PRs branched from an older base
+      - name: Checkout
         uses: actions/checkout@v7
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
           submodules: 'false'
           fetch-depth: 0
 
       - name: Fetch base branch
         run: |
-          git remote add upstream ${{ github.event.pull_request.base.repo.clone_url }}
-          git fetch upstream ${{ github.event.pull_request.base.ref }}
+          git fetch origin ${{ github.event.pull_request.base.ref }}
 
       - name: Check mavutil.location ratchet
         shell: bash
         run: |
-          Tools/scripts/check_mavutil_location_ratchet.py --base-ref "upstream/${{ github.event.pull_request.base.ref }}"
+          Tools/scripts/check_mavutil_location_ratchet.py --base-ref "origin/${{ github.event.pull_request.base.ref }}"

--- a/Tools/scripts/check_mavutil_location_ratchet.py
+++ b/Tools/scripts/check_mavutil_location_ratchet.py
@@ -24,15 +24,28 @@ import re
 import subprocess
 import sys
 
+# each counted pattern is paired with the frame-aware replacement to
+# suggest when new uses appear
 PATTERNS = [
-    re.compile(r"mavutil\.location\("),
-    re.compile(r"\.mav\.location\("),
-    re.compile(r"\.get_mav_location\("),
-    re.compile(r"\.home_position_as_mav_location\("),
-    re.compile(r"\.sim_location\("),
-    re.compile(r"\.home_relative_loc_ne\("),
-    re.compile(r"\.home_relative_loc_neu\("),
-    re.compile(r"\.position_target_loc\("),
+    (re.compile(r"mavutil\.location\("),
+     "vehicle_test_suite.Location with an explicit AltFrame, "
+     "or Location.latlon_only() where the altitude is unused"),
+    (re.compile(r"\.mav\.location\("),
+     "self.get_location(); frame=AltFrame.ABOVE_HOME replaces relative_alt=True"),
+    (re.compile(r"\.get_mav_location\("),
+     "self.get_location()"),
+    (re.compile(r"\.home_position_as_mav_location\("),
+     "self.home_position_as_location()"),
+    (re.compile(r"\.sim_location\("),
+     "self.get_location('SIMSTATE')"),
+    (re.compile(r"\.home_relative_loc_ne\("),
+     "self.offset_location_ne(self.home_position_as_location(), n, e)"),
+    (re.compile(r"\.home_relative_loc_neu\("),
+     "self.offset_location_ne(self.home_position_as_location(), n, e) "
+     "then set_alt_m(u, AltFrame.ABOVE_HOME)"),
+    (re.compile(r"\.position_target_loc\("),
+     "a Location built from POSITION_TARGET_GLOBAL_INT carrying the frame "
+     "the target was commanded in"),
 ]
 
 AUTOTEST_DIR = os.path.join(
@@ -53,24 +66,24 @@ def run_git(args):
 def count_uses(content):
     count = 0
     for line in content.splitlines():
-        for pattern in PATTERNS:
+        for pattern, _ in PATTERNS:
             count += len(pattern.findall(line))
     return count
 
 
-def tree_counts():
-    '''return {filename: count} for the working tree'''
+def tree_contents():
+    '''return {filename: content} for the working tree'''
     ret = {}
     for filename in os.listdir(AUTOTEST_DIR):
         if not filename.endswith(".py"):
             continue
         with open(os.path.join(AUTOTEST_DIR, filename)) as f:
-            ret[filename] = count_uses(f.read())
+            ret[filename] = f.read()
     return ret
 
 
-def base_counts(base):
-    '''return {filename: count} for Tools/autotest at base'''
+def base_contents(base):
+    '''return {filename: content} for Tools/autotest at base'''
     ls = run_git(["ls-tree", "--name-only", base, "./"])
     if ls.returncode != 0:
         raise SystemExit(f"Failed to list {base}: {ls.stderr.strip()}")
@@ -82,8 +95,37 @@ def base_counts(base):
         show = run_git(["show", f"{base}:./{filename}"])
         if show.returncode != 0:
             continue
-        ret[filename] = count_uses(show.stdout)
+        ret[filename] = show.stdout
     return ret
+
+
+GUIDANCE = ("mavutil.location is frameless and being phased out of autotest; "
+            "use vehicle_test_suite.Location instead "
+            "(for the current position: self.get_location())")
+
+
+def emit_annotations(filename, old_content, new_content):
+    '''emit a GitHub Actions error annotation for each line adding a
+    counted use, suggesting the matched helper's specific replacement,
+    so the guidance lands inline on the PR diff'''
+    if os.environ.get("GITHUB_ACTIONS") != "true":
+        return
+    old_matching = {}
+    for line in old_content.splitlines():
+        if count_uses(line):
+            old_matching[line] = old_matching.get(line, 0) + 1
+    seen = {}
+    for lineno, line in enumerate(new_content.splitlines(), 1):
+        suggestions = [s for pattern, s in PATTERNS if pattern.search(line)]
+        if not suggestions:
+            continue
+        seen[line] = seen.get(line, 0) + 1
+        if seen[line] > old_matching.get(line, 0):
+            print(f"::error file=Tools/autotest/{filename},line={lineno},"
+                  "title=new frameless location use::"
+                  f"replace with {'; '.join(suggestions)} "
+                  "(mavutil.location and its producers are being phased "
+                  "out of autotest: they carry no altitude frame)")
 
 
 def resolve_base(base_ref):
@@ -100,15 +142,16 @@ def resolve_base(base_ref):
 def check(base_ref):
     merge_base, ref_name = resolve_base(base_ref)
     print(f"Comparing against {ref_name} (merge-base {merge_base[:10]})")
-    old = base_counts(merge_base)
-    new = tree_counts()
+    old = base_contents(merge_base)
+    new = tree_contents()
     failed = False
     for filename in sorted(set(old) | set(new)):
-        old_count = old.get(filename, 0)
-        new_count = new.get(filename, 0)
+        old_count = count_uses(old.get(filename, ""))
+        new_count = count_uses(new.get(filename, ""))
         if new_count > old_count:
             print(f"FAIL {filename}: mavutil.location uses increased {old_count} -> {new_count}; "
-                  "use vehicle_test_suite.Location for new code")
+                  f"{GUIDANCE}")
+            emit_annotations(filename, old.get(filename, ""), new.get(filename, ""))
             failed = True
         elif new_count < old_count:
             print(f"GOOD {filename}: mavutil.location uses lowered {old_count} -> {new_count}")


### PR DESCRIPTION
### Summary

Make it abundantly clear why the location ratchet failed and how to fix it

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Testing in this PR. I'm opening it with a commit adding a bunch of violations. I will post the screenshot when it fails.

### Description

It will take some time for the old pattern to be replaced, so we'll see a lot of copy-paste and LLM-driven violations until the new pattern is more established. The more clarity I can provide for the failures, the better.

Additionally, I noticed in my first victim's failure that the script was non-existent for them, but the CI ran and just complained about the missing script. This made me realize I need to actually check out the merge-ref (the code state after a hypothetical merge of the PR; this is the default for the checkout action, but we rightly avoid using in most other workflows) to ensure the latest master version of the script is always used, even if you're on an older base.