### PR TITLE
Compile ArduPilot with -Werror=null-dereference

### DIFF
--- a/ArduPlane/failsafe.cpp
+++ b/ArduPlane/failsafe.cpp
@@ -107,7 +107,7 @@ void Plane::failsafe_check(void)
         // we're manipulating surfaces
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
         GCS_MAVLINK *chan = gcs().chan(0);
-        if (HAVE_PAYLOAD_SPACE(chan->get_chan(), SERVO_OUTPUT_RAW)) {
+        if (chan != nullptr && HAVE_PAYLOAD_SPACE(chan->get_chan(), SERVO_OUTPUT_RAW)) {
             chan->send_servo_output_raw();
         }
 #endif

--- a/ArduSub/actuators.cpp
+++ b/ArduSub/actuators.cpp
@@ -63,6 +63,9 @@ void Actuators::initialize_actuators() {
             continue;
         }
         SRV_Channel* chan = SRV_Channels::srv_channel(channel_number);
+        if (chan == nullptr) {
+            continue;
+        }
         uint16_t servo_min = chan->get_output_min();
         uint16_t servo_max = chan->get_output_max();
         uint16_t servo_range = servo_max - servo_min;
@@ -82,6 +85,9 @@ void Actuators::update_actuators() {
             continue;
         }
         SRV_Channel* chan = SRV_Channels::srv_channel(channel_number);
+        if (chan == nullptr) {
+            continue;
+        }
         uint16_t servo_min = chan->get_output_min();
         uint16_t servo_max = chan->get_output_max();
         uint16_t servo_range = servo_max - servo_min;

--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -288,6 +288,7 @@ class Board:
             '-Werror=format-extra-args',
             '-Werror=ignored-qualifiers',
             '-Werror=undef',
+            '-Werror=null-dereference',
             '-DARDUPILOT_BUILD',
         ]
 
@@ -389,6 +390,7 @@ class Board:
             '-Werror=reorder',
             '-Werror=cast-align',
             '-Werror=attributes',
+            '-Werror=null-dereference',
             '-Werror=format-security',
             '-Werror=format-extra-args',
             '-Werror=enum-compare',

--- a/Tools/ardupilotwaf/gtest.py
+++ b/Tools/ardupilotwaf/gtest.py
@@ -41,7 +41,12 @@ def configure(cfg):
 
 @conf
 def libgtest(bld, **kw):
-    kw['cxxflags'] = Utils.to_list(kw.get('cxxflags', [])) + ['-Wno-undef']
+    kw['cxxflags'] = Utils.to_list(kw.get('cxxflags', [])) + [
+        '-Wno-undef',
+        # gtest is not clean for -Wnull-dereference and we do not
+        # modify submodule code:
+        '-Wno-null-dereference',
+    ]
     kw.update(
         source='modules/gtest/googletest/src/gtest-all.cc',
         target='gtest/gtest',

--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -500,13 +500,18 @@ void AC_PrecLand::handle_msg(const mavlink_landing_target_t &packet, uint32_t ti
 void AC_PrecLand::run_estimator(float rangefinder_alt_m, bool rangefinder_alt_valid)
 {
     _inertial_data_delayed = (*_inertial_history)[0];
+    if (_inertial_data_delayed == nullptr) {
+        // can't happen; the history always has an entry pushed before
+        // this method is called
+        return;
+    }
 
     switch ((EstimatorType)_estimator_type.get()) {
         case EstimatorType::RAW_SENSOR: {
             // Return if there's any invalid velocity data
             for (uint8_t i=0; i<_inertial_history->available(); i++) {
                 const struct inertial_data_frame_s *inertial_data = (*_inertial_history)[i];
-                if (!inertial_data->inertialNavVelocityValid) {
+                if (inertial_data == nullptr || !inertial_data->inertialNavVelocityValid) {
                     _target_acquired = false;
                     return;
                 }
@@ -729,6 +734,9 @@ void AC_PrecLand::run_output_prediction()
     // Predict forward from delayed time horizon
     for (uint8_t i=1; i<_inertial_history->available(); i++) {
         const struct inertial_data_frame_s *inertial_data = (*_inertial_history)[i];
+        if (inertial_data == nullptr) {
+            continue;
+        }
         _target_vel_rel_out_ne_ms.x -= inertial_data->correctedVehicleDeltaVelocityNED.x;
         _target_vel_rel_out_ne_ms.y -= inertial_data->correctedVehicleDeltaVelocityNED.y;
         _target_pos_rel_out_ne_m.x += _target_vel_rel_out_ne_ms.x * inertial_data->dt;

--- a/libraries/APM_Control/examples/AP_FW_Controller_test/AP_FW_Controller_test.cpp
+++ b/libraries/APM_Control/examples/AP_FW_Controller_test/AP_FW_Controller_test.cpp
@@ -259,6 +259,11 @@ void loop(void)
             break;
     }
 
+    if (info == nullptr) {
+        // can't happen; all axis values are covered above
+        return;
+    }
+
     // Print results
     ::printf("%f,%f,%f,%f,%f,%f,%f,%f,%f,%f,%f,%f,%f,%u,%u,%u,%u\n",
         waveform_time_s,

--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -513,6 +513,10 @@ void AP_BLHeli::msp_process_command(void)
         debug("MSP_MOTOR_CONFIG(n=%u, p=%u)", num_motors, motor_poles.get());
         uint8_t buf[10];
         SRV_Channel* channel = SRV_Channels::srv_channel(blheli_chan_to_output_chan(0));
+        if (channel == nullptr) {
+            // no reply, the same as for an unhandled command
+            break;
+        }
         putU16(&buf[0], channel->get_output_min()); // min throttle
         putU16(&buf[2], channel->get_output_max()); // max throttle
         putU16(&buf[4], channel->get_output_min()); // min command

--- a/libraries/AP_HAL/utility/RingBuffer.h
+++ b/libraries/AP_HAL/utility/RingBuffer.h
@@ -567,7 +567,14 @@ public:
         }
         // take advantage of the [] operator for simple shift of the array elements
         for (uint16_t i=n; i<_count-1; i++) {
-            *(*this)[i] = *(*this)[i+1];
+            T *to = (*this)[i];
+            T *from = (*this)[i+1];
+            if (to == nullptr || from == nullptr) {
+                // the indexes are within _count so this can't happen,
+                // but the check keeps the compiler happy
+                break;
+            }
+            *to = *from;
         }
         _count--;
         return true;

--- a/libraries/AP_HAL_Linux/RCInput_RPI.cpp
+++ b/libraries/AP_HAL_Linux/RCInput_RPI.cpp
@@ -408,7 +408,13 @@ void RCInput_RPI::init_ctrl_data()
     }
     //Make last control block point to the first (to make circle)
     cbp -= sizeof(dma_cb_t);
-    ((dma_cb_t *)con_blocks->get_page(con_blocks->_virt_pages, cbp))->next = (uintptr_t)con_blocks->get_page(con_blocks->_phys_pages, 0);
+    dma_cb_t *last_cb = (dma_cb_t *)con_blocks->get_page(con_blocks->_virt_pages, cbp);
+    if (last_cb == nullptr) {
+        // can't happen; cbp is the offset of the last control block
+        // written by the loop above, so is within the table
+        return;
+    }
+    last_cb->next = (uintptr_t)con_blocks->get_page(con_blocks->_phys_pages, 0);
 }
 
 
@@ -555,9 +561,18 @@ void RCInput_RPI::init()
     hal.scheduler->delay(300);
 
     // Reading first sample
-    curr_tick = *((uint64_t *)circle_buffer->get_page(circle_buffer->_virt_pages, curr_pointer));
+    const uint64_t *tick_ptr = (uint64_t *)circle_buffer->get_page(circle_buffer->_virt_pages, curr_pointer);
+    if (tick_ptr == nullptr) {
+        // can't happen; curr_pointer is at the start of the buffer
+        return;
+    }
+    curr_tick = *tick_ptr;
     curr_pointer += 8;
-    signal_states = *((uint64_t *)circle_buffer->get_page(circle_buffer->_virt_pages, curr_pointer));
+    const uint64_t *signal_ptr = (uint64_t *)circle_buffer->get_page(circle_buffer->_virt_pages, curr_pointer);
+    if (signal_ptr == nullptr) {
+        return;
+    }
+    signal_states = *signal_ptr;
     for (uint32_t i = 0; i < RCIN_RPI_CHN_NUM; ++i) {
         rc_channels[i].prev_tick = curr_tick;
         rc_channels[i].curr_signal = (signal_states & (1 << RcChnGpioTbl[i])) ? RCIN_RPI_SIG_HIGH
@@ -626,12 +641,22 @@ void RCInput_RPI::_timer_tick()
     for (;counter > 0x40;) {
         // Is it timer sample?
         if (curr_pointer % (64) == 0) {
-            curr_tick = *((uint64_t *)circle_buffer->get_page(circle_buffer->_virt_pages, curr_pointer));
+            const uint64_t *tick_ptr = (uint64_t *)circle_buffer->get_page(circle_buffer->_virt_pages, curr_pointer);
+            if (tick_ptr == nullptr) {
+                // can't happen; curr_pointer wraps within the buffer
+                break;
+            }
+            curr_tick = *tick_ptr;
             curr_pointer += 8;
             counter -= 8;
         }
         // Reading required bit
-        signal_states = *((uint64_t *)circle_buffer->get_page(circle_buffer->_virt_pages, curr_pointer));
+        const uint64_t *signal_ptr = (uint64_t *)circle_buffer->get_page(circle_buffer->_virt_pages, curr_pointer);
+        if (signal_ptr == nullptr) {
+            // can't happen; curr_pointer wraps within the buffer
+            break;
+        }
+        signal_states = *signal_ptr;
         for (uint32_t i = 0; i < RCIN_RPI_CHN_NUM; ++i) {
             rc_channels[i].curr_signal = (signal_states & (1 << RcChnGpioTbl[i])) ? RCIN_RPI_SIG_HIGH
                                                                                   : RCIN_RPI_SIG_LOW;

--- a/libraries/AP_Networking/config/lwipopts.h
+++ b/libraries/AP_Networking/config/lwipopts.h
@@ -401,10 +401,10 @@ void sys_check_core_locking(void);
 #ifndef LWIP_PLATFORM_ASSERT
 /* Define LWIP_PLATFORM_ASSERT to something to catch missing stdio.h includes */
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL || defined(HAL_DEBUG_BUILD)
-void ap_networking_platform_assert(const char *msg, int line);
+__attribute__((noreturn)) void ap_networking_platform_assert(const char *msg, int line);
 #define LWIP_PLATFORM_ASSERT(x) ap_networking_platform_assert(x, __LINE__)
 #else
-void ap_networking_platform_assert(int line);
+__attribute__((noreturn)) void ap_networking_platform_assert(int line);
 #define LWIP_PLATFORM_ASSERT(x) ap_networking_platform_assert(__LINE__)
 #endif
 #endif

--- a/libraries/AP_Networking/wscript
+++ b/libraries/AP_Networking/wscript
@@ -33,6 +33,11 @@ def configure(cfg):
     extra_src_inc.extend(['libraries/AP_Networking/config',
                           'libraries/AP_Networking/lwip_hal/include'])
 
+    # the lwip sources are third-party code which is not clean for
+    # some of the warnings we promote to errors; this only affects C
+    # sources, so our own C++ code keeps the errors
+    cfg.env.AP_LIB_EXTRA_CFLAGS['AP_Networking'] = ['-Wno-null-dereference']
+
     cfg.env.AP_LIB_EXTRA_SOURCES['AP_Networking'] = []
     for pattern in extra_src:
         s = cfg.srcnode.ant_glob(pattern, dir=False, src=True)

--- a/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
+++ b/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
@@ -2005,13 +2005,18 @@ AP_CRSF_Telem::ScriptedMenu* AP_CRSF_Telem::ScriptedMenu::add_menu(const char* m
     }
 
     menu->id = tail->id == 0 ? SCRIPTED_MENU_START_ID : tail->id + MAX_SCRIPTED_MENU_SIZE + 1;
-    tail->next_menu = menu;
 
     // dummy parameter for a submenu
     if (parent_menu != 0) {
         ScriptedParameter* param = add_parameter(0, nullptr);
+        if (param == nullptr) {
+            delete menu;
+            return nullptr;
+        }
         param->id = menu->id;
     }
+    tail->next_menu = menu;
+
     return menu;
 }
 

--- a/libraries/AP_SerialManager/AP_SerialManager.cpp
+++ b/libraries/AP_SerialManager/AP_SerialManager.cpp
@@ -454,7 +454,10 @@ void AP_SerialManager::init()
         state[i].idx = i;
 
         if (uart != nullptr) {
-            set_options(i);
+            // setup any special options
+            if (!uart->set_options(state[i].options)) {
+                DEV_PRINTF("Unable to setup options for Serial%u\n", i);
+            }
             switch (state[i].protocol) {
                 case SerialProtocol_None:
 #if HAL_GCS_ENABLED
@@ -790,16 +793,6 @@ bool AP_SerialManager::protocol_match(enum SerialProtocol protocol1, enum Serial
     }
 
     return false;
-}
-
-// setup any special options
-void AP_SerialManager::set_options(uint16_t i)
-{
-    struct UARTState &opt = state[i];
-    // pass through to HAL
-    if (!hal.serial(i)->set_options(opt.options)) {
-        DEV_PRINTF("Unable to setup options for Serial%u\n", i);
-    }
 }
 
 // get the passthru ports if enabled

--- a/libraries/AP_SerialManager/AP_SerialManager.h
+++ b/libraries/AP_SerialManager/AP_SerialManager.h
@@ -227,9 +227,6 @@ private:
     // protocol_match - returns true if the protocols match
     bool protocol_match(enum SerialProtocol protocol1, enum SerialProtocol protocol2) const;
 
-    // setup any special options
-    void set_options(uint16_t i);
-
     bool init_console_done;
 
     void convert_parameters();

--- a/libraries/GCS_MAVLink/GCS_MAVLink.cpp
+++ b/libraries/GCS_MAVLink/GCS_MAVLink.cpp
@@ -37,6 +37,9 @@ extern const AP_HAL::HAL& hal;
 // mavlink/pymavlink project for when MAVLINK_SEPARATE_HELPERS is defined
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmissing-declarations"
+// mavlink_reset_channel_status does not check the
+// mavlink_get_channel_status return value for nullptr:
+#pragma GCC diagnostic ignored "-Wnull-dereference"
 #include "include/mavlink/v2.0/mavlink_helpers.h"
 #pragma GCC diagnostic pop
 #endif

--- a/libraries/GCS_MAVLink/GCS_MAVLink.cpp
+++ b/libraries/GCS_MAVLink/GCS_MAVLink.cpp
@@ -44,6 +44,14 @@ extern const AP_HAL::HAL& hal;
 #pragma GCC diagnostic pop
 #endif
 
+/*
+  without a GCS there are no GCS_MAVLINK objects to supply the
+  per-channel state the mavlink helpers rely on, so it is supplied
+  from static storage, as mavlink's own default implementations
+  would.  The arrays are garbage-collected unless something actually
+  uses the channel-based mavlink APIs (e.g. AP_Periph's ADS-B support
+  uses only the explicit-buffer APIs)
+ */
 mavlink_message_t* mavlink_get_channel_buffer(uint8_t chan) {
 #if HAL_GCS_ENABLED
     GCS_MAVLINK *link = gcs().chan(chan);
@@ -52,7 +60,11 @@ mavlink_message_t* mavlink_get_channel_buffer(uint8_t chan) {
     }
     return link->channel_buffer();
 #else
-    return nullptr;
+    static mavlink_message_t buffers[MAVLINK_COMM_NUM_BUFFERS];
+    if (chan >= MAVLINK_COMM_NUM_BUFFERS) {
+        return nullptr;
+    }
+    return &buffers[chan];
 #endif
 }
 
@@ -64,7 +76,11 @@ mavlink_status_t* mavlink_get_channel_status(uint8_t chan) {
     }
     return link->channel_status();
 #else
-    return nullptr;
+    static mavlink_status_t statuses[MAVLINK_COMM_NUM_BUFFERS];
+    if (chan >= MAVLINK_COMM_NUM_BUFFERS) {
+        return nullptr;
+    }
+    return &statuses[chan];
 #endif
 }
 


### PR DESCRIPTION
### Summary

Adds a compiler flag which tells the compiler to fail compilation where it thinks there might be a nullptr deref.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

~~(I'm currently compiling everything, results will go in here at some stage, but generally this saves bytes - and not just because we're removing a method, but because the compiler's optimisation *improves* with the extra checks!)~~

```
-----------------------  ---------  --------------  -----  ----------  ------  -----  ----------  -----  -----  ----
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli   iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                 *
Durandal                            -152            -152   *           -152    -152               -160   -160   -152
Hitec-Airspeed           *                                 *
KakuteH7-bdshot                     -152            -152   *           -152    -160               -160   -160   -152
MatekF405                           -136            -136   *           -144    -144               -136   -144   -136
Pixhawk1-1M-bdshot                  -128            -136               -136    -136               -144   -136   -136
SITL_x86_64_linux_gnu               0               0                  0       -4096              -4096  0      0
YJUAV_A6SE                          -144            -144   *           -144    -144               -152   -160   -144
f103-QiotekPeriph        *                                 *
f303-MatekGPS            *                                 *
f303-Universal           *                                 *
iomcu                                                                                 *
revo-mini                           -136            -144   *           -144    -136               -136   -144   -136
skyviper-v2450                                                         -136
speedybeef4                         -136            -136   *           -136    -136               -136   -144   -136
-----------------------  ---------  --------------  -----  ----------  ------  -----  ----------  -----  -----  ----
```


### Description

Adds the compiler flags and enough extra code to make gcc happy where it can't prove to itself that a pointer isn't nullptr.

Most of the extra code in here is just to make the compiler happy.  The AP_RCTelemetry patch is real, however - a failed allocation can do bad things in that case.
