### PR TITLE
AP_HAL_ChibiOS: report offset and value of low memory writes

### DIFF
--- a/libraries/AP_HAL_ChibiOS/Scheduler.cpp
+++ b/libraries/AP_HAL_ChibiOS/Scheduler.cpp
@@ -604,11 +604,33 @@ void Scheduler::check_low_memory_is_zero()
         // read using assembly so we don't invoke UB dereferencing nullptr
         __asm__("\tldr %0, [%1]\n\t" : "=r"(val) : "r"(addr));
         if (val != 0) {
+            // report before AP_memory_guard_error(), which does not
+            // return when we are disarmed
+            report_low_memory_write(uint16_t(addr), val);
             // re-use memory guard internal error
             AP_memory_guard_error(1023);
             break;
         }
     }
+}
+
+/*
+  report a write into the reserved low memory region.  The offset is
+  the offset from a nullptr base which was written through, and the
+  value is the data which was written; together these narrow down the
+  code responsible.  We do not clear the region, so we only report a
+  given value once to avoid repeating the same message on every check
+ */
+void Scheduler::report_low_memory_write(uint16_t offset, uint32_t value)
+{
+    if (offset == last_low_memory_offset && value == last_low_memory_value) {
+        return;
+    }
+    last_low_memory_offset = offset;
+    last_low_memory_value = value;
+
+    GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "low memory write 0x%03x=0x%08x",
+                  unsigned(offset), unsigned(value));
 }
 #endif // MEMCHECK_ENABLED
 

--- a/libraries/AP_HAL_ChibiOS/Scheduler.h
+++ b/libraries/AP_HAL_ChibiOS/Scheduler.h
@@ -198,6 +198,12 @@ private:
 
 #if MEMCHECK_ENABLED
     void check_low_memory_is_zero();
+    void report_low_memory_write(uint16_t offset, uint32_t value);
+
+    // last write reported in the reserved low memory region, used to
+    // avoid repeating the same message on every check
+    uint16_t last_low_memory_offset;
+    uint32_t last_low_memory_value;
 #endif
 
     // check for free stack space


### PR DESCRIPTION
### Summary

Adds a statustext-send with more information about low-memory writes

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
HOLD> nullptr_write IREALLYMEANIT
HOLD> Sending nullptr-deref-write command
Got COMMAND_ACK: PREFLIGHT_REBOOT_SHUTDOWN: ACCEPTED
memory guard size=1023memory guard error size=1023

AP: low memory write 0x004=0x0000AB00
AP: Internal Errors 0x4000020
AP: PreArm: Hardware safety switch
AP: PreArm: 3D Accel calibration needed
AP: PreArm: Compass not calibrated
AP: PreArm: Battery 1 unhealthy
AP: PreArm: Radio failsafe on
AP: PreArm: Internal errors 0x4000020 l:330 panic,mem_guard
memory guard size=1023
memory guard size=1023
memory guard size=1023
memory guard size=1023
memory guard size=1023
memory guard size=1023
memory guard size=1023
memory guard size=1023
memory guard size=1023
memory guard size=1023
memory guard size=1023
memory guard size=1023
```


### Description

the low memory check tells us that something wrote through a bad pointer, but not what.  Send a statustext with the offset from nullptr and the value found there; the offset is the member offset and the value is the data written, which together narrow down the culprit.

the region is not cleared, so only report a given value once to avoid repeating the same message on every check.


(A larger change might change the whole "pass size through to the memory-guard-check function" so the repeated message shows more information?)
