### PR TITLE
autotest: run BatteryFailsafe at default speedup

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -1446,7 +1446,6 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         '''Fly Battery Failsafe'''
         self.progress("Configure battery failsafe parameters")
         self.set_parameters({
-            'SIM_SPEEDUP': 4,
             'BATT_LOW_VOLT': 11.5,
             'BATT_CRT_VOLT': 10.1,
             'BATT_FS_LOW_ACT': 0,


### PR DESCRIPTION
### Summary

Remove pointless speed limiting in battery failsafe testing

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

This has been soak-tested in my own fork.

```
● BatteryFailsafe savings, measured on real CI runners (from the 120-sample soak, not local):

  ┌───────────────────────┬──────────────────────────────────┬─────────────────────────────────────────┬──────────────────────────┐
  │                       │      Before (SIM_SPEEDUP=4)      │         After (default speedup)         │          Saved           │
  ├───────────────────────┼──────────────────────────────────┼─────────────────────────────────────────┼──────────────────────────┤
  │ Unloaded runner       │ 322 s (10-run production median) │ 89.5 s (median of 15, spread 88.7–92.8) │ ~232 s ≈ 3.9 min         │
  ├───────────────────────┼──────────────────────────────────┼─────────────────────────────────────────┼──────────────────────────┤
  │ Under 2 CPU stressers │ —                                │ 105.1 s                                 │ still ~217 s vs baseline │
  └───────────────────────┴──────────────────────────────────┴─────────────────────────────────────────┴──────────────────────────┘
```

### Description

BatteryFailsafe pins SIM_SPEEDUP to 4 for its entire duration, making it the fourth most expensive test in all of CI at ~320 wall-seconds per run.  The override has been carried through several refactors with no recorded rationale; the original 2013 test did not set it.

Battery failsafe timing is entirely simulation-time: the voltage comes from SIM_BATT_VOLTAGE and BATT_LOW_TIMER counts simulation seconds, so there is no wall-clock coupling that would require a reduced speedup (unlike the GCS failsafe tests, where the test framework's wall-paced heartbeats justify one).  Remove the override so the test runs at the suite default.
