### PR TITLE
Minor: Fix f-strings in Quadplane SimBatteryResistance test

### DIFF
--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -2499,28 +2499,29 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         # with sag disabled the pack should read close to its resting voltage
         self.set_parameter("SIM_BATT_RES_OHM", 0)
         v_no_sag = hover_voltage()
-        self.progress(f"hover voltage, sag disabled: {v_no_sag}V")
+        self.progress(f"hover voltage, sag disabled: {v_no_sag:.4f}V")
         if abs(v_no_sag - 12.6) > 0.2:
             raise NotAchievedException(
-                "Expected ~resting voltage with sag disabled, got {v_no_sag}V")
+                f"Expected ~resting voltage with sag disabled, got {v_no_sag:.4f}V")
 
         # introducing resistance should sag the voltage under the same load
         hover_voltage_ohms = 0.05
         self.set_parameter("SIM_BATT_RES_OHM", hover_voltage_ohms)
         v_sag = hover_voltage()
-        self.progress("hover voltage, {hover_voltage_ohms}ohm: {v_sag}V")
+        self.progress(f"hover voltage, {hover_voltage_ohms:.4f}ohm: {v_sag:.4f}V")
         if v_sag > v_no_sag - 0.3:
             raise NotAchievedException(
-                "Expected voltage sag with resistance, got {v_sag}V (no-sag {v_no_sag}V)")
+                f"Expected voltage sag with resistance, got {v_sag:.4f}V (no-sag {v_no_sag:.4f}V)")
 
         # more resistance should sag the voltage further still
         hover_voltage_more_ohms = 0.1
         self.set_parameter("SIM_BATT_RES_OHM", hover_voltage_more_ohms)
         v_more_sag = hover_voltage()
-        self.progress("hover voltage, {hover_voltage_more_ohms}ohm: {v_more_sag}V")
+        self.progress(f"hover voltage, {hover_voltage_more_ohms:.4f}ohm: {v_more_sag:.4f}V")
         if v_more_sag > v_sag - 0.2:
             raise NotAchievedException(
-                "Expected more sag at higher resistance, got {v_more_sag}V ({hover_voltage_more_ohms}ohm {v_sag}V)")
+                f"Expected more sag at higher resistance, got {v_more_sag:.4f}V"
+                f" ({hover_voltage_more_ohms:.4f}ohm {v_sag:.4f}V)")
 
         # restore full thrust before landing so the RTL is not handicapped
         self.set_parameter("SIM_BATT_RES_OHM", 0)


### PR DESCRIPTION
### Summary

Tiny fix to autotest output strings, no changes to code or test behavior.

Also, by default ~10 decimals were unnecessarily printed. So now print only 4 decimal places.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

(Found these while working on something else, the number now prints as expected.)

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
