### PR TITLE
Remove Vector3f-returning AHRS wind_estimate method

### DIFF
--- a/ArduCopter/GCS_MAVLink_Copter.cpp
+++ b/ArduCopter/GCS_MAVLink_Copter.cpp
@@ -1262,7 +1262,10 @@ void GCS_MAVLINK_Copter::send_wind() const
         // valid wind estimate on copters
         return;
     }
-    const Vector3f wind = AP::ahrs().wind_estimate();
+    Vector3f wind;
+    // send the estimate even if it is not marked valid, to preserve
+    // existing behaviour
+    IGNORE_RETURN(AP::ahrs().get_wind(wind));
     mavlink_msg_wind_send(
         chan,
         degrees(atan2f(-wind.y, -wind.x)),
@@ -1320,7 +1323,9 @@ uint8_t GCS_MAVLINK_Copter::high_latency_wind_speed() const
     Vector3f wind;
     // return units are m/s*5
     if (AP::ahrs().airspeed_vector_TAS(airspeed_vec_bf)) {
-        wind = AP::ahrs().wind_estimate();
+        // use the estimate even if it is not marked valid, to preserve
+        // existing behaviour
+        IGNORE_RETURN(AP::ahrs().get_wind(wind));
         return wind.xy().length() * 5;
     }
     return 0; 
@@ -1332,7 +1337,9 @@ uint8_t GCS_MAVLINK_Copter::high_latency_wind_direction() const
     Vector3f wind;
     // return units are deg/2
     if (AP::ahrs().airspeed_vector_TAS(airspeed_vec_bf)) {
-        wind = AP::ahrs().wind_estimate();
+        // use the estimate even if it is not marked valid, to preserve
+        // existing behaviour
+        IGNORE_RETURN(AP::ahrs().get_wind(wind));
         // need to convert -180->180 to 0->360/2
         return wrap_360(degrees(atan2f(-wind.y, -wind.x))) / 2;
     }

--- a/ArduPlane/GCS_MAVLink_Plane.cpp
+++ b/ArduPlane/GCS_MAVLink_Plane.cpp
@@ -292,7 +292,10 @@ float GCS_MAVLINK_Plane::vfr_hud_climbrate() const
 
 void GCS_MAVLINK_Plane::send_wind() const
 {
-    const Vector3f wind = AP::ahrs().wind_estimate();
+    Vector3f wind;
+    // send the estimate even if it is not marked valid, to preserve
+    // existing behaviour
+    IGNORE_RETURN(AP::ahrs().get_wind(wind));
     mavlink_msg_wind_send(
         chan,
         degrees(atan2f(-wind.y, -wind.x)), // use negative, to give
@@ -1228,7 +1231,9 @@ uint8_t GCS_MAVLINK_Plane::high_latency_tgt_airspeed() const
 uint8_t GCS_MAVLINK_Plane::high_latency_wind_speed() const
 {
     Vector3f wind;
-    wind = AP::ahrs().wind_estimate();
+    // use the estimate even if it is not marked valid, to preserve
+    // existing behaviour
+    IGNORE_RETURN(AP::ahrs().get_wind(wind));
 
     // return units are m/s*5
     return MIN(wind.xy().length() * 5, UINT8_MAX);
@@ -1236,7 +1241,10 @@ uint8_t GCS_MAVLINK_Plane::high_latency_wind_speed() const
 
 uint8_t GCS_MAVLINK_Plane::high_latency_wind_direction() const
 {
-    const Vector3f wind = AP::ahrs().wind_estimate();
+    Vector3f wind;
+    // use the estimate even if it is not marked valid, to preserve
+    // existing behaviour
+    IGNORE_RETURN(AP::ahrs().get_wind(wind));
 
     // return units are deg/2
     // need to convert -180->180 to 0->360/2

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -1079,7 +1079,10 @@ bool Plane::verify_landing_vtol_approach(const AP_Mission::Mission_Command &cmd)
                 nav_controller->update_loiter(cmd.content.location, abs_radius, direction);
 
                 if (labs(loiter.sum_cd) > 1 && (loiter.reached_target_alt || loiter.unable_to_achieve_target_alt)) {
-                    Vector3f wind = ahrs.wind_estimate();
+                    Vector3f wind;
+                    // use the estimate even if it is not marked valid,
+                    // to preserve existing behaviour
+                    IGNORE_RETURN(ahrs.get_wind(wind));
                     vtol_approach_s.approach_direction_deg = degrees(atan2f(-wind.y, -wind.x));
                     gcs().send_text(MAV_SEVERITY_INFO, "Selected an approach path of %.1f", (double)vtol_approach_s.approach_direction_deg);
                     vtol_approach_s.approach_stage = VTOLApproach::Stage::ENSURE_RADIUS;

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2630,7 +2630,11 @@ void QuadPlane::vtol_position_controller(void)
                 target_speed_ne_ms = diff_wp_norm * approach_speed_ms;
                 
                 // adjust target yaw angle into the apparent wind
-                const Vector2f wind_ms = plane.ahrs.wind_estimate().xy();
+                Vector3f wind_ned_ms;
+                // use the estimate even if it is not marked valid, to
+                // preserve existing behaviour
+                IGNORE_RETURN(plane.ahrs.get_wind(wind_ned_ms));
+                const Vector2f wind_ms = wind_ned_ms.xy();
                 const Vector2f airspeed_ne_ms = plane.ahrs.groundspeed_vector() - wind_ms;
                 if (airspeed_ne_ms.length_squared() < 1) {
                     // Don't cause unpredictable yaw swings if the airspeed vector
@@ -4422,9 +4426,12 @@ float QuadPlane::get_land_airspeed_ms(void)
     
     // calculate speed based on landing desired velocity
     Vector2f vel_ne_ms = landing_desired_closing_velocity_NE_ms();
-    const Vector2f wind_ms = plane.ahrs.wind_estimate().xy();
+    Vector3f wind_ned_ms;
+    // use the estimate even if it is not marked valid, to preserve
+    // existing behaviour
+    IGNORE_RETURN(plane.ahrs.get_wind(wind_ned_ms));
     const float eas2tas = plane.ahrs.get_EAS2TAS();
-    vel_ne_ms -= wind_ms;
+    vel_ne_ms -= wind_ned_ms.xy();
     vel_ne_ms /= eas2tas;
     return vel_ne_ms.length();
 }

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -753,7 +753,11 @@ void Tailsitter::speed_scaling(void)
                     float reverse_airspeed = 0.0;
                     Vector3f vel;
                     if (quadplane.ahrs.get_velocity_NED(vel)) {
-                        reverse_airspeed = quadplane.ahrs.earth_to_body(vel - quadplane.ahrs.wind_estimate()).x;
+                        Vector3f wind;
+                        // use the estimate even if it is not marked
+                        // valid, to preserve existing behaviour
+                        IGNORE_RETURN(quadplane.ahrs.get_wind(wind));
+                        reverse_airspeed = quadplane.ahrs.earth_to_body(vel - wind).x;
                     }
                     // make sure actually negative
                     reverse_airspeed = MIN(reverse_airspeed, 0.0);

--- a/Blimp/GCS_MAVLink_Blimp.cpp
+++ b/Blimp/GCS_MAVLink_Blimp.cpp
@@ -326,7 +326,10 @@ void GCS_MAVLINK_Blimp::send_wind() const
         // valid wind estimate on blimps
         return;
     }
-    const Vector3f wind = AP::ahrs().wind_estimate();
+    Vector3f wind;
+    // send the estimate even if it is not marked valid, to preserve
+    // existing behaviour
+    IGNORE_RETURN(AP::ahrs().get_wind(wind));
     mavlink_msg_wind_send(
         chan,
         degrees(atan2f(-wind.y, -wind.x)),
@@ -344,7 +347,10 @@ uint8_t GCS_MAVLINK_Blimp::high_latency_wind_speed() const
         return 0;
     }
     // return units are m/s*5
-    const Vector3f wind = AP::ahrs().wind_estimate();
+    Vector3f wind;
+    // use the estimate even if it is not marked valid, to preserve
+    // existing behaviour
+    IGNORE_RETURN(AP::ahrs().get_wind(wind));
     return wind.xy().length() * 5;
 }
 
@@ -356,7 +362,10 @@ uint8_t GCS_MAVLINK_Blimp::high_latency_wind_direction() const
         // valid wind estimate on blimps
         return 0;
     }
-    const Vector3f wind = AP::ahrs().wind_estimate();
+    Vector3f wind;
+    // use the estimate even if it is not marked valid, to preserve
+    // existing behaviour
+    IGNORE_RETURN(AP::ahrs().get_wind(wind));
     // need to convert -180->180 to 0->360/2
     return wrap_360(degrees(atan2f(-wind.y, -wind.x))) / 2;
 }

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -758,8 +758,12 @@ float AP_AHRS::wind_alignment(const float heading_deg) const
  */
 float AP_AHRS::head_wind(void) const
 {
+    Vector3f wind;
+    // wind_alignment() has already returned zero if we have no valid
+    // estimate, so the validity of the wind vector is not checked here
+    IGNORE_RETURN(get_wind(wind));
     const float alignment = wind_alignment(get_yaw_deg());
-    return alignment * wind_estimate().xy().length();
+    return alignment * wind.xy().length();
 }
 
 /*

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -746,7 +746,7 @@ float AP_AHRS::get_error_yaw(void) const
 float AP_AHRS::wind_alignment(const float heading_deg) const
 {
     Vector3f wind;
-    if (!wind_estimate(wind)) {
+    if (!get_wind(wind)) {
         return 0;
     }
     const float wind_heading_rad = atan2f(-wind.y, -wind.x);
@@ -2340,7 +2340,7 @@ bool AP_AHRS::get_location(Location &loc) const
 }
 
 // return a wind estimation vector in "wind" (m/s); returns false on failure
-bool AP_AHRS::wind_estimate(Vector3f &wind) const
+bool AP_AHRS::get_wind(Vector3f &wind) const
 {
     wind = active_estimates->wind;
     return active_estimates->wind_valid;

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -122,9 +122,6 @@ public:
     // wind_estimation_enabled returns true if wind estimation is enabled
     bool get_wind_estimation_enabled() const { return wind_estimation_enabled; }
 
-    // return a wind estimation vector, in m/s; returns 0,0,0 on failure
-    const Vector3f &wind_estimate() const { return active_estimates->wind; }
-
     // return a wind estimation vector in "wind" (m/s); returns false if
     // we have no valid estimate
     bool get_wind(Vector3f &wind) const;

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -125,8 +125,9 @@ public:
     // return a wind estimation vector, in m/s; returns 0,0,0 on failure
     const Vector3f &wind_estimate() const { return active_estimates->wind; }
 
-    // return a wind estimation vector, in m/s; returns 0,0,0 on failure
-    bool wind_estimate(Vector3f &wind) const;
+    // return a wind estimation vector in "wind" (m/s); returns false if
+    // we have no valid estimate
+    bool get_wind(Vector3f &wind) const;
 
     // Determine how aligned heading_deg is with the wind. Return result
     // is 1.0 when perfectly aligned heading into wind, -1 when perfectly

--- a/libraries/AP_AHRS/AP_AHRS_Backend.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.cpp
@@ -202,7 +202,9 @@ void AP_AHRS::update_AOA_SSA(void)
         return;
     }
 
-    aoa_wind = wind_estimate();
+    // use the wind estimate even if it is not marked valid; a zero or
+    // stale wind vector simply degrades the AOA/SSA estimate
+    IGNORE_RETURN(get_wind(aoa_wind));
 
     // Rotate vectors to the body frame and calculate velocity and wind
     const Matrix3f &rot = get_rotation_body_to_ned();

--- a/libraries/AP_AHRS/AP_AHRS_View.h
+++ b/libraries/AP_AHRS/AP_AHRS_View.h
@@ -93,8 +93,8 @@ public:
         return ahrs.get_location(loc);
     }
 
-    bool wind_estimate(Vector3f &wind) {
-        return ahrs.wind_estimate(wind);
+    bool get_wind(Vector3f &wind) {
+        return ahrs.get_wind(wind);
     }
 
     bool airspeed_EAS(float &airspeed_ret) const WARN_IF_UNUSED {

--- a/libraries/AP_Frsky_Telem/AP_Frsky_SPort_Passthrough.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_SPort_Passthrough.cpp
@@ -765,7 +765,9 @@ uint32_t AP_Frsky_SPort_Passthrough::calc_wind(void)
     {
         AP_AHRS &ahrs = AP::ahrs();
         WITH_SEMAPHORE(ahrs.get_semaphore());
-        v = ahrs.wind_estimate();
+        // use the estimate even if it is not marked valid, to preserve
+        // existing behaviour
+        IGNORE_RETURN(ahrs.get_wind(v));
     }
     // wind angle in 3 degree increments 0,360 (unsigned)
     uint32_t value = prep_number(roundf(wrap_360(degrees(atan2f(-v.y, -v.x))) * (1.0f/3.0f)), 2, 0);

--- a/libraries/AP_Landing/AP_Landing_Deepstall.cpp
+++ b/libraries/AP_Landing/AP_Landing_Deepstall.cpp
@@ -300,7 +300,12 @@ bool AP_Landing_Deepstall::verify_land(const Location &prev_WP_loc, Location &ne
             }
         }
 
-        const float travel_distance = predict_travel_distance(landing.ahrs.wind_estimate(), height_above_target, false);
+        Vector3f wind;
+        // use the estimate even if it is not marked valid, to preserve
+        // existing behaviour
+        IGNORE_RETURN(landing.ahrs.get_wind(wind));
+
+        const float travel_distance = predict_travel_distance(wind, height_above_target, false);
 
         memcpy(&entry_point, &landing_point, sizeof(Location));
         entry_point.offset_bearing(target_heading_deg + 180.0, travel_distance);
@@ -312,7 +317,7 @@ bool AP_Landing_Deepstall::verify_land(const Location &prev_WP_loc, Location &ne
             }
             return false;
         }
-        predict_travel_distance(landing.ahrs.wind_estimate(), height_above_target, true);
+        predict_travel_distance(wind, height_above_target, true);
         stage = DEEPSTALL_STAGE_LAND;
         stall_entry_time = AP_HAL::millis();
 
@@ -507,7 +512,10 @@ void AP_Landing_Deepstall::build_approach_path(bool use_current_heading)
 {
     float loiter_radius = landing.nav_controller->loiter_radius(landing.aparm.loiter_radius);
 
-    Vector3f wind = landing.ahrs.wind_estimate();
+    Vector3f wind;
+    // use the estimate even if it is not marked valid, to preserve
+    // existing behaviour
+    IGNORE_RETURN(landing.ahrs.get_wind(wind));
     // TODO: Support a user defined approach heading
     target_heading_deg = use_current_heading ? landing.ahrs.get_yaw_deg() : (degrees(atan2f(-wind.y, -wind.x)));
 

--- a/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
+++ b/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
@@ -289,7 +289,9 @@ void AP_MSP_Telem_Backend::update_flight_mode_str(char *flight_mode_str, uint8_t
         Vector3f v;
         {
             WITH_SEMAPHORE(ahrs.get_semaphore());
-            v = ahrs.wind_estimate();
+            // use the estimate even if it is not marked valid, to
+            // preserve existing behaviour
+            IGNORE_RETURN(ahrs.get_wind(v));
         }
         bool invert_wind = false;
 #if OSD_ENABLED

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -1940,7 +1940,10 @@ void AP_OSD_Screen::draw_wind(uint8_t x, uint8_t y)
 #if !APM_BUILD_TYPE(APM_BUILD_Rover)
     AP_AHRS &ahrs = AP::ahrs();
     WITH_SEMAPHORE(ahrs.get_semaphore());
-    Vector3f v = ahrs.wind_estimate();
+    Vector3f v;
+    // draw the estimate even if it is not marked valid, to preserve
+    // existing behaviour
+    IGNORE_RETURN(ahrs.get_wind(v));
     float angle = 0;
     const float length = v.length();
     if (length > 1.0f) {

--- a/libraries/AP_Scripting/applets/RockBlock.lua
+++ b/libraries/AP_Scripting/applets/RockBlock.lua
@@ -777,7 +777,7 @@ function HLSatcom()
         -- update HL2 packet
         hl2.timestamp = millis():tofloat()
         local position = ahrs:get_location()
-        local wind = ahrs:wind_estimate()
+        local wind = ahrs:get_wind()
 
         if position then
             hl2.latitude = tonumber(position:lat())

--- a/libraries/AP_Scripting/applets/plane_follow.lua
+++ b/libraries/AP_Scripting/applets/plane_follow.lua
@@ -47,7 +47,9 @@ MAV_DATA_STREAM = { MAV_DATA_STREAM_ALL=0, MAV_DATA_STREAM_RAW_SENSORS=1, MAV_DA
 FLIGHT_MODE = {AUTO=10, RTL=11, LOITER=12, GUIDED=15, QHOVER=18, QLOITER=19, QRTL=21}
 
 local ahrs_eas2tas = ahrs:get_EAS2TAS()
-local windspeed_vector = ahrs:wind_estimate()
+-- assume zero wind if we have no estimate; this is only used to derive an
+-- airspeed vector from the ground velocity
+local windspeed_vector = ahrs:get_wind() or Vector3f()
 
 local now_ms = millis()
 local now_target_heading_ms = now_ms
@@ -719,7 +721,7 @@ end
 function Update()
    now_ms = millis()
    ahrs_eas2tas = ahrs:get_EAS2TAS()
-   windspeed_vector = ahrs:wind_estimate()
+   windspeed_vector = ahrs:get_wind() or Vector3f()
 
    simulate_failure.check()
    follow_mode.check()

--- a/libraries/AP_Scripting/applets/plane_ship_landing.lua
+++ b/libraries/AP_Scripting/applets/plane_ship_landing.lua
@@ -183,8 +183,8 @@ function stopping_distance()
    -- get the target true airspeed for approach
    local tas = get_land_airspeed() * ahrs:get_EAS2TAS()
 
-   -- add in wind in direction of flight
-   local wind = ahrs:wind_estimate():xy()
+   -- add in wind in direction of flight, assuming zero wind if we have no estimate
+   local wind = (ahrs:get_wind() or Vector3f()):xy()
 
    -- rotate wind to be in approach frame
    wind:rotate(-math.rad(target_heading + SHIP_LAND_ANGLE:get()))

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -3846,6 +3846,10 @@ function ahrs:get_velocity_NED() end
 ---@return Vector2f_ud -- ground speed vector, North East, meters / second
 function ahrs:groundspeed_vector() end
 
+-- Returns nil, or a Vector3f containing the current wind estimate for the vehicle.
+---@return Vector3f_ud|nil -- wind estimate North, East, Down meters / second if available
+function ahrs:get_wind() end
+
 -- Returns a Vector3f containing the current wind estimate for the vehicle.
 ---@return Vector3f_ud -- wind estiamte North, East, Down meters / second
 function ahrs:wind_estimate() end

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -3851,6 +3851,9 @@ function ahrs:groundspeed_vector() end
 function ahrs:get_wind() end
 
 -- Returns a Vector3f containing the current wind estimate for the vehicle.
+-- Deprecated, use get_wind; this gives no indication of whether the vehicle
+-- actually has a valid wind estimate, so the returned vector may be zero or stale.
+---@deprecated Use get_wind
 ---@return Vector3f_ud -- wind estiamte North, East, Down meters / second
 function ahrs:wind_estimate() end
 

--- a/libraries/AP_Scripting/examples/MAVLinkHL.lua
+++ b/libraries/AP_Scripting/examples/MAVLinkHL.lua
@@ -496,7 +496,7 @@ function HLSatcom()
         -- update HL2 packet
         hl2.timestamp = millis():tofloat()
         local position = ahrs:get_location()
-        local wind = ahrs:wind_estimate()
+        local wind = ahrs:get_wind()
 
         if position then
             hl2.latitude = tonumber(position:lat())

--- a/libraries/AP_Scripting/examples/glide_into_wind.lua
+++ b/libraries/AP_Scripting/examples/glide_into_wind.lua
@@ -242,8 +242,9 @@ function update()
     -- Get the heading angle
     hdg = math.floor(math.deg(ahrs:get_yaw_rad()))
 
-    -- Get wind direction. Function wind_estimate returns x and y for direction wind blows in, add pi to get true wind dir
-    wind = ahrs:wind_estimate()
+    -- Get wind direction. Function get_wind returns x and y for direction wind blows in, add pi to get true wind dir
+    -- fall back to zero wind if we have no estimate, as we must still pick a heading
+    wind = ahrs:get_wind() or Vector3f()
     wind_dir_rad = math.atan(wind:y(), wind:x())+math.pi
     wind_dir_180 = math.floor(wrap_180(math.deg(wind_dir_rad)))
     hdg_error = wrap_180(wind_dir_180 - hdg)

--- a/libraries/AP_Scripting/examples/jump_tags_into_wind_landing.lua
+++ b/libraries/AP_Scripting/examples/jump_tags_into_wind_landing.lua
@@ -88,7 +88,9 @@ function check_wind_and_jump_to_INTO_wind_landing()
         return
     end
 
-    local wind = ahrs:wind_estimate()
+    -- fall back to zero wind if we have no estimate; the tailwind
+    -- threshold below then keeps us on the normal landing direction
+    local wind = ahrs:get_wind() or Vector3f()
     local tail_wind = (math.sin(reverse_land_bearing) * wind:y()) + (math.cos(reverse_land_bearing) * wind:x())
 
     -- we need at least 10 cm/s of tailwind. With very little wind (or a noisy 0 value) we don't want to flip around.

--- a/libraries/AP_Scripting/examples/plane-wind-failsafe.lua
+++ b/libraries/AP_Scripting/examples/plane-wind-failsafe.lua
@@ -10,7 +10,7 @@ local warning_interval_ms = uint32_t(15000) -- send user message every 15s
 local warning_last_sent_ms = uint32_t() -- time we last sent a warning message to the user
 
 function update()
-    local wind = ahrs:wind_estimate() -- get the wind estimate
+    local wind = ahrs:get_wind() -- get the wind estimate
     if wind then
         -- make a 2D wind vector
         wind_xy = Vector2f()

--- a/libraries/AP_Scripting/examples/plane-wind-fs.lua
+++ b/libraries/AP_Scripting/examples/plane-wind-fs.lua
@@ -92,7 +92,7 @@ local timer_active = true
 local function time_to_home()
   local home = ahrs:get_home()
   local position = ahrs:get_location()
-  local wind = ahrs:wind_estimate()
+  local wind = ahrs:get_wind()
 
   if home and position and wind then
     local bearing = position:get_bearing(home)

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -49,7 +49,9 @@ singleton AP_AHRS method get_home Location
 singleton AP_AHRS method get_gyro Vector3f
 singleton AP_AHRS method get_accel Vector3f
 singleton AP_AHRS method get_hagl boolean float'Null
-singleton AP_AHRS method wind_estimate Vector3f
+-- compatibility binding for the removed Vector3f-returning
+-- AP_AHRS::wind_estimate() method; see lua_AP_AHRS_wind_estimate
+singleton AP_AHRS manual wind_estimate lua_AP_AHRS_wind_estimate 0 1
 singleton AP_AHRS method wind_alignment float'skip_check float'skip_check
 singleton AP_AHRS method head_wind float'skip_check
 singleton AP_AHRS method groundspeed_vector Vector2f

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -49,6 +49,7 @@ singleton AP_AHRS method get_home Location
 singleton AP_AHRS method get_gyro Vector3f
 singleton AP_AHRS method get_accel Vector3f
 singleton AP_AHRS method get_hagl boolean float'Null
+singleton AP_AHRS method get_wind boolean Vector3f'Null
 -- compatibility binding for the removed Vector3f-returning
 -- AP_AHRS::wind_estimate() method; see lua_AP_AHRS_wind_estimate
 singleton AP_AHRS manual wind_estimate lua_AP_AHRS_wind_estimate 0 1

--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -11,6 +11,7 @@
 #include <AP_Logger/AP_Logger.h>
 #include <AP_Filesystem/AP_Filesystem.h>
 #include <AP_GPS/AP_GPS.h>
+#include <AP_AHRS/AP_AHRS.h>
 
 #include "lua_bindings.h"
 
@@ -1222,6 +1223,31 @@ int lua_gps_inject_data(lua_State *L)
 }
 
 #endif  // AP_GPS_ENABLED
+
+#if AP_AHRS_ENABLED
+/*
+  compatibility binding for the Vector3f-returning
+  AP_AHRS::wind_estimate() method which has been removed from the AHRS
+  interface.  Scripting has no way of receiving both the vector and the
+  validity flag from AP_AHRS::get_wind(), so the validity is discarded
+  here and the vector returned regardless; it may be zero or stale.
+ */
+int lua_AP_AHRS_wind_estimate(lua_State *L)
+{
+    binding_argcheck(L, 1);
+    AP_AHRS *ahrs = check_AP_AHRS(L);
+
+    Vector3f wind;
+    {
+        WITH_SEMAPHORE(ahrs->get_semaphore());
+        IGNORE_RETURN(ahrs->get_wind(wind));
+    }
+
+    *new_Vector3f(L) = wind;
+
+    return 1;
+}
+#endif  // AP_AHRS_ENABLED
 
 #if AP_SCRIPTING_BINDING_VEHICLE_ENABLED
 int lua_AP_Vehicle_set_target_velocity_NED(lua_State *L)

--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -20,6 +20,7 @@
 
 #include <AP_Scheduler/AP_Scheduler.h>
 #include <AP_Scripting/AP_Scripting.h>
+#include <AP_Scripting/lua_scripts.h>
 #include <string.h>
 
 #include "lua/src/lauxlib.h"
@@ -1226,16 +1227,26 @@ int lua_gps_inject_data(lua_State *L)
 
 #if AP_AHRS_ENABLED
 /*
-  compatibility binding for the Vector3f-returning
+  deprecated compatibility binding for the Vector3f-returning
   AP_AHRS::wind_estimate() method which has been removed from the AHRS
-  interface.  Scripting has no way of receiving both the vector and the
-  validity flag from AP_AHRS::get_wind(), so the validity is discarded
-  here and the vector returned regardless; it may be zero or stale.
+  interface.  The validity of the estimate is discarded here and the
+  vector returned regardless; it may be zero or stale.  Scripts should
+  use ahrs:get_wind() instead.
+
+  the generator can not attach a deprecation warning to a manual
+  binding, so it is emitted here in the same manner as the generated
+  bindings do it.
  */
 int lua_AP_AHRS_wind_estimate(lua_State *L)
 {
     binding_argcheck(L, 1);
     AP_AHRS *ahrs = check_AP_AHRS(L);
+
+    static bool warned;
+    if (!warned) {
+        lua_scripts::set_and_print_new_error_message(MAV_SEVERITY_WARNING, "ahrs:wind_estimate Use get_wind");
+        warned = true;
+    }
 
     Vector3f wind;
     {

--- a/libraries/AP_Scripting/lua_bindings.h
+++ b/libraries/AP_Scripting/lua_bindings.h
@@ -37,4 +37,5 @@ int lua_range_finder_handle_script_msg(lua_State *L);
 int lua_GCS_command_int(lua_State *L);
 int lua_DroneCAN_get_FlexDebug(lua_State *L);
 int lua_gps_inject_data(lua_State *L);
+int lua_AP_AHRS_wind_estimate(lua_State *L);
 int lua_AP_Vehicle_set_target_velocity_NED(lua_State *L);

--- a/libraries/AP_Soaring/AP_Soaring.cpp
+++ b/libraries/AP_Soaring/AP_Soaring.cpp
@@ -325,7 +325,12 @@ void SoaringController::update_thermalling()
         return;
     }
 
-    Vector3f wind_drift = _ahrs.wind_estimate()*deltaT*_vario.get_filtered_climb()/_ekf.X[0];
+    Vector3f wind;
+    // use the estimate even if it is not marked valid, to preserve
+    // existing behaviour
+    IGNORE_RETURN(_ahrs.get_wind(wind));
+
+    Vector3f wind_drift = wind*deltaT*_vario.get_filtered_climb()/_ekf.X[0];
 
     // update the filter
     _ekf.update(_vario.reading, current_position.x, current_position.y, wind_drift.x, wind_drift.y);
@@ -392,7 +397,10 @@ void SoaringController::update_cruising()
     // Calculate the optimal airspeed for the current conditions of wind along current direction,
     // expected lift in next thermal and filtered sink rate.
 
-    Vector3f wind    = AP::ahrs().wind_estimate();
+    Vector3f wind;
+    // use the estimate even if it is not marked valid, to preserve
+    // existing behaviour
+    IGNORE_RETURN(AP::ahrs().get_wind(wind));
     Vector3f wind_bf = AP::ahrs().earth_to_body(wind);
 
     const float wx = wind_bf.x;


### PR DESCRIPTION
### Summary

Removes one of the two accessors we have for the wind estimate

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli   iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                 *
Durandal                            -152            -152   *           -152    -152               -160   -160   -152
Hitec-Airspeed           *                                 *
KakuteH7-bdshot                     -152            -152   *           -152    -160               -160   -160   -152
MatekF405                           -136            -136   *           -144    -144               -136   -144   -136
Pixhawk1-1M-bdshot                  -128            -136               -136    -136               -144   -136   -136
SITL_x86_64_linux_gnu               0               0                  0       -4096              -4096  0      0
YJUAV_A6SE                          -144            -144   *           -144    -144               -152   -160   -144
f103-QiotekPeriph        *                                 *
f303-MatekGPS            *                                 *
f303-Universal           *                                 *
iomcu                                                                                 *
revo-mini                           -136            -144   *           -144    -136               -136   -144   -136
skyviper-v2450                                                         -136
speedybeef4                         -136            -136   *           -136    -136               -136   -144   -136
```


### Description

Removes the Vector3f-returning method and changes callers to use the boolean-return method.

No functional change.

Also renames `bool wind_estimate` to be `bool get_wind` to match our other accessors.

Scripting gets a (deprecated) compatability wrapper.  Several scripts are checking the return value of the old method for truthiness - and that won't work on a Vector3f, 0,0,0 is still true!
