### PR TITLE
hwdef: support SPL06 barometer in FlywooF405S-AIO and HD boards

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/FlywooF405S-AIO/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/FlywooF405S-AIO/hwdef.dat
@@ -123,11 +123,11 @@ define HAL_OSD_TYPE_DEFAULT 1
 ROMFS_WILDCARD libraries/AP_OSD/fonts/font0.bin
 
 # Barometer setup
+define AP_BARO_SPL06_ENABLED 1
 BARO BMP280 I2C:0:0x76
-        
-# Barometer setup
 BARO DPS310 I2C:0:0x76
-        
+BARO SPL06  I2C:0:0x76        
+
 # IMU setup
 SPIDEV icm42688  SPI1 DEVID1 GYRO1_CS   MODE3   2*MHZ   16*MHZ
 SPIDEV mpu6000   SPI1 DEVID1 GYRO1_CS   MODE3   1*MHZ   8*MHZ


### PR DESCRIPTION
### Summary

<!-- Put a one or two line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Tested on an FlywooF405S-AIO board owned by the PR author, also reported to work wrt barometer on a related FlywooF405HD-AIOv2 board in [this post](https://discuss.ardupilot.org/t/flywoof405hd-aiov2-onboard-barometer-not-detected-baro1-devid-0-on-two-different-boards).

### Description

FlywooF405S-AIO and FlywooF405HD-AIOv2 boards are produced also with SPL06 barometers, which seem to be covered by other barometer code in Betaflight but require enabling a separate driver in Ardupilot. This adds the necessary lines to hwdef.