### PR TITLE
Bugfix/tkoff idle thr auto

### DIFF
--- a/ArduPlane/Plane.cpp
+++ b/ArduPlane/Plane.cpp
@@ -683,19 +683,32 @@ void Plane::update_alt()
  */
 void Plane::update_flight_stage(void)
 {
-    // Update the speed & height controller states
+    // First check if we are flying in VTOL.
+#if HAL_QUADPLANE_ENABLED
     if (control_mode->does_auto_throttle() && !throttle_suppressed) {
         if (control_mode == &mode_auto) {
-#if HAL_QUADPLANE_ENABLED
             if (quadplane.in_vtol_auto()) {
                 set_flight_stage(AP_FixedWing::FlightStage::VTOL);
                 return;
             }
-#endif
+        }
+    }
+#endif // HAL_QUADPLANE_ENABLED
+
+    // Allow going into TAKEOFF, even if throttle_supressed (waiting on the ground).
+    if (control_mode->does_auto_throttle()) {
+        if (control_mode == &mode_auto) {
             if (auto_state.takeoff_complete == false) {
                 set_flight_stage(AP_FixedWing::FlightStage::TAKEOFF);
                 return;
-            } else if (mission.get_current_nav_cmd().id == MAV_CMD_NAV_LAND) {
+            }
+        }
+    }
+
+    // Examine the rest of the cases.
+    if (control_mode->does_auto_throttle() && !throttle_suppressed) {
+        if (control_mode == &mode_auto) {
+            if (mission.get_current_nav_cmd().id == MAV_CMD_NAV_LAND) {
                 if (landing.is_commanded_go_around() || flight_stage == AP_FixedWing::FlightStage::ABORT_LANDING) {
                     // abort mode is sticky, it must complete while executing NAV_LAND
                     set_flight_stage(AP_FixedWing::FlightStage::ABORT_LANDING);

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -5654,13 +5654,26 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             "TKOFF_THR_IDLE": 20.0,
             "TKOFF_THR_MINSPD": 3.0,
         })
-        self.change_mode("TAKEOFF")
+        expected_idle_throttle = 1000+10*self.get_parameter("TKOFF_THR_IDLE")
 
+        self.upload_simple_relhome_mission([
+            (mavutil.mavlink.MAV_CMD_NAV_TAKEOFF, 0, 0, 30),
+            (mavutil.mavlink.MAV_CMD_NAV_LOITER_UNLIM, 0, 0, 30),
+        ])
+
+        self.change_mode("AUTO")
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+        # Ensure that the throttle rises to idle throttle.
+        self.assert_servo_channel_range(3, expected_idle_throttle-10, expected_idle_throttle+10)
+
+        self.disarm_vehicle()
+
+        self.change_mode("TAKEOFF")
         self.wait_ready_to_arm()
         self.arm_vehicle()
 
         # Ensure that the throttle rises to idle throttle.
-        expected_idle_throttle = 1000+10*self.get_parameter("TKOFF_THR_IDLE")
         self.assert_servo_channel_range(3, expected_idle_throttle-10, expected_idle_throttle+10)
 
         # Launch the catapult


### PR DESCRIPTION
### Summary

Always to go FlightStage::TAKEOFF when on AUTO-takeoff.
Done to fix `TKOFF_THR_IDLE` not applying when waiting with throttle suppressed.

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [X] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Extended the autotest to catch the problem. I rebased the test on top of https://github.com/ArduPilot/ardupilot/commit/19bce3b1 and observed that the feature was broken since the beginning.

I prefer this fix compared to https://github.com/ArduPilot/ardupilot/pull/33650, because it pushes the complexity in the FlightStage decision logic, and away from `servos.cpp`, which I consider "more frontend".

Now FlightStage goes to TAKEOFF when we switch to AUTO with a takeoff waypoint:
<img width="1363" height="925" alt="image" src="https://github.com/user-attachments/assets/fdb433c3-e2ae-4749-acff-a42be58aef51" />

and the throttle goes to idle when we arm:
<img width="1363" height="925" alt="image" src="https://github.com/user-attachments/assets/1f68c94b-4f83-4221-8c12-3938832cfe2e" />

FWIW, Claude verified that the order of operations and checks is preserved, except for an edge case which should not apply:

> The one residual (very narrow) new divergence: a suppressed fixed-wing auto takeoff (takeoff_complete == false) with the quadplane in in_assisted_flight() (Q_ASSIST) — original hit the bottom branch → VTOL; new gives TAKEOFF. This requires Q_ASSIST to trigger during the pre-launch throttle-suppressed phase, which is unlikely on the ground, and setting TAKEOFF there is arguably the more correct behavior anyway. Worth a mention in the PR description, but not a bug.
