### PR TITLE
BMP390 soft reset to clear sensor config

### DIFF
--- a/libraries/AP_Baro/AP_Baro_BMP388.cpp
+++ b/libraries/AP_Baro/AP_Baro_BMP388.cpp
@@ -52,6 +52,8 @@ extern const AP_HAL::HAL &hal;
 #define BMP388_REG_CAL_P     0x36
 #define BMP388_REG_CAL_T     0x31
 
+#define BMP388_SOFT_RESET    0xB6
+
 AP_Baro_BMP388::AP_Baro_BMP388(AP_Baro &baro, AP_HAL::Device &_dev)
     : AP_Baro_Backend(baro)
     , dev(&_dev)
@@ -81,6 +83,11 @@ bool AP_Baro_BMP388::init()
     if (dev->bus_type() == AP_HAL::Device::BUS_TYPE_SPI) {
         dev->set_read_flag(0x80);
     }
+    // BMP390 soft reset, sensor unready without
+    if (!dev->write_register(BMP388_REG_CMD, BMP388_SOFT_RESET)) {
+        return false;
+    }
+    hal.scheduler->delay(10);
 
     // normal mode, temp and pressure
     dev->write_register(BMP388_REG_PWR_CTRL, 0x33, true);

--- a/libraries/AP_Baro/AP_Baro_BMP388.cpp
+++ b/libraries/AP_Baro/AP_Baro_BMP388.cpp
@@ -83,15 +83,6 @@ bool AP_Baro_BMP388::init()
     if (dev->bus_type() == AP_HAL::Device::BUS_TYPE_SPI) {
         dev->set_read_flag(0x80);
     }
-    // BMP390 soft reset, sensor unready without
-    if (!dev->write_register(BMP388_REG_CMD, BMP388_SOFT_RESET)) {
-        return false;
-    }
-    hal.scheduler->delay(10);
-
-    // normal mode, temp and pressure
-    dev->write_register(BMP388_REG_PWR_CTRL, 0x33, true);
-    
     uint8_t whoami;
     if (!read_registers(BMP388_REG_ID, &whoami, 1)) {
         return false;
@@ -107,6 +98,15 @@ bool AP_Baro_BMP388::init()
     default:
         return false;
     }
+
+    // BMP390 needs a soft reset to start converting 
+    if (!dev->write_register(BMP388_REG_CMD, BMP388_SOFT_RESET)) {
+        return false;
+    }
+    hal.scheduler->delay(10);
+
+    // normal mode, temp and pressure
+    dev->write_register(BMP388_REG_PWR_CTRL, 0x33, true);
 
     // read the calibration data
     read_registers(BMP388_REG_CAL_P, (uint8_t *)&calib_p, sizeof(calib_p));


### PR DESCRIPTION
  ### Summary

  BMP390 powers up in sleep and can keep stale config, halting boot at "Baro: unable to calibrate"

  Solution: an unchecked soft reset at init.

  Related PR [#27724](https://github.com/ArduPilot/ardupilot/pull/27724)

  ### Classification & Testing (check all that apply and add your own)

  - [x] Checked by a human programmer
  - [ ] Non-functional change
  - [ ] No-binary change
  - [ ] Infrastructure change (e.g. unit tests, helper scripts)
  - [ ] Automated test(s) verify changes (e.g. unit test, autotest)
  - [x] Tested manually, description below (e.g. SITL)
  - [x] Tested on hardware
  - [ ] Logs attached
  - [x] Logs available on request

  Tested on an ARK ARKV6X with Bosch BMP390. Before: `SCALED_PRESSURE` reads 0.0 hPa / 0.0 C every sample and boot halts at
  `Config Error: Baro: unable to calibrate`. After: stable ~1014 hPa, boots normally, and the compass (previously blocked
  by the halt) comes up healthy.

  ### Description

  `AP_Baro_BMP388`  writes `PWR_CTRL` at init but never soft-resets the sensor. A BMP390
  that powers up in sleep holding stale config returns 0 and boot halts at "Baro: unable to calibrate".

  Fix: a one-time soft reset (`0xB6` -> `CMD`) at the top of `init()`, before the `PWR_CTRL` write and the
  calibration reads, then a 10 ms wait. 
