### PR TITLE
AP_HAL_ChibiOS: RCOutput push() as a zero-copy buffer swap

### DIFF
--- a/libraries/AP_HAL_ChibiOS/RCOutput.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.cpp
@@ -1375,7 +1375,10 @@ void RCOutput::push(void)
         INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
     }
     corked = false;
-    memcpy(period, period_corked, sizeof(period));
+    // swap the live and shadow buffers instead of copying (zero copy)
+    uint16_t *period_tmp = period;
+    period = period_corked;
+    period_corked = period_tmp;
     push_local();
 #if HAL_WITH_IO_MCU
     if (iomcu_enabled) {

--- a/libraries/AP_HAL_ChibiOS/RCOutput.h
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.h
@@ -571,8 +571,10 @@ private:
 
     // these values are for the local channels. Non-local channels are handled by IOMCU
     uint32_t en_mask;
-    uint16_t period[max_channels];
-    uint16_t period_corked[max_channels];
+    // double-buffer the period array so push() is a zero-copy pointer swap
+    uint16_t period_buf[2][max_channels];
+    uint16_t *period = &period_buf[0][0];
+    uint16_t *period_corked = &period_buf[1][0];
 
     // handling of bi-directional dshot
     struct {


### PR DESCRIPTION
### Summary

Builds on #29521. `push()` makes the corked-write handoff atomic by copying the full 32-channel `period` array every cycle; this double-buffers `period`/`period_corked` and has `push()` swap the pointers instead of copying between them — same atomicity, no copy.

### Classification & Testing (check all that apply and add your own)

- [ ] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Not run through ArduPilot's own SITL/autotest — validated with a standalone harness reproducing `RCOutput::write()`/`push()`'s logic against the real ChibiOS source, timed on both x86 and a Cortex-M7 emulated in QEMU (mps2-an500, deterministic `-icount`). Correctness: output hash-identical to the current (post-#29521) behavior over 5000 cork/push cycles. Timing on the real M7-emulated target, ns per cork/push cycle, this patch vs current `master`:

| channels active | current (copy) | this PR (swap) | delta |
|---|---|---|---|
| 4 (quad) | 17.26 | 11.23 | 1.54x faster |
| 6 (hexa) | 16.51 | 16.32 | ~tied |
| 16 | 36.07 | 43.23 | 0.83x, regresses |
| 32 (full) | 75.02 | 88.23 | 0.85x, regresses |

Worth being upfront about the shape of this: `period` becoming a pointer instead of a fixed array adds one indirection to every per-channel access in `write()`/`push_local()`, which is the hot path this runs on every write, not just every push. For boards with a handful of motors (quad/hexa/octa — the common case) that indirection is cheaper than the copy it removes. Past roughly 8-16 active channels it's the opposite: the extra indirection on every write outweighs the copy avoided, and it's slower than both the current code and pre-#29521 base at 16 and 32 channels. So this is a net win for typical small multirotor/plane setups and a net loss for boards driving many channels through the FMU directly — not a universal improvement, and I'd rather say that plainly than only show the quad/hexa numbers.

### Description

`push()`'s `memcpy(period, period_corked, sizeof(period))` (added by #29521 to make the corked-write handoff atomic against a DShot DMA-done ISR reading mid-update) copies all 32 channels every cycle regardless of how many are actually in use. This patch double-buffers `period`/`period_corked` as two halves of one array and has `push()` swap which half is "live" instead of copying — same atomicity guarantee (the ISR always sees either the old or new frame, never a mix), same output, and for low channel counts it's cheaper than the copy it replaces.

This patch (and the honest regression it carries at higher channel counts) came out of an automated perf-optimization pass that profiles merged PRs for further headroom — flagging that plainly since it's directly relevant to reviewing the tradeoff above. AI-assisted: the diagnosis (profiling `push()`'s added copy as the cost) and this specific fix (the pointer-swap) were generated by that tool; I applied it against current `master`, checked it still matches this file's present structure, and verified the correctness/timing claims above via the tool's own test harness rather than taking them on faith.