### PR TITLE
board_types: reserve ID for CORVON_G1 & CORVON_G2

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -441,6 +441,9 @@ AP_HW_HCR-551                        1960
 AP_HW_HCR-565                        1961
 AP_HW_HCR-566                        1962
 
+AP_HW_CORVON_G1                      1963
+AP_HW_CORVON_G2                      1964
+
 AP_HW_MFT-SEMA100                    2000
 
 AP_HW_SULILGH7-P1-P2                 2005

--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -453,6 +453,9 @@ AP_HW_HCR-551                        1960
 AP_HW_HCR-565                        1961
 AP_HW_HCR-566                        1962
 
+AP_HW_CORVON_G1                      1963
+AP_HW_CORVON_G2                      1964
+
 AP_HW_MFT-SEMA100                    2000
 
 AP_HW_SULILGH7-P1-P2                 2005


### PR DESCRIPTION
reserve IDs for CORVON G-series GNSS modules, thanks.