### PR TITLE
AP_Filesystem: AP_Filesystem_ESP32.cpp: int64_t return values are truncated

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem_ESP32.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_ESP32.cpp
@@ -170,9 +170,7 @@ int64_t AP_Filesystem_ESP32::disk_free(const char *path)
     /* Get total sectors and free sectors */
     fre_sect = fre_clust * fs->csize;
 
-    int64_t tmp_free_bytes = fre_sect * FF_SS_SDCARD;
-
-    return tmp_free_bytes;
+    return (int64_t)fre_sect * FF_SS_SDCARD;
 }
 
 // return total disk space in bytes
@@ -193,9 +191,7 @@ int64_t AP_Filesystem_ESP32::disk_space(const char *path)
     /* Get total sectors and free sectors */
     tot_sect = (fs->n_fatent - 2) * fs->csize;
 
-    int64_t tmp_total_bytes = tot_sect * FF_SS_SDCARD;
-
-    return tmp_total_bytes;
+    return (int64_t)tot_sect * FF_SS_SDCARD;
 }
 
 /*


### PR DESCRIPTION

### Summary
Due to missing casting to (int64_t) of at least one multiplier factor the result of the multiplication remains as int32_t

### Classification & Testing (check all that apply and add your own)

- [x ] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Issue: https://github.com/ArduPilot/ardupilot/issues/33522

https://discuss.ardupilot.org/t/learning-ardupilot-starting-with-esp32/115834/28
https://discuss.ardupilot.org/t/learning-ardupilot-starting-with-esp32/115834/30

This error causes log files on the SD card to be deleted even though there is more than enough space available. However, this deletion process can lead to delays and potentially even system resets—though the latter remains to be verified.
Issue details

The two functions
int64_t AP_Filesystem_ESP32::disk_free(const char *path){ }
int64_t AP_Filesystem_ESP32::disk_space(const char *path){ }
should return a 64-bit value.
Although an int64_t variable is defined for this purpose, the values ​​are truncated to 32 bits during the calculation.

Possible changes
```
int64_t AP_Filesystem_ESP32::disk_free(const char *path){
...
//remove
int64_t tmp_free_bytes = fre_sect * FF_SS_SDCARD;
return tmp_free_bytes;
// add
return (int64_t)fre_sect * FF_SS_SDCARD;
}
```

```
int64_t AP_Filesystem_ESP32::disk_space(const char *path){
...
//remove
int64_t tmp_total_bytes = tot_sect * FF_SS_SDCARD;
return tmp_total_bytes;
// add
return (int64_t)tot_sect * FF_SS_SDCARD;
}
```

