### PR TITLE
AP_GPS: Fix compiler warning for pre-C++17 compilers

### DIFF
--- a/libraries/AP_GPS/AP_GPS_UBLOX.h
+++ b/libraries/AP_GPS/AP_GPS_UBLOX.h
@@ -744,7 +744,8 @@ private:
     };
 
 #if AP_GPS_UBLOX_CFGV2_ENABLED
-    #define UBLOX_GNSS_TYPE_ASSERT(NAME, INDEX) static_assert(AP_GPS_UBLOX::GNSS_##NAME == INDEX);
+    #define UBLOX_GNSS_TYPE_ASSERT(NAME, INDEX) \
+        static_assert(AP_GPS_UBLOX::GNSS_##NAME == INDEX, "GNSS_" #NAME " has incorrect index");
     UBLOX_GNSS(UBLOX_GNSS_TYPE_ASSERT)
     #undef UBLOX_GNSS_TYPE_ASSERT
 #endif


### PR DESCRIPTION
### Summary

When compiling for VOXL2 this warning is being generated a few times:

`../../libraries/AP_GPS/AP_GPS_UBLOX.h:748:16: warning: static_assert with no message is a C++17 extension [-Wc++17-extensions]
    UBLOX_GNSS(UBLOX_GNSS_TYPE_ASSERT)`

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [X] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Tested with ModalAI-VOXL2 build

### Description

Added an assert message to make it pre-c++17 compatible.

