### PR TITLE
ModalAI VOXL3 packaging updates

### DIFF
--- a/libraries/AP_HAL_QURT/packaging/pkg/control/control.in
+++ b/libraries/AP_HAL_QURT/packaging/pkg/control/control.in
@@ -3,6 +3,6 @@ Version: FW_VERSION
 Section: devel
 Priority: optional
 Architecture: arm64
-Depends: modalai-slpi(>=1.1.19), libslpi-link
+Depends: modalai-slpi(>=1.2.3) | modalai-adsp(>=1.0.8), libslpi-link(>=1.0.2)
 Maintainer: Eric Katzfey <eric.katzfey@modalai.com>
 Description: ModalAI ArduPilot flight controller

--- a/libraries/AP_HAL_QURT/packaging/pkg/control/postinst
+++ b/libraries/AP_HAL_QURT/packaging/pkg/control/postinst
@@ -1,9 +1,17 @@
 #!/bin/bash
 
+# Detect the platform for platform-specific APM setup
+PLATFORM=$(/usr/bin/voxl-platform 2>/dev/null || true)
+
 # Create directory for APM use
 cd /data
 mkdir -p APM
-chown system:system APM
+
+if [ "$PLATFORM" = "M0197" ]; then
+    chown fastrpc:fastrpc APM
+else
+    chown system:system APM
+fi
 
 # Make sure the run scripts are executable
 cd /usr/bin


### PR DESCRIPTION
### Summary

A couple of tweaks to the packaging for ModalAI VOXL platforms to account for the upcoming VOXL3 board

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [ ] Non-functional change
- [X] No-binary change
- [X] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

The permissions on the APM directory for the VOXL3 board need to be set slightly different than for VOXL2.
Also, the dependencies for VOXL2 package installation are slightly different.
