### PR TITLE
Make your-commit-messages-suck error message clearer in CI

### DIFF
--- a/Tools/scripts/build_script_base.py
+++ b/Tools/scripts/build_script_base.py
@@ -22,6 +22,7 @@ import time
 from abc import ABC
 from abc import abstractmethod
 
+import allowed_subsystems
 import board_list
 
 # map from vehicle names to binary names
@@ -53,6 +54,9 @@ class BuildScriptBase(ABC):
         if self._bootloader_blacklist is None:
             self._bootloader_blacklist = self.make_bootloader_blacklist()
         return self._bootloader_blacklist
+
+    # populated on first use by get_allowed_subsystems()
+    _allowed_subsystems = None
 
     def __init__(self, progress_file=None):
         self.tmpdir = None  # Can be set by subclasses that need it
@@ -398,6 +402,42 @@ class BuildScriptBase(ABC):
             if parts[0] == 'libraries' and len(parts) >= 3:
                 created.add(parts[1])
         return created
+
+    def get_allowed_subsystems(self):
+        '''return an AllowedSubsystems for this repository, created on first
+        use and cached thereafter'''
+        if self._allowed_subsystems is None:
+            repo_root = self.run_git(
+                ['rev-parse', '--show-toplevel'], show_output=False,
+            ).strip()
+            self._allowed_subsystems = allowed_subsystems.AllowedSubsystems(repo_root)
+        return self._allowed_subsystems
+
+    def subsystem_for_commit(self, commit: str) -> str | None:
+        '''return the subsystem the given commit belongs to, or None if its
+        changed files do not all resolve to one common subsystem'''
+        subsystems = self.get_allowed_subsystems()
+        common = None
+        ordering = []
+        for path in self.get_changed_paths_for_commit(commit):
+            candidates = subsystems.subsystems_for_path(path)
+            if not candidates:
+                return None
+            if common is None:
+                # the first path's ordering decides which of several shared
+                # candidates is the most conventional one to name
+                ordering = candidates
+                common = set(candidates)
+            else:
+                common &= set(candidates)
+            if not common:
+                return None
+        if not common:
+            return None
+        for name in ordering:
+            if name in common:
+                return name
+        return None
 
     def run_waf(self, args, compiler=None, show_output=True, source_dir=None):
         # try to modify the environment so we can consistent builds:

--- a/Tools/scripts/build_script_base.py
+++ b/Tools/scripts/build_script_base.py
@@ -22,6 +22,7 @@ import time
 from abc import ABC
 from abc import abstractmethod
 
+import allowed_subsystems
 import board_list
 
 # map from vehicle names to binary names
@@ -41,6 +42,9 @@ VEHICLE_MAP = {
 
 class BuildScriptBase(ABC):
     """Base class for build scripts with common utilities for running programs"""
+
+    # populated on first use by get_allowed_subsystems()
+    _allowed_subsystems = None
 
     def __init__(self, progress_file=None):
         self.tmpdir = None  # Can be set by subclasses that need it
@@ -399,6 +403,42 @@ class BuildScriptBase(ABC):
             if parts[0] == 'libraries' and len(parts) >= 3:
                 created.add(parts[1])
         return created
+
+    def get_allowed_subsystems(self):
+        '''return an AllowedSubsystems for this repository, created on first
+        use and cached thereafter'''
+        if self._allowed_subsystems is None:
+            repo_root = self.run_git(
+                ['rev-parse', '--show-toplevel'], show_output=False,
+            ).strip()
+            self._allowed_subsystems = allowed_subsystems.AllowedSubsystems(repo_root)
+        return self._allowed_subsystems
+
+    def subsystem_for_commit(self, commit: str) -> str | None:
+        '''return the subsystem the given commit belongs to, or None if its
+        changed files do not all resolve to one common subsystem'''
+        subsystems = self.get_allowed_subsystems()
+        common = None
+        ordering = []
+        for path in self.get_changed_paths_for_commit(commit):
+            candidates = subsystems.subsystems_for_path(path)
+            if not candidates:
+                return None
+            if common is None:
+                # the first path's ordering decides which of several shared
+                # candidates is the most conventional one to name
+                ordering = candidates
+                common = set(candidates)
+            else:
+                common &= set(candidates)
+            if not common:
+                return None
+        if not common:
+            return None
+        for name in ordering:
+            if name in common:
+                return name
+        return None
 
     def run_waf(self, args, compiler=None, show_output=True, source_dir=None):
         # try to modify the environment so we can consistent builds:

--- a/Tools/scripts/build_script_base.py
+++ b/Tools/scripts/build_script_base.py
@@ -377,6 +377,19 @@ class BuildScriptBase(ABC):
         )
         return [line.strip() for line in output.splitlines() if line.strip()]
 
+    def get_changed_paths_for_commit(self, commit: str) -> list:
+        '''return the list of paths changed in a single commit'''
+        output = self.run_git(
+            ['diff-tree', '--no-commit-id', '-r', '--name-only', commit],
+            show_output=False,
+        )
+        paths = []
+        for line in output.splitlines():
+            line = line.strip()
+            if line:
+                paths.append(line)
+        return paths
+
     def created_library_dirs(self, commit: str) -> set:
         '''libraries/<X> subsystem names introduced by files added in commit'''
         created = set()

--- a/Tools/scripts/build_script_base.py
+++ b/Tools/scripts/build_script_base.py
@@ -378,6 +378,19 @@ class BuildScriptBase(ABC):
         )
         return [line.strip() for line in output.splitlines() if line.strip()]
 
+    def get_changed_paths_for_commit(self, commit: str) -> list:
+        '''return the list of paths changed in a single commit'''
+        output = self.run_git(
+            ['diff-tree', '--no-commit-id', '-r', '--name-only', commit],
+            show_output=False,
+        )
+        paths = []
+        for line in output.splitlines():
+            line = line.strip()
+            if line:
+                paths.append(line)
+        return paths
+
     def created_library_dirs(self, commit: str) -> set:
         '''libraries/<X> subsystem names introduced by files added in commit'''
         created = set()

--- a/Tools/scripts/check_branch_conventions.py
+++ b/Tools/scripts/check_branch_conventions.py
@@ -268,19 +268,6 @@ class CheckBranchConventions(build_script_base.BuildScriptBase):
                     result[name_to_path[name]] = parts[1]
         return result
 
-    def get_changed_paths_for_commit(self, commit: str) -> list:
-        '''return the list of paths changed in a single commit'''
-        output = self.run_git(
-            ['diff-tree', '--no-commit-id', '-r', '--name-only', commit],
-            show_output=False,
-        )
-        paths = []
-        for line in output.splitlines():
-            line = line.strip()
-            if line:
-                paths.append(line)
-        return paths
-
     def check_submodule_isolation(self) -> bool:
         '''check that each submodule update is isolated in its own commit'''
         submodule_paths = self.get_submodule_paths()

--- a/Tools/scripts/check_branch_conventions.py
+++ b/Tools/scripts/check_branch_conventions.py
@@ -28,7 +28,6 @@ import sys
 import urllib.error
 import urllib.request
 
-import allowed_subsystems
 import build_script_base
 
 DOCS_URL = "https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html"
@@ -114,10 +113,19 @@ class CheckBranchConventions(build_script_base.BuildScriptBase):
             if not line.strip():
                 continue
             # strip leading hash from --oneline format
-            subject = line.split(" ", 1)[1] if " " in line else line
+            sha, separator, subject = line.partition(" ")
+            if not separator:
+                sha, subject = "", line
             if ":" not in subject:
-                print(f"{FAIL} Commit is missing subsystem prefix: {line}")
-                print(f"       Reword to e.g. 'AP_Compass: {subject}'")
+                suggestion = self.subsystem_for_commit(sha) if sha else None
+                print(f"{FAIL} Commit message subject is missing its subsystem prefix: {line}")
+                print("       (this is about the git commit message, not the pull request title)")
+                if suggestion is not None:
+                    print(f"       Reword the commit message to: '{suggestion}: {subject}'")
+                else:
+                    print(f"       Reword the commit message to e.g. 'AP_Compass: {subject}'")
+                print("       Use 'git commit --amend' for the most recent commit, "
+                      "'git rebase -i' for an older one.")
                 print(f"       See: {DOCS_URL}")
                 ok = False
                 continue
@@ -140,10 +148,7 @@ class CheckBranchConventions(build_script_base.BuildScriptBase):
            - the declared prefix is in the allowed-subsystem list, and
            - every file changed in the commit belongs to that subsystem.
         '''
-        repo_root = self.run_git(
-            ['rev-parse', '--show-toplevel'], show_output=False,
-        ).strip()
-        subsystems = allowed_subsystems.AllowedSubsystems(repo_root)
+        subsystems = self.get_allowed_subsystems()
         commits_raw = self.run_git(
             ['log', f'{self.base_branch}..HEAD', '--reverse',
              '--pretty=format:%H %s'],


### PR DESCRIPTION
### Summary

Tries to make the error message presented on bad commit prefix clearer

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
  Testing — built six throwaway prefix-less commits, ran the checker against
  them, then git reset --hard them away:

  ┌────────────────────────────────────────────────────┬────────────────────┐
  │                   commit touches                   │     suggested      │
  ├────────────────────────────────────────────────────┼────────────────────┤
  │ libraries/AP_GPS/AP_GPS.cpp                        │ AP_GPS:            │
  ├────────────────────────────────────────────────────┼────────────────────┤
  │                                                    │ autotest:          │
  │ Tools/autotest/arducopter.py                       │ (preferred over    │
  │                                                    │ Tools)             │
  ├────────────────────────────────────────────────────┼────────────────────┤
  │                                                    │ AP_HAL_ChibiOS:    │
  │ libraries/AP_HAL_ChibiOS/hwdef/Pixhawk1/hwdef.dat  │ (preferred over    │
  │                                                    │ hwdef)             │
  ├────────────────────────────────────────────────────┼────────────────────┤
  │ Tools/autotest/arduplane.py +                      │ Tools: (the shared │
  │ Tools/scripts/build_ci.sh                          │  candidate)        │
  ├────────────────────────────────────────────────────┼────────────────────┤
  │ libraries/AP_GPS/AP_GPS.h + ArduPlane/Plane.h      │ falls back to e.g. │
  │                                                    │  'AP_Compass:'     │
  ├────────────────────────────────────────────────────┼────────────────────┤
  │ unmapped zzz_unmapped/f.txt                        │ falls back to e.g. │
  │                                                    │  'AP_Compass:'     │
  └────────────────────────────────────────────────────┴────────────────────┘

```

### Description

Adjusts the error message to give a likely-looking subsystem rather than the static "AP_Compass".

Also rewords things to try to make it clear we're talking about the commit message - not the PR title.  We're *still* not clear enough on the subject.
