### PR TITLE
GCS_MAVLink: correct diagnostic pop typo

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3635,7 +3635,7 @@ MAV_RESULT GCS_MAVLINK::handle_preflight_reboot(const mavlink_command_int_t &pac
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
 #endif
             send_text(MAV_SEVERITY_INFO, "x: %u", (unsigned)*foo);
-#pragma GCSS diagnostic pop
+#pragma GCC diagnostic pop
 
             return MAV_RESULT_ACCEPTED;
         }


### PR DESCRIPTION
### Summary

corrects typo in gcc diagnostic pop - so re-enables the stringop-overflow for the rest of the file

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                 *
Durandal                            *               *      *           *       *                 *      *      *
Hitec-Airspeed           *                                 *
KakuteH7-bdshot                     *               *      *           *       *                 *      *      *
MatekF405                           *               *      *           *       *                 *      *      *
Pixhawk1-1M-bdshot                  *               *                  *       *                 *      *      *
SITL_x86_64_linux_gnu               *               *                  *       *                 *      *      *
YJUAV_A6SE                          *               *      *           *       *                 *      *      *
f103-QiotekPeriph        *                                 *
f303-MatekGPS            *                                 *
f303-Universal           *                                 *
iomcu                                                                                *
revo-mini                           *               *      *           *       *                 *      *      *
skyviper-v2450                                                         *
speedybeef4                         *               *      *           *       *                 *      *      *
```

### Description

this would leave stringop-overflow unpopped for the rest of the compilation unit
