### PR TITLE
AC_AttitudeControl: WeatherVane: Add new accel method for testing

### DIFF
--- a/libraries/AC_AttitudeControl/AC_WeatherVane.cpp
+++ b/libraries/AC_AttitudeControl/AC_WeatherVane.cpp
@@ -24,7 +24,7 @@ const AP_Param::GroupInfo AC_WeatherVane::var_info[] = {
     // @Param: ENABLE
     // @DisplayName: Enable
     // @Description: Enable weather vaning.  When active, the aircraft will automatically yaw into wind when in a VTOL position controlled mode. Pilot yaw commands override the weathervaning action.
-    // @Values: -1:Only use during takeoffs or landing see weathervane takeoff and land override parameters,0:Disabled,1:Nose into wind,2:Nose or tail into wind,3:Side into wind,4:tail into wind
+    // @Values: -1:Only use during takeoffs or landing see weathervane takeoff and land override parameters,0:Disabled,1:Nose into wind,2:Nose or tail into wind,3:Side into wind,4:tail into wind,5:Zero sideslip
     // @User: Standard
     AP_GROUPINFO_FLAGS("ENABLE", 1, AC_WeatherVane, _direction, WVANE_PARAM_ENABLED, AP_PARAM_FLAG_ENABLE),
 
@@ -76,14 +76,14 @@ const AP_Param::GroupInfo AC_WeatherVane::var_info[] = {
     // @Param: TAKEOFF
     // @DisplayName: Takeoff override
     // @Description: Override the weather vaning behaviour when in takeoffs
-    // @Values: -1:No override,0:Disabled,1:Nose into wind,2:Nose or tail into wind,3:Side into wind,4:tail into wind
+    // @Values: -1:No override,0:Disabled,1:Nose into wind,2:Nose or tail into wind,3:Side into wind,4:tail into wind,5:Zero sideslip
     // @User: Standard
     AP_GROUPINFO("TAKEOFF", 7, AC_WeatherVane, _takeoff_direction, -1),
 
     // @Param: LAND
     // @DisplayName: Landing override
     // @Description: Override the weather vaning behaviour when in landing
-    // @Values: -1:No override,0:Disabled,1:Nose into wind,2:Nose or tail into wind,3:Side into wind,4:tail into wind
+    // @Values: -1:No override,0:Disabled,1:Nose into wind,2:Nose or tail into wind,3:Side into wind,4:tail into wind,5:Zero sideslip
     // @User: Standard
     AP_GROUPINFO("LAND", 8, AC_WeatherVane, _landing_direction, -1),
 
@@ -216,6 +216,30 @@ bool AC_WeatherVane::get_yaw_out(float &yaw_output, const int16_t pilot_yaw, con
             }
             dir_string = "tail in";
             break;
+
+        case Direction::ZERO_SIDESLIP: {
+            // Get the measured lateral acceleration corrected for roll and pitch
+            const Vector3f accel_body = AP::ahrs().get_accel() - AP::ahrs().get_accel_bias();
+            const Vector3f accel_NED = AP::ahrs().get_rotation_body_to_ned() * accel_body;
+            const float yaw = AP::ahrs().get_yaw_rad();
+            const float accel_y = -sinf(yaw) * accel_NED.x + cosf(yaw) * accel_NED.y;
+
+            // Expected acceleration from vertical thrust vector
+            const float expected_accel_y = GRAVITY_MSS * sinf(AP::ahrs().get_roll_rad()) * cosf(AP::ahrs().get_pitch_rad());
+
+            // Any difference in acceleration must be due to drag which we want to minimize
+            // Convert to a equivalent roll angle for similar behaviour to exiting methods
+            const float accel_cdeg = rad_to_cd(atan2f(expected_accel_y - accel_y, GRAVITY_MSS));
+
+            // Apply deadzone and restore sign
+            output = MAX(fabsf(accel_cdeg) - deadzone_cdeg, 0.0f);
+            if (is_negative(accel_cdeg)) {
+                output *= -1.0f;
+            }
+
+            dir_string = "zero sideslip";
+            break;
+        }
     }
 
     if (active_msg_dir != dir) {

--- a/libraries/AC_AttitudeControl/AC_WeatherVane.h
+++ b/libraries/AC_AttitudeControl/AC_WeatherVane.h
@@ -30,6 +30,7 @@ class AC_WeatherVane {
             NOSE_OR_TAIL_IN = 2, // Nose in or tail into wind, which ever is closest
             SIDE_IN = 3, // Side into wind for copter tailsitters
             TAIL_IN = 4, // backwards, for tailsitters, makes it easier to descend
+            ZERO_SIDESLIP = 5, // Yaw to zero lateral body acceleration (sideslip)
         };
 
         enum class Options {


### PR DESCRIPTION
### Summary

This adds a new option for weather vaneing on Quadplane. It uses measured lateral accelerations and vehicle attitude. This is faster to respond than the exiting method which use target attitude. It also does a better job when the vehicle is actively accelerating. 

<!-- Put a one or two line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->

Really I don't want to add this as a new option, if it seems better it should replace the existing options. So far I have only tested in realflight, testing on real vehicles will show if the acceleration measurements are too noisy. Because its (more or less) estimating drag it is more sensitive with higher airspeeds and not sensitive at low airspeeds, its possible some linearization would improve this. However, that requires having a good wind estimate...
