### PR TITLE
Correct Topotek handling of network connections

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -7838,6 +7838,41 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.mount_test_body(pitch_rc_neutral=1818, do_rate_tests=False,
                              constrain_sysid_target=False)
 
+    def MountTopotekNetwork(self):
+        '''test Topotek gimbal connected via a network port rather than a serial port'''
+        self.set_parameters({
+            "MNT1_TYPE": 12,      # Topotek
+            "CAM1_TYPE": 4,       # Mount
+            "NET_ENABLE": 1,
+            "NET_P1_TYPE": 3,     # TCP client
+            "NET_P1_PROTOCOL": 8,  # gimbal
+            "NET_P1_IP0": 127,
+            "NET_P1_IP1": 0,
+            "NET_P1_IP2": 0,
+            "NET_P1_IP3": 1,
+            "NET_P1_PORT": 15005,
+        })
+        # the simulated gimbal listens on a TCP socket rather than
+        # being attached to one of the autopilot's serial ports:
+        self.customise_SITL_commandline(["--net-device=topotek:15005"])
+        # the gimbal sends its replies out of the interface named in the
+        # address field of our requests, so this only works if the
+        # driver tells the gimbal we are talking to it over the network
+        self.mount_check_camera_information(
+            "Topotek", "SIM_TP",
+            expected_fw_version=1,
+            expected_cap_flags=0x6C3,
+        )
+        # command an angle and check the gimbal reports reaching it,
+        # which requires traffic in both directions:
+        self.set_mount_mode(mavutil.mavlink.MAV_MOUNT_MODE_MAVLINK_TARGETING)
+        self.run_cmd(
+            mavutil.mavlink.MAV_CMD_DO_MOUNT_CONTROL,
+            p1=-30,  # pitch angle in degrees
+            p7=mavutil.mavlink.MAV_MOUNT_MODE_MAVLINK_TARGETING,
+        )
+        self.wait_mount_roll_pitch_yaw_deg(p=-30)
+
     def MountViewPro(self):
         '''test Viewpro gimbal using SIM_Viewpro simulator'''
         self.set_parameters({
@@ -18677,6 +18712,7 @@ return update, 1000
             self.LuaCopterCircleSpeed,
             self.TakeoffWithLocation,
             self.MountTopotek,
+            self.MountTopotekNetwork,
             self.MountViewPro,
             self.MountAVTCM62,
             self.MountAVTCM62Dual,

--- a/libraries/AP_HAL/UARTDriver.h
+++ b/libraries/AP_HAL/UARTDriver.h
@@ -164,6 +164,19 @@ public:
      */
     virtual bool is_dma_enabled() const { return false; }
 
+    /*
+      return true if this port carries its data over a network
+      connection (e.g. a NET_Pn port) rather than over a physical
+      serial port.
+
+      If you are calling this you are probably doing something wrong;
+      users of a port should be agnostic as to how the bytes reach the
+      other end.  It exists only for the rare device whose protocol
+      itself cares - e.g. a gimbal which is told which of its own
+      interfaces to send its replies out of.
+     */
+    virtual bool is_network_port() const { return false; }
+
 #if HAL_UART_STATS_ENABLED
     // Helper to keep track of data usage since last call
     struct StatsTracker {

--- a/libraries/AP_HAL_SITL/SITL_State_common.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State_common.cpp
@@ -349,11 +349,53 @@ SITL::SerialDevice *SITL_State_Common::create_serial_sim(const char *name, const
     AP_HAL::panic("unknown simulated device: %s", name);
 }
 
+#if AP_SIM_SERIALDEVICE_NETWORK_ENABLED
+/*
+  create a simulated device which the autopilot connects to over TCP
+  rather than over one of its simulated serial ports.  This is used to
+  simulate devices attached to the autopilot's network ports (NET_Pn).
+  spec is of the form NAME:TCPPORT e.g. "topotek:15005"
+ */
+void SITL_State_Common::create_net_serial_sim(const char *spec)
+{
+    if (num_net_serial_sims >= ARRAY_SIZE(net_serial_sims)) {
+        AP_HAL::panic("Too many network-attached simulated devices");
+    }
+
+    char *s = strdup(spec);
+    if (s == nullptr) {
+        AP_HAL::panic("out of memory");
+    }
+    char *saveptr = nullptr;
+    const char *name = strtok_r(s, ":", &saveptr);
+    const char *port_str = strtok_r(nullptr, ":", &saveptr);
+    if (name == nullptr || port_str == nullptr) {
+        AP_HAL::panic("Bad network device (%s); expected NAME:TCPPORT", spec);
+    }
+
+    SITL::SerialDevice *device = create_serial_sim(name, nullptr, 0);
+    if (!device->listen_on_tcp_port(atoi(port_str))) {
+        AP_HAL::panic("Failed to attach %s to TCP port %s", name, port_str);
+    }
+    net_serial_sims[num_net_serial_sims++] = device;
+
+    free(s);
+}
+#endif  // AP_SIM_SERIALDEVICE_NETWORK_ENABLED
+
 /*
   update simulators
  */
 void SITL_State_Common::sim_update(void)
 {
+#if AP_SIM_SERIALDEVICE_NETWORK_ENABLED
+    // move data between the autopilot and any device attached via TCP;
+    // for serially-attached devices the SITL UART driver does this:
+    for (uint8_t i=0; i<num_net_serial_sims; i++) {
+        net_serial_sims[i]->network_update();
+    }
+#endif  // AP_SIM_SERIALDEVICE_NETWORK_ENABLED
+
 #if AP_SIM_SOLOGIMBAL_ENABLED
     if (gimbal != nullptr) {
         gimbal->update(*sitl_model);

--- a/libraries/AP_HAL_SITL/SITL_State_common.h
+++ b/libraries/AP_HAL_SITL/SITL_State_common.h
@@ -84,6 +84,13 @@ public:
     // name parameter
     SITL::SerialDevice *create_serial_sim(const char *name, const char *arg, const uint8_t portNumber);
 
+#if AP_SIM_SERIALDEVICE_NETWORK_ENABLED
+    // create a simulated device which the autopilot connects to over
+    // TCP rather than over a simulated serial port; spec is of the
+    // form NAME:TCPPORT e.g. "topotek:15005"
+    void create_net_serial_sim(const char *spec);
+#endif  // AP_SIM_SERIALDEVICE_NETWORK_ENABLED
+
     // simulated airspeed, sonar and battery monitor
     float sonar_pin_voltage;    // pin 0
     float airspeed_pin_voltage[AIRSPEED_MAX_SENSORS]; // pin 1
@@ -209,6 +216,13 @@ public:
 
     // Simulated ELRS radio
     SITL::ELRS *elrs;
+
+#if AP_SIM_SERIALDEVICE_NETWORK_ENABLED
+    // simulated devices attached to the autopilot via TCP rather than
+    // via a simulated serial port:
+    SITL::SerialDevice *net_serial_sims[4];
+    uint8_t num_net_serial_sims;
+#endif  // AP_SIM_SERIALDEVICE_NETWORK_ENABLED
 
     // returns a voltage between 0V to 5V which should appear as the
     // voltage from the sensor

--- a/libraries/AP_HAL_SITL/SITL_cmdline.cpp
+++ b/libraries/AP_HAL_SITL/SITL_cmdline.cpp
@@ -108,6 +108,7 @@ void SITL_State::_usage(void)
            "\t--serial8 device         set device string for SERIAL8\n"
            "\t--serial9 device         set device string for SERIAL9\n"
            "\t--uartA device           alias for --serial0 (do not use)\n"
+           "\t--net-device NAME:PORT   attach simulated device NAME to TCP port PORT rather than to a serial port\n"
            "\t--base-port PORT         set port num for base port(default 5670) must be before -I option\n"
            "\t--rc-in-port PORT        set port num for rc in\n"
            "\t--sim-address ADDR       set address string for simulator\n"
@@ -264,6 +265,12 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
     _irlock_port = IRLOCK_PORT;
     struct AP_Param::defaults_table_struct temp_cmdline_param{};
 
+#if AP_SIM_SERIALDEVICE_NETWORK_ENABLED
+    // NAME:TCPPORT strings from --net-device options:
+    const char *net_device_strings[4];
+    uint8_t num_net_device_strings = 0;
+#endif  // AP_SIM_SERIALDEVICE_NETWORK_ENABLED
+
     // Set default start time to the real system time.
     // This will be overwritten if argument provided.
     static struct timeval first_tv;
@@ -296,6 +303,9 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
         CMDLINE_SERIAL7,
         CMDLINE_SERIAL8,
         CMDLINE_SERIAL9,
+#if AP_SIM_SERIALDEVICE_NETWORK_ENABLED
+        CMDLINE_NET_DEVICE,
+#endif  // AP_SIM_SERIALDEVICE_NETWORK_ENABLED
         CMDLINE_BASE_PORT,
         CMDLINE_RCIN_PORT,
         CMDLINE_SIM_ADDRESS,
@@ -358,6 +368,9 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
         {"serial7",         true,   0, CMDLINE_SERIAL7},
         {"serial8",         true,   0, CMDLINE_SERIAL8},
         {"serial9",         true,   0, CMDLINE_SERIAL9},
+#if AP_SIM_SERIALDEVICE_NETWORK_ENABLED
+        {"net-device",      true,   0, CMDLINE_NET_DEVICE},
+#endif  // AP_SIM_SERIALDEVICE_NETWORK_ENABLED
         {"base-port",       true,   0, CMDLINE_BASE_PORT},
         {"rc-in-port",      true,   0, CMDLINE_RCIN_PORT},
         {"sim-address",     true,   0, CMDLINE_SIM_ADDRESS},
@@ -515,6 +528,17 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
         case CMDLINE_SERIAL9:
             _serial_path[opt - CMDLINE_SERIAL0] = gopt.optarg;
             break;
+#if AP_SIM_SERIALDEVICE_NETWORK_ENABLED
+        case CMDLINE_NET_DEVICE:
+            // the simulated device is created below, once the vehicle
+            // model it may attach itself to exists
+            if (num_net_device_strings >= ARRAY_SIZE(net_device_strings)) {
+                printf("Too many --net-device options\n");
+                exit(1);
+            }
+            net_device_strings[num_net_device_strings++] = gopt.optarg;
+            break;
+#endif  // AP_SIM_SERIALDEVICE_NETWORK_ENABLED
         case CMDLINE_BASE_PORT:
             _base_port = atoi(gopt.optarg);
             break;
@@ -645,6 +669,15 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
         printf("Vehicle model (%s) not found\n", model_str);
         exit(1);
     }
+
+#if AP_SIM_SERIALDEVICE_NETWORK_ENABLED
+    // create devices which the autopilot connects to over the network
+    // rather than over a serial port.  This is done here as some
+    // devices attach themselves to the vehicle model:
+    for (uint8_t i=0; i<num_net_device_strings; i++) {
+        create_net_serial_sim(net_device_strings[i]);
+    }
+#endif  // AP_SIM_SERIALDEVICE_NETWORK_ENABLED
 
     if (storage_posix_enabled && storage_flash_enabled) {
         // this will change in the future!

--- a/libraries/AP_Mount/AP_Mount_Topotek.cpp
+++ b/libraries/AP_Mount/AP_Mount_Topotek.cpp
@@ -1092,7 +1092,7 @@ bool AP_Mount_Topotek::send_variablelen_packet(HeaderType header, AddressByte ad
     send_buff[send_buff_ofs++] = (header == HeaderType::FIXED_LEN) ? 'P' : 'p';
 
     // address (bytes 3, 4)
-    send_buff[send_buff_ofs++] = (uint8_t)AddressByte::UART;
+    send_buff[send_buff_ofs++] = (uint8_t)source_address();
     send_buff[send_buff_ofs++] = (uint8_t)address;
 
     // data length (byte 5)

--- a/libraries/AP_Mount/AP_Mount_Topotek.h
+++ b/libraries/AP_Mount/AP_Mount_Topotek.h
@@ -239,6 +239,15 @@ private:
     // gimbal distance information analysis
     void gimbal_dist_info_analyse();
 
+    // return the address to send as the source of our packets.  The
+    // gimbal sends its replies out of the interface named here, so this
+    // must be the interface we are actually connected to.  This is one
+    // of the few places it is legitimate to ask a port how it is
+    // connected; the protocol itself carries that information
+    AddressByte source_address() const {
+        return _uart->is_network_port() ? AddressByte::NETWORK : AddressByte::UART;
+    }
+
     // calculate checksum
     uint8_t calculate_crc(const uint8_t *cmd, uint8_t len) const;
 

--- a/libraries/AP_Networking/AP_Networking.h
+++ b/libraries/AP_Networking/AP_Networking.h
@@ -257,6 +257,9 @@ private:
         bool tx_pending() override {
             return false;
         }
+        bool is_network_port() const override {
+            return true;
+        }
 
         void udp_client_init(void);
         void udp_server_init(void);

--- a/libraries/SITL/SIM_SerialDevice.cpp
+++ b/libraries/SITL/SIM_SerialDevice.cpp
@@ -31,6 +31,9 @@ SerialDevice::SerialDevice(uint16_t tx_bufsize, uint16_t rx_bufsize)
 {
     to_autopilot = NEW_NOTHROW ByteBuffer{tx_bufsize};
     from_autopilot = NEW_NOTHROW ByteBuffer{rx_bufsize};
+    // devices attached to a simulated serial port have this set when
+    // the autopilot opens that port:
+    autopilot_baud = 0;
 }
 
 bool SerialDevice::init_sitl_pointer()
@@ -134,6 +137,82 @@ ssize_t SerialDevice::write_to_device(const char *buffer, const size_t size) con
     const ssize_t ret = from_autopilot->write((uint8_t*)buffer, size);
     return ret;
 }
+
+#if AP_SIM_SERIALDEVICE_NETWORK_ENABLED
+/*
+  attach this device to a TCP server socket.  The autopilot connects to
+  this socket (e.g. with a NET_Pn port configured as a TCP client)
+  instead of talking to the device over a simulated serial port
+ */
+bool SerialDevice::listen_on_tcp_port(const uint16_t port)
+{
+    listener = NEW_NOTHROW SocketAPM_native(false);
+    if (listener == nullptr) {
+        return false;
+    }
+    listener->reuseaddress();
+    if (!listener->bind("127.0.0.1", port) ||
+        !listener->listen(1) ||
+        !listener->set_blocking(false)) {
+        ::fprintf(stderr, "SIM: failed to listen on TCP port %u: %m\n", unsigned(port));
+        delete listener;
+        listener = nullptr;
+        return false;
+    }
+    ::printf("SIM: device listening for autopilot on TCP port %u\n", unsigned(port));
+    return true;
+}
+
+/*
+  move bytes between the network socket and this device.  This performs
+  the same role the SITL UART driver performs for serially-attached
+  devices
+ */
+void SerialDevice::network_update()
+{
+    if (listener == nullptr) {
+        // not attached to a socket
+        return;
+    }
+
+    if (sock == nullptr) {
+        sock = listener->accept(0);
+        if (sock == nullptr) {
+            return;
+        }
+        sock->set_blocking(false);
+    }
+
+    char buffer[512];
+
+    // device to autopilot:
+    while (true) {
+        const ssize_t nread = read_from_device(buffer, sizeof(buffer));
+        if (nread <= 0) {
+            break;
+        }
+        if (sock->send(buffer, nread) != nread) {
+            // if the autopilot is not keeping up we simply drop the data
+            break;
+        }
+    }
+
+    // autopilot to device:
+    while (true) {
+        const ssize_t nread = sock->recv(buffer, sizeof(buffer), 0);
+        if (nread == 0) {
+            // autopilot closed the connection; wait for it to reconnect
+            delete sock;
+            sock = nullptr;
+            return;
+        }
+        if (nread < 0) {
+            break;
+        }
+        write_to_device(buffer, nread);
+    }
+}
+#endif  // AP_SIM_SERIALDEVICE_NETWORK_ENABLED
 
 /**
  * baudrates match

--- a/libraries/SITL/SIM_SerialDevice.h
+++ b/libraries/SITL/SIM_SerialDevice.h
@@ -18,8 +18,14 @@
 
 #pragma once
 
+#include "SIM_config.h"
+
 #include <unistd.h>
 #include <AP_HAL/utility/RingBuffer.h>
+
+#if AP_SIM_SERIALDEVICE_NETWORK_ENABLED
+#include <AP_HAL/utility/Socket_native.h>
+#endif  // AP_SIM_SERIALDEVICE_NETWORK_ENABLED
 
 namespace SITL {
 
@@ -39,6 +45,24 @@ public:
     virtual ssize_t write_to_autopilot(const char *buffer, size_t size) const;
     virtual uint32_t device_baud() const { return 0; }  // 0 meaning unset
 
+#if AP_SIM_SERIALDEVICE_NETWORK_ENABLED
+    // attach this device to a TCP server socket rather than to a
+    // simulated serial port.  This simulates a device which the
+    // autopilot reaches over the network (e.g. via a NET_Pn port)
+    // rather than over one of its serial ports.  Returns true on success
+    bool listen_on_tcp_port(uint16_t port) WARN_IF_UNUSED;
+
+    // true if this device is attached to the autopilot via a network
+    // socket rather than via a simulated serial port
+    bool is_network_attached() const { return listener != nullptr; }
+
+    // move bytes between the network socket and this device.  Does
+    // nothing if the device is not attached to a socket
+    void network_update();
+#else
+    bool is_network_attached() const { return false; }
+#endif  // AP_SIM_SERIALDEVICE_NETWORK_ENABLED
+
 protected:
 
     class SIM *_sitl;
@@ -52,7 +76,14 @@ private:
 
     bool is_match_baud(void) const;
 
+    // baudrate the autopilot has this device open at; zero if the
+    // device is not attached to a simulated serial port
     uint32_t autopilot_baud;
+
+#if AP_SIM_SERIALDEVICE_NETWORK_ENABLED
+    SocketAPM_native *listener = nullptr;  // socket the autopilot connects to, nullptr if serially attached
+    SocketAPM_native *sock = nullptr;      // socket to the connected autopilot, nullptr if not connected
+#endif  // AP_SIM_SERIALDEVICE_NETWORK_ENABLED
 
     ssize_t corrupt_transfer(char *buffer, const ssize_t ret, const size_t size) const;
 };

--- a/libraries/SITL/SIM_Topotek.cpp
+++ b/libraries/SITL/SIM_Topotek.cpp
@@ -179,6 +179,10 @@ void Topotek::handle_packet(uint8_t data_len)
         return;
     }
 
+    // byte [3] is the source address of the sender; replies (including
+    // the attitude stream) are sent to that address from now on
+    _reply_address = _buf[3];
+
     // ID is at bytes [7..9]
     const char *id = (const char*)&_buf[7];
 
@@ -236,7 +240,7 @@ void Topotek::send_packet(char addr2, const char id[3], bool write, const uint8_
     pkt[ofs++] = '#';
     pkt[ofs++] = 'T';
     pkt[ofs++] = 'P';
-    pkt[ofs++] = 'U';
+    pkt[ofs++] = _reply_address;
     pkt[ofs++] = (uint8_t)addr2;
     pkt[ofs++] = hex2char(len & 0x0f);   // data length as single ASCII hex char
     pkt[ofs++] = write ? 'w' : 'r';
@@ -252,6 +256,12 @@ void Topotek::send_packet(char addr2, const char id[3], bool write, const uint8_
     const uint8_t crc = crc_sum_of_bytes(pkt, ofs);
     pkt[ofs++] = hex2char((crc >> 4) & 0x0f);
     pkt[ofs++] = hex2char(crc & 0x0f);
+
+    if (_reply_address != connected_interface()) {
+        // the packet is sent out of an interface the autopilot is not
+        // connected to, so it is lost
+        return;
+    }
 
     write_to_autopilot((const char*)pkt, ofs);
 }

--- a/libraries/SITL/SIM_Topotek.h
+++ b/libraries/SITL/SIM_Topotek.h
@@ -21,6 +21,22 @@ param set MNT1_TYPE 12        # topotek
 param set SERIAL5_PROTOCOL 8  # gimbal
 reboot
 
+The gimbal can also be simulated as being connected to one of the
+autopilot's network ports rather than to one of its serial ports:
+
+./Tools/autotest/sim_vehicle.py --gdb --debug -v ArduCopter -A --net-device=topotek:15005 --speedup=1
+
+param set MNT1_TYPE 12        # topotek
+param set NET_ENABLE 1
+param set NET_P1_TYPE 3       # TCP client
+param set NET_P1_PROTOCOL 8   # gimbal
+param set NET_P1_IP0 127
+param set NET_P1_IP1 0
+param set NET_P1_IP2 0
+param set NET_P1_IP3 1
+param set NET_P1_PORT 15005
+reboot
+
 */
 
 #pragma once
@@ -54,6 +70,24 @@ private:
     // last commanded angles from GIP/GIY packets (wire centidegrees, same sign as sent by driver)
     int16_t _commanded_pitch_cd;
     int16_t _commanded_yaw_cd;
+
+    // The gimbal sends each reply out of the interface named by the
+    // source address in the request (the 4th byte of the packet), not
+    // out of the interface the request arrived on.  If the autopilot
+    // says it is on our UART when it is really on our network port then
+    // our replies go out of the UART and are lost.
+    static constexpr uint8_t ADDRESS_UART = 'U';
+    static constexpr uint8_t ADDRESS_NETWORK = 'P';
+
+    // address of the interface the autopilot is really connected to
+    uint8_t connected_interface() const {
+        return is_network_attached() ? ADDRESS_NETWORK : ADDRESS_UART;
+    }
+
+    // address the gimbal is currently sending its replies to; updated
+    // from the source address of each packet received.  Defaults to the
+    // UART as that is where the gimbal talks before being told otherwise
+    uint8_t _reply_address = ADDRESS_UART;
 
     // read and dispatch incoming packets from autopilot
     void update_input();

--- a/libraries/SITL/SIM_config.h
+++ b/libraries/SITL/SIM_config.h
@@ -142,6 +142,13 @@
 #define AP_SIM_SERIALDEVICE_CORRUPTION_ENABLED 0
 #endif
 
+// allow simulated serial devices to be attached to a TCP socket rather
+// than to a simulated serial port, so devices connected to the
+// autopilot's network ports can be simulated:
+#ifndef AP_SIM_SERIALDEVICE_NETWORK_ENABLED
+#define AP_SIM_SERIALDEVICE_NETWORK_ENABLED (CONFIG_HAL_BOARD == HAL_BOARD_SITL)
+#endif  // AP_SIM_SERIALDEVICE_NETWORK_ENABLED
+
 #ifndef AP_SIM_GPS_ENABLED
 #define AP_SIM_GPS_ENABLED AP_SIM_ENABLED
 #endif


### PR DESCRIPTION
### Summary

If Topotek is connected to a network port then reflect that in the packet we send to the gimbal so it sends out its correct interface

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

The Topotek gimbal uses the information in the packet we send it to work out where to send its replies.

On master we always say "uart"  - if you are actually connecting via a NET_Px then the gimbal will never get data back to the autopilot.
