### PR TITLE
AP_Filesystem: make fgets buflen semantics match C's fgets

### DIFF
--- a/Tools/Replay/Replay.cpp
+++ b/Tools/Replay/Replay.cpp
@@ -387,7 +387,7 @@ void Replay::load_param_file(const char *pfilename)
     }
     char line[100];
 
-    while (fs.fgets(line, sizeof(line)-1, fd)) {
+    while (fs.fgets(line, sizeof(line), fd)) {
         char *pname;
         float value;
         if (!parse_param_line(line, &pname, value)) {

--- a/libraries/AP_Filesystem/AP_Filesystem.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem.cpp
@@ -341,9 +341,17 @@ FileData *AP_Filesystem::load_file(const char *filename)
     return backend.fs.load_file(filename);
 }
 
-// returns null-terminated string; cr or lf terminates line
+// reads a line into buf, guaranteeing null-termination.  buflen is
+// the full size of buf, including the space required for the null
+// terminator, so up to buflen-1 characters are returned.  cr or lf
+// terminates the line and is consumed but not returned.
 bool AP_Filesystem::fgets(char *buf, uint8_t buflen, int fd)
 {
+    if (buflen == 0) {
+        // we can't null-terminate the buffer, which we guarantee
+        return false;
+    }
+
     const Backend &backend = backend_by_fd(fd);
 
     // we will need to seek back to the right location at the end
@@ -352,7 +360,7 @@ bool AP_Filesystem::fgets(char *buf, uint8_t buflen, int fd)
         return false;
     }
 
-    auto n = backend.fs.read(fd, buf, buflen);
+    auto n = backend.fs.read(fd, buf, buflen-1U);
     if (n <= 0) {
         return false;
     }

--- a/libraries/AP_Filesystem/AP_Filesystem.h
+++ b/libraries/AP_Filesystem/AP_Filesystem.h
@@ -129,7 +129,10 @@ public:
     // unmount filesystem for reboot
     void unmount(void);
 
-    // returns null-terminated string; cr or lf terminates line
+    // reads a line into buf, guaranteeing null-termination.  buflen
+    // is the full size of buf, including the space required for the
+    // null terminator, so up to buflen-1 characters are returned.  cr
+    // or lf terminates the line and is consumed but not returned.
     bool fgets(char *buf, uint8_t buflen, int fd);
 
     // run crc32 over file with given name, returns true if successful

--- a/libraries/AP_Param/AP_Param.cpp
+++ b/libraries/AP_Param/AP_Param.cpp
@@ -2327,7 +2327,7 @@ bool AP_Param::count_defaults_in_file(const char *filename, uint16_t &num_defaul
     /*
       work out how many parameter default structures to allocate
      */
-    while (AP::FS().fgets(line, sizeof(line)-1, file_apfs)) {
+    while (AP::FS().fgets(line, sizeof(line), file_apfs)) {
         char *pname;
         float value;
         bool read_only;
@@ -2356,7 +2356,7 @@ bool AP_Param::read_param_defaults_file(const char *filename, bool last_pass, ui
 
     bool done_all = true;
     char line[100];
-    while (AP::FS().fgets(line, sizeof(line)-1, file_apfs)) {
+    while (AP::FS().fgets(line, sizeof(line), file_apfs)) {
         char *pname;
         float value;
         bool read_only;

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -7189,7 +7189,7 @@ void GCS_MAVLINK::get_intervals_from_filepath(const char *path, DefaultIntervals
     }
 
     char line[20];
-    while (AP::FS().fgets(line, sizeof(line)-1, f)) {
+    while (AP::FS().fgets(line, sizeof(line), f)) {
         char *saveptr = nullptr;
         const char *mavlink_id_str = strtok_r(line, " ", &saveptr);
         if (mavlink_id_str == nullptr || strlen(mavlink_id_str) == 0) {


### PR DESCRIPTION
### Summary

Follow-on from https://github.com/ArduPilot/ardupilot/pull/33744 - fixes potential (and in one case real) buffer overflow.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

buflen now includes the space required for the null terminator, so up to buflen-1 characters are returned.  Previously fgets could write buf[buflen], one byte beyond the caller-nominated length.  All in-tree callers passed sizeof(buf)-1 to compensate, but posix_compat's apfs_fgets forwards its C-style size argument directly, so a caller supplying a size-byte buffer could have that buffer overrun by one byte on an over-long line.

Update callers to pass the full buffer size; usable capacity is unchanged.
