### PR TITLE
AP_InertialSensor: add LSM6DSO and LSM6DSO32 IMU drivers

### DIFF
--- a/Tools/scripts/decode_devid.py
+++ b/Tools/scripts/decode_devid.py
@@ -116,6 +116,7 @@ imu_types = {
     0x42 : "DEVTYPE_INS_LSM6DSV32X",
     0x43 : "DEVTYPE_INS_LSM6DSK320X",
     0x44 : "DEVTYPE_INS_LSM6DSO",
+    0x45 : "DEVTYPE_INS_LSM6DSO32",
 }
 
 baro_types = {

--- a/Tools/scripts/decode_devid.py
+++ b/Tools/scripts/decode_devid.py
@@ -115,6 +115,7 @@ imu_types = {
     0x40 : "DEVTYPE_INS_ADIS16607",
     0x42 : "DEVTYPE_INS_LSM6DSV32X",
     0x43 : "DEVTYPE_INS_LSM6DSK320X",
+    0x44 : "DEVTYPE_INS_LSM6DSO",
 }
 
 baro_types = {

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -41,6 +41,7 @@
 #include "AP_InertialSensor_SCHA63T.h"
 #include "AP_InertialSensor_ASM330.h"
 #include "AP_InertialSensor_LSM6DSO.h"
+#include "AP_InertialSensor_LSM6DSO32.h"
 #include "AP_InertialSensor_ADIS16607.h"
 #include <AP_Scheduler/AP_Scheduler.h>
 #include "AP_InertialSensor_ZeroOne_FPGA_SCH16T.h"

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -40,6 +40,7 @@
 #include "AP_InertialSensor_NONE.h"
 #include "AP_InertialSensor_SCHA63T.h"
 #include "AP_InertialSensor_ASM330.h"
+#include "AP_InertialSensor_LSM6DSO.h"
 #include "AP_InertialSensor_ADIS16607.h"
 #include <AP_Scheduler/AP_Scheduler.h>
 #include "AP_InertialSensor_ZeroOne_FPGA_SCH16T.h"

--- a/libraries/AP_InertialSensor/AP_InertialSensor_ASM330.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_ASM330.cpp
@@ -60,6 +60,21 @@ AP_InertialSensor_Backend *AP_InertialSensor_ASM330::probe(AP_InertialSensor &im
     return sensor;
 }
 
+uint8_t AP_InertialSensor_ASM330::expected_whoami() const
+{
+    return WHO_AM_I;
+}
+
+AP_InertialSensor_Backend::DevTypes AP_InertialSensor_ASM330::devtype() const
+{
+    return DEVTYPE_INS_ASM330;
+}
+
+const char *AP_InertialSensor_ASM330::sensor_name() const
+{
+    return "ASM330";
+}
+
 bool AP_InertialSensor_ASM330::init_sensor()
 {
     bool success = hardware_init();
@@ -78,8 +93,8 @@ bool AP_InertialSensor_ASM330::hardware_init()
     dev->set_read_flag(0x80);
 
     const uint8_t whoami = register_read(ASM330_REG_WHO_AM_I);
-    if (whoami != WHO_AM_I) {
-        DEV_PRINTF("ASM330: unexpected acc/gyro WHOAMI 0x%x\n", whoami);
+    if (whoami != expected_whoami()) {
+        DEV_PRINTF("%s: unexpected acc/gyro WHOAMI 0x%x\n", sensor_name(), whoami);
         return false;
     }
 
@@ -113,7 +128,7 @@ bool AP_InertialSensor_ASM330::hardware_init()
     dev->set_speed(AP_HAL::Device::SPEED_HIGH);
 
     if (!reset_success) {
-        DEV_PRINTF("ASM330: Failed to boot ASM330\n");
+        DEV_PRINTF("%s: failed to boot\n", sensor_name());
         return false;
     }
 
@@ -125,8 +140,8 @@ bool AP_InertialSensor_ASM330::hardware_init()
  */
 void AP_InertialSensor_ASM330::start(void)
 {
-    if (!_imu.register_gyro(gyro_instance, GYRO_SAMPLE_RATE, dev->get_bus_id_devtype(DEVTYPE_INS_ASM330)) ||
-        !_imu.register_accel(accel_instance, ACCEL_SAMPLE_RATE, dev->get_bus_id_devtype(DEVTYPE_INS_ASM330))) {
+    if (!_imu.register_gyro(gyro_instance, GYRO_SAMPLE_RATE, dev->get_bus_id_devtype(devtype())) ||
+        !_imu.register_accel(accel_instance, ACCEL_SAMPLE_RATE, dev->get_bus_id_devtype(devtype()))) {
         return;
     }
 
@@ -321,38 +336,48 @@ void AP_InertialSensor_ASM330::poll_data()
         uint8_t fifo_tmp[7] = {0, 0, 0, 0, 0, 0, 0};
 
         if (!dev->transfer(&fifo_reg, 1, (uint8_t *)&fifo_tmp, sizeof(fifo_tmp))) {
-            DEV_PRINTF("ASM330: error reading fifo data\n");
+            DEV_PRINTF("%s: error reading fifo data\n", sensor_name());
             return;
         }
 
-        struct sensor_raw_data raw_data;
-
-        const uint8_t tag = (uint8_t)((fifo_tmp[0] & 0xF8) >> 3);
-        raw_data.x = (int16_t)(fifo_tmp[1] + (fifo_tmp[2] << 8));
-        raw_data.y = (int16_t)(fifo_tmp[3] + (fifo_tmp[4] << 8));
-        raw_data.z = (int16_t)(fifo_tmp[5] + (fifo_tmp[6] << 8));
-
-        switch (tag) {
-        case 0x01:
-            update_transaction_g(raw_data);
-            break;
-        case 0x02:
-            update_transaction_x(raw_data);
-            break;
-        default:
-            // unused fifo data
-            ;
-            break;
-        }
+        process_fifo_word(fifo_tmp);
     }
 
-    if (temperature_counter++ >= 10) {
+    poll_housekeeping();
+}
+
+void AP_InertialSensor_ASM330::process_fifo_word(const uint8_t *word)
+{
+    struct sensor_raw_data raw_data;
+
+    const uint8_t tag = (uint8_t)((word[0] & 0xF8) >> 3);
+    raw_data.x = (int16_t)(word[1] + (word[2] << 8));
+    raw_data.y = (int16_t)(word[3] + (word[4] << 8));
+    raw_data.z = (int16_t)(word[5] + (word[6] << 8));
+
+    switch (tag) {
+    case 0x01:
+        update_transaction_g(raw_data);
+        break;
+    case 0x02:
+        update_transaction_x(raw_data);
+        break;
+    default:
+        // unused fifo data
+        ;
+        break;
+    }
+}
+
+void AP_InertialSensor_ASM330::poll_housekeeping()
+{
+    if (temperature_counter++ >= temperature_decimation()) {
         const uint8_t temperature_reg = ASM330_REG_OUT_TEMP_L | 0x80;
         int16_t temperature_tmp;
         if (dev->transfer(&temperature_reg, 1, (uint8_t *)&temperature_tmp, sizeof(temperature_tmp))) {
             temperature_degc = temperature_filter.apply((float)temperature_tmp / 256.0f + 25.0f);
         } else {
-            DEV_PRINTF("ASM330: error reading temperature data\n");
+            DEV_PRINTF("%s: error reading temperature data\n", sensor_name());
         }
         temperature_counter = 0;
     }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_ASM330.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_ASM330.cpp
@@ -133,7 +133,12 @@ void AP_InertialSensor_ASM330::start(void)
     set_accel_orientation(accel_instance, rot);
     set_gyro_orientation(gyro_instance, rot);
 
-    fifo_reset();
+    {
+        // bus transfers fail unless the caller owns the semaphore, and start()
+        // does not run on the bus thread
+        WITH_SEMAPHORE(dev->get_semaphore());
+        fifo_reset();
+    }
 
     // start the timer process to read samples
     dev->register_periodic_callback(1000, FUNCTOR_BIND_MEMBER(&AP_InertialSensor_ASM330::poll_data, void));
@@ -173,8 +178,9 @@ void AP_InertialSensor_ASM330::fifo_reset()
 {
     const uint8_t fifo_ctrl4 = register_read(ASM330_REG_FIFO_CTRL4);
 
-    // FIFO_MODE is Bypass mode
-    register_write(ASM330_REG_FIFO_CTRL4, fifo_ctrl4 |
+    // FIFO_MODE is Bypass mode. FIFO_MODE_BYPASS is zero, so the mode field
+    // has to be cleared rather than ORed in for the FIFO to actually flush.
+    register_write(ASM330_REG_FIFO_CTRL4, (fifo_ctrl4 & ~ASM330_REG_FIFO_CTRL4_FIFO_MODE_MASK) |
                                            ASM330_REG_FIFO_CTRL4_FIFO_MODE_BYPASS);
 
     // Revert FIFO_MODE

--- a/libraries/AP_InertialSensor/AP_InertialSensor_ASM330.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_ASM330.h
@@ -19,7 +19,7 @@ public:
     static AP_InertialSensor_Backend *probe(AP_InertialSensor &imu,
                                             AP_HAL::OwnPtr<AP_HAL::Device> dev,
                                             enum Rotation rotation);
-private:
+protected:
     AP_InertialSensor_ASM330(AP_InertialSensor &imu,
                              AP_HAL::OwnPtr<AP_HAL::Device> dev,
                              enum Rotation rotation);
@@ -32,6 +32,12 @@ private:
         int16_t z;
     };
 
+    // identity of the part being driven. Subclasses covering other members
+    // of this register-compatible ST family override these.
+    virtual uint8_t expected_whoami() const;
+    virtual DevTypes devtype() const;
+    virtual const char *sensor_name() const;
+
     bool init_sensor();
     bool hardware_init();
 
@@ -42,13 +48,23 @@ private:
     void fifo_reset();
 
     void common_init();
-    void fifo_init();
-    void gyro_init();
-    void accel_init();
+    virtual void fifo_init();
+    virtual void gyro_init();
+    virtual void accel_init();
 
     uint16_t get_count_fifo_unread_data();
 
-    void poll_data();
+    virtual void poll_data();
+
+    // decode one 7-byte FIFO word (tag + 3 axes) and publish it
+    void process_fifo_word(const uint8_t *word);
+
+    // temperature read and register-value check, run at the tail of poll_data()
+    void poll_housekeeping();
+
+    // poll_data() calls between temperature reads, sized to hold the ~100 Hz
+    // rate that temperature_filter is configured for
+    virtual uint8_t temperature_decimation() const { return 10; }
 
     void update_transaction_g(struct sensor_raw_data raw_data);
     void update_transaction_x(struct sensor_raw_data raw_data);

--- a/libraries/AP_InertialSensor/AP_InertialSensor_ASM330_registers.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_ASM330_registers.h
@@ -68,6 +68,7 @@
 #   define ASM330_REG_FIFO_CTRL4_ODR_T_BATCH_12500mHz       (0x2 << 4)
 #   define ASM330_REG_FIFO_CTRL4_ODR_T_BATCH_52Hz           (0x3 << 4)
 // FIFO_MODE
+#   define ASM330_REG_FIFO_CTRL4_FIFO_MODE_MASK             (0x7)
 #   define ASM330_REG_FIFO_CTRL4_FIFO_MODE_BYPASS           (0x0)
 #   define ASM330_REG_FIFO_CTRL4_FIFO_MODE_FIFO             (0x1)
 #   define ASM330_REG_FIFO_CTRL4_FIFO_MODE_CONT_TO_FIFO     (0x3)

--- a/libraries/AP_InertialSensor/AP_InertialSensor_ASM330_registers.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_ASM330_registers.h
@@ -14,7 +14,7 @@
 #define ODR_208Hz       (0x5 << 4)
 #define ODR_416Hz       (0x6 << 4)
 #define ODR_833Hz       (0x7 << 4)
-#define ODR_1666Hz      (0x8 << 4)
+#define ODR_1667Hz      (0x8 << 4)
 #define ODR_3333Hz      (0x9 << 4)
 #define ODR_6667Hz      (0xA << 4)
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -177,6 +177,7 @@ public:
         DEVTYPE_INS_ZEROONE_FPGA_SCH16T = 0x41,
         DEVTYPE_INS_LSM6DSV32X = 0x42,
         DEVTYPE_INS_LSM6DSK320X = 0x43,
+        DEVTYPE_INS_LSM6DSO = 0x44,
     };
 
 protected:

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -178,6 +178,7 @@ public:
         DEVTYPE_INS_LSM6DSV32X = 0x42,
         DEVTYPE_INS_LSM6DSK320X = 0x43,
         DEVTYPE_INS_LSM6DSO = 0x44,
+        DEVTYPE_INS_LSM6DSO32 = 0x45,
     };
 
 protected:

--- a/libraries/AP_InertialSensor/AP_InertialSensor_LSM6DSO.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_LSM6DSO.cpp
@@ -1,0 +1,300 @@
+/*
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/*
+ *  driver for ST LSM6DSO IMU
+ *
+ *  The LSM6DSO shares its register map with the ASM330LHH, so this derives
+ *  from that driver and changes only what differs: the WHO_AM_I value, an
+ *  ODR selected from INS_FAST_SAMPLE / INS_GYRO_RATE rather than fixed at
+ *  3333 Hz, and a burst FIFO read in place of one transfer per sample.
+*/
+
+#include "AP_InertialSensor_LSM6DSO.h"
+#include "AP_InertialSensor_ASM330_registers.h"
+
+#include <AP_HAL/AP_HAL.h>
+
+#include <stdio.h>
+#include <utility>
+
+extern const AP_HAL::HAL& hal;
+
+#define LSM6DSO_WHOAMI                  0x6C
+
+// CTRL9_XL bit1. ST recommend disabling I3C when it is not in use.
+#define LSM6DSO_CTRL9_XL_I3C_DISABLE    (1U << 1)
+
+// slowest rate the sensor is run at, and the step of the ODR ladder below
+#define LSM6DSO_BASE_RATE_HZ            833
+
+// bytes per FIFO word: one tag byte plus three 16-bit axes
+#define LSM6DSO_FIFO_WORD_SIZE          7
+
+// Words per burst transfer. Reading more than one word at a time relies on the
+// address auto-increment wrapping from FIFO_DATA_OUT_Z_H (7Eh) back to
+// FIFO_DATA_OUT_TAG (78h), which the datasheet does not spell out. Setting this
+// to 1 falls back to a transfer per word, as the ASM330 driver does.
+#define LSM6DSO_FIFO_BURST_WORDS        16
+
+// most words drained in a single poll
+#define LSM6DSO_FIFO_MAX_DRAIN_WORDS    64
+
+#define LSM6DSO_FIFO_BUFFER_SIZE        (LSM6DSO_FIFO_BURST_WORDS * LSM6DSO_FIFO_WORD_SIZE + 1)
+
+/*
+  ODR ladder, stepping in powers of two from the 833 Hz base rate. The
+  sensor's rates are not exact multiples of the base, so the true ODR is
+  what gets reported to the frontend - the harmonic notch is tuned off it.
+ */
+static const struct {
+    uint16_t rate_hz;
+    uint8_t odr;      // CTRL1_XL / CTRL2_G ODR field, pre-shifted
+    uint8_t bdr_gy;
+    uint8_t bdr_xl;
+} odr_table[] = {
+    {  833, ASM330_REG_CTRL1_XL_ODR_XL_833Hz,  ASM330_REG_FIFO_CTRL3_BDR_GY_833Hz,  ASM330_REG_FIFO_CTRL3_BDR_XL_833Hz  },
+    { 1667, ASM330_REG_CTRL1_XL_ODR_XL_1667Hz, ASM330_REG_FIFO_CTRL3_BDR_GY_1667Hz, ASM330_REG_FIFO_CTRL3_BDR_XL_1667Hz },
+    { 3333, ASM330_REG_CTRL1_XL_ODR_XL_3333Hz, ASM330_REG_FIFO_CTRL3_BDR_GY_3333Hz, ASM330_REG_FIFO_CTRL3_BDR_XL_3333Hz },
+    { 6667, ASM330_REG_CTRL1_XL_ODR_XL_6667Hz, ASM330_REG_FIFO_CTRL3_BDR_GY_6667Hz, ASM330_REG_FIFO_CTRL3_BDR_XL_6667Hz },
+};
+
+AP_InertialSensor_LSM6DSO::AP_InertialSensor_LSM6DSO(AP_InertialSensor &imu,
+        AP_HAL::OwnPtr<AP_HAL::Device> device,
+        enum Rotation rotation)
+    : AP_InertialSensor_ASM330(imu, std::move(device), rotation)
+{
+    // probe runs at the top of the ladder; start() re-programs the ODR once
+    // the fast sampling parameters are known
+    odr_index = ARRAY_SIZE(odr_table) - 1;
+    backend_rate_hz = odr_table[odr_index].rate_hz;
+    backend_period_us = 1000000UL / backend_rate_hz;
+}
+
+AP_InertialSensor_LSM6DSO::~AP_InertialSensor_LSM6DSO()
+{
+    if (fifo_buffer != nullptr) {
+        hal.util->free_type(fifo_buffer, LSM6DSO_FIFO_BUFFER_SIZE, AP_HAL::Util::MEM_DMA_SAFE);
+    }
+}
+
+AP_InertialSensor_Backend *AP_InertialSensor_LSM6DSO::probe(AP_InertialSensor &imu,
+        AP_HAL::OwnPtr<AP_HAL::Device> device,
+        enum Rotation rotation)
+{
+    if (!device) {
+        return nullptr;
+    }
+
+    AP_InertialSensor_LSM6DSO *sensor =
+        NEW_NOTHROW AP_InertialSensor_LSM6DSO(imu, std::move(device), rotation);
+    if (!sensor || !sensor->init_sensor()) {
+        delete sensor;
+        return nullptr;
+    }
+
+    return sensor;
+}
+
+uint8_t AP_InertialSensor_LSM6DSO::expected_whoami() const
+{
+    return LSM6DSO_WHOAMI;
+}
+
+AP_InertialSensor_Backend::DevTypes AP_InertialSensor_LSM6DSO::devtype() const
+{
+    return DEVTYPE_INS_LSM6DSO;
+}
+
+const char *AP_InertialSensor_LSM6DSO::sensor_name() const
+{
+    return "LSM6DSO";
+}
+
+uint8_t AP_InertialSensor_LSM6DSO::temperature_decimation() const
+{
+    return uint8_t(MAX(1U, backend_rate_hz / 100U));
+}
+
+/*
+  select the ODR from the fast sampling parameters
+ */
+void AP_InertialSensor_LSM6DSO::set_backend_rate()
+{
+    uint8_t mult = 1;
+
+    fast_sampling = (dev->bus_type() == AP_HAL::Device::BUS_TYPE_SPI) &&
+                    enable_fast_sampling(accel_instance) &&
+                    get_fast_sampling_rate() > 1;
+    if (fast_sampling) {
+        mult = get_fast_sampling_rate();
+    }
+
+    // never run the sensor slower than the loop rate
+    while (LSM6DSO_BASE_RATE_HZ * mult < get_loop_rate_hz() && mult < 8) {
+        mult *= 2;
+    }
+
+    odr_index = 0;
+    while (odr_index + 1U < ARRAY_SIZE(odr_table) && (1U << (odr_index + 1)) <= mult) {
+        odr_index++;
+    }
+
+    backend_rate_hz = odr_table[odr_index].rate_hz;
+    backend_period_us = 1000000UL / backend_rate_hz;
+}
+
+void AP_InertialSensor_LSM6DSO::gyro_init()
+{
+    // CTRL7_G(16h) : 00h - HPF disabled, offset correction bypassed
+    register_write(ASM330_REG_CTRL7_G, ASM330_REG_CTRL7_G_HP_EN_G_DISABLE |
+                   ASM330_REG_CTRL7_G_HPM_G_16mHz |
+                   ASM330_REG_CTRL7_G_USR_OFF_ON_OUT_BYPASS, true);
+
+    // CTRL2_G(11h) : ODR from the ladder, FS = 1100b (2000dps)
+    register_write(ASM330_REG_CTRL2_G, odr_table[odr_index].odr |
+                   ASM330_REG_CTRL2_G_FS_G_2000DPS, true);
+}
+
+void AP_InertialSensor_LSM6DSO::accel_init()
+{
+    // CTRL8_XL(17h) : 00h - LPF2 and HPF bypassed, XL_FS_MODE = 0 so that
+    // FS_XL selects the full +/-16 g range
+    register_write(ASM330_REG_CTRL8_XL, ASM330_REG_CTRL8_XL_HPCF_XL_ODR_PER_4 |
+                   ASM330_REG_CTRL8_XL_HP_REF_MODE_XL_DISABLE |
+                   ASM330_REG_CTRL8_XL_FASTSETTL_MODE_XL_DISABLE |
+                   ASM330_REG_CTRL8_XL_HP_SLOPE_XL_EN_DISABLE |
+                   ASM330_REG_CTRL8_XL_LOW_PASS_ON_6D_LPF1, true);
+
+    // CTRL9_XL(18h) : E2h - reset default plus I3C disabled
+    register_write(ASM330_REG_CTRL9_XL, ASM330_REG_CTRL9_XL_DEN_X_ENABLE |
+                   ASM330_REG_CTRL9_XL_DEN_Y_ENABLE |
+                   ASM330_REG_CTRL9_XL_DEN_Z_ENABLE |
+                   ASM330_REG_CTRL9_XL_DEN_XL_G_GYRO |
+                   ASM330_REG_CTRL9_XL_DEN_XL_EN_EXT_DISABLE |
+                   ASM330_REG_CTRL9_XL_DEN_LH_ACTIVE_LOW |
+                   LSM6DSO_CTRL9_XL_I3C_DISABLE, true);
+
+    // CTRL1_XL(10h) : ODR from the ladder, FS_XL = 01b (16g), LPF2 disabled
+    register_write(ASM330_REG_CTRL1_XL, odr_table[odr_index].odr |
+                   ASM330_REG_CTRL1_XL_FS_XL_16G |
+                   ASM330_REG_CTRL1_XL_LPF2_XL_EN_DISABLE, true);
+}
+
+void AP_InertialSensor_LSM6DSO::fifo_init()
+{
+    // FIFO_CTRL1(07h), FIFO_CTRL2(08h) : 00h - no watermark
+    register_write(ASM330_REG_FIFO_CTRL1, 0x00, true);
+    register_write(ASM330_REG_FIFO_CTRL2, 0x00, true);
+
+    // FIFO_CTRL3(09h) : batch both sensors at the selected ODR
+    register_write(ASM330_REG_FIFO_CTRL3, odr_table[odr_index].bdr_gy |
+                   odr_table[odr_index].bdr_xl, true);
+
+    // FIFO_CTRL4(0Ah) : 06h - no timestamp or temperature batching, continuous mode
+    register_write(ASM330_REG_FIFO_CTRL4, ASM330_REG_FIFO_CTRL4_DEC_TS_BATCH_NOT_BATCH |
+                   ASM330_REG_FIFO_CTRL4_ODR_T_BATCH_NOT_BATCH |
+                   ASM330_REG_FIFO_CTRL4_FIFO_MODE_CONT, true);
+}
+
+void AP_InertialSensor_LSM6DSO::start(void)
+{
+    // the fast sampling parameters are per-instance, so the ODR cannot be
+    // chosen until the instance numbers are known
+    if (!_imu.get_gyro_instance(gyro_instance) ||
+        !_imu.get_accel_instance(accel_instance)) {
+        return;
+    }
+
+    set_backend_rate();
+
+    if (!_imu.register_gyro(gyro_instance, backend_rate_hz, dev->get_bus_id_devtype(devtype())) ||
+        !_imu.register_accel(accel_instance, backend_rate_hz, dev->get_bus_id_devtype(devtype()))) {
+        return;
+    }
+
+    set_accel_orientation(accel_instance, rot);
+    set_gyro_orientation(gyro_instance, rot);
+
+    fifo_buffer = (uint8_t *)hal.util->malloc_type(LSM6DSO_FIFO_BUFFER_SIZE, AP_HAL::Util::MEM_DMA_SAFE);
+    if (fifo_buffer == nullptr) {
+        AP_HAL::panic("LSM6DSO: unable to allocate FIFO buffer");
+    }
+
+    {
+        WITH_SEMAPHORE(dev->get_semaphore());
+        // re-program the ODR, which hardware_init() could only set to the default
+        gyro_init();
+        accel_init();
+        fifo_init();
+        fifo_reset();
+    }
+
+    periodic_handle = dev->register_periodic_callback(backend_period_us,
+                      FUNCTOR_BIND_MEMBER(&AP_InertialSensor_LSM6DSO::poll_data, void));
+}
+
+bool AP_InertialSensor_LSM6DSO::get_output_banner(char* banner, uint8_t banner_len)
+{
+    snprintf(banner, banner_len, "IMU%u: LSM6DSO %s sampling %.1fkHz",
+             gyro_instance,
+             fast_sampling ? "fast" : "normal",
+             backend_rate_hz * 0.001f);
+    return true;
+}
+
+/*
+  read n_words FIFO words into fifo_buffer. The buffer is passed whole to
+  the SPI layer so that the DMA-safe allocation is used all the way down.
+ */
+bool AP_InertialSensor_LSM6DSO::read_fifo_block(uint16_t n_words)
+{
+    fifo_buffer[0] = ASM330_REG_FIFO_DATA_OUT_TAG | 0x80;
+    // the transfer sends as well as receives, make sure it sends zeros
+    memset(fifo_buffer + 1, 0, n_words * LSM6DSO_FIFO_WORD_SIZE);
+
+    return dev->transfer_fullduplex(fifo_buffer, n_words * LSM6DSO_FIFO_WORD_SIZE + 1);
+}
+
+void AP_InertialSensor_LSM6DSO::poll_data()
+{
+    uint16_t samples = get_count_fifo_unread_data();
+
+    if (samples > 0) {
+        // keep the callback in step with the incoming data
+        dev->adjust_periodic_callback(periodic_handle, backend_period_us);
+    }
+    if (samples > LSM6DSO_FIFO_MAX_DRAIN_WORDS) {
+        samples = LSM6DSO_FIFO_MAX_DRAIN_WORDS;
+    }
+
+    while (samples > 0) {
+        const uint16_t n = MIN(samples, uint16_t(LSM6DSO_FIFO_BURST_WORDS));
+
+        if (!read_fifo_block(n)) {
+            DEV_PRINTF("LSM6DSO: error reading fifo data\n");
+            _inc_accel_error_count(accel_instance);
+            _inc_gyro_error_count(gyro_instance);
+            break;
+        }
+
+        const uint8_t *word = fifo_buffer + 1;
+        for (uint16_t i = 0; i < n; i++, word += LSM6DSO_FIFO_WORD_SIZE) {
+            process_fifo_word(word);
+        }
+        samples -= n;
+    }
+
+    poll_housekeeping();
+}

--- a/libraries/AP_InertialSensor/AP_InertialSensor_LSM6DSO.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_LSM6DSO.cpp
@@ -36,6 +36,13 @@ extern const AP_HAL::HAL& hal;
 // CTRL9_XL bit1. ST recommend disabling I3C when it is not in use.
 #define LSM6DSO_CTRL9_XL_I3C_DISABLE    (1U << 1)
 
+// INTERNAL_FREQ_FINE (63h) reports this part's ODR deviation from nominal as a
+// signed count of 0.15% steps. The oscillator is not trimmed tightly - parts
+// have been measured 4.6% slow - and the frontend tunes the harmonic notch off
+// the rate we declare, so apply it rather than declaring the nominal.
+#define LSM6DSO_REG_INTERNAL_FREQ_FINE  0x63
+#define LSM6DSO_FREQ_FINE_STEP          0.0015f
+
 // slowest rate the sensor is run at, and the step of the ODR ladder below
 #define LSM6DSO_BASE_RATE_HZ            833
 
@@ -156,7 +163,8 @@ void AP_InertialSensor_LSM6DSO::set_backend_rate()
         odr_index++;
     }
 
-    backend_rate_hz = odr_table[odr_index].rate_hz;
+    const uint16_t nominal_hz = odr_table[odr_index].rate_hz;
+    backend_rate_hz = uint16_t(nominal_hz * (1.0f + LSM6DSO_FREQ_FINE_STEP * freq_fine) + 0.5f);
     backend_period_us = 1000000UL / backend_rate_hz;
 }
 
@@ -220,6 +228,11 @@ void AP_InertialSensor_LSM6DSO::start(void)
     if (!_imu.get_gyro_instance(gyro_instance) ||
         !_imu.get_accel_instance(accel_instance)) {
         return;
+    }
+
+    {
+        WITH_SEMAPHORE(dev->get_semaphore());
+        freq_fine = int8_t(register_read(LSM6DSO_REG_INTERNAL_FREQ_FINE));
     }
 
     set_backend_rate();

--- a/libraries/AP_InertialSensor/AP_InertialSensor_LSM6DSO.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_LSM6DSO.cpp
@@ -44,8 +44,8 @@ extern const AP_HAL::HAL& hal;
 
 // Words per burst transfer. Reading more than one word at a time relies on the
 // address auto-increment wrapping from FIFO_DATA_OUT_Z_H (7Eh) back to
-// FIFO_DATA_OUT_TAG (78h), which the datasheet does not spell out. Setting this
-// to 1 falls back to a transfer per word, as the ASM330 driver does.
+// FIFO_DATA_OUT_TAG (78h). The datasheet does not spell that out, but it holds
+// on hardware. Setting this to 1 falls back to a transfer per word.
 #define LSM6DSO_FIFO_BURST_WORDS        16
 
 // most words drained in a single poll
@@ -122,6 +122,11 @@ const char *AP_InertialSensor_LSM6DSO::sensor_name() const
     return "LSM6DSO";
 }
 
+uint8_t AP_InertialSensor_LSM6DSO::accel_fs_bits() const
+{
+    return ASM330_REG_CTRL1_XL_FS_XL_16G;
+}
+
 uint8_t AP_InertialSensor_LSM6DSO::temperature_decimation() const
 {
     return uint8_t(MAX(1U, backend_rate_hz / 100U));
@@ -186,9 +191,9 @@ void AP_InertialSensor_LSM6DSO::accel_init()
                    ASM330_REG_CTRL9_XL_DEN_LH_ACTIVE_LOW |
                    LSM6DSO_CTRL9_XL_I3C_DISABLE, true);
 
-    // CTRL1_XL(10h) : ODR from the ladder, FS_XL = 01b (16g), LPF2 disabled
+    // CTRL1_XL(10h) : ODR from the ladder, +/-16g, LPF2 disabled
     register_write(ASM330_REG_CTRL1_XL, odr_table[odr_index].odr |
-                   ASM330_REG_CTRL1_XL_FS_XL_16G |
+                   accel_fs_bits() |
                    ASM330_REG_CTRL1_XL_LPF2_XL_EN_DISABLE, true);
 }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_LSM6DSO.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_LSM6DSO.h
@@ -27,7 +27,7 @@ public:
     static AP_InertialSensor_Backend *probe(AP_InertialSensor &imu,
                                             AP_HAL::OwnPtr<AP_HAL::Device> dev,
                                             enum Rotation rotation);
-private:
+protected:
     AP_InertialSensor_LSM6DSO(AP_InertialSensor &imu,
                               AP_HAL::OwnPtr<AP_HAL::Device> dev,
                               enum Rotation rotation);
@@ -37,6 +37,11 @@ private:
     const char *sensor_name() const override;
     uint8_t temperature_decimation() const override;
 
+    // CTRL1_XL FS_XL field selecting +/-16g. The LSM6DSO32 shifts this
+    // ladder by one range, so it overrides.
+    virtual uint8_t accel_fs_bits() const;
+
+private:
     void fifo_init() override;
     void gyro_init() override;
     void accel_init() override;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_LSM6DSO.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_LSM6DSO.h
@@ -1,0 +1,60 @@
+/*
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#pragma once
+
+#include "AP_InertialSensor_ASM330.h"
+
+class AP_InertialSensor_LSM6DSO : public AP_InertialSensor_ASM330
+{
+public:
+    virtual ~AP_InertialSensor_LSM6DSO();
+
+    void start(void) override;
+    bool get_output_banner(char* banner, uint8_t banner_len) override;
+
+    static AP_InertialSensor_Backend *probe(AP_InertialSensor &imu,
+                                            AP_HAL::OwnPtr<AP_HAL::Device> dev,
+                                            enum Rotation rotation);
+private:
+    AP_InertialSensor_LSM6DSO(AP_InertialSensor &imu,
+                              AP_HAL::OwnPtr<AP_HAL::Device> dev,
+                              enum Rotation rotation);
+
+    uint8_t expected_whoami() const override;
+    DevTypes devtype() const override;
+    const char *sensor_name() const override;
+    uint8_t temperature_decimation() const override;
+
+    void fifo_init() override;
+    void gyro_init() override;
+    void accel_init() override;
+    void poll_data() override;
+
+    // pick the ODR from the fast sampling parameters. Only valid once the
+    // accel instance number is known, so this runs from start().
+    void set_backend_rate();
+
+    bool read_fifo_block(uint16_t n_words);
+
+    AP_HAL::Device::PeriodicHandle periodic_handle;
+
+    // index into the ODR ladder, see odr_table in the implementation
+    uint8_t odr_index;
+    uint16_t backend_rate_hz;
+    uint32_t backend_period_us;
+    bool fast_sampling;
+
+    uint8_t *fifo_buffer;
+};

--- a/libraries/AP_InertialSensor/AP_InertialSensor_LSM6DSO.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_LSM6DSO.h
@@ -61,5 +61,8 @@ private:
     uint32_t backend_period_us;
     bool fast_sampling;
 
+    // this part's ODR deviation from nominal, from INTERNAL_FREQ_FINE
+    int8_t freq_fine;
+
     uint8_t *fifo_buffer;
 };

--- a/libraries/AP_InertialSensor/AP_InertialSensor_LSM6DSO32.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_LSM6DSO32.cpp
@@ -1,0 +1,65 @@
+/*
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/*
+ *  driver for ST LSM6DSO32 IMU
+ *
+ *  Identical to the LSM6DSO apart from the accelerometer full-scale
+ *  ladder, which is shifted up one range: 00 = +/-4g, 01 = +/-32g,
+ *  10 = +/-8g, 11 = +/-16g. Both parts report WHO_AM_I 0x6C and cannot be
+ *  told apart in software, so the board's hwdef has to name the right one.
+ *  Getting it wrong reads half or double scale rather than failing.
+*/
+
+#include "AP_InertialSensor_LSM6DSO32.h"
+#include "AP_InertialSensor_ASM330_registers.h"
+
+#include <utility>
+
+// CTRL1_XL FS_XL = 11b, the LSM6DSO32 coding for +/-16g. Sensitivity is
+// then 0.488 mg/LSB, matching the scale the base driver applies.
+#define LSM6DSO32_CTRL1_XL_FS_XL_16G    (0x3 << 2)
+
+AP_InertialSensor_Backend *AP_InertialSensor_LSM6DSO32::probe(AP_InertialSensor &imu,
+        AP_HAL::OwnPtr<AP_HAL::Device> device,
+        enum Rotation rotation)
+{
+    if (!device) {
+        return nullptr;
+    }
+
+    AP_InertialSensor_LSM6DSO32 *sensor =
+        NEW_NOTHROW AP_InertialSensor_LSM6DSO32(imu, std::move(device), rotation);
+    if (!sensor || !sensor->init_sensor()) {
+        delete sensor;
+        return nullptr;
+    }
+
+    return sensor;
+}
+
+AP_InertialSensor_Backend::DevTypes AP_InertialSensor_LSM6DSO32::devtype() const
+{
+    return DEVTYPE_INS_LSM6DSO32;
+}
+
+const char *AP_InertialSensor_LSM6DSO32::sensor_name() const
+{
+    return "LSM6DSO32";
+}
+
+uint8_t AP_InertialSensor_LSM6DSO32::accel_fs_bits() const
+{
+    return LSM6DSO32_CTRL1_XL_FS_XL_16G;
+}

--- a/libraries/AP_InertialSensor/AP_InertialSensor_LSM6DSO32.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_LSM6DSO32.h
@@ -1,0 +1,31 @@
+/*
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#pragma once
+
+#include "AP_InertialSensor_LSM6DSO.h"
+
+class AP_InertialSensor_LSM6DSO32 : public AP_InertialSensor_LSM6DSO
+{
+public:
+    static AP_InertialSensor_Backend *probe(AP_InertialSensor &imu,
+                                            AP_HAL::OwnPtr<AP_HAL::Device> dev,
+                                            enum Rotation rotation);
+private:
+    using AP_InertialSensor_LSM6DSO::AP_InertialSensor_LSM6DSO;
+
+    DevTypes devtype() const override;
+    const char *sensor_name() const override;
+    uint8_t accel_fs_bits() const override;
+};


### PR DESCRIPTION
### Summary

Add drivers for the ST LSM6DSO and LSM6DSO32 IMUs, derived from the existing ASM330 driver which shares their register map.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Tested on hardware

Tested on an SPRacingH7NFAIO carrying two LSM6DSO32 parts. Accelerometer reads 1g correctly (2049 LSB at +/-16g), gyro noise and rates are correct, fast sampling works at the selected ODR, and the compass/EKF come up cleanly. The FIFO burst read and the INTERNAL_FREQ_FINE ODR correction were both validated against the parts own timestamp counter.

### Description

The LSM6DSO shares the ASM330LHH register map, so the driver derives from AP_InertialSensor_ASM330 and overrides only what differs. To make that possible the ASM330 driver is first opened up for subclassing (members protected, per-part identity and init/poll entry points made virtual, the FIFO-word decode and the temperature/register-check tail split out for reuse). That refactor is its own commit and is a no-op for the ASM330.

LSM6DSO specifics over the ASM330:
- WHO_AM_I 0x6C, I3C disabled as ST recommend.
- ODR follows INS_FAST_SAMPLE / INS_GYRO_RATE (833/1667/3333/6667 Hz) rather than a fixed 3333 Hz. The true ODR is registered with the frontend so the harmonic notch is tuned off the real rate.
- FIFO is read in 16-word bursts into a DMA-safe buffer.
- INTERNAL_FREQ_FINE is applied to the declared rate. The oscillator is not trimmed tightly (the test parts were ~4.6% off nominal), and declaring the nominal rate leaves the notch and gyro filters mistuned until the frontend rate estimator converges.

The LSM6DSO32 differs from the LSM6DSO only in the accelerometer full-scale ladder, which is shifted up one range (00=+/-4g, 01=+/-32g, 10=+/-8g, 11=+/-16g), so it overrides just the FS bits. Both parts report WHO_AM_I 0x6C and cannot be distinguished in software - the board hwdef must name the correct one. Picking wrong reads half or double scale rather than failing to probe.

Two ASM330 fixes lead the series. The 1667Hz ODR define fix is a build dependency of the LSM6DSO driver (the ODR_1667Hz constant did not previously exist). The FIFO reset fix is an independent correctness fix on the ASM330 that the LSM6DSO inherits (FIFO_MODE_BYPASS is zero, so the old code ORed it in and never flushed the FIFO, and the reset ran without holding the bus semaphore). Happy to split the FIFO reset fix into its own PR if preferred.