### PR TITLE
Copter: make AltHold an optional build feature

### DIFF
--- a/ArduCopter/APM_Config.h
+++ b/ArduCopter/APM_Config.h
@@ -6,6 +6,7 @@
 //#define AUTOTUNE_ENABLED      0            // disable the auto tune functionality to save 7k of flash
 //#define NAV_GUIDED            0            // disable external navigation computer ability to control vehicle through MAV_CMD_NAV_GUIDED mission commands
 //#define MODE_ACRO_ENABLED     0            // disable acrobatic mode support
+//#define MODE_ALTHOLD_ENABLED  0            // disable altitude hold mode support
 //#define MODE_AUTO_ENABLED     0            // disable auto mode support
 //#define MODE_BRAKE_ENABLED    0            // disable brake mode support
 //#define MODE_CIRCLE_ENABLED   0            // disable circle mode support

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -151,6 +151,10 @@
 #include <AC_CustomControl/AC_CustomControl.h>                  // Custom control library
 #endif
 
+#if MODE_BRAKE_ENABLED && !MODE_ALTHOLD_ENABLED
+  #error Brake mode requires AltHold; disable MODE_BRAKE_ENABLED or enable MODE_ALTHOLD_ENABLED
+#endif
+
 #if AP_AVOIDANCE_ENABLED && !AP_FENCE_ENABLED
   #error AC_Avoidance relies on AP_FENCE_ENABLED which is disabled
 #endif
@@ -1031,7 +1035,9 @@ private:
     ModeAcro mode_acro;
 #endif
 #endif
+#if MODE_ALTHOLD_ENABLED
     ModeAltHold mode_althold;
+#endif
 #if MODE_AUTO_ENABLED
     ModeAuto mode_auto;
 #endif

--- a/ArduCopter/GCS_MAVLink_Copter.cpp
+++ b/ArduCopter/GCS_MAVLink_Copter.cpp
@@ -1362,7 +1362,9 @@ uint8_t GCS_MAVLINK_Copter::send_available_mode(uint8_t index) const
         &copter.mode_acro,
 #endif
         &copter.mode_stabilize,
+#if MODE_ALTHOLD_ENABLED
         &copter.mode_althold,
+#endif
 #if MODE_CIRCLE_ENABLED
         &copter.mode_circle,
 #endif

--- a/ArduCopter/RC_Channel_Copter.cpp
+++ b/ArduCopter/RC_Channel_Copter.cpp
@@ -531,9 +531,11 @@ bool RC_Channel_Copter::do_aux_function(const AuxFuncTrigger &trigger)
             break;
 #endif
 
+#if MODE_ALTHOLD_ENABLED
         case AUX_FUNC::ALTHOLD:
             do_aux_function_change_mode(Mode::Number::ALT_HOLD, ch_flag);
             break;
+#endif
 
 #if MODE_ACRO_ENABLED
         case AUX_FUNC::ACRO:

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -143,6 +143,12 @@
 #endif
 
 //////////////////////////////////////////////////////////////////////////////
+// AltHold - fly vehicle with automatic altitude control
+#ifndef MODE_ALTHOLD_ENABLED
+# define MODE_ALTHOLD_ENABLED 1
+#endif
+
+//////////////////////////////////////////////////////////////////////////////
 // Auto mode - allows vehicle to trace waypoints and perform automated actions
 // Copter's one-and-only AP_Mission object is a member of ModeAuto, so the two
 // must be enabled and disabled together; see the checks below.
@@ -647,6 +653,10 @@
 
 #if TOY_MODE_ENABLED && FRAME_CONFIG == HELI_FRAME
   #error Toy mode is not available on Helicopters
+#endif
+
+#if TOY_MODE_ENABLED && !MODE_ALTHOLD_ENABLED
+  #error Toy mode requires AltHold mode support
 #endif
 
 #ifndef HAL_FRAME_TYPE_DEFAULT

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -41,8 +41,10 @@ Mode *Copter::mode_from_mode_num(const Mode::Number mode)
         case Mode::Number::STABILIZE:
             return &mode_stabilize;
 
+#if MODE_ALTHOLD_ENABLED
         case Mode::Number::ALT_HOLD:
             return &mode_althold;
+#endif
 
 #if MODE_AUTO_ENABLED
         case Mode::Number::AUTO:
@@ -225,7 +227,9 @@ uint32_t Copter::get_available_mode_enabled_mask() const
         &copter.mode_acro,
 #endif
         &copter.mode_stabilize,
+#if MODE_ALTHOLD_ENABLED
         &copter.mode_althold,
+#endif
 #if MODE_CIRCLE_ENABLED
         &copter.mode_circle,
 #endif
@@ -309,7 +313,8 @@ uint32_t Copter::get_available_mode_enabled_mask() const
 // set_mode - change flight mode and perform any necessary initialisation
 // optional force parameter used to force the flight mode change (used only first time mode is set)
 // returns true if mode was successfully set
-// ACRO, STABILIZE, ALTHOLD, LAND, DRIFT and SPORT can always be set successfully but the return state of other flight modes should be checked and the caller should deal with failures appropriately
+// compiled-in ACRO, STABILIZE, ALTHOLD, LAND, DRIFT and SPORT modes can always be set successfully,
+// but the return state of other flight modes should be checked and the caller should deal with failures appropriately
 bool Copter::set_mode(Mode::Number mode, ModeReason reason)
 {
     // update last reason
@@ -777,7 +782,9 @@ void Mode::land_run_horizontal_control()
             LOGGER_WRITE_EVENT(LogEvent::LAND_CANCELLED_BY_PILOT);
             // exit land if throttle is high
             if (!set_mode(Mode::Number::LOITER, ModeReason::THROTTLE_LAND_ESCAPE)) {
+#if MODE_ALTHOLD_ENABLED
                 set_mode(Mode::Number::ALT_HOLD, ModeReason::THROTTLE_LAND_ESCAPE);
+#endif
             }
         }
 
@@ -871,7 +878,9 @@ void Mode::precland_retry_position(const Vector3p &retry_pos_ned_m)
             LOGGER_WRITE_EVENT(LogEvent::LAND_CANCELLED_BY_PILOT);
             // exit land if throttle is high
             if (!set_mode(Mode::Number::LOITER, ModeReason::THROTTLE_LAND_ESCAPE)) {
+#if MODE_ALTHOLD_ENABLED
                 set_mode(Mode::Number::ALT_HOLD, ModeReason::THROTTLE_LAND_ESCAPE);
+#endif
             }
         }
 

--- a/ArduCopter/mode_althold.cpp
+++ b/ArduCopter/mode_althold.cpp
@@ -1,5 +1,6 @@
 #include "Copter.h"
 
+#if MODE_ALTHOLD_ENABLED
 
 /*
  * Init and run calls for althold, flight mode
@@ -101,3 +102,5 @@ void ModeAltHold::run()
     // run the vertical position controller and set output throttle
     pos_control->D_update_controller();
 }
+
+#endif // MODE_ALTHOLD_ENABLED

--- a/ArduCopter/mode_land.cpp
+++ b/ArduCopter/mode_land.cpp
@@ -154,11 +154,13 @@ void ModeLand::nogps_run()
 
     // process pilot inputs
     if (rc().has_valid_input()) {
+#if MODE_ALTHOLD_ENABLED
         if ((g.throttle_behavior & THR_BEHAVE_HIGH_THROTTLE_CANCELS_LAND) != 0 && copter.rc_throttle_control_in_filter.get() > LAND_CANCEL_TRIGGER_THR){
             LOGGER_WRITE_EVENT(LogEvent::LAND_CANCELLED_BY_PILOT);
             // exit land if throttle is high
             copter.set_mode(Mode::Number::ALT_HOLD, ModeReason::THROTTLE_LAND_ESCAPE);
         }
+#endif
 
         if (g.land_repositioning) {
             // apply SIMPLE mode transform to pilot inputs

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -341,7 +341,9 @@ void ModeRTL::descent_run()
             LOGGER_WRITE_EVENT(LogEvent::LAND_CANCELLED_BY_PILOT);
             // exit land if throttle is high
             if (!copter.set_mode(Mode::Number::LOITER, ModeReason::THROTTLE_LAND_ESCAPE)) {
+#if MODE_ALTHOLD_ENABLED
                 copter.set_mode(Mode::Number::ALT_HOLD, ModeReason::THROTTLE_LAND_ESCAPE);
+#endif
             }
         }
 

--- a/Tools/autotest/test_build_options.py
+++ b/Tools/autotest/test_build_options.py
@@ -218,6 +218,11 @@ class TestBuildOptions(object):
                     'AP_RANGEFINDER_NRA24_CAN_ENABLED',
                     'AP_RANGEFINDER_HEXSOONRADAR_ENABLED',
                 ])
+                if target.lower() == 'sub':
+                    # ArduSub has its own ModeAlthold, which is unrelated
+                    # to Copter's MODE_ALTHOLD_ENABLED build option.
+                    feature_define_whitelist.add('MODE_ALTHOLD_ENABLED')
+
                 if define in compiled_in_feature_defines:
                     error = f"feature gated by {define} still compiled into ({target}); extract_features.py bug?"
                     if define in feature_define_whitelist:
@@ -291,6 +296,7 @@ class TestBuildOptions(object):
             'AP_GPS_DEBUG_LOGGING_ENABLED',  # must have a backend compiled in to be present
         ])
         if target.lower() != "copter":
+            feature_define_whitelist.add('MODE_ALTHOLD_ENABLED')
             feature_define_whitelist.add('MODE_ZIGZAG_ENABLED')
             feature_define_whitelist.add('MODE_SYSTEMID_ENABLED')
             feature_define_whitelist.add('MODE_SPORT_ENABLED')

--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -189,6 +189,7 @@ BUILD_OPTIONS = [
 
     Feature('Camera', 'RUNCAM', 'AP_CAMERA_RUNCAM_ENABLED', 'Enable RunCam control', 0, 'Camera'),
 
+    Feature('Copter', 'MODE_ALTHOLD', 'MODE_ALTHOLD_ENABLED', 'Enable Mode AltHold', 1, None),
     Feature('Copter', 'MODE_ZIGZAG', 'MODE_ZIGZAG_ENABLED', 'Enable Mode ZigZag', 0, None),
     Feature('Copter', 'MODE_SYSTEMID', 'MODE_SYSTEMID_ENABLED', 'Enable Mode SystemID', 0, 'Logging'),
     Feature('Copter', 'MODE_SPORT', 'MODE_SPORT_ENABLED', 'Enable Mode Sport', 0, None),
@@ -197,7 +198,7 @@ BUILD_OPTIONS = [
     Feature('Copter', 'MODE_GUIDED_NOGPS', 'MODE_GUIDED_NOGPS_ENABLED', 'Enable Mode Guided NoGPS', 0, None),
     Feature('Copter', 'MODE_FLOWHOLD', 'MODE_FLOWHOLD_ENABLED', 'Enable Mode Flowhold', 0, "OPTICALFLOW"),
     Feature('Copter', 'MODE_FLIP', 'MODE_FLIP_ENABLED', 'Enable Mode Flip', 0, None),
-    Feature('Copter', 'MODE_BRAKE', 'MODE_BRAKE_ENABLED', 'Enable Mode Brake', 0, None),
+    Feature('Copter', 'MODE_BRAKE', 'MODE_BRAKE_ENABLED', 'Enable Mode Brake', 0, 'MODE_ALTHOLD'),
     Feature('Copter', 'MODE_THROW', 'MODE_THROW_ENABLED', 'Enable Mode Throw', 0, None),
     Feature('Copter', 'COPTER_ADVANCED_FAILSAFE', 'AP_COPTER_ADVANCED_FAILSAFE_ENABLED', 'Enable Advanced Failsafe', 0, "ADVANCED_FAILSAFE"),  # NOQA: E501
     Feature('Copter', 'COPTER_AHRS_AUTO_TRIM', 'AP_COPTER_AHRS_AUTO_TRIM_ENABLED', 'Enable Copter AHRS AutoTrim', 0, None),  # NOQA: E501


### PR DESCRIPTION
### Summary

Makes Copter AltHold an optional build feature while keeping it enabled by default for backward compatibility.

Builds that do not require the onboard AltHold flight mode can exclude it with `--disable-MODE_ALTHOLD`.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

Manual SITL testing was performed with both the default and disabled configurations.

<img width="1035" height="363" alt="スクリーンショット 2026-07-26 16 20 31" src="https://github.com/user-attachments/assets/ba4b21ae-0255-4e64-a65c-69599d78c85f" />

Default configuration:

```bash
./waf configure --board sitl
./waf copter
```

Verified that AltHold remains included by default:

```text
ModeAltHold::init(bool)
ModeAltHold::run()
vtable for ModeAltHold
```

Disabled configuration:

```bash
./waf configure --board sitl --disable-MODE_ALTHOLD
./waf copter
```

Verified that the build configuration contains:

```text
-DMODE_ALTHOLD_ENABLED=0
```

Verified that the resulting binary contains no `ModeAltHold` implementation symbols:

```text
No ModeAltHold symbols
```

SITL was also started with AltHold disabled:

```bash
Tools/autotest/sim_vehicle.py \
    -v ArduCopter \
    -f quad \
    --console \
    --waf-configure-arg="--disable-MODE_ALTHOLD"
```

Requests to enter AltHold by name and by mode number were rejected, while the vehicle remained in Stabilize:

```text
Got COMMAND_ACK: DO_SET_MODE: FAILED
AP: No such mode 2
```

### Description

AltHold is currently always included in Copter builds.

Altitude control does not necessarily require the vehicle to use the onboard AltHold flight mode. Some systems provide altitude control from an external application while operating the vehicle in Stabilize mode. For these configurations, AltHold is not a required flight mode and can be excluded from the firmware.

This change adds the `MODE_ALTHOLD_ENABLED` build option and keeps it enabled by default, preserving existing behavior.

AltHold can be excluded using:

```bash
./waf configure --board <board> --disable-MODE_ALTHOLD
```

It can also be explicitly enabled using:

```bash
./waf configure --board <board> --enable-MODE_ALTHOLD
```

When disabled, this change excludes:

- the `ModeAltHold` instance
- AltHold mode registration and selection
- AltHold from the available-mode list
- the AltHold RC auxiliary-function handling
- the AltHold mode implementation from the final binary

The numerical mode definition for `ALT_HOLD` remains unchanged for MAVLink and parameter compatibility. A request for mode 2 is rejected as unavailable when AltHold is excluded.

Toy mode requires AltHold support, so the build reports an error if Toy mode is enabled while AltHold is disabled.

The build-option metadata and build-option autotest exclusions are also updated for the new Copter-specific option.
