### PR TITLE
AP_HAL_SITL: send multicast state from the servo socket

### DIFF
--- a/libraries/AP_HAL_SITL/SITL_Periph_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_Periph_State.cpp
@@ -165,7 +165,10 @@ void SimMCast::servo_fd_open(void)
     if (in_addr == nullptr) {
         return;
     }
-    if (!servo_sock.connect(in_addr, SITL_SERVO_PORT)) {
+    // reply to the address and port the state came from; the master
+    // sends state from its servo socket (bound to SITL_SERVO_PORT +
+    // its instance number) precisely so this works for any instance
+    if (!servo_sock.connect(in_addr, port)) {
         fprintf(stderr, "servo socket failed - %s\n", strerror(errno));
         exit(1);
     }

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -453,35 +453,12 @@ void SITL_State::multicast_state_open(void)
 #ifdef HAVE_SOCK_SIN_LEN
     sockaddr.sin_len = sizeof(sockaddr);
 #endif
-    sockaddr.sin_port = htons(SITL_MCAST_PORT);
     sockaddr.sin_family = AF_INET;
-    sockaddr.sin_addr.s_addr = inet_addr(SITL_MCAST_IP);
-
-    mc_out_fd = socket(AF_INET, SOCK_DGRAM, 0);
-    if (mc_out_fd == -1) {
-        fprintf(stderr, "socket failed - %s\n", strerror(errno));
-        exit(1);
-    }
-    ret = fcntl(mc_out_fd, F_SETFD, FD_CLOEXEC);
-    if (ret == -1) {
-        fprintf(stderr, "fcntl failed on setting FD_CLOEXEC - %s\n", strerror(errno));
-        exit(1);
-    }
-
-    // try to setup for broadcast, this may fail if insufficient privileges
-    int one = 1;
-    setsockopt(mc_out_fd,SOL_SOCKET,SO_BROADCAST,(char *)&one,sizeof(one));
-
-    ret = connect(mc_out_fd, (struct sockaddr *)&sockaddr, sizeof(sockaddr));
-    if (ret == -1) {
-        fprintf(stderr, "udp connect failed on port %u - %s\n",
-                (unsigned)ntohs(sockaddr.sin_port),
-                strerror(errno));
-        exit(1);
-    }
 
     /*
-      open servo input socket
+      open the servo input socket; state is also sent from this socket
+      so that peripherals can reply to the source address and port they
+      observe, whatever this instance's servo port is
      */
     servo_in_fd = socket(AF_INET, SOCK_DGRAM, 0);
     if (servo_in_fd == -1) {
@@ -494,14 +471,28 @@ void SITL_State::multicast_state_open(void)
         exit(1);
     }
 
+    // try to setup for broadcast, this may fail if insufficient privileges
+    int one = 1;
+    setsockopt(servo_in_fd, SOL_SOCKET, SO_BROADCAST, (char *)&one, sizeof(one));
+
     sockaddr.sin_addr.s_addr = htonl(INADDR_ANY);
     sockaddr.sin_port = htons(SITL_SERVO_PORT + _instance);
 
     ret = bind(servo_in_fd, (struct sockaddr *)&sockaddr, sizeof(sockaddr));
     if (ret == -1) {
-        fprintf(stderr, "udp servo connect failed\n");
+        fprintf(stderr, "udp servo bind failed\n");
         exit(1);
     }
+
+    // destination address for the multicast state
+    mc_dest = {};
+#ifdef HAVE_SOCK_SIN_LEN
+    mc_dest.sin_len = sizeof(mc_dest);
+#endif
+    mc_dest.sin_family = AF_INET;
+    mc_dest.sin_port = htons(SITL_MCAST_PORT);
+    mc_dest.sin_addr.s_addr = inet_addr(SITL_MCAST_IP);
+
     ::printf("multicast initialised\n");
 }
 
@@ -513,11 +504,11 @@ void SITL_State::multicast_state_send(void)
     if (_sitl == nullptr) {
         return;
     }
-    if (mc_out_fd == -1) {
+    if (servo_in_fd == -1) {
         multicast_state_open();
     }
     const auto &sfdm = _sitl->state;
-    send(mc_out_fd, (void*)&sfdm, sizeof(sfdm), 0);
+    sendto(servo_in_fd, (void*)&sfdm, sizeof(sfdm), 0, (struct sockaddr *)&mc_dest, sizeof(mc_dest));
 
     check_servo_input();
 }

--- a/libraries/AP_HAL_SITL/SITL_State.h
+++ b/libraries/AP_HAL_SITL/SITL_State.h
@@ -11,6 +11,8 @@
 #include "SITL_Periph_State.h"
 #else
 
+#include <netinet/in.h>
+
 class HAL_SITL;
 
 class HALSITL::SITL_State : public SITL_State_Common {
@@ -123,8 +125,8 @@ private:
     float _sonar_pin_voltage() const;
 
     // multicast state
-    int mc_out_fd = -1;
     int servo_in_fd = -1;
+    struct sockaddr_in mc_dest;
 
     // send out SITL state as UDP multicast
     void multicast_state_open(void);

--- a/libraries/AP_HAL_SITL/SITL_State_common.h
+++ b/libraries/AP_HAL_SITL/SITL_State_common.h
@@ -214,9 +214,6 @@ public:
     // voltage from the sensor
     float _sonar_pin_voltage() const;
 
-    // multicast state
-    int mc_out_fd = -1;
-    
     // send out SITL state as UDP multicast
     void multicast_state_open(void);
     void multicast_state_send(void);


### PR DESCRIPTION
### Summary

Corrects multicast port used to send peripheral servo state back to main SITL process

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

The simulated-peripheral servo return channel was broken for all but instance-zero vehicles: the peripheral connected back to the flat SITL_SERVO_PORT while the vehicle binds SITL_SERVO_PORT plus its instance number, so servo returns from AP_Periph simulations never reached a non-zero-instance vehicle.

Send the multicast state from the servo socket itself and have the peripheral reply to the source address and port it observes, making the reply path correct for any instance number.  This also lets a future peripheral-lockstep scheme treat the state/reply pair as a request/response channel.  The now-unused mc_out_fd is removed, including the vestigial copy in SITL_State_common.
