### PR TITLE
AP_Math: kinematic_limit: cross-multiply instead of normalizing first

### DIFF
--- a/libraries/AP_Math/control.cpp
+++ b/libraries/AP_Math/control.cpp
@@ -745,31 +745,29 @@ float kinematic_limit(float dir_xy, float dir_z, float max_xy, float max_z_neg, 
         return max_xy;
     }
 
-    // Normalize the direction vector (only ratio matters)
-    dir_xy /= dir_length;
-    dir_z /= dir_length;
-
     // Compare the direction slope (|dir_z/dir_xy|) to the limit slope
-    // (max_z/max_xy) to determine which axis constraint is hit first.
-    const float slope = dir_z / dir_xy;
-
-    if (is_positive(slope)) {
+    // (max_z/max_xy) to determine which axis constraint is hit first, without
+    // normalizing dir_xy/dir_z first: dir_xy > 0 here, so the slope and its
+    // sign are scale-invariant and cross-multiplication tests them without a
+    // divide. dir_length is folded into the single divide that survives in
+    // the taken branch below instead of two divides spent normalizing.
+    if (dir_z >= FLT_EPSILON * dir_xy) {
         // Positive-Z: constrained by max_z_pos
-        if (slope < max_z_pos / max_xy) {
+        if (dir_z * max_xy < max_z_pos * dir_xy) {
             // Shallow direction: horizontal limit reached first
-            return max_xy / dir_xy;
+            return max_xy * dir_length / dir_xy;
         }
         // Steep direction: vertical limit reached first
-        return max_z_pos / dir_z;
+        return max_z_pos * dir_length / dir_z;
     }
 
     // Negative-Z: constrained by max_z_neg
-    if (-slope < max_z_neg / max_xy) {
+    if (-dir_z * max_xy < max_z_neg * dir_xy) {
         // Shallow direction: horizontal limit reached first
-        return max_xy / dir_xy;
+        return max_xy * dir_length / dir_xy;
     }
     // Steep direction: vertical limit reached first
-    return -max_z_neg / dir_z;
+    return -max_z_neg * dir_length / dir_z;
 }
 
 // Applies an exponential curve to a normalized input in the range [-1, 1].


### PR DESCRIPTION
### Summary

`kinematic_limit`'s only real caller, `AC_PosControl`, already hands it a normalized direction, but the function normalizes it again internally before deciding which axis limit applies. That decision only cares about the ratio of the two components, so it can be made with a cross-multiply instead of a divide, and the division that's actually needed at the end can be done once instead of five times.

### Classification & Testing (check all that apply and add your own)

- [ ] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

I built a standalone copy of both the current function and this version and threw five million random directions, magnitudes, and limit combinations at them side by side, including a bunch sitting right on the `FLT_EPSILON` boundary the branch decision uses, since that's exactly the spot a cross-multiply rewrite could quietly disagree with the original. They match to about one float ULP everywhere. I didn't get this into SITL or onto real hardware from here, so please treat the numbers below as a strong x86 signal rather than a flight test.

### Description

A while back this function's own callers pass it a direction that's already unit length, but it re-derives the length with a `safe_sqrt`, normalizes both components (2 divides), then divides again to get the slope it branches on, then divides once more for whichever return path gets taken. Four of those five divides are spent getting back to information the caller already had.

Leonard Hall's recent cleanup (`0760b4c7c0`, `c2045d7198`) already moved the zero-length checks ahead of normalization and dropped some now-redundant `fabsf` calls, which helps the pure-vertical and pure-horizontal edge cases skip the divides entirely. But the general case, anything that isn't purely vertical or horizontal, is the common one in real flight, and it still does the full normalize-then-divide dance. This picks up from there: the slope comparison `dir_z/dir_xy` vs `max_z/max_xy` becomes `dir_z*max_xy` vs `max_z*dir_xy`, which needs no division and no normalizing, and `dir_length` gets folded into whichever single divide survives at the return. `safe_sqrt` stays exactly where it was, so the function is just as correct for inputs that aren't unit length as it always was.

On x86 (a conservative stand-in for the Cortex-M7 this actually runs on, where every one of those divides removed is a ~14-cycle blocking op instead of a comparatively cheap FPU divide pipeline):

| | current | this change | speedup |
|---|---|---|---|
| kinematic_limit alone | 6.74 ns | 4.85 ns | 1.39x |
| full AC_PosControl limiter block | 13.22 ns | 11.10 ns | 1.19x |

Consistent across every slope regime and every input magnitude tested (1.39x-1.47x on the function itself). The block-level number is lower because the caller's own normalize and length calls sit outside this function and aren't touched here.

Worth saying plainly: this runs once per position-control cycle at ~400 Hz, so the actual CPU time saved is small in absolute terms. What made it worth doing is that a function everyone assumed was already tight (it had *just* been cleaned up) turned out to still be spending most of its divides on unwinding information its own caller had already computed.

This came out of an automated tool that re-profiles merged PRs looking for exactly this kind of leftover headroom, and this patch is what it found here; I verified the numbers and the correctness claim myself rather than taking them as given.