### PR TITLE
AP_GPS: rename a local variable to not mislead

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -882,7 +882,7 @@ void AP_GPS::update_instance(uint8_t instance)
     // if we did not get a message, and the idle timer of 2 seconds
     // has expired, re-initialise the GPS. This will cause GPS
     // detection to run again
-    bool data_should_be_logged = false;
+    bool new_data_or_timeout = false;
     if (!result) {
         if (tnow - timing[instance].last_message_time_ms > GPS_TIMEOUT_MS) {
             memset((void *)&state[instance], 0, sizeof(state[instance]));
@@ -906,7 +906,7 @@ void AP_GPS::update_instance(uint8_t instance)
             }
             // log this data as a "flag" that the GPS is no longer
             // valid (see PR#8144)
-            data_should_be_logged = true;
+            new_data_or_timeout = true;
         }
     } else {
         if (state[instance].corrected_timestamp_updated) {
@@ -931,7 +931,7 @@ void AP_GPS::update_instance(uint8_t instance)
             timing[instance].last_fix_time_ms = tnow;
         }
 
-        data_should_be_logged = true;
+        new_data_or_timeout = true;
     }
 
 #if GPS_MAX_RECEIVERS > 1
@@ -953,7 +953,7 @@ void AP_GPS::update_instance(uint8_t instance)
     }
 #endif
 
-    if (data_should_be_logged) {
+    if (new_data_or_timeout) {
         // keep count of delayed frames and average frame delay for health reporting
         const uint16_t gps_max_delta_ms = 245; // 200 ms (5Hz) + 45 ms buffer
         GPS_timing &t = timing[instance];
@@ -973,11 +973,11 @@ void AP_GPS::update_instance(uint8_t instance)
     }
 
 #if HAL_LOGGING_ENABLED
-    if (data_should_be_logged && should_log()) {
+    if (new_data_or_timeout && should_log()) {
         Write_GPS(instance);
     }
 #else
-    (void)data_should_be_logged;
+    (void)new_data_or_timeout;
 #endif
 
 #if AP_RTC_ENABLED


### PR DESCRIPTION
### Summary

the variable gates much more than the old "logging" wording implies.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                 *                                                   
Durandal                            *               *      *           *       *                 *      *      *
Hitec-Airspeed           *                                 *                                                   
KakuteH7-bdshot                     *               *      *           *       *                 *      *      *
MatekF405                           *               *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot                  *               *                  *       *                 *      *      *
SITL_x86_64_linux_gnu               *               *                  *       *                 *      *      *
YJUAV_A6SE                          *               *      *           *       *                 *      *      *
f103-QiotekPeriph        *                                 *                                                   
f303-MatekGPS            *                                 *                                                   
f303-Universal           *                                 *                                                   
iomcu                                                                                *                         
revo-mini                           *               *      *           *       *                 *      *      *
skyviper-v2450                                                         *                                       
speedybeef4                         *               *      *           *       *                 *      *      *
```

### Description

this variable is critical for determining GPS health - rename it to try to reflect what it actually does

One of the code blocks this gates is all about the health of the unit.  There's also a bug in that code where we don't reset the low-pass-filter when a GPS is redected, meaning under certain circumstances you need many seconds of good data before GPS health will return.
