### PR TITLE
Tools: pace sitl_calibration magcal poses in simulation time

### DIFF
--- a/Tools/mavproxy_modules/sitl_calibration.py
+++ b/Tools/mavproxy_modules/sitl_calibration.py
@@ -20,7 +20,6 @@
 import math
 from pymavlink import quaternion
 import random
-import time
 
 from MAVProxy.modules.lib import mp_module
 
@@ -245,11 +244,17 @@ class AccelcalController(CalController):
 
 
 class MagcalController(CalController):
+    '''All pacing in this controller is done in the simulation time
+    domain (clocked from ATTITUDE.time_boot_ms): the vehicle rotates at
+    rotation_angspeed in simulation rad/s and the calibrator consumes
+    samples in simulation time, so at SITL speedup the poses advance
+    correspondingly faster in wall-clock terms.'''
+
     yaw_increment = math.radians(45)
     yaw_noise_range = math.radians(5)
 
     rotation_angspeed = math.pi / 4
-    '''rotation angular speed in rad/s'''
+    '''rotation angular speed in simulation rad/s'''
     rotation_angspeed_noise = math.radians(2)
     rotation_axes = (
         (1, 0, 0),
@@ -258,6 +263,7 @@ class MagcalController(CalController):
     )
 
     full_turn_time = 2 * math.pi / rotation_angspeed
+    '''time for a full turn in simulation seconds'''
 
     max_full_turns = 3
     '''maximum number of full turns to be performed for each initial attitude'''
@@ -268,6 +274,7 @@ class MagcalController(CalController):
         self.rotation_start_time = 0
         self.last_progress = {}
         self.rotation_axis_idx = 0
+        self.sim_time = 0
 
     def start(self):
         super(MagcalController, self).start()
@@ -278,7 +285,7 @@ class MagcalController(CalController):
         angspeed = self.rotation_angspeed
         angspeed += random.uniform(-1, 1) * self.rotation_angspeed_noise
         self.angvel(x, y, z, angspeed)
-        self.rotation_start_time = time.time()
+        self.rotation_start_time = self.sim_time
 
     def next_rotation(self):
         self.rotation_axis_idx += 1
@@ -299,6 +306,11 @@ class MagcalController(CalController):
         if not self.active:
             return
 
+        if m.get_type() == 'ATTITUDE':
+            # our simulation clock
+            self.sim_time = m.time_boot_ms * 0.001
+            return
+
         if m.get_type() == 'MAG_CAL_REPORT':
             # NOTE: This may be not the ideal way to handle it
             if m.compass_id in self.last_progress:
@@ -315,7 +327,7 @@ class MagcalController(CalController):
         if not self.rotation_start_time:
             return
 
-        t = time.time()
+        t = self.sim_time
         m.time = t
 
         if m.compass_id not in self.last_progress:


### PR DESCRIPTION
### Summary

Significantly reduces the time taken to run the mag-cal test, one of the longest-running tests in the suite.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

This has been soak-tested on my own repo.

### Description

MagcalController advanced calibration poses using wall-clock timers (time.time()): 24 wall-seconds maximum dwell per pose and 4 wall-seconds of unchanged-progress before rotating.  The vehicle rotation and the calibrator's sample consumption are both simulation time, so at SITL speedup the sphere coverage for a pose completes in a fraction of a wall second and the controller then sat idle for the rest of the wall-clock dwell.  This made SITLCompassCalibration the second most expensive test in CI at ~370 wall-seconds.

Clock the controller from ATTITUDE.time_boot_ms instead so every quantity in the controller is in the simulation time domain; the existing constants keep their values, now correctly denominated in simulation seconds (a full turn at pi/4 rad/s genuinely takes 8 simulation seconds).  Locally the test drops from ~370 to ~80-90 seconds.
