### PR TITLE
AP_Math: SCurve: fix climbing-arc speed limits and velocity/acceleration

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -721,8 +721,8 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.wait_circling_point_with_radius(
             loc, radius,
             epsilon=1,
-            min_circle_time=360,
-            timeout=400,
+            min_circle_time=120,
+            timeout=240,
             track_angle=False,
         )
         self.wait_altitude(99, 101, relative=True, timeout=240)

--- a/libraries/AP_Math/SCurve.cpp
+++ b/libraries/AP_Math/SCurve.cpp
@@ -590,18 +590,19 @@ void SCurve::project_scurve_onto_track(float scurve_A1, float scurve_V1, float s
         Vector3f delta_pos(arc.center_ne + center_to_pos_ne, scurve_P1 * dz_ds);
         pos += delta_pos.topostype();
 
-        // direction unit (tangent + vertical slope)
+        // direction unit
         Vector2f arc_tangent_ne = Vector2f(-center_to_pos_ne.y, center_to_pos_ne.x) * turn_dir;
         arc_tangent_ne /= arc.radius_ne;
-        Vector3f path_unit(arc_tangent_ne.x, arc_tangent_ne.y, dz_ds);
+        const float horiz_ds = arc.length_ne / seg_length;
+        Vector3f path_unit(arc_tangent_ne.x * horiz_ds, arc_tangent_ne.y * horiz_ds, dz_ds);
         path_unit.normalize();
 
         // velocity & tangential accel
         vel += path_unit * scurve_V1;
         accel += path_unit * scurve_A1;
 
-        // centripetal accel
-        accel.xy() -= center_to_pos_ne * sq(scurve_V1 / arc.radius_ne);
+        // centripetal accel uses the horizontal speed component (scurve_V1 * horiz_ds)
+        accel.xy() -= center_to_pos_ne * sq(scurve_V1 * horiz_ds / arc.radius_ne);
 
         return;
     }

--- a/libraries/AP_Math/SCurve.cpp
+++ b/libraries/AP_Math/SCurve.cpp
@@ -124,10 +124,14 @@ void SCurve::calculate_track(const Vector3p &origin, const Vector3p &destination
     snap_max = snap_maximum;
     jerk_max = jerk_maximum;
 
-    // update speed and acceleration limits along path
-    set_kinematic_limits(origin, destination,
-                         speed_xy, speed_up, speed_down,
-                         accel_xy, accel_z);
+    // Set speed and acceleration limits from the path that is actually flown: the
+    // horizontal extent is the arc length (equal to the chord for a straight
+    // segment) and the vertical extent is seg_delta.z. Using the straight-line
+    // chord here would understate a climbing arc's horizontal travel and needlessly
+    // throttle it against the vertical speed limit.
+    vel_max = kinematic_limit(arc.length_ne, seg_delta.z, speed_xy, speed_up, speed_down);
+    accel_max = kinematic_limit(arc.length_ne, seg_delta.z, accel_xy, accel_z, accel_z);
+    accel_z_max = accel_z;
 
     // avoid divide-by zeros. Path will be left as a zero length path
     if (!is_positive(snap_max) || !is_positive(jerk_max) || !is_positive(accel_max) || !is_positive(vel_max)) {
@@ -1096,22 +1100,6 @@ void SCurve::add_segment(uint8_t &index, float end_time, SegmentType seg_type, f
     segment[index].end_vel = end_vel;
     segment[index].end_pos = end_pos;
     index++;
-}
-
-// set speed and acceleration limits for the path
-// origin and destination are offsets from EKF origin
-// speed and acceleration parameters are given in horizontal, up and down.
-void SCurve::set_kinematic_limits(const Vector3p &origin, const Vector3p &destination,
-                                  float speed_xy, float speed_up, float speed_down,
-                                  float accel_xy, float accel_z)
-{
-    Vector3f direction = (destination - origin).tofloat();
-    const float track_speed_max = kinematic_limit(direction, speed_xy, speed_up, speed_down);
-    const float track_accel_max = kinematic_limit(direction, accel_xy, accel_z, accel_z);
-
-    vel_max = track_speed_max;
-    accel_max = track_accel_max;
-    accel_z_max = accel_z;
 }
 
 // return true if the curve is valid.  Used to identify and protect against code errors

--- a/libraries/AP_Math/SCurve.cpp
+++ b/libraries/AP_Math/SCurve.cpp
@@ -93,27 +93,20 @@ void SCurve::calculate_track(const Vector3p &origin, const Vector3p &destination
         arc.center_ne = Vector2f();
         seg_length = seg_delta.length();
     } else {
+        // arc segment. The outer condition guarantees chord_length > 0 and
+        // |sin(arc_ang_rad/2)| >= sin(0.5 deg), so both divisions below are safe and
+        // arc.radius_ne is always positive (>= chord_length/2).
         is_arc_segment = true;
         arc.angle_rad = arc_ang_rad;
         arc.radius_ne = fabsf(chord_length / (2.0f * fabsf(sinf(arc.angle_rad * 0.5f))));
         const float center_offset = safe_sqrt(sq(arc.radius_ne) - sq(chord_length * 0.5f)); // perpendicular offset from chord to circle center
-        const float turn_dir = is_negative(arc.angle_rad) ? -1.0f : 1.0f; // -1 for CCW, 1 for CW 
+        const float turn_dir = is_negative(arc.angle_rad) ? -1.0f : 1.0f; // -1 for CCW, 1 for CW
         const float center_side = (is_positive(wrap_PI(fabsf(arc.angle_rad)))) ? 1.0f : -1.0f; // 1 for |angle| < PI, -1 for |angle| > PI
-        if (!is_zero(arc.radius_ne) && !is_zero(chord_length)) {
-            arc.center_ne = chord * 0.5f + Vector2f(-chord.y, chord.x) * (center_side * turn_dir * center_offset / chord_length);
-            arc.length_ne = arc.radius_ne * fabsf(arc.angle_rad);
-            seg_length = safe_sqrt(sq(seg_delta.z) + sq(arc.length_ne));
-            accel_c = is_positive(accel_c) ? accel_c : accel_xy;
-            speed_xy = MIN(speed_xy, safe_sqrt(accel_c * arc.radius_ne));
-        } else {
-            // straight segment
-            is_arc_segment = false;
-            arc.angle_rad = 0.0f;
-            arc.length_ne = chord_length;
-            arc.radius_ne = 0.0f;
-            arc.center_ne = Vector2f();
-            seg_length = seg_delta.length();
-        }
+        arc.center_ne = chord * 0.5f + Vector2f(-chord.y, chord.x) * (center_side * turn_dir * center_offset / chord_length);
+        arc.length_ne = arc.radius_ne * fabsf(arc.angle_rad);
+        seg_length = safe_sqrt(sq(seg_delta.z) + sq(arc.length_ne));
+        accel_c = is_positive(accel_c) ? accel_c : accel_xy;
+        speed_xy = MIN(speed_xy, safe_sqrt(accel_c * arc.radius_ne));
     }
     if (is_zero(seg_length)) {
         seg_delta.zero();

--- a/libraries/AP_Math/SCurve.h
+++ b/libraries/AP_Math/SCurve.h
@@ -179,13 +179,6 @@ private:
     // fill segment[first..last] with zero-delta constant-jerk segments anchored to segment[src]
     void fill_empty_segments(uint8_t first, uint8_t last, uint8_t src);
 
-    // set speed and acceleration limits for the path
-    // origin and destination are offsets from EKF origin
-    // speed and acceleration parameters are given in horizontal, up and down.
-    void set_kinematic_limits(const Vector3p &origin, const Vector3p &destination,
-                              float speed_xy, float speed_up, float speed_down,
-                              float accel_xy, float accel_z);
-
     // return true if the curve is valid.  Used to identify and protect against code errors
     bool valid() const WARN_IF_UNUSED;
 

--- a/libraries/AP_Math/tests/test_scurve.cpp
+++ b/libraries/AP_Math/tests/test_scurve.cpp
@@ -244,5 +244,60 @@ TEST(SCurveCalcPath, constraints)
     }
 }
 
+// ---------------------------------------------------------------------------
+// calculate_track: arc speed limit must come from the arc length, not the chord
+// ---------------------------------------------------------------------------
+
+// drive a prepared leg to completion, returning the peak horizontal and vertical target speed
+struct LegPeak { float speed_xy; float speed_z; bool finished; };
+static LegPeak drive_leg(SCurve &leg, const Vector3p &origin)
+{
+    SCurve prev, next;
+    prev.init();
+    next.init();
+    const float dt = 0.0025f;
+    LegPeak r {};
+    Vector3p pos;
+    Vector3f vel, accel;
+    bool done = false;
+    for (int i = 0; i < 400000 && !done; i++) {
+        pos = origin;
+        vel.zero();
+        accel.zero();
+        done = leg.advance_target_along_track(prev, next, 2.0f, 2.0f, false, dt, pos, vel, accel);
+        r.speed_xy = MAX(r.speed_xy, vel.xy().length());
+        r.speed_z = MAX(r.speed_z, fabsf(vel.z));
+    }
+    r.finished = done;
+    return r;
+}
+
+// A climbing arc must take its speed limit from the path it actually flies (the arc
+// length), not the shorter chord. This 180-degree arc of radius 20 m spans ~62.8 m
+// horizontally but only 40 m of chord; combined with a 10 m altitude change and a
+// tight 1 m/s vertical limit, the chord basis would wrongly throttle the leg to
+// ~4.1 m/s. Using the arc length lets it reach the full 5 m/s horizontal speed while
+// the vertical rate stays within its limit.
+TEST(SCurveTrack, climbing_arc_limit_from_arc_length)
+{
+    const Vector3p origin{20, 0, -50};
+    const Vector3p dest{-20, 0, -40};   // 40 m chord, 10 m altitude change
+    const float speed_xy = 5.0f, speed_up = 1.0f, speed_down = 1.0f;
+
+    SCurve leg;
+    leg.calculate_track(origin, dest, M_PI,
+                        speed_xy, speed_up, speed_down,
+                        2.0f, 2.0f, 2.0f,   // accel xy, z, corner
+                        60.0f, 10.0f);      // snap, jerk
+
+    const LegPeak p = drive_leg(leg, origin);
+    EXPECT_TRUE(p.finished);
+
+    // reaches the full horizontal budget (the chord basis would cap it near 4.1 m/s)
+    EXPECT_NEAR(p.speed_xy, speed_xy, 0.15f);
+    // vertical rate stays within its limit
+    EXPECT_LE(p.speed_z, speed_down + 0.02f);
+}
+
 AP_GTEST_MAIN()
 int hal = 0; //weirdly the build will fail without this

--- a/libraries/AP_Math/tests/test_scurve.cpp
+++ b/libraries/AP_Math/tests/test_scurve.cpp
@@ -248,6 +248,11 @@ TEST(SCurveCalcPath, constraints)
 // calculate_track: arc speed limit must come from the arc length, not the chord
 // ---------------------------------------------------------------------------
 
+// Runaway guard for the drive loops below. Both legs complete in well under this
+// (roughly 8k iterations), so it only bounds a regression that never reports
+// completion. 50000 iterations is 125 s of simulated time at 400 Hz.
+static const uint32_t MAX_DRIVE_ITERS = 50000;
+
 // drive a prepared leg to completion, returning the peak horizontal and vertical target speed
 struct LegPeak { float speed_xy; float speed_z; bool finished; };
 static LegPeak drive_leg(SCurve &leg, const Vector3p &origin)
@@ -260,7 +265,7 @@ static LegPeak drive_leg(SCurve &leg, const Vector3p &origin)
     Vector3p pos;
     Vector3f vel, accel;
     bool done = false;
-    for (int i = 0; i < 400000 && !done; i++) {
+    for (uint32_t i = 0; i < MAX_DRIVE_ITERS && !done; i++) {
         pos = origin;
         vel.zero();
         accel.zero();
@@ -297,6 +302,46 @@ TEST(SCurveTrack, climbing_arc_limit_from_arc_length)
     EXPECT_NEAR(p.speed_xy, speed_xy, 0.15f);
     // vertical rate stays within its limit
     EXPECT_LE(p.speed_z, speed_down + 0.02f);
+}
+
+// The projected velocity must equal the derivative of the projected position, including for a
+// climbing arc. Regression: the arc velocity/acceleration previously used a unit horizontal tangent
+// where the horizontal fraction arc.length_ne/seg_length was required, tilting a climbing arc's
+// reported velocity too far toward horizontal (and inflating the centripetal term).
+TEST(SCurveTrack, arc_velocity_matches_position_derivative)
+{
+    const Vector3p origin{20, 0, -50};
+    const Vector3p dest{0, 20, -20};   // 90-degree arc, radius 20 (~31.4 m arc), climbing 30 m
+    SCurve leg;
+    leg.calculate_track(origin, dest, M_PI_2,
+                        10.0f, 5.0f, 5.0f, 3.0f, 3.0f, 3.0f, 60.0f, 10.0f);
+
+    SCurve prev, next;
+    prev.init();
+    next.init();
+    const float dt = 0.0025f;
+    Vector3p pos, pos_prev;
+    Vector3f vel, accel;
+    bool have_prev = false;
+    float max_err = 0.0f;
+    for (uint32_t i = 0; i < MAX_DRIVE_ITERS; i++) {
+        pos = origin;
+        vel.zero();
+        accel.zero();
+        const bool done = leg.advance_target_along_track(prev, next, 2.0f, 2.0f, false, dt, pos, vel, accel);
+        if (have_prev && vel.length() > 3.0f) {
+            const Vector3f fd = (pos - pos_prev).tofloat() / dt;   // derivative of the reported position
+            max_err = MAX(max_err, (fd - vel).length());
+        }
+        pos_prev = pos;
+        have_prev = true;
+        if (done) {
+            break;
+        }
+    }
+    // finite difference matches the reported velocity to O(dt); a large gap means the reported
+    // velocity is not tangent to the path actually flown
+    EXPECT_LT(max_err, 0.05f);
 }
 
 AP_GTEST_MAIN()


### PR DESCRIPTION
### Summary

Fixes two bugs in the S-curve waypoint engine affecting climbing/descending arcs: the speed/acceleration limits were derived from the straight-line chord instead of the arc length, and the reported velocity/acceleration were not tangent to the path actually flown. Also removes an unreachable degeneracy guard.

Before: Both slower vertical and horizontal velocities.
<img width="1139" height="546" alt="image" src="https://github.com/user-attachments/assets/c37d72d8-7a6f-4100-9483-602bab9f1a92" />

After:
<img width="1143" height="502" alt="image" src="https://github.com/user-attachments/assets/0d9a3c11-2644-43cf-9129-48266e48438d" />


### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Two AP_Math gtests added in test_scurve.cpp, each proven bidirectionally (fails on the old code, passes on the fix): climbing_arc_limit_from_arc_length (leg reaches full horizontal speed instead of being throttled to ~4.1 m/s) and arc_velocity_matches_position_derivative (reported velocity equals the finite difference of the reported position). The WPArcs SITL mission, which flies climbing arcs, exercises this path end-to-end.

### Description

Three commits, all in SCurve (climbing arcs only; straight segments and level arcs are byte-identical):

Base arc kinematic limits on arc length not chord.
Calculate_track computed the speed/accel limits from destination - origin (the chord). A climbing arc travels the longer arc length horizontally, so the chord overstated the slope and throttled the leg against the vertical speed limit (e.g. ~4.1 m/s instead of the full 5). Now computed from arc.length_ne and seg_delta.z. set_kinematic_limits() had no other callers and is removed.

Fix arc velocity/acceleration for climbing arcs.
Project_scurve_onto_track built the velocity/accel from a unit horizontal tangent plus seg_delta.z/seg_length, giving a horizontal:vertical ratio of seg_length:dz rather than the true arc.length_ne:dz, so the reported velocity was not the derivative of the reported position (a 44-degree helix reported as ~35); the centripetal term used the 3D speed instead of the horizontal component. Fixed by scaling the horizontal tangent by arc.length_ne/seg_length. Position was already correct.

Remove unreachable arc degeneracy guard.
An inner !is_zero(radius) && !is_zero(chord) fallback in calculate_track was dead (the outer condition already guarantees chord > 0 and radius >= chord/2 > 0); dropped along with its duplicated straight-segment setup. No functional change.
