### PR TITLE
GCS_MAVLink: rework `AVAILABLE_MODES_MONITOR` to only stream after a change

### DIFF
--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -732,4 +732,12 @@ bool GCS::sysid_is_gcs(uint8_t _sysid) const
     return _sysid >= mav_gcs_sysid && _sysid <= mav_gcs_sysid_high;
 }
 
+// Increment the available modes sequence number for each channel
+void GCS::available_modes_changed() {
+    for (uint8_t i=0; i<num_gcs(); i++) {
+        GCS_MAVLINK &c = *chan(i);
+        c.available_modes_changed();
+    }
+}
+
 #endif  // HAL_GCS_ENABLED

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -1110,13 +1110,18 @@ private:
 
     // Handling of AVAILABLE_MODES
     struct {
+        bool requested;
         bool should_send;
         // Note these start at 1
         uint8_t requested_index;
         uint8_t next_index;
+        // Sequence number should be incremented when available modes changes
+        // Sent in AVAILABLE_MODES_MONITOR msg
+        uint8_t available_modes_sequence;
     } available_modes;
     bool send_available_modes();
     bool send_available_mode_monitor();
+    void available_modes_changed();
 
 };
 
@@ -1312,8 +1317,7 @@ public:
 
     // Sequence number should be incremented when available modes changes
     // Sent in AVAILABLE_MODES_MONITOR msg
-    uint8_t get_available_modes_sequence() const { return available_modes_sequence; }
-    void available_modes_changed() { available_modes_sequence += 1; }
+    void available_modes_changed();
 
 protected:
 
@@ -1406,9 +1410,6 @@ private:
     // time in which they are permitted to send messages.
     uint8_t first_backend_to_send;
 
-    // Sequence number should be incremented when available modes changes
-    // Sent in AVAILABLE_MODES_MONITOR msg
-    uint8_t available_modes_sequence;
 };
 
 GCS &gcs();

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3297,13 +3297,10 @@ MAV_RESULT GCS_MAVLINK::handle_command_request_message(const mavlink_command_int
 
     switch(id) {
     case MSG_AVAILABLE_MODES:
+        available_modes.requested = true;
         available_modes.should_send = true;
         available_modes.next_index = 1;
         available_modes.requested_index = (uint8_t)packet.param2;
-
-        // After the first request sequnece is streamed in the AVAILABLE_MODES_MONITOR message
-        // This allows the GCS to re-request modes if there is a change
-        set_ap_message_interval(MSG_AVAILABLE_MODES_MONITOR, 5000);
         break;
 
 #if AP_CAMERA_ENABLED
@@ -6601,10 +6598,24 @@ bool GCS_MAVLINK::send_available_mode_monitor()
 
     mavlink_msg_available_modes_monitor_send(
         chan,
-        gcs().get_available_modes_sequence()
+        available_modes.available_modes_sequence
     );
 
     return true;
+}
+
+void GCS_MAVLINK::available_modes_changed()
+{
+    // Only increment the counter if this channel is tracking modes
+    if (!available_modes.requested) {
+        return;
+    }
+
+    available_modes.available_modes_sequence += 1;
+
+    // Stream the AVAILABLE_MODES_MONITOR message
+    // This allows the GCS to re-request modes
+    set_ap_message_interval(MSG_AVAILABLE_MODES_MONITOR, 5000);
 }
 
 bool GCS_MAVLINK::try_send_message(const enum ap_message id)


### PR DESCRIPTION
### Summary

<!-- Put a one or two line summary of what your PR does here -->

The spec says this should be streamed after a change rather than from the start. See: https://github.com/ArduPilot/ardupilot/issues/33811

This also changes to track the sequence per channel so the first change seem the same to a gcs.

This does not resolve the issue of a GCS connecting after the message has already started streaming. Its likely that the GCS will still end up fetching the modes twice in that case.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->

I still need to test in QGC.