### PR TITLE
board_types：Reserve AIUAV-PlatFly-H7 board ID

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -462,6 +462,9 @@ AP_HW_SkyRukh_Surge_H7               2815
 AP_HW_KRSHKF7_MINI                   4000
 AP_HW_KARSHAKH743VTOL                4002
 
+# IDs 4100-4109 reserved for AIUAV
+AP_HW_AIUAV_PlatFly_H7               4100
+
 # IDs 4200-4220 reserved for HAKRC
 AP_HW_HAKRC_F405                     4200
 AP_HW_HAKRC_F405Wing                 4201


### PR DESCRIPTION
### Summary

Reserve board ID for AIUAV brand products, and also add a new board ID for the PlatFly H7 flight controller.

### Classification & Testing (check all that apply and add your own)

- [y ] Checked by a human programmer
- [y ] Non-functional change
- [y ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [y ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
