### PR TITLE
AUTO cleanup

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1534,8 +1534,8 @@ public:
     enum class SubMode : uint8_t {
         STARTING,
         INITIAL_CLIMB,
-        RETURN_HOME,
-        LOITER_AT_HOME,
+        FLY_TO_RETURN_POINT,
+        HOLD_AT_RETURN_POINT,
         FINAL_DESCENT,
         LAND
     };
@@ -1589,8 +1589,8 @@ private:
     void climb_start();
     void return_start();
     void climb_return_run();
-    void loiterathome_start();
-    void loiterathome_run();
+    void hold_at_return_point_start();
+    void hold_at_return_point_run();
     void build_path();
     void compute_return_target();
 
@@ -1600,7 +1600,7 @@ private:
     AP_Float alt_final_m;
     AP_Float climb_min_m;
 
-    SubMode _state = SubMode::INITIAL_CLIMB;  // records state of rtl (initial climb, returning home, etc)
+    SubMode _state = SubMode::INITIAL_CLIMB;  // records state of rtl (initial climb, returning, etc)
     bool _state_complete = false; // set to true if the current state is completed
 
     struct {
@@ -1618,8 +1618,8 @@ private:
         TERRAINDATABASE = 2
     };
 
-    // Loiter timer - Records how long we have been in loiter
-    uint32_t _loiter_start_time;
+    // Hold timer - Records how long we have been holding at the return point
+    uint32_t _hold_start_time;
 
     bool terrain_following_allowed;
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1687,11 +1687,11 @@ protected:
 
 private:
 
+    void set_submode(SubMode submode);
     void wait_cleanup_run();
     void path_follow_run();
     void pre_land_position_run();
-    void land();
-    SubMode smart_rtl_state = SubMode::PATH_FOLLOW;
+    SubMode smart_rtl_state = SubMode::WAIT_FOR_PATH_CLEANUP;
 
     // keep track of how long we have failed to get another return
     // point while following our path home.  If we take too long we

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -561,6 +561,7 @@ public:
 
     // Auto modes
     enum class SubMode : uint8_t {
+        STARTING,       // initial submode; holds position until the mission dispatches the first navigation submode
         TAKEOFF,
         WP,
         LAND,
@@ -682,7 +683,7 @@ private:
     // returns false if the location cannot be determined which only happens if the terrain data is unavailable
     bool get_loc_from_cmd(const AP_Mission::Mission_Command& cmd, const Location& default_loc, Location& loc) const WARN_IF_UNUSED;
 
-    SubMode _mode = SubMode::TAKEOFF;   // controls which auto controller is run
+    SubMode _mode = SubMode::STARTING;   // controls which auto controller is run
 
     // subtract position controller offsets from target location
     // should be used when the location will be used as a target for the position controller

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1586,8 +1586,14 @@ protected:
 
 private:
 
+    // advance_state - move to the next stage when the current one is complete
+    void advance_state();
+
+    // set_submode - performs all normal stage changes; sets _state, clears _state_complete and runs the stage's entry init
+    void set_submode(SubMode submode);
+
     void climb_start();
-    void return_start();
+    bool return_start();
     void climb_return_run();
     void hold_at_return_point_start();
     void hold_at_return_point_run();
@@ -1600,7 +1606,7 @@ private:
     AP_Float alt_final_m;
     AP_Float climb_min_m;
 
-    SubMode _state = SubMode::INITIAL_CLIMB;  // records state of rtl (initial climb, returning, etc)
+    SubMode _state = SubMode::STARTING;
     bool _state_complete = false; // set to true if the current state is completed
 
     struct {
@@ -1618,8 +1624,8 @@ private:
         TERRAINDATABASE = 2
     };
 
-    // Hold timer - Records how long we have been holding at the return point
-    uint32_t _hold_start_time;
+    // time the current stage was entered (set by set_submode); used by the hold timer
+    uint32_t _stage_start_ms;
 
     bool terrain_following_allowed;
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -585,15 +585,6 @@ public:
     bool resume() override;
     bool paused() const;
 
-    bool loiter_start();
-    void rtl_start();
-    void takeoff_start(const Location& dest_loc);
-    bool wp_start(const Location& dest_loc);
-    void land_start();
-    void circle_movetoedge_start(const Location &circle_center, float radius_m, bool ccw_turn);
-    void circle_start();
-    void nav_guided_start();
-
     bool is_landing() const override;
 
     bool is_taking_off() const override;
@@ -667,6 +658,15 @@ private:
     void exit_mission();
 
     bool check_for_mission_change();    // detect external changes to mission
+
+    bool loiter_start();
+    void rtl_start();
+    void takeoff_start(const Location& dest_loc);
+    bool wp_start(const Location& dest_loc);
+    void land_start();
+    void circle_movetoedge_start(const Location &circle_center, float radius_m, bool ccw_turn);
+    void circle_start();
+    void nav_guided_start();
 
     void takeoff_run();
     void wp_run();

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1595,6 +1595,7 @@ private:
 
     void climb_start();
     bool return_start();
+    bool run_wp_controllers();
     void climb_return_run();
     void hold_at_return_point_start();
     void hold_at_return_point_run();

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -545,7 +545,7 @@ public:
     bool has_manual_throttle() const override { return false; }
     bool allows_arming(AP_Arming::Method method) const override;
     bool is_autopilot() const override { return true; }
-    bool in_guided_mode() const override { return _mode == SubMode::NAVGUIDED || _mode == SubMode::NAV_SCRIPT_TIME; }
+    bool in_guided_mode() const override { return _mode == SubMode::NAV_GUIDED || _mode == SubMode::NAV_SCRIPT_TIME; }
 #if FRAME_CONFIG == HELI_FRAME
     bool allows_inverted() const override { return true; };
 #endif
@@ -567,7 +567,7 @@ public:
         RTL,
         CIRCLE_MOVE_TO_EDGE,
         CIRCLE,
-        NAVGUIDED,
+        NAV_GUIDED,
         LOITER,
         LOITER_TO_ALT,
 #if AP_MISSION_NAV_PAYLOAD_PLACE_ENABLED && AC_PAYLOAD_PLACE_ENABLED
@@ -577,7 +577,7 @@ public:
         NAV_ATTITUDE_TIME,
     };
 
-    // set submode.  returns true on success, false on failure
+    // set the auto submode (rechecks the EKF failsafe when leaving NAV_ATTITUDE_TIME)
     void set_submode(SubMode new_submode);
 
     // pause continue in auto mode
@@ -766,11 +766,11 @@ private:
     uint32_t condition_start;
 
     // Land within Auto state
-    enum class State {
+    enum class LandState {
         FlyToLocation = 0,
         Descending = 1
     };
-    State state = State::FlyToLocation;
+    LandState land_state = LandState::FlyToLocation;
 
     bool waiting_to_start;  // true if waiting for vehicle to be armed or EKF origin before starting mission
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1539,10 +1539,11 @@ public:
         FINAL_DESCENT,
         LAND
     };
-    SubMode state() { return _state; }
-
-    // this should probably not be exposed
-    bool state_complete() const { return _state_complete; }
+    
+    // true once RTL has completed its final stage: the final descent has reached
+    // RTL_ALT_FINAL, or the vehicle has landed and spooled to ground idle;
+    // used by ModeAuto::verify_RTL
+    bool is_complete() const;
 
     virtual bool is_landing() const override;
 

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -2234,8 +2234,8 @@ bool ModeAuto::verify_loiter_to_alt() const
 bool ModeAuto::verify_RTL()
 {
     return (copter.mode_rtl.state_complete() && 
-            (copter.mode_rtl.state() == ModeRTL::SubMode::FINAL_DESCENT || copter.mode_rtl.state() == ModeRTL::SubMode::LAND) &&
-            (motors->get_spool_state() == AP_Motors::SpoolState::GROUND_IDLE));
+            ((copter.mode_rtl.state() == ModeRTL::SubMode::FINAL_DESCENT) ||
+             (copter.mode_rtl.state() == ModeRTL::SubMode::LAND && motors->get_spool_state() == AP_Motors::SpoolState::GROUND_IDLE)));
 }
 
 /********************************************************************************/

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -19,7 +19,7 @@
  *  Code in this file implements the navigation commands
  */
 
-// auto_init - initialise auto controller
+// init - initialise auto controller
 bool ModeAuto::init(bool ignore_checks)
 {
     auto_RTL = false;
@@ -80,7 +80,7 @@ void ModeAuto::exit()
     auto_RTL = false;
 }
 
-// auto_run - runs the auto controller
+// run - runs the auto controller
 //      should be called at 100hz or more
 void ModeAuto::run()
 {
@@ -137,7 +137,7 @@ void ModeAuto::run()
         circle_run();
         break;
 
-    case SubMode::NAVGUIDED:
+    case SubMode::NAV_GUIDED:
     case SubMode::NAV_SCRIPT_TIME:
 #if AC_NAV_GUIDED || AP_SCRIPTING_ENABLED
         nav_guided_run();
@@ -225,14 +225,14 @@ bool ModeAuto::allows_weathervaning() const
 // determine EKF reset handling method based on Guide submode
 bool ModeAuto::move_vehicle_on_ekf_reset() const
 {
-        // call the correct auto controller
+    // decide based on the current submode
     switch (_mode) {
     case SubMode::TAKEOFF:
     case SubMode::LAND:
     case SubMode::RTL:
     case SubMode::CIRCLE_MOVE_TO_EDGE:
     case SubMode::CIRCLE:
-    case SubMode::NAVGUIDED:
+    case SubMode::NAV_GUIDED:
     case SubMode::LOITER:
     case SubMode::LOITER_TO_ALT:
 #if AP_MISSION_NAV_PAYLOAD_PLACE_ENABLED && AC_PAYLOAD_PLACE_ENABLED
@@ -358,7 +358,7 @@ void ModeAuto::nav_script_time_done(uint16_t id)
 #endif
 }
 
-// auto_loiter_start - initialises loitering in auto mode
+// loiter_start - initialises loitering in auto mode
 //  returns success/failure because this can be called by exit_mission
 bool ModeAuto::loiter_start()
 {
@@ -381,7 +381,7 @@ bool ModeAuto::loiter_start()
     return true;
 }
 
-// auto_rtl_start - initialises RTL in AUTO flight mode
+// rtl_start - initialises RTL in AUTO flight mode
 void ModeAuto::rtl_start()
 {
     // call regular rtl flight mode initialisation and ask it to ignore checks
@@ -448,7 +448,7 @@ void ModeAuto::takeoff_start(const Location& dest_loc)
     set_submode(SubMode::TAKEOFF);
 }
 
-// auto_wp_start - initialises waypoint controller to implement flying to a particular destination
+// wp_start - initialises waypoint controller to implement flying to a particular destination
 bool ModeAuto::wp_start(const Location& dest_loc)
 {
     // init wpnav and set origin if transitioning from takeoff
@@ -488,7 +488,7 @@ bool ModeAuto::wp_start(const Location& dest_loc)
     return true;
 }
 
-// auto_land_start - initialises controller to implement a landing
+// land_start - initialises controller to implement a landing
 void ModeAuto::land_start()
 {
     // set horizontal speed and acceleration limits
@@ -581,7 +581,7 @@ void ModeAuto::circle_movetoedge_start(const Location &circle_center, float radi
     }
 }
 
-// auto_circle_start - initialises controller to fly a circle in AUTO flight mode
+// circle_start - initialises controller to fly a circle in AUTO flight mode
 //   assumes that circle_nav object has already been initialised with circle center and radius
 void ModeAuto::circle_start()
 {
@@ -597,7 +597,7 @@ void ModeAuto::circle_start()
 }
 
 #if AC_NAV_GUIDED
-// auto_nav_guided_start - hand over control to external navigation controller in AUTO mode
+// nav_guided_start - hand over control to external navigation controller in AUTO mode
 void ModeAuto::nav_guided_start()
 {
     // call regular guided flight mode initialisation
@@ -611,7 +611,7 @@ void ModeAuto::nav_guided_start()
     copter.mode_guided.limit_init_time_and_pos();
 
     // set submode
-    set_submode(SubMode::NAVGUIDED);
+    set_submode(SubMode::NAV_GUIDED);
 }
 #endif //AC_NAV_GUIDED
 
@@ -634,7 +634,7 @@ bool ModeAuto::is_taking_off() const
 }
 
 #if AC_PAYLOAD_PLACE_ENABLED
-// auto_payload_place_start - initialises controller to implement a placing
+// PayloadPlace::start_descent - initialise the position controllers for the payload place descent
 void PayloadPlace::start_descent()
 {
     auto *pos_control = copter.pos_control;
@@ -675,7 +675,7 @@ bool ModeAuto::use_pilot_yaw(void) const
         case SubMode::RTL:
             return copter.mode_rtl.use_pilot_yaw();
 #if AC_NAV_GUIDED
-        case SubMode::NAVGUIDED:
+        case SubMode::NAV_GUIDED:
             return copter.mode_guided.use_pilot_yaw();
 #endif
         default:
@@ -917,7 +917,7 @@ float ModeAuto::wp_bearing_deg() const
 bool ModeAuto::get_wp(Location& destination) const
 {
     switch (_mode) {
-    case SubMode::NAVGUIDED:
+    case SubMode::NAV_GUIDED:
         return copter.mode_guided.get_wp(destination);
     case SubMode::WP:
         return wp_nav->get_oa_wp_destination(destination);
@@ -1082,7 +1082,7 @@ void ModeAuto::takeoff_run()
     auto_takeoff.run();
 }
 
-// auto_wp_run - runs the auto waypoint controller
+// wp_run - runs the auto waypoint controller
 //      called by auto_run at 100hz or more
 void ModeAuto::wp_run()
 {
@@ -1106,7 +1106,7 @@ void ModeAuto::wp_run()
     attitude_control->input_thrust_vector_heading(pos_control->get_thrust_vector(), auto_yaw.get_heading());
 }
 
-// auto_land_run - lands in auto mode
+// land_run - lands in auto mode
 //      called by auto_run at 100hz or more
 void ModeAuto::land_run()
 {
@@ -1124,7 +1124,7 @@ void ModeAuto::land_run()
     land_run_normal_or_precland();
 }
 
-// auto_rtl_run - rtl in AUTO flight mode
+// rtl_run - rtl in AUTO flight mode
 //      called by auto_run at 100hz or more
 void ModeAuto::rtl_run()
 {
@@ -1132,7 +1132,7 @@ void ModeAuto::rtl_run()
     copter.mode_rtl.run(false);
 }
 
-// auto_circle_run - circle in AUTO flight mode
+// circle_run - circle in AUTO flight mode
 //      called by auto_run at 100hz or more
 void ModeAuto::circle_run()
 {
@@ -1148,7 +1148,7 @@ void ModeAuto::circle_run()
 }
 
 #if AC_NAV_GUIDED || AP_SCRIPTING_ENABLED
-// auto_nav_guided_run - allows control by external navigation controller
+// nav_guided_run - allows control by external navigation controller
 //      called by auto_run at 100hz or more
 void ModeAuto::nav_guided_run()
 {
@@ -1157,7 +1157,7 @@ void ModeAuto::nav_guided_run()
 }
 #endif  // AC_NAV_GUIDED || AP_SCRIPTING_ENABLED
 
-// auto_loiter_run - loiter in AUTO flight mode
+// loiter_run - loiter in AUTO flight mode
 //      called by auto_run at 100hz or more
 void ModeAuto::loiter_run()
 {
@@ -1179,7 +1179,7 @@ void ModeAuto::loiter_run()
     attitude_control->input_thrust_vector_heading(pos_control->get_thrust_vector(), auto_yaw.get_heading());
 }
 
-// auto_loiter_run - loiter to altitude in AUTO flight mode
+// loiter_to_alt_run - loiter to altitude in AUTO flight mode
 //      called by auto_run at 100hz or more
 void ModeAuto::loiter_to_alt_run()
 {
@@ -1276,7 +1276,7 @@ void ModeAuto::nav_attitude_time_run()
 }
 
 #if AC_PAYLOAD_PLACE_ENABLED
-// auto_payload_place_run - places an object in auto mode
+// PayloadPlace::run - places an object in auto mode
 //      called by auto_run at 100hz or more
 void PayloadPlace::run()
 {
@@ -1672,7 +1672,7 @@ void ModeAuto::do_land(const AP_Mission::Mission_Command& cmd)
     // if location provided we fly to that location at current altitude
     if (cmd.content.location.lat != 0 || cmd.content.location.lng != 0) {
         // set state to fly to location
-        state = State::FlyToLocation;
+        land_state = LandState::FlyToLocation;
 
         // calculate default location used when alt is zero
         Location default_loc = copter.current_loc;
@@ -1691,7 +1691,7 @@ void ModeAuto::do_land(const AP_Mission::Mission_Command& cmd)
         }
     } else {
         // set landing state
-        state = State::Descending;
+        land_state = LandState::Descending;
 
         // initialise landing controller
         land_start();
@@ -2130,19 +2130,19 @@ bool ModeAuto::verify_land()
 {
     bool retval = false;
 
-    switch (state) {
-        case State::FlyToLocation:
+    switch (land_state) {
+        case LandState::FlyToLocation:
             // check if we've reached the location
             if (copter.wp_nav->reached_wp_destination()) {
                 // initialise landing controller
                 land_start();
 
                 // advance to next state
-                state = State::Descending;
+                land_state = LandState::Descending;
             }
             break;
 
-        case State::Descending:
+        case LandState::Descending:
             // rely on THROTTLE_LAND mode to correctly update landing status
             retval = copter.ap.land_complete && (motors->get_spool_state() == AP_Motors::SpoolState::GROUND_IDLE);
             if (retval && !mission.continue_after_land_check_for_takeoff() && copter.motors->armed()) {

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -1161,22 +1161,8 @@ void ModeAuto::nav_guided_run()
 //      called by auto_run at 100hz or more
 void ModeAuto::loiter_run()
 {
-    // if not armed set throttle to zero and exit immediately
-    if (is_disarmed_or_landed()) {
-        make_safe_ground_handling();
-        return;
-    }
-
-    // set motors to full range
-    motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
-
-    // run waypoint and z-axis position controller
-    copter.failsafe_terrain_set_status(wp_nav->update_wpnav());
-
-    pos_control->D_update_controller();
-
-    // call attitude controller with auto yaw
-    attitude_control->input_thrust_vector_heading(pos_control->get_thrust_vector(), auto_yaw.get_heading());
+    // loiter runs the same waypoint controller as wp_run
+    wp_run();
 }
 
 // loiter_to_alt_run - loiter to altitude in AUTO flight mode

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -2233,9 +2233,7 @@ bool ModeAuto::verify_loiter_to_alt() const
 // returns true with RTL has completed successfully
 bool ModeAuto::verify_RTL()
 {
-    return (copter.mode_rtl.state_complete() && 
-            ((copter.mode_rtl.state() == ModeRTL::SubMode::FINAL_DESCENT) ||
-             (copter.mode_rtl.state() == ModeRTL::SubMode::LAND && motors->get_spool_state() == AP_Motors::SpoolState::GROUND_IDLE)));
+    return copter.mode_rtl.is_complete();
 }
 
 /********************************************************************************/

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -30,7 +30,7 @@ bool ModeAuto::init(bool ignore_checks)
             return false;
         }
 
-        _mode = SubMode::LOITER;
+        _mode = SubMode::STARTING;
 
         // stop ROI from carrying over from previous runs of the mission
         // To-Do: reset the yaw as part of auto_wp_start when the previous command was not a wp command to remove the need for this special ROI check
@@ -115,6 +115,11 @@ void ModeAuto::run()
 
     // call the correct auto controller
     switch (_mode) {
+
+    case SubMode::STARTING:
+        // hold position until the mission dispatches the first navigation submode
+        loiter_run();
+        break;
 
     case SubMode::TAKEOFF:
         takeoff_run();
@@ -227,6 +232,7 @@ bool ModeAuto::move_vehicle_on_ekf_reset() const
 {
     // decide based on the current submode
     switch (_mode) {
+    case SubMode::STARTING:
     case SubMode::TAKEOFF:
     case SubMode::LAND:
     case SubMode::RTL:

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -372,7 +372,6 @@ bool ModeAuto::loiter_start()
     if (!copter.position_ok()) {
         return false;
     }
-    _mode = SubMode::LOITER;
 
     // calculate stopping point
     Vector3p stopping_point_ned_m;
@@ -383,6 +382,9 @@ bool ModeAuto::loiter_start()
 
     // hold yaw at current heading
     auto_yaw.set_mode(AutoYaw::Mode::HOLD);
+
+    // set submode
+    set_submode(SubMode::LOITER);
 
     return true;
 }

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -144,9 +144,11 @@ void ModeRTL::run(bool disarm_on_land)
     switch (_state) {
 
     case SubMode::STARTING:
-        // should not be reached:
-        _state = SubMode::INITIAL_CLIMB;
-        FALLTHROUGH;
+        // reached only after an in-cycle restart_without_terrain(); hold on the
+        // current target this loop and let advance_state() rebuild the path next loop
+        climb_return_run();
+        _state_complete = true;
+        break;
 
     case SubMode::INITIAL_CLIMB:
     case SubMode::FLY_TO_RETURN_POINT:

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -252,14 +252,14 @@ bool ModeRTL::return_start()
     return destination_set;
 }
 
-// climb_return_run - runs the initial climb and return portions of RTL, both of which rely on the wp controller
-//      called by rtl_run at 100hz or more
-void ModeRTL::climb_return_run()
+// run_wp_controllers - run the wp_nav horizontal, vertical and attitude controllers shared by
+//   the climb, return and hold stages.  Returns false when disarmed/landed (caller returns).
+bool ModeRTL::run_wp_controllers()
 {
     // if not armed set throttle to zero and exit immediately
     if (is_disarmed_or_landed()) {
         make_safe_ground_handling();
-        return;
+        return false;
     }
 
     // set motors to full range
@@ -274,6 +274,17 @@ void ModeRTL::climb_return_run()
 
     // call attitude controller with auto yaw
     attitude_control->input_thrust_vector_heading(pos_control->get_thrust_vector(), auto_yaw.get_heading());
+
+    return true;
+}
+
+// climb_return_run - runs the initial climb and return portions of RTL, both of which rely on the wp controller
+//      called by rtl_run at 100hz or more
+void ModeRTL::climb_return_run()
+{
+    if (!run_wp_controllers()) {
+        return;
+    }
 
     // check if we've completed this stage of RTL
     _state_complete = wp_nav->reached_wp_destination();
@@ -294,24 +305,9 @@ void ModeRTL::hold_at_return_point_start()
 //      called by rtl_run at 100hz or more
 void ModeRTL::hold_at_return_point_run()
 {
-    // if not armed set throttle to zero and exit immediately
-    if (is_disarmed_or_landed()) {
-        make_safe_ground_handling();
+    if (!run_wp_controllers()) {
         return;
     }
-
-    // set motors to full range
-    motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
-
-    // run waypoint controller
-    copter.failsafe_terrain_set_status(wp_nav->update_wpnav());
-
-    // WP_Nav has set the vertical position control targets
-    // run the vertical position controller and set output throttle
-    pos_control->D_update_controller();
-
-    // call attitude controller with auto yaw
-    attitude_control->input_thrust_vector_heading(pos_control->get_thrust_vector(), auto_yaw.get_heading());
 
     // check if we've completed this stage of RTL
     const uint32_t hold_elapsed_ms = millis() - _stage_start_ms;

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -135,36 +135,12 @@ void ModeRTL::run(bool disarm_on_land)
         return;
     }
 
-    // check if we need to move to next state
+    // advance the state machine at most one stage per loop
     if (_state_complete) {
-        switch (_state) {
-        case SubMode::STARTING:
-            build_path();
-            climb_start();
-            break;
-        case SubMode::INITIAL_CLIMB:
-            return_start();
-            break;
-        case SubMode::FLY_TO_RETURN_POINT:
-            hold_at_return_point_start();
-            break;
-        case SubMode::HOLD_AT_RETURN_POINT:
-            if (rtl_path.land || copter.failsafe.radio) {
-                land_start();
-            } else {
-                descent_start();
-            }
-            break;
-        case SubMode::FINAL_DESCENT:
-            // do nothing
-            break;
-        case SubMode::LAND:
-            // do nothing - rtl_land_run will take care of disarming motors
-            break;
-        }
+        advance_state();
     }
 
-    // call the correct run function
+    // run the controller for the current stage
     switch (_state) {
 
     case SubMode::STARTING:
@@ -191,12 +167,65 @@ void ModeRTL::run(bool disarm_on_land)
     }
 }
 
+// advance_state - move to the next stage when the current one is complete
+void ModeRTL::advance_state()
+{
+    switch (_state) {
+    case SubMode::STARTING:
+        build_path();
+        set_submode(SubMode::INITIAL_CLIMB);
+        break;
+    case SubMode::INITIAL_CLIMB:
+        set_submode(SubMode::FLY_TO_RETURN_POINT);
+        break;
+    case SubMode::FLY_TO_RETURN_POINT:
+        set_submode(SubMode::HOLD_AT_RETURN_POINT);
+        break;
+    case SubMode::HOLD_AT_RETURN_POINT:
+        set_submode((rtl_path.land || copter.failsafe.radio) ? SubMode::LAND : SubMode::FINAL_DESCENT);
+        break;
+    case SubMode::FINAL_DESCENT:
+    case SubMode::LAND:
+        // terminal stages
+        break;
+    }
+}
+
+// set_submode - performs all normal stage changes; sets _state, clears _state_complete and runs the stage's entry init
+void ModeRTL::set_submode(SubMode submode)
+{
+    _state = submode;
+    _state_complete = false;
+    _stage_start_ms = millis();
+
+    switch (submode) {
+    case SubMode::STARTING:
+        // path (re)build handled by advance_state(); nothing to init here
+        break;
+    case SubMode::INITIAL_CLIMB:
+        climb_start();
+        break;
+    case SubMode::FLY_TO_RETURN_POINT:
+        if (!return_start()) {
+            // terrain data missing: rebuild the path with terrain following off
+            restart_without_terrain();
+        }
+        break;
+    case SubMode::HOLD_AT_RETURN_POINT:
+        hold_at_return_point_start();
+        break;
+    case SubMode::FINAL_DESCENT:
+        descent_start();
+        break;
+    case SubMode::LAND:
+        land_start();
+        break;
+    }
+}
+
 // climb_start - initialise climb to RTL altitude
 void ModeRTL::climb_start()
 {
-    _state = SubMode::INITIAL_CLIMB;
-    _state_complete = false;
-
     // set the destination
     if (!wp_nav->set_wp_destination_loc(rtl_path.climb_target) || !wp_nav->set_wp_destination_next_loc(rtl_path.return_target)) {
         // this should not happen because build_path will have checked terrain data was available
@@ -211,18 +240,16 @@ void ModeRTL::climb_start()
 }
 
 // return_start - initialise the return to the return point (home or nearest rally point)
-void ModeRTL::return_start()
+//   returns false if the destination could not be set (missing terrain data)
+bool ModeRTL::return_start()
 {
-    _state = SubMode::FLY_TO_RETURN_POINT;
-    _state_complete = false;
-
-    if (!wp_nav->set_wp_destination_loc(rtl_path.return_target)) {
-        // failure must be caused by missing terrain data, restart RTL
-        restart_without_terrain();
-    }
+    // failure to set the destination must be caused by missing terrain data
+    const bool destination_set = wp_nav->set_wp_destination_loc(rtl_path.return_target);
 
     // initialise yaw to point at the return point (maybe)
     auto_yaw.set_mode_to_default(true);
+
+    return destination_set;
 }
 
 // climb_return_run - runs the initial climb and return portions of RTL, both of which rely on the wp controller
@@ -255,10 +282,6 @@ void ModeRTL::climb_return_run()
 // hold_at_return_point_start - initialise the hold over the return point (home or nearest rally point)
 void ModeRTL::hold_at_return_point_start()
 {
-    _state = SubMode::HOLD_AT_RETURN_POINT;
-    _state_complete = false;
-    _hold_start_time = millis();
-
     // yaw back to initial take-off heading yaw unless pilot has already overridden yaw
     if (auto_yaw.default_mode(true) != AutoYaw::Mode::HOLD) {
         auto_yaw.set_mode(AutoYaw::Mode::RESET_TO_ARMED_YAW);
@@ -291,7 +314,8 @@ void ModeRTL::hold_at_return_point_run()
     attitude_control->input_thrust_vector_heading(pos_control->get_thrust_vector(), auto_yaw.get_heading());
 
     // check if we've completed this stage of RTL
-    if ((millis() - _hold_start_time) >= (uint32_t)g.rtl_loiter_time.get()) {
+    const uint32_t hold_elapsed_ms = millis() - _stage_start_ms;
+    if (hold_elapsed_ms >= (uint32_t)g.rtl_loiter_time.get()) {
         if (auto_yaw.mode() == AutoYaw::Mode::RESET_TO_ARMED_YAW) {
             // check if heading is within 2 degrees of heading when vehicle was armed
             // todo: Use the target heading instead of the actual heading to allow landing even if yaw control is lost.
@@ -308,9 +332,6 @@ void ModeRTL::hold_at_return_point_run()
 // descent_start - initialise descent to final alt
 void ModeRTL::descent_start()
 {
-    _state = SubMode::FINAL_DESCENT;
-    _state_complete = false;
-
     // initialise altitude target to stopping point
     pos_control->D_init_controller_stopping_point();
 
@@ -384,9 +405,6 @@ void ModeRTL::descent_run()
 // land_start - initialise controllers to hold over the return point
 void ModeRTL::land_start()
 {
-    _state = SubMode::LAND;
-    _state_complete = false;
-
     // set horizontal speed and acceleration limits
     pos_control->NE_set_max_speed_accel_m(wp_nav->get_default_speed_NE_ms(), wp_nav->get_wp_acceleration_mss());
     pos_control->NE_set_correction_speed_accel_m(wp_nav->get_default_speed_NE_ms(), wp_nav->get_wp_acceleration_mss());

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -77,7 +77,7 @@ void ModeRTL::convert_params()
  * and the lower implementation of the waypoint or landing controllers within those states
  */
 
-// rtl_init - initialise rtl controller
+// init - initialise rtl controller
 bool ModeRTL::init(bool ignore_checks)
 {
     if (!ignore_checks) {
@@ -127,7 +127,7 @@ ModeRTL::RTLAltType ModeRTL::get_alt_type() const
     return RTLAltType::RELATIVE;
 }
 
-// rtl_run - runs the return-to-launch controller
+// run - runs the return-to-launch controller
 // should be called at 100hz or more
 void ModeRTL::run(bool disarm_on_land)
 {
@@ -145,10 +145,10 @@ void ModeRTL::run(bool disarm_on_land)
         case SubMode::INITIAL_CLIMB:
             return_start();
             break;
-        case SubMode::RETURN_HOME:
-            loiterathome_start();
+        case SubMode::FLY_TO_RETURN_POINT:
+            hold_at_return_point_start();
             break;
-        case SubMode::LOITER_AT_HOME:
+        case SubMode::HOLD_AT_RETURN_POINT:
             if (rtl_path.land || copter.failsafe.radio) {
                 land_start();
             } else {
@@ -173,12 +173,12 @@ void ModeRTL::run(bool disarm_on_land)
         FALLTHROUGH;
 
     case SubMode::INITIAL_CLIMB:
-    case SubMode::RETURN_HOME:
+    case SubMode::FLY_TO_RETURN_POINT:
         climb_return_run();
         break;
 
-    case SubMode::LOITER_AT_HOME:
-        loiterathome_run();
+    case SubMode::HOLD_AT_RETURN_POINT:
+        hold_at_return_point_run();
         break;
 
     case SubMode::FINAL_DESCENT:
@@ -191,7 +191,7 @@ void ModeRTL::run(bool disarm_on_land)
     }
 }
 
-// rtl_climb_start - initialise climb to RTL altitude
+// climb_start - initialise climb to RTL altitude
 void ModeRTL::climb_start()
 {
     _state = SubMode::INITIAL_CLIMB;
@@ -199,7 +199,7 @@ void ModeRTL::climb_start()
 
     // set the destination
     if (!wp_nav->set_wp_destination_loc(rtl_path.climb_target) || !wp_nav->set_wp_destination_next_loc(rtl_path.return_target)) {
-        // this should not happen because rtl_build_path will have checked terrain data was available
+        // this should not happen because build_path will have checked terrain data was available
         gcs().send_text(MAV_SEVERITY_CRITICAL,"RTL: unexpected error setting climb target");
         LOGGER_WRITE_ERROR(LogErrorSubsystem::NAVIGATION, LogErrorCode::FAILED_TO_SET_DESTINATION);
         copter.set_mode(Mode::Number::LAND, ModeReason::TERRAIN_FAILSAFE);
@@ -210,10 +210,10 @@ void ModeRTL::climb_start()
     auto_yaw.set_mode(AutoYaw::Mode::HOLD);
 }
 
-// rtl_return_start - initialise return to home
+// return_start - initialise the return to the return point (home or nearest rally point)
 void ModeRTL::return_start()
 {
-    _state = SubMode::RETURN_HOME;
+    _state = SubMode::FLY_TO_RETURN_POINT;
     _state_complete = false;
 
     if (!wp_nav->set_wp_destination_loc(rtl_path.return_target)) {
@@ -221,11 +221,11 @@ void ModeRTL::return_start()
         restart_without_terrain();
     }
 
-    // initialise yaw to point home (maybe)
+    // initialise yaw to point at the return point (maybe)
     auto_yaw.set_mode_to_default(true);
 }
 
-// rtl_climb_return_run - implements the initial climb, return home and descent portions of RTL which all rely on the wp controller
+// climb_return_run - runs the initial climb and return portions of RTL, both of which rely on the wp controller
 //      called by rtl_run at 100hz or more
 void ModeRTL::climb_return_run()
 {
@@ -252,12 +252,12 @@ void ModeRTL::climb_return_run()
     _state_complete = wp_nav->reached_wp_destination();
 }
 
-// loiterathome_start - initialise return to home
-void ModeRTL::loiterathome_start()
+// hold_at_return_point_start - initialise the hold over the return point (home or nearest rally point)
+void ModeRTL::hold_at_return_point_start()
 {
-    _state = SubMode::LOITER_AT_HOME;
+    _state = SubMode::HOLD_AT_RETURN_POINT;
     _state_complete = false;
-    _loiter_start_time = millis();
+    _hold_start_time = millis();
 
     // yaw back to initial take-off heading yaw unless pilot has already overridden yaw
     if (auto_yaw.default_mode(true) != AutoYaw::Mode::HOLD) {
@@ -267,9 +267,9 @@ void ModeRTL::loiterathome_start()
     }
 }
 
-// rtl_climb_return_descent_run - implements the initial climb, return home and descent portions of RTL which all rely on the wp controller
+// hold_at_return_point_run - holds over the return point until RTL_LOIT_TIME elapses (and the armed heading is reached, if realigning yaw)
 //      called by rtl_run at 100hz or more
-void ModeRTL::loiterathome_run()
+void ModeRTL::hold_at_return_point_run()
 {
     // if not armed set throttle to zero and exit immediately
     if (is_disarmed_or_landed()) {
@@ -291,7 +291,7 @@ void ModeRTL::loiterathome_run()
     attitude_control->input_thrust_vector_heading(pos_control->get_thrust_vector(), auto_yaw.get_heading());
 
     // check if we've completed this stage of RTL
-    if ((millis() - _loiter_start_time) >= (uint32_t)g.rtl_loiter_time.get()) {
+    if ((millis() - _hold_start_time) >= (uint32_t)g.rtl_loiter_time.get()) {
         if (auto_yaw.mode() == AutoYaw::Mode::RESET_TO_ARMED_YAW) {
             // check if heading is within 2 degrees of heading when vehicle was armed
             // todo: Use the target heading instead of the actual heading to allow landing even if yaw control is lost.
@@ -299,13 +299,13 @@ void ModeRTL::loiterathome_run()
                 _state_complete = true;
             }
         } else {
-            // we have loitered long enough
+            // we have held long enough
             _state_complete = true;
         }
     }
 }
 
-// rtl_descent_start - initialise descent to final alt
+// descent_start - initialise descent to final alt
 void ModeRTL::descent_start()
 {
     _state = SubMode::FINAL_DESCENT;
@@ -323,7 +323,7 @@ void ModeRTL::descent_start()
 #endif
 }
 
-// rtl_descent_run - implements the final descent to the RTL_ALT_M
+// descent_run - implements the final descent to the RTL_ALT_M
 //      called by rtl_run at 100hz or more
 void ModeRTL::descent_run()
 {
@@ -381,7 +381,7 @@ void ModeRTL::descent_run()
     _state_complete = fabsf(rtl_path.descent_target.alt * 0.01 - pos_control->get_pos_estimate_U_m()) < 0.2;
 }
 
-// land_start - initialise controllers to loiter over home
+// land_start - initialise controllers to hold over the return point
 void ModeRTL::land_start()
 {
     _state = SubMode::LAND;
@@ -391,7 +391,7 @@ void ModeRTL::land_start()
     pos_control->NE_set_max_speed_accel_m(wp_nav->get_default_speed_NE_ms(), wp_nav->get_wp_acceleration_mss());
     pos_control->NE_set_correction_speed_accel_m(wp_nav->get_default_speed_NE_ms(), wp_nav->get_wp_acceleration_mss());
 
-    // initialise loiter target destination
+    // initialise the horizontal position controller
     if (!pos_control->NE_is_active()) {
         pos_control->NE_init_controller();
     }
@@ -588,8 +588,8 @@ bool ModeRTL::get_wp(Location& destination) const
     switch (_state) {
     case SubMode::STARTING:
     case SubMode::INITIAL_CLIMB:
-    case SubMode::RETURN_HOME:
-    case SubMode::LOITER_AT_HOME:
+    case SubMode::FLY_TO_RETURN_POINT:
+    case SubMode::HOLD_AT_RETURN_POINT:
     case SubMode::FINAL_DESCENT:
         return wp_nav->get_oa_wp_destination(destination);
     case SubMode::LAND:

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -433,6 +433,16 @@ bool ModeRTL::is_landing() const
     return _state == SubMode::LAND;
 }
 
+// true once RTL has completed its final stage: the final descent has reached RTL_ALT_FINAL,
+// or (when landing) the vehicle has touched down and spooled to ground idle.
+// Used by ModeAuto::verify_RTL.
+bool ModeRTL::is_complete() const
+{
+    return _state_complete &&
+           ((_state == SubMode::FINAL_DESCENT) ||
+            (_state == SubMode::LAND && motors->get_spool_state() == AP_Motors::SpoolState::GROUND_IDLE));
+}
+
 // land_run - run the landing controllers to put the aircraft on the ground
 // called by rtl_run at 100hz or more
 void ModeRTL::land_run(bool disarm_on_land)

--- a/ArduCopter/mode_smart_rtl.cpp
+++ b/ArduCopter/mode_smart_rtl.cpp
@@ -31,11 +31,36 @@ bool ModeSmartRTL::init(bool ignore_checks)
         auto_yaw.set_mode_to_default(true);
 
         // wait for cleanup of return path
-        smart_rtl_state = SubMode::WAIT_FOR_PATH_CLEANUP;
+        set_submode(SubMode::WAIT_FOR_PATH_CLEANUP);
         return true;
     }
 
     return false;
+}
+
+// set_submode - the only writer of smart_rtl_state; runs the stage's entry init
+void ModeSmartRTL::set_submode(SubMode submode)
+{
+    smart_rtl_state = submode;
+
+    switch (submode) {
+    case SubMode::WAIT_FOR_PATH_CLEANUP:
+        // initialised in init()
+        break;
+    case SubMode::PATH_FOLLOW:
+        path_follow_last_pop_fail_ms = 0;
+        break;
+    case SubMode::PRELAND_POSITION:
+        // wp destination is data-dependent and set by the caller
+        break;
+    case SubMode::DESCEND:
+        set_descent_target_alt(get_alt_final_m() * 100);
+        descent_start();
+        break;
+    case SubMode::LAND:
+        land_start();
+        break;
+    }
 }
 
 // perform cleanup required when leaving smart_rtl
@@ -88,8 +113,7 @@ void ModeSmartRTL::wait_cleanup_run()
 
     // check if return path is computed and if yes, begin journey home
     if (g2.smart_rtl.request_thorough_cleanup()) {
-        path_follow_last_pop_fail_ms = 0;
-        smart_rtl_state = SubMode::PATH_FOLLOW;
+        set_submode(SubMode::PATH_FOLLOW);
     }
 }
 
@@ -111,7 +135,7 @@ void ModeSmartRTL::path_follow_run()
             if (g2.smart_rtl.get_num_points() == 0) {
                 // this is the very last point, add 2m to the target alt and move to pre-land state
                 dest_NED.z -= 2.0f;
-                smart_rtl_state = SubMode::PRELAND_POSITION;
+                set_submode(SubMode::PRELAND_POSITION);
                 wp_nav->set_wp_destination_NED_m(dest_NED);
             } else {
                 // peek at the next point.  this can fail if the IO task currently has the path semaphore
@@ -134,7 +158,7 @@ void ModeSmartRTL::path_follow_run()
             // We should never get here; should always have at least
             // two points and the "zero points left" is handled above.
             INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
-            smart_rtl_state = SubMode::PRELAND_POSITION;
+            set_submode(SubMode::PRELAND_POSITION);
         } else if (path_follow_last_pop_fail_ms == 0) {
             // first time we've failed to pop off (ever, or after a success)
             path_follow_last_pop_fail_ms = AP_HAL::millis();
@@ -142,7 +166,7 @@ void ModeSmartRTL::path_follow_run()
             // we failed to pop a point off for 10 seconds.  This is
             // almost certainly a bug.
             INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
-            smart_rtl_state = SubMode::PRELAND_POSITION;
+            set_submode(SubMode::PRELAND_POSITION);
         }
     }
 
@@ -161,12 +185,9 @@ void ModeSmartRTL::pre_land_position_run()
     if (wp_nav->reached_wp_destination()) {
         // choose descend and hold, or land based on user parameter rtl_alt_final_cm
         if (get_alt_final_m() <= 0 || copter.failsafe.radio) {
-            land_start();
-            smart_rtl_state = SubMode::LAND;
+            set_submode(SubMode::LAND);
         } else {
-            set_descent_target_alt(get_alt_final_m() * 100);
-            descent_start();
-            smart_rtl_state = SubMode::DESCEND;
+            set_submode(SubMode::DESCEND);
         }
     }
 


### PR DESCRIPTION
### Summary

Tidy up ModeAuto with the same treatment applied to ModeRTL: naming and comment cleanup, tighter encapsulation, removal of a duplicated run body, and an explicit STARTING submode in place of the old "pretend to be LOITER" startup. Two small behaviour changes are called out in the description.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

This is a cleanup pass over ModeAuto, mirroring the direction of the companion ModeRTL cleanup. It is five commits, each reviewed and built in order. Most of it is non functional. The two behaviour changes are small and called out explicitly.

Rename and comment cleanup (no functional change). Drops the stale auto_ prefix from the function header comments, fixes the copy paste comments on loiter_to_alt_run and PayloadPlace, corrects the set_submode header (it returns void), and fixes the stray move_vehicle comment. Renames SubMode::NAVGUIDED to NAV_GUIDED for consistency with the other NAV_ submodes, and renames the land sub state machine State/state to LandState/land_state so it is no longer confused with _mode or with PayloadPlace's own State.

Make the submode start helpers private (no functional change). The *_start() helpers (loiter_start, rtl_start, takeoff_start, wp_start, land_start, circle_movetoedge_start, circle_start, nav_guided_start) are only called from ModeAuto's own command handlers, so they move from public to private.

Remove the duplicated loiter run body (no functional change). loiter_run() ran a control block identical to wp_run(), so it now just calls wp_run().

Add an explicit STARTING submode. The old behaviour set _mode = LOITER in init() so the vehicle held position before the mission dispatched its first navigation command. That is replaced by an explicit SubMode::STARTING. The vehicle still holds via loiter_run() during startup, so flight behaviour is unchanged. Only the reported submode label changes from LOITER to STARTING, which is more accurate, and real LOITER mission commands are unaffected.

Route loiter_start() through set_submode(). This is the one real behaviour change. loiter_start() previously wrote _mode = SubMode::LOITER directly, bypassing the EKF failsafe recheck that set_submode() performs on every other submode transition. Entering LOITER, for example from NAV_ATTITUDE_TIME, now rechecks the EKF failsafe like every other entry. The state write moves to after the controller setup as in the other *_start() helpers, and nothing in loiter_start reads _mode in between, so that reordering is inert.
