### PR TITLE
Tools: prefer hwdef over HAL name when splitting/relabelling commits

### DIFF
--- a/Tools/gittools/git-subsystems-split
+++ b/Tools/gittools/git-subsystems-split
@@ -186,6 +186,11 @@ class GitSubsystemsSplit(object):
         valid, otherwise the most specific shared subsystem.  Only when no
         shared subsystem exists are the paths split by primary subsystem.
 
+        'hwdef' is always preferred over a HAL library name (e.g.
+        AP_HAL_ChibiOS) when both are shared candidates, even if the HAL name
+        is already the declared prefix -- the deepest directory name is the
+        canonical tag for any libraries/<HAL>/hwdef/... change.
+
         returns (groups, unmatched).
         '''
         paths = [p for p in paths if p]
@@ -205,7 +210,9 @@ class GitSubsystemsSplit(object):
         for p in paths[1:]:
             common &= set(cand[p])
         if common:
-            if declared in common:
+            if 'hwdef' in common:
+                chosen = 'hwdef'
+            elif declared in common:
                 chosen = declared
             else:
                 chosen = next(s for s in cand[paths[0]] if s in common)

--- a/Tools/scripts/allowed_subsystems.py
+++ b/Tools/scripts/allowed_subsystems.py
@@ -209,9 +209,11 @@ class AllowedSubsystems(object):
                     return ['Tools']
                 return []
             lib = parts[1]
-            # libraries/<HAL>/hwdef/... belongs to hwdef as well as the HAL
+            # libraries/<HAL>/hwdef/... belongs to hwdef -- the deepest
+            # library directory name is the conventional tag, not the HAL
+            # itself -- but the HAL name is still accepted as a fallback.
             if len(parts) >= 4 and parts[2] == 'hwdef':
-                return [lib, 'hwdef']
+                return ['hwdef', lib]
             # allow special prefixes from SPECIAL_SUBSYSTEMS
             filename = parts[-1]
             for sub_prefix in self.SPECIAL_SUBSYSTEMS.get(lib, []):


### PR DESCRIPTION
libraries/<HAL>/hwdef/... changes were being tagged with the HAL library name (e.g. AP_HAL_ChibiOS) since it was listed before hwdef as a candidate subsystem, and an already-declared HAL name was treated as valid and left alone. Make hwdef -- the deepest directory in the path -- the canonical tag in both cases, since it applies uniformly across every HAL rather than being tied to one library. @andyp1per routinely flags this in his board reviews as a change required. This updates the user tool to correctly behave in accordance with his reviews.

todo: the Malformed commits CI check routinely lets unsplit commits (commits with multiple library changes) pass if they have any valid library name. Board contributors routinely do this and it passes CI. We really need to find a way to reject this.


### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [x ] Tested on lcoal branches
- [ ] Logs attached
- [ ] Logs available on request


