### PR TITLE
Tools: add --progress-file option to build_boards and size_compare_branches

### DIFF
--- a/Tools/scripts/build_boards.py
+++ b/Tools/scripts/build_boards.py
@@ -38,8 +38,9 @@ class BuildBoards(BuildScriptBase):
                  parallel_copies=None,
                  jobs=None,
                  configure_only=False,
+                 progress_file=None,
                  ):
-        super().__init__()
+        super().__init__(progress_file=progress_file)
 
         if board is None:
             board = []
@@ -72,6 +73,23 @@ class BuildBoards(BuildScriptBase):
 
     def progress_prefix(self):
         return 'BB'
+
+    def write_task_progress(self, all_tasks, remaining_tasks):
+        '''write task counts, remaining tasks and failures to the
+        progress file, if one was specified'''
+        if self.progress_file is None:
+            return
+        content = (f"total-tasks={len(all_tasks)} " +
+                   f"remaining-tasks={len(remaining_tasks)} " +
+                   f"failures={len(self.failure_exceptions)}\n")
+        for t in remaining_tasks:
+            content += f"remaining: {t}\n"
+        for f in self.failure_exceptions:
+            content += f"failure: {f}\n"
+        self.write_progress_file(content)
+
+    def parallel_progress_hook(self, tasks):
+        self.write_task_progress(tasks, copy.copy(self.parallel_tasks))
 
     class Task():
         def __init__(self, board: str, vehicles_to_build: list) -> None:
@@ -156,13 +174,17 @@ class BuildBoards(BuildScriptBase):
             failures = self.failure_exceptions
         else:
             # traditional build everything in sequence:
-            failures = []
+            self.failure_exceptions = []
+            remaining = copy.copy(tasks)
             for task in tasks:
                 try:
                     self.run_build_task(task)
                 except Exception as ex:  # noqa: BLE001 — record failure, continue with remaining boards
                     self.progress(f"Build failed: {task} ({ex})")
-                    failures.append(f"{task}")
+                    self.failure_exceptions.append(f"{task}")
+                remaining.pop(0)
+                self.write_task_progress(tasks, remaining)
+            failures = self.failure_exceptions
 
         return failures
 
@@ -205,6 +227,10 @@ def main():
                         action='store_true',
                         default=False,
                         help="only run waf configure for each board, do not build")
+    parser.add_argument("--progress-file",
+                        type=str,
+                        default=None,
+                        help="file to write task progress and failures to as builds complete")
     args = parser.parse_args()
 
     if args.configure_only and len(args.vehicle) == 0 and not args.all_vehicles:
@@ -233,6 +259,7 @@ def main():
         parallel_copies=args.parallel_copies,
         jobs=args.jobs,
         configure_only=args.configure_only,
+        progress_file=args.progress_file,
     )
     failures = bb.run()
     if failures:

--- a/Tools/scripts/build_script_base.py
+++ b/Tools/scripts/build_script_base.py
@@ -42,8 +42,15 @@ VEHICLE_MAP = {
 class BuildScriptBase(ABC):
     """Base class for build scripts with common utilities for running programs"""
 
-    def __init__(self):
+    def __init__(self, progress_file=None):
         self.tmpdir = None  # Can be set by subclasses that need it
+        self.progress_file = progress_file
+
+    def write_progress_file(self, content: str):
+        '''write content to the progress file, if one was specified'''
+        if self.progress_file is None:
+            return
+        pathlib.Path(self.progress_file).write_text(content)
 
     def resolve_board_and_vehicle_lists(self, all_boards=False, all_vehicles=False, exclude_board_glob=None):
         '''populate self.boards_by_name and self.vehicle_map; expand or

--- a/Tools/scripts/size_compare_branches.py
+++ b/Tools/scripts/size_compare_branches.py
@@ -84,8 +84,9 @@ class SizeCompareBranches(BuildScriptBase):
                  features=False,
                  symbols=False,
                  compare_object_files=False,
+                 progress_file=None,
                  ):
-        super().__init__()
+        super().__init__(progress_file=progress_file)
 
         if board is None:
             board = ["MatekF405-Wing"]
@@ -213,8 +214,7 @@ class SizeCompareBranches(BuildScriptBase):
         # progress CSV:
         pairs = self.pairs_from_task_results(task_results)
         csv_for_results = self.csv_for_results(self.compare_task_results_sizes(pairs))
-        path = pathlib.Path("/tmp/some.csv")
-        path.write_text(csv_for_results)
+        self.write_progress_file(csv_for_results)
 
     class Task():
         def __init__(self,
@@ -286,9 +286,8 @@ class SizeCompareBranches(BuildScriptBase):
                 task_results.append(self.gather_results_for_task(task))
 
                 # progress CSV:
-                with open("/tmp/some.csv", "w") as f:
-                    pairs = self.pairs_from_task_results(task_results)
-                    f.write(self.csv_for_results(self.compare_task_results_sizes(pairs)))
+                pairs = self.pairs_from_task_results(task_results)
+                self.write_progress_file(self.csv_for_results(self.compare_task_results_sizes(pairs)))
 
         return self.compare_task_results(task_results)
 
@@ -821,6 +820,11 @@ def main():
                       default=False,
                       help="Build all vehicles")
     parser.add_option("",
+                      "--progress-file",
+                      type="string",
+                      default=None,
+                      help="file to write progress CSV to as results come in")
+    parser.add_option("",
                       "--parallel-copies",
                       type=int,
                       default=None,
@@ -866,6 +870,7 @@ def main():
         features=cmd_opts.features,
         symbols=cmd_opts.symbols,
         compare_object_files=cmd_opts.compare_object_files,
+        progress_file=cmd_opts.progress_file,
     )
     x.run()
 


### PR DESCRIPTION
### Summary

Make the progress "some.csv" suck less by providing command-line option specifying location to put content in

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

size_compare_branches wrote its progress CSV to the hardcoded path /tmp/some.csv; make the destination a command-line option, and write no progress file at all when the option is not given.  The write helper lives in the shared base class, and build_boards gains the same option, writing task counts, remaining tasks and failures as builds complete (in both parallel and sequential modes).
