### PR TITLE
AP_Mount: fix AlexMos yaw angle scaling

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Alexmos.cpp
+++ b/libraries/AP_Mount/AP_Mount_Alexmos.cpp
@@ -156,7 +156,7 @@ void AP_Mount_Alexmos::send_target_angles(const MountAngleTarget& angle_target_r
     outgoing_buffer.angle_speed.speed_pitch = DEGREE_PER_SEC_TO_VALUE(AP_MOUNT_ALEXMOS_SPEED);
     outgoing_buffer.angle_speed.angle_pitch = DEGREE_TO_VALUE(degrees(angle_target_rad.pitch));
     outgoing_buffer.angle_speed.speed_yaw = DEGREE_PER_SEC_TO_VALUE(AP_MOUNT_ALEXMOS_SPEED);
-    outgoing_buffer.angle_speed.angle_yaw = DEGREE_TO_VALUE(angle_target_rad.get_bf_yaw());
+    outgoing_buffer.angle_speed.angle_yaw = DEGREE_TO_VALUE(degrees(angle_target_rad.get_bf_yaw()));
     send_command(CMD_CONTROL, (uint8_t *)&outgoing_buffer.angle_speed, sizeof(alexmos_angles_speed));
 }
 


### PR DESCRIPTION
MountAngleTarget::get_bf_yaw() returns radians, while DEGREE_TO_VALUE expects degrees. Convert the body-frame yaw to degrees before encoding it, matching the roll and pitch handling.

### Summary

Fix the unit conversion applied to AlexMos yaw angle targets.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Tested on actual Alexmos hardware (connected to MatekH743)

### Description

`MountAngleTarget::get_bf_yaw()` returns the body-frame yaw angle in
radians, but the result is passed directly to `DEGREE_TO_VALUE()`,
which expects degrees.

Roll and pitch already convert their radian targets using `degrees()`.

As a result, AlexMos yaw angle commands are approximately 57.3 times
smaller than requested. For example, a 90-degree target is encoded as
approximately 1.57 degrees.

### Change

Convert the body-frame yaw target to degrees before passing it to
`DEGREE_TO_VALUE()`:

```cpp
DEGREE_TO_VALUE(degrees(angle_target_rad.get_bf_yaw()))