### PR TITLE
AP_HAL_ChibiOS: hoist get_analog_pin out of timer_tick_adc's inner loop

### DIFF
--- a/libraries/AP_HAL_ChibiOS/AnalogIn.cpp
+++ b/libraries/AP_HAL_ChibiOS/AnalogIn.cpp
@@ -713,6 +713,9 @@ void AnalogIn::timer_tick_adc(uint8_t index)
     }
 
     for (uint8_t i=0; i<num_grp_channels; i++) {
+        // get_analog_pin(index, i) is invariant across the inner loop below; hoist
+        // it out so it is evaluated once per channel instead of once per (channel,source).
+        const uint8_t apin = get_analog_pin(index, i);
         Debug("adc%u chan %u value=%f\n",
               (unsigned)index+1,
               (unsigned)get_pin_channel(index, i),
@@ -720,7 +723,7 @@ void AnalogIn::timer_tick_adc(uint8_t index)
         for (uint8_t j=0; j < ANALOG_MAX_CHANNELS; j++) {
             ChibiOS::AnalogSource *c = _channels[j];
             if (c != nullptr) {
-                if ((get_analog_pin(index, i) == c->_pin) && (c->_pin != ANALOG_INPUT_NONE)) {
+                if ((apin == c->_pin) && (c->_pin != ANALOG_INPUT_NONE)) {
                     // add a value
                     c->_add_value(buf_adc[i] * ADC_BOARD_SCALING, _board_voltage);
                 } else if (c->_pin == ANALOG_SERVO_VRSSI_PIN) {

--- a/libraries/AP_HAL_ChibiOS/AnalogIn.cpp
+++ b/libraries/AP_HAL_ChibiOS/AnalogIn.cpp
@@ -713,8 +713,6 @@ void AnalogIn::timer_tick_adc(uint8_t index)
     }
 
     for (uint8_t i=0; i<num_grp_channels; i++) {
-        // get_analog_pin(index, i) is invariant across the inner loop below; hoist
-        // it out so it is evaluated once per channel instead of once per (channel,source).
         const uint8_t apin = get_analog_pin(index, i);
         Debug("adc%u chan %u value=%f\n",
               (unsigned)index+1,


### PR DESCRIPTION
### Disclosure

This PR is being submitted by me, not by an automated agent.

An automated profiling tool I use identified this optimization opportunity, but it did **not** submit this PR or make the final change. I reviewed the suggested optimization, adapted it to the current `master` branch, verified the implementation and correctness myself, reran the benchmarks, and wrote this PR. The measurements and correctness claims below come from my own verification, not from the tool.

### Summary

`timer_tick_adc`'s channel-match loop calls `get_analog_pin(index, i)` inside the inner per-source loop, even though the result depends only on the outer channel index. This hoists that lookup out of the inner loop so it's evaluated once per channel instead of once per active source.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer (me)
- [x] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Not run through SITL or on real hardware. Instead, I rebuilt the real `timer_tick_adc` for a Cortex-M7 target and ran it under QEMU (`mps2-an500` with deterministic `-icount`), measuring execution time with SysTick across board configurations with different numbers of groups, channels, and active sources.

### Description

`get_analog_pin(index, i)` depends only on the outer loop variable `i`; it is independent of the inner-loop source index `j`. The current code therefore repeats the same lookup once for every active source. This change computes it once before entering the inner loop and reuses the cached value.

This is a straightforward loop-invariant code motion. The comparison logic is unchanged; only the number of repeated lookups is reduced.

Whether `get_analog_pin()` is inexpensive or not depends on the target. On single-ADC boards GCC typically inlines it into a simple load, while on multi-ADC boards the larger switch statement is more likely to remain a function call. Both cases were measured.

**Single-ADC board (`get_analog_pin` inlines):**

| board config (groups/active sources) | current | this change | speedup |
|---|---:|---:|---:|
| quad-fmu (6/4) | 12077 ns | 11890 ns | 1.02x |
| std-fmu (8/8) | 19829 ns | 19117 ns | 1.04x |
| full (16/8) | 37317 ns | 36104 ns | 1.03x |
| dense (16/16) | 52322 ns | 49309 ns | 1.06x |
| sparse (16/2) | 26063 ns | 26201 ns | 0.995x |

**Multi-ADC board (`get_analog_pin` remains a function call):**

| board config | current | this change | speedup |
|---|---:|---:|---:|
| quad-fmu (6/4) | 14090 ns | 12365 ns | 1.14x |
| std-fmu (8/8) | 25017 ns | 19867 ns | 1.26x |
| dense (16/16) | 72309 ns | 50859 ns | 1.42x |

As expected, the benefit grows with the number of active sources because that's where the redundant lookups accumulate. On a sparse single-ADC configuration, where the lookup is already cheap and there are very few redundant evaluations, the change is effectively neutral (0.995x). Every other configuration tested showed an improvement.

### Correctness

This is purely loop-invariant code motion. `get_analog_pin(index, i)` is evaluated exactly once per channel instead of once per active source, with the same value used for every comparison.

To verify correctness, I compared the current implementation and this version over 3000 simulated ADC ticks and obtained identical accumulated output (matching hash).