### PR TITLE
AP_HAL_Linux: read multiple UDP packets per cycle

### DIFF
--- a/libraries/AP_HAL_Linux/UDPDevice.cpp
+++ b/libraries/AP_HAL_Linux/UDPDevice.cpp
@@ -6,6 +6,13 @@
 
 #include <AP_HAL/AP_HAL.h>
 
+// UDP read() will give up after receiving this many packets
+// including ones that are discarded (e.g. our own multicasts)
+// Tune in hwdef.dat if necessary
+#ifndef HAL_LINUX_MAX_UDP_PACKETS
+    #define HAL_LINUX_MAX_UDP_PACKETS 20
+#endif
+
 UDPDevice::UDPDevice(const char *ip, uint16_t port, bool bcast, bool input):
     _ip(ip),
     _port(port),
@@ -35,14 +42,51 @@ ssize_t UDPDevice::write(const uint8_t *buf, uint16_t n)
 
 ssize_t UDPDevice::read(uint8_t *buf, uint16_t n)
 {
-    ssize_t ret = socket.recv(buf, n, 0);
-    if (!_connected && ret > 0) {
-        const char *ip;
-        uint16_t port;
-        socket.last_recv_address(ip, port);
-        _connected = socket.connect(ip, port);
+    ssize_t bytes_read = 0;
+    ssize_t packets_read = 0;
+
+    // recv() only retrieves a single datagram on UDP sockets
+    // peek & read multiple until the buffer full
+    // poll each time because FIONREAD can't distinguish between
+    // no data and empty datagrams
+    while (bytes_read < n && socket.pollin(0) && packets_read < HAL_LINUX_MAX_UDP_PACKETS) {
+        int in_size = 0;
+        if (ioctl(socket.get_read_fd(), FIONREAD, &in_size) < 0) {
+            return -1;
+        }
+
+        // read the first packet unconditionally
+        // read subsequent packets if they fit into the remaining buffer
+        // this ensures that if the incoming packet is somehow larger than
+        // the entire RX ring-buffer, we get a truncated packet rather
+        // than end up being unable to read any further
+        // NOTE: Linux HAL allocates a 8192 byte RX buffer so this should
+        // not happen unless the buffer size is redefined
+        if (bytes_read > 0 && in_size > n - bytes_read) {
+            break;
+        }
+
+        ssize_t ret = socket.recv(&buf[bytes_read], n - bytes_read, 0);
+        if (!_connected && ret > 0) {
+            const char *ip;
+            uint16_t port;
+            socket.last_recv_address(ip, port);
+            _connected = socket.connect(ip, port);
+        }
+
+        // socket.read() may return -1 if we're reading ourselves on multicast
+        if (ret > 0) {
+            bytes_read += ret;
+        }
+
+        packets_read++;
     }
-    return ret;
+
+    if (bytes_read == 0) {
+        return -1;
+    }
+
+    return bytes_read;
 }
 
 bool UDPDevice::open()

--- a/libraries/AP_HAL_Linux/UDPDevice.cpp
+++ b/libraries/AP_HAL_Linux/UDPDevice.cpp
@@ -35,14 +35,48 @@ ssize_t UDPDevice::write(const uint8_t *buf, uint16_t n)
 
 ssize_t UDPDevice::read(uint8_t *buf, uint16_t n)
 {
-    ssize_t ret = socket.recv(buf, n, 0);
-    if (!_connected && ret > 0) {
-        const char *ip;
-        uint16_t port;
-        socket.last_recv_address(ip, port);
-        _connected = socket.connect(ip, port);
+    ssize_t bytes_read = 0;
+
+    // recv() only retrieves a single datagram on UDP sockets
+    // peek & read multiple until the buffer full
+    // poll each time because FIONREAD can't distinguish between
+    // no data and empty datagrams
+    while (bytes_read < n && socket.pollin(0)) {
+        int in_size = 0;
+        if (ioctl(socket.get_read_fd(), FIONREAD, &in_size) < 0) {
+            return -1;
+        }
+
+        // read the first packet unconditionally
+        // read subsequent packets if they fit into the remaining buffer
+        // this ensures that if the incoming packet is somehow larger than
+        // the entire RX ring-buffer, we get a truncated packet rather
+        // than end up being unable to read any further
+        // NOTE: Linux HAL allocates a 8192 byte RX buffer so this should
+        // not happen unless the buffer size is redefined
+        if (bytes_read > 0 && in_size > n - bytes_read) {
+            break;
+        }
+
+        ssize_t ret = socket.recv(&buf[bytes_read], n - bytes_read, 0);
+        if (!_connected && ret > 0) {
+            const char *ip;
+            uint16_t port;
+            socket.last_recv_address(ip, port);
+            _connected = socket.connect(ip, port);
+        }
+
+        // socket.read() may return -1 if we're reading ourselves on multicast
+        if (ret > 0) {
+            bytes_read += ret;
+        }
     }
-    return ret;
+
+    if (bytes_read == 0) {
+        return -1;
+    }
+
+    return bytes_read;
 }
 
 bool UDPDevice::open()


### PR DESCRIPTION
### Summary

Fixes a bug in the Linux HAL implementation that caused each read on UDP socket to only read one packet of the queue.

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [X] Tested manually, description below (e.g. SITL)
- [X] Tested on hardware
- [ ] Logs attached
- [X] Logs available on request

Seems to work well. Appreciate independent testing to ensure it doesn't break anything.

### Description

On Linux `recv()` over a UDP socket only retrieves the next packet in line in order not to mess the packet boundaries up, as opposed to the entire buffered bytestream. This means that each attempt to fill the RX ring-buffer from a UDP socket would only read a single packet and quit until the next iteration. This causes a small delay in normal circumstances (e.g. GCS control of an aircraft with occasional heartbeats, parameter requests and maybe control inputs), but in case of multi-vehicle setups such as UAV+AntennaTracker or other non-MavLink traffic that involves a lot of incoming packets, the RX queue can fill up very quickly. For AntennaTracker the operation becomes impossible since the MavLink stream is parsed with a delay on the order of several seconds. E.g., running AP on Linux and feeding the outbound mavlink traffic from a SITL over UDP instance causes this:
```
root@foo:~# netstat -anu | head -n 2; for i in `seq 1 10`; do  netstat -anu | grep ESTABL; sleep 1; done
Active Internet connections (servers and established)
Proto Recv-Q Send-Q Local Address           Foreign Address         State       
udp   166656      0 127.0.0.1:59558         127.0.0.1:14550         ESTABLISHED 
udp   158592      0 127.0.0.1:59558         127.0.0.1:14550         ESTABLISHED 
udp   169344      0 127.0.0.1:59558         127.0.0.1:14550         ESTABLISHED 
udp   163072      0 127.0.0.1:59558         127.0.0.1:14550         ESTABLISHED 
udp   172928      0 127.0.0.1:59558         127.0.0.1:14550         ESTABLISHED 
udp   168448      0 127.0.0.1:59558         127.0.0.1:14550         ESTABLISHED 
udp   159488      0 127.0.0.1:59558         127.0.0.1:14550         ESTABLISHED 
udp   171136      0 127.0.0.1:59558         127.0.0.1:14550         ESTABLISHED 
udp   164864      0 127.0.0.1:59558         127.0.0.1:14550         ESTABLISHED 
udp   155904      0 127.0.0.1:59558         127.0.0.1:14550         ESTABLISHED 
```

Switching to TCP immediately resolves the queue as expected.

The PR changes the UDP processing in the Linux HAL to attempt reading as much as possible so long as the data can fit into the RX buffer provided. Implementation details:
- Need to `poll()` twice in order to distinguish between no incoming data and zero-length incoming packets;
- `FIONREAD` returns the size of the next packet in queue _on Linux_ (behaviour varies from OS to OS);
- The first packet is always read even if ends up being truncated, this prevents the socket from being stuck in case if the RX buffer is somehow smaller than the incoming packet, by default it shouldn't happen since the Linux HAL redefines the RX buffer size to 8kb.

Resulting behaviour after the changes in the PR:
```
root@foo:~# netstat -anu | head -n 2; for i in `seq 1 10`; do  netstat -anu | grep ESTABL; sleep 1; done
Active Internet connections (servers and established)
Proto Recv-Q Send-Q Local Address           Foreign Address         State       
udp        0      0 127.0.0.1:40243         127.0.0.1:14550         ESTABLISHED 
udp        0      0 127.0.0.1:40243         127.0.0.1:14550         ESTABLISHED 
udp        0      0 127.0.0.1:40243         127.0.0.1:14550         ESTABLISHED 
udp        0      0 127.0.0.1:40243         127.0.0.1:14550         ESTABLISHED 
udp        0      0 127.0.0.1:40243         127.0.0.1:14550         ESTABLISHED 
udp        0      0 127.0.0.1:40243         127.0.0.1:14550         ESTABLISHED 
udp        0      0 127.0.0.1:40243         127.0.0.1:14550         ESTABLISHED 
udp        0      0 127.0.0.1:40243         127.0.0.1:14550         ESTABLISHED 
udp        0      0 127.0.0.1:40243         127.0.0.1:14550         ESTABLISHED 
udp        0      0 127.0.0.1:40243         127.0.0.1:14550         ESTABLISHED 
```

Rarely there is a couple hundred bytes queue still that gets revolved on the next read,  I assume this is because of scheduling jitter. No persistent queue is ever formed.

