### PR TITLE
Copter: auto mode fix to continue past RTL if rtl-final-descent non-zero

### DIFF
--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -2228,14 +2228,27 @@ bool ModeAuto::verify_loiter_to_alt() const
     return false;
 }
 
-// verify_RTL - handles any state changes required to implement RTL
+// verify_RTL - return true once RTL has completed successfully
 // do_RTL should have been called once first to initialise all variables
-// returns true with RTL has completed successfully
 bool ModeAuto::verify_RTL()
 {
-    return (copter.mode_rtl.state_complete() && 
-            (copter.mode_rtl.state() == ModeRTL::SubMode::FINAL_DESCENT || copter.mode_rtl.state() == ModeRTL::SubMode::LAND) &&
-            (motors->get_spool_state() == AP_Motors::SpoolState::GROUND_IDLE));
+    // return immediately if RTL's current state has not completed
+    if (!copter.mode_rtl.state_complete()) {
+        return false;
+    }
+
+    switch (copter.mode_rtl.state()) {
+        case ModeRTL::SubMode::FINAL_DESCENT:
+            return true;
+        case ModeRTL::SubMode::LAND:
+            // if landing ensure motors have spooled down
+            return motors->get_spool_state() == AP_Motors::SpoolState::GROUND_IDLE;
+        default:
+            break;
+    }
+
+    // RTL has not completed
+    return false;
 }
 
 /********************************************************************************/

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -13995,6 +13995,25 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.change_mode("LAND")
         self.wait_landed_and_disarmed()
 
+    def MissionRTLAltFinalContinue(self):
+        '''ensure AUTO mission can continue past a NAV_RETURN_TO_LAUNCH item
+        even if the vehicle holds altitude at RTL_ALT_FINAL_M'''
+        target_alt = 5
+        self.set_parameters({
+            "AUTO_OPTIONS": 3,
+            "RTL_ALT_FINAL_M": target_alt,
+        })
+        self.start_flying_simple_relhome_mission([
+            (mavutil.mavlink.MAV_CMD_NAV_TAKEOFF, 0, 0, 20),
+            (mavutil.mavlink.MAV_CMD_NAV_RETURN_TO_LAUNCH, 0, 0, 0),
+            (mavutil.mavlink.MAV_CMD_NAV_TAKEOFF, 0, 0, 20),
+            (mavutil.mavlink.MAV_CMD_NAV_LAND, 0, 0, 0),
+        ])
+
+        # ensure the vehicle reaches the LAND command instead of getting stuck at RTL
+        self.wait_current_waypoint(4, timeout=60)
+        self.wait_disarmed()
+
     def SMART_RTL(self):
         '''Check SMART_RTL'''
         self.progress("arm the vehicle and takeoff in Guided")
@@ -18796,6 +18815,7 @@ return update, 1000
             self.EKFYawResetLogged,
             self.AP_Avoidance,
             self.RTL_ALT_FINAL_M,
+            self.MissionRTLAltFinalContinue,
             self.SMART_RTL,
             self.MAV_CMD_DO_SET_HOME_bad_location,
             self.SMART_RTL_EnterLeave,


### PR DESCRIPTION
### Summary

This resolves issue https://github.com/ArduPilot/ardupilot/issues/33796 by correcting Auto mode's verify_RTL function.  Previously it always required that the spool state get to GROUND_IDLE (e.g. the motors have spooled down) but this is of course incorrect when RTL has been configured so that it won't land (e.g. RTL_ALT_FINAL_M > 0)

I've lightly tested this in SITL to confirm that Auto mode correctly proceeds on to the next command even if RTL_ALT_FINAL_M = 0 o 2.

Here is the BEFORE test:
<img width="832" height="751" alt="sitl-test-image" src="https://github.com/user-attachments/assets/83e72977-5a7e-46d3-b515-636baa16eae4" />

Here is the AFTER test:
<img width="816" height="617" alt="sitl-test-image-fixed" src="https://github.com/user-attachments/assets/35378f9b-b97d-4457-9997-1e2376f6e1c8" />



### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description **above** (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request