### PR TITLE
Pre-builds firmwares that the tests build to warm cache

### DIFF
--- a/.github/workflows/test_sitl_copter.yml
+++ b/.github/workflows/test_sitl_copter.yml
@@ -199,6 +199,23 @@ jobs:
           ./waf build --target bin/arducopter
           ccache -s
           ccache -z
+      # Pre-build the firmware that tests build at test time, so those
+      # objects are in the saved ccache and the in-test builds become
+      # ccache hits.  Only master pushes save the cache (see
+      # save-ccache), so only they pay for this - on PR runs the chunks
+      # restore master's cache and the pre-build would be pure waste.
+      - name: pre-build test-time firmware
+        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+        shell: bash
+        run: |
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}
+          PATH="/github/home/.local/bin:$PATH"
+          ./waf build --target tool/Replay
+          # PeriphMultiUARTTunnel builds this into build-periph; the out
+          # directory must match (ccache sees it via generated-header paths)
+          ./waf configure --board sitl_periph_can_to_serial --debug --out build-periph
+          ./waf build --target bin/AP_Periph
+          ccache -s
       - uses: ./.github/actions/save-ccache
         with:
           key-suffix: ${{ matrix.toolchain }}

--- a/.github/workflows/test_sitl_plane.yml
+++ b/.github/workflows/test_sitl_plane.yml
@@ -200,6 +200,25 @@ jobs:
           ./waf build --target bin/arduplane
           ccache -s
           ccache -z
+      # Pre-build the firmware that tests build at test time, so those
+      # objects are in the saved ccache and the in-test builds become
+      # ccache hits.  Only master pushes save the cache (see
+      # save-ccache), so only they pay for this - on PR runs the chunks
+      # restore master's cache and the pre-build would be pure waste.
+      - name: pre-build test-time firmware
+        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+        shell: bash
+        run: |
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}
+          PATH="/github/home/.local/bin:$PATH"
+          ./waf build --target tool/Replay
+          # PPPPeriph rebuilds the plane and a sitl_periph_PPP AP_Periph via
+          # restart_SITL_frame('quadplane-PPP', extra_configure_args=['--debug'])
+          ./waf configure --board sitl --enable-PPP --enable-networking-tests --debug
+          ./waf build --target bin/arduplane
+          ./waf configure --board sitl_periph_PPP --enable-PPP --enable-networking-tests --debug
+          ./waf build --target bin/AP_Periph
+          ccache -s
       - uses: ./.github/actions/save-ccache
         with:
           key-suffix: ${{ matrix.toolchain }}

--- a/.github/workflows/test_sitl_rover.yml
+++ b/.github/workflows/test_sitl_rover.yml
@@ -199,6 +199,21 @@ jobs:
           ./waf build --target bin/ardurover
           ccache -s
           ccache -z
+      # Pre-build the firmware that tests build at test time, so those
+      # objects are in the saved ccache and the in-test builds become
+      # ccache hits.  Only master pushes save the cache (see
+      # save-ccache), so only they pay for this - on PR runs the chunks
+      # restore master's cache and the pre-build would be pure waste.
+      - name: pre-build test-time firmware
+        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+        shell: bash
+        run: |
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}
+          PATH="/github/home/.local/bin:$PATH"
+          # NetworkingWebServerPPP rebuilds the rover with PPP enabled
+          ./waf configure --board sitl --debug --enable-math-check-indexes --enable-PPP
+          ./waf build --target bin/ardurover
+          ccache -s
       - uses: ./.github/actions/save-ccache
         with:
           key-suffix: ${{ matrix.toolchain }}

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -6757,7 +6757,11 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.progress('rebuilding rover with ppp enabled')
         import shutil
         shutil.copy('build/sitl/bin/ardurover', 'build/sitl/bin/ardurover.noppp')
-        util.build_SITL('bin/ardurover', clean=False, configure=True, extra_configure_args=['--enable-PPP', '--debug'])
+        # --enable-math-check-indexes matches the CI rover build
+        # configuration, so in CI this rebuild is a ccache hit against
+        # the pre-built PPP rover from the build job
+        util.build_SITL('bin/ardurover', clean=False, configure=True,
+                        extra_configure_args=['--enable-PPP', '--enable-math-check-indexes', '--debug'])
 
         self.reboot_sitl()
 


### PR DESCRIPTION
### Summary

This allows the build steps to take advantage of ccache, which we don't use during the test steps

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
  PR-shape (what every PR run will experience)

  ┌──────────┬────────────┬───────────────┬──────────────────────────────┐
  │ Workflow │ Build step │ Prebuild step │     In-test build tests      │
  ├──────────┼────────────┼───────────────┼──────────────────────────────┤
  │ copter   │ 75 s       │ skipped (0 s) │ tunnel 107 s, Replay 152 s   │
  ├──────────┼────────────┼───────────────┼──────────────────────────────┤
  │ plane    │ 107 s      │ skipped       │ PPPPeriph 129 s, Replay 31 s │
  ├──────────┼────────────┼───────────────┼──────────────────────────────┤
  │ rover    │ 91 s       │ skipped       │ webserver 100 s              │
  └──────────┴────────────┴───────────────┴──────────────────────────────┘

  Build steps sit exactly at the stock baseline (upstream medians 92–99 s), the gate skips cleanly, and the in-test builds run warm off the cache — versus cold baselines of 274/387/248 s. PR
  runs get the full ~8–9 minute test-side saving at zero build-side cost.

  Master-shape (the cache-maintaining pushes)

  ┌──────────┬───────────────────┬──────────────────────┬──────────────────────────────┐
  │ Workflow │ Build step (cold) │ Prebuild step (cold) │        In-test tests         │
  ├──────────┼───────────────────┼──────────────────────┼──────────────────────────────┤
  │ copter   │ 410 s             │ +230 s               │ tunnel 99 s, Replay 100 s    │
  ├──────────┼───────────────────┼──────────────────────┼──────────────────────────────┤
  │ plane    │ 301 s             │ +381 s               │ PPPPeriph 157 s, Replay 21 s │
  ├──────────┼───────────────────┼──────────────────────┼──────────────────────────────┤
  │ rover    │ 372 s             │ +130 s               │ webserver 77 s               │
  └──────────┴───────────────────┴──────────────────────┴──────────────────────────────┘

  Two things this proves: the prebuild cost is now cleanly isolated in its own step (nice for future monitoring), and — the key structural property — the same run's chunks restored the cache
  the build job had just saved, so even the cache-maintaining master pushes get warm in-test builds. A fully-cold master push (first merge, or after a config-header invalidation) pays +741
  s of prebuild against ~570 s of test savings — about 3 minutes net cost, once; routine warm master pushes pay the ~65–95 s/workflow prebuild we measured earlier and come out clearly ahead.
```

### Description

Builds builds in the build bit.

Saves a chunk of wallclock time by re-using ccache.

Also fixes up some compiler flags when building Rover so we get more cache hits
