### PR TITLE
Filter: add harmonic support to PID notch filters

### DIFF
--- a/Blimp/system.cpp
+++ b/Blimp/system.cpp
@@ -97,10 +97,10 @@ void Blimp::init_ardupilot()
     }
 
     //Initialise velocity filters
-    vel_x_filter.init(scheduler.get_loop_rate_hz(), motors->freq_hz, 0.5f, 15.0f);
-    vel_y_filter.init(scheduler.get_loop_rate_hz(), motors->freq_hz, 0.5f, 15.0f);
-    vel_z_filter.init(scheduler.get_loop_rate_hz(), motors->freq_hz, 1.0f, 15.0f);
-    vel_yaw_filter.init(scheduler.get_loop_rate_hz(), motors->freq_hz, 5.0f, 15.0f);
+    vel_x_filter.init(scheduler.get_loop_rate_hz(), motors->freq_hz, 0.5f, 15.0f, 1);
+    vel_y_filter.init(scheduler.get_loop_rate_hz(), motors->freq_hz, 0.5f, 15.0f, 1);
+    vel_z_filter.init(scheduler.get_loop_rate_hz(), motors->freq_hz, 1.0f, 15.0f, 1);
+    vel_yaw_filter.init(scheduler.get_loop_rate_hz(), motors->freq_hz, 5.0f, 15.0f, 1);
 
     // attempt to switch to MANUAL, if this fails then switch to Land
     if (!set_mode((enum Mode::Number)g.initial_mode.get(), ModeReason::INITIALISED)) {

--- a/libraries/Filter/AP_Filter.h
+++ b/libraries/Filter/AP_Filter.h
@@ -57,6 +57,7 @@ public:
     AP_Float _center_freq_hz;
     AP_Float _quality;
     AP_Float _attenuation_dB;
+    AP_Int32 _harmonics;
 };
 
 class AP_Filters {

--- a/libraries/Filter/AP_NotchFilter_params.cpp
+++ b/libraries/Filter/AP_NotchFilter_params.cpp
@@ -31,6 +31,28 @@ const AP_Param::GroupInfo AP_NotchFilter_params::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("NOTCH_ATT", 3, AP_NotchFilter_params, _attenuation_dB, 40),
 
+    // @Param: NOTCH_HMNC
+    // @DisplayName: Harmonic Notch Filter harmonics
+    // @Description: Bitmask of harmonic frequencies to apply Harmonic Notch Filter to. A value of 0 disables this filter. The first harmonic refers to the base frequency.
+    // @Bitmask: 0:  1st harmonic
+    // @Bitmask: 1:  2nd harmonic
+    // @Bitmask: 2:  3rd harmonic
+    // @Bitmask: 3:  4th harmonic
+    // @Bitmask: 4:  5th harmonic
+    // @Bitmask: 5:  6th harmonic
+    // @Bitmask: 6:  7th harmonic
+    // @Bitmask: 7:  8th harmonic
+    // @Bitmask: 8:  9th harmonic
+    // @Bitmask: 9:  10th harmonic
+    // @Bitmask: 10: 11th harmonic
+    // @Bitmask: 11: 12th harmonic
+    // @Bitmask: 12: 13th harmonic
+    // @Bitmask: 13: 14th harmonic
+    // @Bitmask: 14: 15th harmonic
+    // @Bitmask: 15: 16th harmonic
+    // @User: Advanced
+    AP_GROUPINFO("NOTCH_HMNC", 4, AP_NotchFilter_params, _harmonics, 1),
+
     AP_GROUPEND
 };
 
@@ -41,13 +63,15 @@ AP_NotchFilter_params::AP_NotchFilter_params() : AP_Filter(AP_Filter::FilterType
 
 bool AP_NotchFilter_params::setup_notch_filter(NotchFilterFloat& filter, float sample_rate)
 {
-    if (is_zero(_quality) || is_zero(_center_freq_hz) || is_zero(_attenuation_dB)) {
+    if (is_zero(_quality) || is_zero(_center_freq_hz) || is_zero(_attenuation_dB) || (_harmonics == 0)) {
         return false;
     }
 
     if (!is_equal(sample_rate, filter.sample_freq_hz())
-        || !is_equal(_center_freq_hz.get(), filter.center_freq_hz())) {
-        filter.init(sample_rate, _center_freq_hz, _center_freq_hz / _quality, _attenuation_dB);
+        || !is_equal(_center_freq_hz.get(), filter.center_freq_hz())
+        || (_harmonics.get() != filter.harmonics())) {
+        filter.init(sample_rate, _center_freq_hz, _center_freq_hz / _quality, _attenuation_dB, (uint16_t)_harmonics.get());
+        return _harmonics.get() == filter.harmonics();
     }
     return true;
 }

--- a/libraries/Filter/HarmonicNotchFilter.cpp
+++ b/libraries/Filter/HarmonicNotchFilter.cpp
@@ -247,6 +247,8 @@ void HarmonicNotchFilter<T>::expand_filter_count(uint16_t total_notches)
         _alloc_has_failed = true;
         return;
     }
+    // safe shallow copy: HarmonicNotchFilter only calls init_with_A_and_Q on its
+    // internal filters, so _harmonic_filters is always nullptr in this array
     memcpy(filters, _filters, sizeof(filters[0])*_num_filters);
     auto _old_filters = _filters;
     _filters = filters;

--- a/libraries/Filter/NotchFilter.cpp
+++ b/libraries/Filter/NotchFilter.cpp
@@ -26,6 +26,35 @@ const static float NOTCH_MAX_SLEW_LOWER = 1.0f - NOTCH_MAX_SLEW;
 const static float NOTCH_MAX_SLEW_UPPER = 1.0f / NOTCH_MAX_SLEW_LOWER;
 
 /*
+  constructor
+ */
+template <class T>
+NotchFilter<T>::NotchFilter() :
+    initialised(false),
+    need_reset(false),
+    b0(0), b1(0), b2(0), a1(0), a2(0),
+    _center_freq_hz(0),
+    _sample_freq_hz(0),
+    _A(0),
+    _harmonics(1),
+    _num_harmonics(1),
+    _harmonic_filters(nullptr)
+{
+}
+
+/*
+  destructor
+ */
+template <class T>
+NotchFilter<T>::~NotchFilter()
+{
+    if (_harmonic_filters != nullptr) {
+        delete[] _harmonic_filters;
+        _harmonic_filters = nullptr;
+    }
+}
+
+/*
    calculate the attenuation and quality factors of the filter
  */
 template <class T>
@@ -40,23 +69,112 @@ void NotchFilter<T>::calculate_A_and_Q(float center_freq_hz, float bandwidth_hz,
 }
 
 /*
-  initialise filter
+  compute coefficients for a single biquad notch
  */
 template <class T>
-void NotchFilter<T>::init(float sample_freq_hz, float center_freq_hz, float bandwidth_hz, float attenuation_dB)
+void NotchFilter<T>::compute_coefficients(float &b0, float &b1, float &b2, float &a1, float &a2,
+                                          float sample_freq_hz, float center_freq_hz, float A, float Q)
 {
-    // check center frequency is in the allowable range
+    float omega = 2.0 * M_PI * center_freq_hz / sample_freq_hz;
+    float alpha = sinf(omega) / (2 * Q);
+    b0 =  1.0 + alpha*sq(A);
+    b1 = -2.0 * cosf(omega);
+    b2 =  1.0 - alpha*sq(A);
+    a1 = b1;
+    a2 =  1.0 - alpha;
+
+    const float a0_inv =  1.0/(1.0 + alpha);
+
+    // Pre-multiply to save runtime calc
+    b0 *= a0_inv;
+    b1 *= a0_inv;
+    b2 *= a0_inv;
+    a1 *= a0_inv;
+    a2 *= a0_inv;
+}
+
+/*
+  initialise filter, optionally with a bitmask of harmonics (default: fundamental only)
+ */
+template <class T>
+void NotchFilter<T>::init(float sample_freq_hz, float center_freq_hz, float bandwidth_hz, float attenuation_dB, uint16_t harmonics)
+{
+    // free any existing multi-harmonic filters
+    if (_harmonic_filters != nullptr) {
+        delete[] _harmonic_filters;
+        _harmonic_filters = nullptr;
+    }
+    _harmonics = harmonics;
+    _num_harmonics = 0;
     initialised = false;
-    if ((center_freq_hz > 0.5 * bandwidth_hz) && (center_freq_hz < 0.5 * sample_freq_hz)) {
+
+    if (harmonics == 0) {
+        return;
+    }
+
+    if (harmonics == 1) {
+        // single notch at fundamental - use slew-limited single-biquad path
+        _num_harmonics = 1;
         float A, Q;
         calculate_A_and_Q(center_freq_hz, bandwidth_hz, attenuation_dB, A, Q);
         init_with_A_and_Q(sample_freq_hz, center_freq_hz, A, Q);
+        return;
     }
+
+    // multiple harmonics - allocate one NotchFilter per enabled harmonic
+    float A, Q;
+    calculate_A_and_Q(center_freq_hz, bandwidth_hz, attenuation_dB, A, Q);
+    if (Q <= 0.0f) {
+        _harmonics = 0;
+        return;
+    }
+
+    const uint8_t alloc_count = __builtin_popcount(harmonics);
+    _harmonic_filters = NEW_NOTHROW NotchFilter<T>[alloc_count];
+    if (_harmonic_filters == nullptr) {
+        _harmonics = 0;
+        return;
+    }
+
+    uint8_t active_count = 0;
+    for (uint8_t i = 0; i < max_harmonics; i++) {
+        if ((harmonics & (1U << i)) == 0) {
+            continue;
+        }
+        const float harmonic_center = center_freq_hz * (i + 1);
+        if (is_positive(harmonic_center) && (harmonic_center < 0.5 * sample_freq_hz)) {
+            _harmonic_filters[active_count].init_with_A_and_Q(sample_freq_hz, harmonic_center, A, Q);
+            active_count++;
+        }
+    }
+
+    _num_harmonics = active_count;
+    if (_num_harmonics == 0) {
+        delete[] _harmonic_filters;
+        _harmonic_filters = nullptr;
+        _harmonics = 0;
+        return;
+    }
+
+    _center_freq_hz = center_freq_hz;
+    _sample_freq_hz = sample_freq_hz;
+    _A = A;
+    initialised = true;
 }
 
 template <class T>
 void NotchFilter<T>::init_with_A_and_Q(float sample_freq_hz, float center_freq_hz, float A, float Q)
 {
+    // free any existing multi-harmonic filters: this path manages a single biquad only.
+    // init() is the right entry-point for harmonics > 1; calling this directly on a
+    // multi-harmonic filter downgrades it to single-notch and frees the old array.
+    if (_harmonic_filters != nullptr) {
+        delete[] _harmonic_filters;
+        _harmonic_filters = nullptr;
+        _harmonics = 1;
+        _num_harmonics = 1;
+    }
+
     // don't update if no updates required
     if (initialised &&
         is_equal(center_freq_hz, _center_freq_hz) &&
@@ -74,22 +192,7 @@ void NotchFilter<T>::init_with_A_and_Q(float sample_freq_hz, float center_freq_h
     }
 
     if (is_positive(new_center_freq) && (new_center_freq < 0.5 * sample_freq_hz) && (Q > 0.0)) {
-        float omega = 2.0 * M_PI * new_center_freq / sample_freq_hz;
-        float alpha = sinf(omega) / (2 * Q);
-        b0 =  1.0 + alpha*sq(A);
-        b1 = -2.0 * cosf(omega);
-        b2 =  1.0 - alpha*sq(A);
-        a1 = b1;
-        a2 =  1.0 - alpha;
-
-        const float a0_inv =  1.0/(1.0 + alpha);
-
-        // Pre-multiply to save runtime calc
-        b0 *= a0_inv;
-        b1 *= a0_inv;
-        b2 *= a0_inv;
-        a1 *= a0_inv;
-        a2 *= a0_inv;
+        compute_coefficients(b0, b1, b2, a1, a2, sample_freq_hz, new_center_freq, A, Q);
 
         _center_freq_hz = new_center_freq;
         _sample_freq_hz = sample_freq_hz;
@@ -110,12 +213,26 @@ T NotchFilter<T>::apply(const T &sample)
     if (!initialised || need_reset) {
         // if we have not been initialised when return the input
         // sample as output and update delayed samples
-        signal1 = sample;
-        signal2 = sample;
-        ntchsig1 = sample;
-        ntchsig2 = sample;
+        if (_harmonic_filters != nullptr) {
+            for (uint8_t i = 0; i < _num_harmonics; i++) {
+                _harmonic_filters[i].reset();
+            }
+        } else {
+            signal1 = sample;
+            signal2 = sample;
+            ntchsig1 = sample;
+            ntchsig2 = sample;
+        }
         need_reset = false;
         return sample;
+    }
+
+    if (_harmonic_filters != nullptr) {
+        T output = sample;
+        for (uint8_t i = 0; i < _num_harmonics; i++) {
+            output = _harmonic_filters[i].apply(output);
+        }
+        return output;
     }
 
     T output = sample*b0 + ntchsig1*b1 + ntchsig2*b2 - signal1*a1 - signal2*a2;

--- a/libraries/Filter/NotchFilter.h
+++ b/libraries/Filter/NotchFilter.h
@@ -33,16 +33,27 @@ template <class T>
 class NotchFilter {
 public:
     friend class HarmonicNotchFilter<T>;
+
+    NotchFilter();
+    ~NotchFilter();
+    CLASS_NO_COPY(NotchFilter);
+
+    // maximum number of harmonics supported; sized to the width of the harmonics bitmask
+    static constexpr uint8_t max_harmonics = sizeof(uint16_t) * 8;
+
     // set parameters
-    void init(float sample_freq_hz, float center_freq_hz, float bandwidth_hz, float attenuation_dB);
+    void init(float sample_freq_hz, float center_freq_hz, float bandwidth_hz, float attenuation_dB, uint16_t harmonics);
     void init_with_A_and_Q(float sample_freq_hz, float center_freq_hz, float A, float Q);
     T apply(const T &sample);
     void reset();
     float center_freq_hz() const { return _center_freq_hz; }
     float sample_freq_hz() const { return _sample_freq_hz; }
+    // returns the requested harmonics bitmask; may include harmonics above Nyquist
+    // that were not instantiated - check that initialised is true for active state
+    uint16_t harmonics() const { return _harmonics; }
 
     // calculate attenuation and quality from provided center frequency and bandwidth
-    static void calculate_A_and_Q(float center_freq_hz, float bandwidth_hz, float attenuation_dB, float& A, float& Q); 
+    static void calculate_A_and_Q(float center_freq_hz, float bandwidth_hz, float attenuation_dB, float& A, float& Q);
 
     void disable(void) {
         initialised = false;
@@ -52,11 +63,21 @@ public:
     float logging_frequency(void) const;
 
 protected:
+    // compute coefficients for a single biquad notch
+    static void compute_coefficients(float &b0, float &b1, float &b2, float &a1, float &a2,
+                                     float sample_freq_hz, float center_freq_hz, float A, float Q);
 
     bool initialised, need_reset;
     float b0, b1, b2, a1, a2;
     float _center_freq_hz, _sample_freq_hz, _A;
     T ntchsig1, ntchsig2, signal2, signal1;
+    // requested harmonics bitmask as passed to init(); may include bits for harmonics
+    // that were skipped due to Nyquist constraints - use _num_harmonics for active count
+    uint16_t _harmonics;
+    // number of sub-filters actually initialised (≤ popcount(_harmonics))
+    uint8_t _num_harmonics;
+    // array of single-notch filters, one per active harmonic (nullptr when harmonics == 1)
+    NotchFilter<T>* _harmonic_filters;
 };
 
 /*

--- a/libraries/Filter/examples/TransferFunctionCheck/TransferFunctionCheck.cpp
+++ b/libraries/Filter/examples/TransferFunctionCheck/TransferFunctionCheck.cpp
@@ -153,14 +153,14 @@ void setup()
         break;
 
     case filter_type::Notch:
-        notch.init(sample_rate, target_freq, target_freq*0.25, 40);
+        notch.init(sample_rate, target_freq, target_freq*0.25, 40, 1);
         notch.print_transfer_function();
         break;
 
     case filter_type::Combination:
         // A combination of two notches and a biquad lowpass, representative of a typical setup
-        notch.init(sample_rate, target_freq, target_freq*0.25, 40);
-        notch2.init(sample_rate, target_freq*2.00, target_freq*0.25, 40);
+        notch.init(sample_rate, target_freq, target_freq*0.25, 40, 1);
+        notch2.init(sample_rate, target_freq*2.00, target_freq*0.25, 40, 1);
         biquad.set_cutoff_frequency(sample_rate, target_freq*1.5);
         notch.print_transfer_function();
         hal.console->printf("\n");

--- a/libraries/Filter/tests/test_notchfilter.cpp
+++ b/libraries/Filter/tests/test_notchfilter.cpp
@@ -18,7 +18,7 @@ static double ratio_to_dB(double ratio)
 TEST(NotchFilterTest, ResetTest)
 {
     NotchFilter<float> filter;
-    filter.init(1000, 60, 33, 41);
+    filter.init(1000, 60, 33, 41, 1);
     const float const_sample = -0.512;
     filter.reset();
     for (uint32_t i=0; i<100; i++) {
@@ -45,7 +45,7 @@ TEST(NotchFilterTest, SineTest)
     double integral1_out = 0;
     double integral2_in = 0;
     double integral2_out = 0;
-    filter.init(rate_hz, test_freq, test_freq*0.5, attenuation_dB);
+    filter.init(rate_hz, test_freq, test_freq*0.5, attenuation_dB, 1);
     filter.reset();
     for (uint32_t i=0; i<periods * period_samples; i++) {
         const double t = i * dt;
@@ -69,6 +69,63 @@ TEST(NotchFilterTest, SineTest)
     ::printf("ratio1=%f expected_ratio=%f\n", ratio1, expected_ratio);
     const float err_pct = 100 * fabsF(ratio1 - expected_ratio) / ratio1;
     EXPECT_LE(err_pct, 1);
+}
+
+/*
+  helper to measure output amplitude of a notch filter at a given frequency
+ */
+static float measure_attenuation(NotchFilter<float> &filter, float freq, float rate_hz, float test_amplitude=1.0)
+{
+    const double dt = 1.0 / rate_hz;
+    const uint32_t period_samples = MAX(uint32_t(rate_hz / freq), 1U);
+    const uint32_t periods = 200;
+    // Use enough warmup samples for all cascaded-notch transients to decay.
+    // A cascade whose lowest notch is at f_low with quality Q has poles at
+    // |z| = sqrt(a2) close to 1; 200 samples covers τ ≈ 5×22 for the
+    // common Q≈1.7 / 50 Hz case.
+    const uint32_t warmup = MAX(2*period_samples, 200U);
+    double v_max = 0;
+    filter.reset();
+    for (uint32_t i=0; i<periods * period_samples + warmup; i++) {
+        const double t = i * dt;
+        const double sample = sin(freq * t * 2 * M_PI) * test_amplitude;
+        const float v = filter.apply(sample);
+        if (i >= warmup) {
+            v_max = MAX(v_max, fabsF(v));
+        }
+    }
+    return ratio_to_dB(v_max / test_amplitude);
+}
+
+/*
+  test multi-harmonic notch filter
+ */
+TEST(NotchFilterTest, MultiHarmonicNotchTest)
+{
+    const float base_freq = 50;
+    const float bandwidth = base_freq / 2;
+    const float attenuation_dB = 40;
+    const float rate_hz = 2000;
+
+    NotchFilter<float> filter;
+    filter.init(rate_hz, base_freq, bandwidth, attenuation_dB, 0x03); // 1st and 2nd harmonic
+
+    // check the filter reports the correct harmonics and fundamental frequency
+    EXPECT_EQ(filter.harmonics(), 0x03U);
+    EXPECT_FLOAT_EQ(filter.center_freq_hz(), base_freq);
+
+    // we should see strong attenuation at the fundamental and 2nd harmonic
+    EXPECT_LT(measure_attenuation(filter, base_freq, rate_hz), -attenuation_dB + 5);
+    EXPECT_LT(measure_attenuation(filter, base_freq * 2, rate_hz), -attenuation_dB + 5);
+
+    // a non-harmonic frequency should not be strongly attenuated.
+    // With bandwidth = base_freq/2 the 100 Hz notch's -3 dB band spans ~71-129 Hz,
+    // so 75 Hz (= 1.5×base) sits inside it; steady-state cascade gain is ≈ -3.8 dB
+    // (in 10·ln units).  Use -6 as the threshold to allow for this overlap.
+    EXPECT_GT(measure_attenuation(filter, base_freq * 1.5, rate_hz), -6);
+
+    // a higher harmonic that is not enabled should not be strongly attenuated
+    EXPECT_GT(measure_attenuation(filter, base_freq * 3, rate_hz), -3);
 }
 
 /*
@@ -361,6 +418,169 @@ TEST(NotchFilterTest, HarmonicNotchTest5)
                 phase_lags[6]);
     }
     fclose(f);
+}
+
+// -----------------------------------------------------------------------
+// NotchFilter multi-harmonic feature tests
+// -----------------------------------------------------------------------
+
+/*
+  harmonics=0 must leave the filter uninitialised and pass every sample through unchanged.
+ */
+TEST(NotchFilterTest, MultiHarmonicZeroDisablesFilter)
+{
+    NotchFilter<float> filter;
+    filter.init(1000, 50, 25, 40, 0);
+    EXPECT_EQ(filter.harmonics(), 0U);
+    // pass-through: apply() must return the input sample when not initialised
+    for (uint32_t i = 0; i < 100; i++) {
+        const float sample = sinf(50.0f * i * 2.0f * M_PI / 1000.0f);
+        EXPECT_FLOAT_EQ(filter.apply(sample), sample);
+    }
+}
+
+/*
+  when the center frequency is below half the bandwidth, Q is zero and
+  the multi-harmonic init must disable the filter.
+ */
+TEST(NotchFilterTest, MultiHarmonicBadQDisablesFilter)
+{
+    NotchFilter<float> filter;
+    // center_freq_hz=10 < bandwidth_hz/2=15 → Q=0
+    filter.init(1000, 10, 30, 40, 0x03);
+    EXPECT_EQ(filter.harmonics(), 0U);
+    for (uint32_t i = 0; i < 50; i++) {
+        const float sample = sinf(10.0f * i * 2.0f * M_PI / 1000.0f);
+        EXPECT_FLOAT_EQ(filter.apply(sample), sample);
+    }
+}
+
+/*
+  when every selected harmonic falls above the Nyquist frequency none
+  of them can be initialised and the filter must be disabled.
+ */
+TEST(NotchFilterTest, MultiHarmonicAllAboveNyquistDisablesFilter)
+{
+    // sample_rate=2000 Hz → Nyquist=1000 Hz
+    // base_freq=600 Hz, harmonics bits 1&2 → 1200 Hz and 1800 Hz, both > Nyquist
+    NotchFilter<float> filter;
+    filter.init(2000, 600, 200, 40, 0x06);
+    EXPECT_EQ(filter.harmonics(), 0U);
+    for (uint32_t i = 0; i < 50; i++) {
+        const float sample = sinf(300.0f * i * 2.0f * M_PI / 2000.0f);
+        EXPECT_FLOAT_EQ(filter.apply(sample), sample);
+    }
+}
+
+/*
+  reset() on a multi-harmonic filter must not produce a glitch: constant
+  input after reset must yield constant output on every sample.
+ */
+TEST(NotchFilterTest, MultiHarmonicResetNoGlitch)
+{
+    NotchFilter<float> filter;
+    filter.init(1000, 60, 30, 40, 0x03); // 1st and 2nd harmonic
+    const float const_sample = -0.512f;
+    filter.reset();
+    for (uint32_t i = 0; i < 100; i++) {
+        EXPECT_FLOAT_EQ(filter.apply(const_sample), const_sample);
+    }
+}
+
+/*
+  bit 1 selects the 2nd harmonic (2×base) only.  The filter must
+  attenuate there but leave the fundamental unaffected.
+ */
+TEST(NotchFilterTest, MultiHarmonicSecondHarmonicOnly)
+{
+    const float rate_hz = 2000;
+    const float base_freq = 50;
+    const float attenuation_dB = 40;
+
+    NotchFilter<float> filter;
+    filter.init(rate_hz, base_freq, base_freq / 2, attenuation_dB, 0x02); // bit 1 = 2nd harmonic
+    EXPECT_EQ(filter.harmonics(), 0x02U);
+
+    // 2nd harmonic must be strongly attenuated
+    EXPECT_LT(measure_attenuation(filter, base_freq * 2, rate_hz), -attenuation_dB + 5);
+    // fundamental must NOT be strongly attenuated
+    EXPECT_GT(measure_attenuation(filter, base_freq, rate_hz), -3);
+}
+
+/*
+  non-consecutive harmonic selection: bits 0 and 2 → 1st and 3rd harmonics.
+  Only those two frequencies must see significant attenuation.
+ */
+TEST(NotchFilterTest, MultiHarmonicNonConsecutive)
+{
+    const float rate_hz = 2000;
+    const float base_freq = 50;
+    const float attenuation_dB = 40;
+
+    NotchFilter<float> filter;
+    // bits 0,2 → 1×50=50 Hz, 3×50=150 Hz
+    filter.init(rate_hz, base_freq, base_freq / 2, attenuation_dB, 0x05);
+    EXPECT_EQ(filter.harmonics(), 0x05U);
+
+    // 1st and 3rd harmonics must be strongly attenuated
+    EXPECT_LT(measure_attenuation(filter, base_freq * 1, rate_hz), -attenuation_dB + 5);
+    EXPECT_LT(measure_attenuation(filter, base_freq * 3, rate_hz), -attenuation_dB + 5);
+
+    // 2nd harmonic (not selected) must NOT be strongly attenuated
+    EXPECT_GT(measure_attenuation(filter, base_freq * 2, rate_hz), -3);
+}
+
+/*
+  a second call to init() with a different harmonics bitmask must cleanly
+  replace the previous filter bank without crash or leak.
+ */
+TEST(NotchFilterTest, MultiHarmonicReinit)
+{
+    const float rate_hz = 2000;
+    const float base_freq = 50;
+    const float bandwidth = base_freq / 2;
+    const float attenuation_dB = 40;
+
+    NotchFilter<float> filter;
+
+    // first init: 1st and 2nd harmonics
+    filter.init(rate_hz, base_freq, bandwidth, attenuation_dB, 0x03);
+    EXPECT_EQ(filter.harmonics(), 0x03U);
+    EXPECT_LT(measure_attenuation(filter, base_freq,     rate_hz), -attenuation_dB + 5);
+    EXPECT_LT(measure_attenuation(filter, base_freq * 2, rate_hz), -attenuation_dB + 5);
+
+    // second init: 2nd and 3rd harmonics only
+    filter.init(rate_hz, base_freq, bandwidth, attenuation_dB, 0x06);
+    EXPECT_EQ(filter.harmonics(), 0x06U);
+    EXPECT_GT(measure_attenuation(filter, base_freq,     rate_hz), -3);      // 1st: no longer filtered
+    EXPECT_LT(measure_attenuation(filter, base_freq * 2, rate_hz), -attenuation_dB + 5);
+    EXPECT_LT(measure_attenuation(filter, base_freq * 3, rate_hz), -attenuation_dB + 5);
+}
+
+/*
+  when some selected harmonics fall above Nyquist, only those below it
+  are active; the filter is still considered initialised (harmonics()
+  returns the originally requested bitmask).
+ */
+TEST(NotchFilterTest, MultiHarmonicPartialAboveNyquist)
+{
+    // sample_rate=2000 Hz → Nyquist=1000 Hz
+    // base=400 Hz, harmonics=0x07 (bits 0,1,2) → 400, 800, 1200 Hz
+    // Only 400 Hz and 800 Hz are below Nyquist
+    const float rate_hz = 2000;
+    const float base_freq = 400;
+    const float attenuation_dB = 40;
+
+    NotchFilter<float> filter;
+    filter.init(rate_hz, base_freq, 150, attenuation_dB, 0x07);
+    EXPECT_EQ(filter.harmonics(), 0x07U); // requested bitmask is preserved
+
+    // the two active harmonics must be attenuated
+    EXPECT_LT(measure_attenuation(filter, base_freq * 1, rate_hz), -attenuation_dB + 5);
+    EXPECT_LT(measure_attenuation(filter, base_freq * 2, rate_hz), -attenuation_dB + 5);
+
+    // a frequency between the two active harmonics must NOT be attenuated
+    EXPECT_GT(measure_attenuation(filter, base_freq * 1.5f, rate_hz), -3);
 }
 
 AP_GTEST_MAIN()


### PR DESCRIPTION
### Summary

Add a NOTCH_HMNC bitmask to the FILT1 through FILT8 notch filter parameter groups used by the PID target and error notch filters.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Cascade a biquad notch for each enabled harmonic at a multiple of the configured base frequency. Keep the existing single-biquad, slew-limited path for the default fundamental-only mask so existing parameter configurations retain their current behavior.

Refactor the single-biquad coefficient calculation into a shared helper used by both paths. Report PID notch setup failure when a multi-harmonic filter cannot be allocated, allowing the existing PID setup path to disable the unusable filter rather than silently running without it.

Update notch filter examples and add unit coverage for attenuation at the fundamental and second harmonic, while checking that unselected frequencies remain unaffected.
