### PR TITLE
autotest: make FenceMargin combined-warning geometry deterministic

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -2666,10 +2666,17 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
     def FenceMargin(self, timeout=180):
         '''Test warning on crossing fence margin'''
         # enable fence, disable avoidance
+        # margin must be large enough that the circle margin ring
+        # (FENCE_RADIUS-FENCE_MARGIN from home) is reached before the
+        # polygon edge (~117m from home on this test's track) so both
+        # margins are breached simultaneously before any fence is: the
+        # combined "Circle and Polygon fences in ..." warning this test
+        # expects is only emitted while both margin breaches are active,
+        # and an actual fence breach clears that fence's margin state
         self.set_parameters({
             "FENCE_ENABLE": 1,
             "FENCE_TYPE": 6,    # polygon and circle fences
-            "FENCE_MARGIN" : 30,
+            "FENCE_MARGIN" : 45,
             "FENCE_RADIUS" : 150,
             "AVOID_ENABLE": 0,
             "FENCE_OPTIONS": 4


### PR DESCRIPTION
### Summary

<!-- Put a one or two line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<img width="1148" height="1148" alt="image" src="https://github.com/user-attachments/assets/34005526-075a-4ffc-9071-5135ae5b4b61" />

<img width="1148" height="1148" alt="image" src="https://github.com/user-attachments/assets/357018ab-e14f-4196-9403-dbd9ae21decf" />

### Description

FenceMargin expects the combined 'Circle and Polygon fences in ...' warning, which the firmware only emits while margin breaches for both fences are simultaneously active; an actual fence breach clears that fence's margin state.  With the old geometry (150m circle, 110m polygon half-width, 30m margin, heading 160) the circle margin ring began at 120m from home while the polygon fence breached at ~117m, so the two margin zones did not overlap anywhere before a breach.  The message only ever appeared through a race on the RTL return leg where the vehicle re-entered the polygon margin before leaving the circle margin; a CI run missed that window by 60 milliseconds and timed out.

Widen FENCE_MARGIN to 45m: the circle margin now begins at 105m, comfortably before the ~117m polygon breach, so the combined warning fires deterministically on the outbound leg.  The post-breach overshoot (~27m) still stays inside the 150m circle fence.

The test has been marginal since the combined-message expectation was added in dd202fda5d.

