### PR TITLE
Plane: Quadplane: enable weathervane in VTOL auto

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3275,10 +3275,36 @@ void QuadPlane::waypoint_controller(void)
 
     // call attitude controller
     disable_yaw_rate_time_constant();
-    attitude_control->input_euler_angle_roll_pitch_yaw_cd(plane.nav_roll_cd,
-                                                       plane.nav_pitch_cd,
-                                                       wp_nav->get_yaw(),
-                                                       true);
+
+    // Weathervane if enabled
+    float wv_output;
+    if (transition->allow_weathervane() &&
+        weathervane->get_yaw_out(wv_output,
+                                0,
+                                plane.relative_ground_altitude(RangeFinderUse::TAKEOFF_LANDING),
+                                pos_control->get_roll_cd(),
+                                pos_control->get_pitch_cd(),
+                                false,
+                                false)) {
+
+        // Yaw rate target from weathervane controller
+        float wv_yaw_rate_cds = constrain_float(wv_output * (1/45.0), -100.0, 100.0) * command_model_pilot.get_rate() * 0.5;
+
+        // Apply auto mode slew limit
+        const float slew_limit_cds = rad_to_cd(attitude_control->get_slew_yaw_max_rads());
+        wv_yaw_rate_cds = constrain_float(wv_yaw_rate_cds, -slew_limit_cds, slew_limit_cds);
+
+        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw_cd(plane.nav_roll_cd,
+                                                                    plane.nav_pitch_cd,
+                                                                    wv_yaw_rate_cds);
+
+    } else {
+        // Yaw angle target from waypoint navigation
+        attitude_control->input_euler_angle_roll_pitch_yaw_cd(plane.nav_roll_cd,
+                                                        plane.nav_pitch_cd,
+                                                        wp_nav->get_yaw(),
+                                                        true);
+    }
 
     // climb based on altitude error
     set_climb_rate_ms(assist_climb_rate_cms() * 0.01);

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3231,10 +3231,47 @@ void QuadPlane::waypoint_controller(void)
 
     // call attitude controller
     disable_yaw_rate_time_constant();
-    attitude_control->input_euler_angle_roll_pitch_yaw_cd(plane.nav_roll_cd,
-                                                       plane.nav_pitch_cd,
-                                                       wp_nav->get_yaw(),
-                                                       true);
+
+    // Weathervane if enabled
+    const bool allow_weathervane =
+        transition->allow_weathervane() &&
+        motors->armed() &&
+        (motors->get_spool_state() == AP_Motors::SpoolState::THROTTLE_UNLIMITED) &&
+        !should_relax();
+
+    if (!allow_weathervane) {
+        // Reset weathervane controller
+        weathervane->reset();
+    }
+
+    float wv_output;
+    if (allow_weathervane &&
+        weathervane->get_yaw_out(wv_output,
+                                0,
+                                plane.relative_ground_altitude(RangeFinderUse::TAKEOFF_LANDING),
+                                pos_control->get_roll_cd(),
+                                pos_control->get_pitch_cd(),
+                                false,
+                                false)) {
+
+        // Yaw rate target from weathervane controller
+        float wv_yaw_rate_cds = scale_weathervane_output(wv_output);
+
+        // Apply auto mode slew limit
+        const float slew_limit_cds = rad_to_cd(attitude_control->get_slew_yaw_max_rads());
+        wv_yaw_rate_cds = constrain_float(wv_yaw_rate_cds, -slew_limit_cds, slew_limit_cds);
+
+        attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw_cd(plane.nav_roll_cd,
+                                                                    plane.nav_pitch_cd,
+                                                                    wv_yaw_rate_cds);
+
+    } else {
+        // Yaw angle target from waypoint navigation
+        attitude_control->input_euler_angle_roll_pitch_yaw_cd(plane.nav_roll_cd,
+                                                        plane.nav_pitch_cd,
+                                                        wp_nav->get_yaw(),
+                                                        true);
+    }
 
     // climb based on altitude error
     set_climb_rate_ms(assist_climb_rate_cms() * 0.01);
@@ -3840,6 +3877,12 @@ float QuadPlane::forward_throttle_pct()
     return vel_forward.last_pct;
 }
 
+// Scale weathervane output into yaw rate in cds
+float QuadPlane::scale_weathervane_output(float wv_out) const
+{
+    return constrain_float(wv_out * (1/45.0), -100.0, 100.0) * command_model_pilot.get_rate() * 0.5;
+}
+
 /*
   get weathervaning yaw rate in cd/s
  */
@@ -3873,7 +3916,7 @@ float QuadPlane::get_weathervane_yaw_rate_cds(void)
                                      pos_control->get_pitch_cd(),
                                      is_takeoff,
                                      in_vtol_land_sequence())) {
-        return constrain_float(wv_output * (1/45.0), -100.0, 100.0) * command_model_pilot.get_rate() * 0.5;
+        return scale_weathervane_output(wv_output);
     }
 
     return 0.0;

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -132,6 +132,9 @@ public:
 
     // return desired forward throttle percentage
     float forward_throttle_pct();
+
+    // Functions related to weathervaneing
+    float scale_weathervane_output(float wv_out) const;
     float get_weathervane_yaw_rate_cds(void);
 
     // see if we are flying from vtol point of view


### PR DESCRIPTION
### Summary

This enables weathervaning in VTOL auto (Q_ENABLE = 2).

<!-- Put a one or two line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->

This does mean that weathervane can kick in and out, based on the speed threshold for example, once it kicks out the vehicle will default back to pointing at the next waypoint.