### PR TITLE
CIRCLE (LOITER_TURNS) mission item using S-curves

### DIFF
--- a/ArduCopter/autoyaw.cpp
+++ b/ArduCopter/autoyaw.cpp
@@ -264,8 +264,33 @@ float Mode::AutoYaw::yaw_rad()
     case Mode::CIRCLE:
 #if MODE_CIRCLE_ENABLED
         if (copter.circle_nav->is_active()) {
+            // standalone Circle mode provides its own yaw
             _yaw_angle_rad = copter.circle_nav->get_yaw_rad();
+            break;
         }
+        if (!copter.circle_nav->face_direction_of_travel()) {
+            // Auto's S-curve circle: face the circle center held by circle_nav, the parameter
+            // store the orbit leg was built from.  The position target is used rather than the
+            // estimate so the yaw target carries no position noise and does not lag by the
+            // tracking error (AC_Circle does the same).  If the target is exactly at the
+            // center, the last yaw target is held
+            const Vector2f pos_to_center_ne = (copter.circle_nav->get_center_NED_m().xy() - copter.pos_control->get_pos_desired_NED_m().xy()).tofloat();
+            if (!pos_to_center_ne.is_zero()) {
+                _yaw_angle_rad = pos_to_center_ne.angle();
+            }
+            break;
+        }
+        {
+            // FACE_DIRECTION_OF_TRAVEL option set: yaw follows the desired direction of travel.
+            // The last yaw target is held while the desired velocity is too small to define one
+            const Vector2f vel_desired_ne_ms = copter.pos_control->get_vel_desired_NED_ms().xy();
+            if (vel_desired_ne_ms.length() > 0.1f) {
+                _yaw_angle_rad = vel_desired_ne_ms.angle();
+            }
+        }
+#else
+        // circle mode compiled out: yaw follows the position controller's travel direction
+        _yaw_angle_rad = copter.pos_control->get_yaw_rad();
 #endif
         break;
 

--- a/ArduCopter/autoyaw.cpp
+++ b/ArduCopter/autoyaw.cpp
@@ -264,8 +264,31 @@ float Mode::AutoYaw::yaw_rad()
     case Mode::CIRCLE:
 #if MODE_CIRCLE_ENABLED
         if (copter.circle_nav->is_active()) {
+            // standalone Circle mode provides its own yaw
             _yaw_angle_rad = copter.circle_nav->get_yaw_rad();
+            break;
         }
+        if (!copter.circle_nav->face_direction_of_travel()) {
+            // Auto's S-curve circle: face the circle center held by circle_nav, the parameter
+            // store the orbit leg was built from.  If the vehicle is exactly at the center,
+            // the last yaw target is held
+            const Vector2f pos_to_center_ne = (copter.circle_nav->get_center_NED_m().xy() - copter.pos_control->get_pos_estimate_NED_m().xy()).tofloat();
+            if (!pos_to_center_ne.is_zero()) {
+                _yaw_angle_rad = pos_to_center_ne.angle();
+            }
+            break;
+        }
+        {
+            // FACE_DIRECTION_OF_TRAVEL option set: yaw follows the desired direction of travel.
+            // The last yaw target is held while the desired velocity is too small to define one
+            const Vector2f vel_desired_ne_ms = copter.pos_control->get_vel_desired_NED_ms().xy();
+            if (vel_desired_ne_ms.length() > 0.1f) {
+                _yaw_angle_rad = vel_desired_ne_ms.angle();
+            }
+        }
+#else
+        // circle mode compiled out: yaw follows the position controller's travel direction
+        _yaw_angle_rad = copter.pos_control->get_yaw_rad();
 #endif
         break;
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -673,7 +673,6 @@ private:
     void wp_run();
     void land_run();
     void rtl_run();
-    void circle_run();
     void nav_guided_run();
     void loiter_run();
     void loiter_to_alt_run();
@@ -809,7 +808,10 @@ private:
         float down;   // desired speed downwards in m/s. 0 if unset
     } desired_speed_override_ms;
 
-    float circle_last_num_complete;
+    float circle_turns_signed;  // signed number of turns for the active LOITER_TURNS orbit (sign selects direction)
+    float circle_radius_m;      // commanded LOITER_TURNS radius (0 = panorama; circle_nav's get_radius_m() falls back to the parameter so cannot express zero)
+    uint32_t circle_panorama_start_ms;  // system time a radius-0 LOITER_TURNS yaw spin started (0 = not a panorama)
+    float circle_panorama_spin_time_ms; // latched duration of the radius-0 LOITER_TURNS yaw spin
 };
 #endif  // MODE_AUTO_ENABLED
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -591,7 +591,7 @@ public:
     void takeoff_start(const Location& dest_loc);
     bool wp_start(const Location& dest_loc);
     void land_start();
-    void circle_movetoedge_start(const Location &circle_center, float radius_m, bool ccw_turn);
+    void circle_movetoedge_start(const Location &circle_center, float radius_m);
     void circle_start();
     void nav_guided_start();
 
@@ -673,7 +673,6 @@ private:
     void wp_run();
     void land_run();
     void rtl_run();
-    void circle_run();
     void nav_guided_run();
     void loiter_run();
     void loiter_to_alt_run();
@@ -809,7 +808,11 @@ private:
         float down;   // desired speed downwards in m/s. 0 if unset
     } desired_speed_override_ms;
 
-    float circle_last_num_complete;
+    float circle_turns_signed;  // signed number of turns for the active LOITER_TURNS orbit (sign selects direction)
+    float circle_radius_m;      // commanded LOITER_TURNS radius (0 = panorama; circle_nav's get_radius_m() falls back to the parameter so cannot express zero)
+    uint16_t circle_turns_reported;  // number of whole orbit turns already announced to the GCS
+    uint32_t circle_panorama_start_ms;  // time the radius-0 panorama started
+    float circle_panorama_rate_rads;    // yaw rate the radius-0 panorama was commanded at
 };
 #endif  // MODE_AUTO_ENABLED
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -808,11 +808,14 @@ private:
         float down;   // desired speed downwards in m/s. 0 if unset
     } desired_speed_override_ms;
 
-    float circle_turns_signed;  // signed number of turns for the active LOITER_TURNS orbit (sign selects direction)
-    float circle_radius_m;      // commanded LOITER_TURNS radius (0 = panorama; circle_nav's get_radius_m() falls back to the parameter so cannot express zero)
-    uint16_t circle_turns_reported;  // number of whole orbit turns already announced to the GCS
-    uint32_t circle_panorama_start_ms;  // time the radius-0 panorama started
-    float circle_panorama_rate_rads;    // yaw rate the radius-0 panorama was commanded at
+    // LOITER_TURNS state
+    struct {
+        float turns_signed;         // signed number of turns for the active LOITER_TURNS orbit (sign selects direction)
+        float radius_m;             // commanded LOITER_TURNS radius (0 = panorama; circle_nav's get_radius_m() falls back to the parameter so cannot express zero)
+        uint16_t turns_reported;    // number of whole orbit turns already announced to the GCS
+        uint32_t panorama_start_ms; // time the radius-0 panorama started
+        float panorama_rate_rads;   // yaw rate the radius-0 panorama was commanded at
+    } circle;
 };
 #endif  // MODE_AUTO_ENABLED
 

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -122,6 +122,8 @@ void ModeAuto::run()
 
     case SubMode::WP:
     case SubMode::CIRCLE_MOVE_TO_EDGE:
+    case SubMode::CIRCLE:
+        // the circle orbit is flown as an S-curve waypoint leg
         wp_run();
         break;
 
@@ -131,10 +133,6 @@ void ModeAuto::run()
 
     case SubMode::RTL:
         rtl_run();
-        break;
-
-    case SubMode::CIRCLE:
-        circle_run();
         break;
 
     case SubMode::NAVGUIDED:
@@ -230,8 +228,6 @@ bool ModeAuto::move_vehicle_on_ekf_reset() const
     case SubMode::TAKEOFF:
     case SubMode::LAND:
     case SubMode::RTL:
-    case SubMode::CIRCLE_MOVE_TO_EDGE:
-    case SubMode::CIRCLE:
     case SubMode::NAVGUIDED:
     case SubMode::LOITER:
     case SubMode::LOITER_TO_ALT:
@@ -242,8 +238,11 @@ bool ModeAuto::move_vehicle_on_ekf_reset() const
     case SubMode::NAV_ATTITUDE_TIME:
         // these submodes reset their targets so the vehicle does not physically move
         return false;
-    case SubMode::WP:    
+    case SubMode::WP:
+    case SubMode::CIRCLE_MOVE_TO_EDGE:
+    case SubMode::CIRCLE:
         // these submodes smoothly move to maintain an absolute position
+        // (the circle orbit and the move-to-edge leg are S-curve waypoint legs, like WP)
         return true;
     }
 
@@ -534,62 +533,91 @@ void ModeAuto::circle_movetoedge_start(const Location &circle_center, float radi
     // set circle center
     copter.circle_nav->set_center(circle_center);
 
-    // set circle radius
+    // set circle radius. The commanded radius is also kept in circle_radius_m because
+    // circle_nav's get_radius_m() falls back to the CIRCLE_RADIUS parameter when the
+    // commanded radius is zero, so it cannot report a zero (panorama) radius
     copter.circle_nav->set_radius_m(radius_m);
+    circle_radius_m = radius_m;
 
-    // set circle direction by using rate
-    float current_rate = copter.circle_nav->get_rate_degs();
-    current_rate = ccw_turn ? -fabsf(current_rate) : fabsf(current_rate);
-    copter.circle_nav->set_rate_degs(current_rate);
-
-    // check our distance from edge of circle
+    // Always fly to the exact edge of the circle first: circle_start() derives the S-curve
+    // orbit's radius and origin speed purely from wp_nav's current destination, with no
+    // closed-loop correction across the orbit, so that destination must land exactly on the
+    // circle at zero speed. If the vehicle is already there this leg is short and completes
+    // within a tick or two, so this costs nothing in the common case.
     Vector3p circle_edge_ned_m;
     float dist_to_edge_m;
     copter.circle_nav->get_closest_point_on_circle_NED_m(circle_edge_ned_m, dist_to_edge_m);
 
-    // if more than 3m then fly to edge
-    if (dist_to_edge_m > 3.0) {
-        // convert circle_edge_ned_m to Location
-        Location circle_edge = Location::from_ekf_offset_NED_m(circle_edge_ned_m, Location::AltFrame::ABOVE_ORIGIN);
+    // convert circle_edge_ned_m to Location
+    Location circle_edge = Location::from_ekf_offset_NED_m(circle_edge_ned_m, Location::AltFrame::ABOVE_ORIGIN);
 
-        // convert altitude to same as command
-        circle_edge.copy_alt_from(circle_center);
+    // convert altitude to same as command
+    circle_edge.copy_alt_from(circle_center);
 
-        // initialise wpnav to move to edge of circle
-        if (!wp_nav->set_wp_destination_loc(circle_edge)) {
-            // failure to set destination can only be because of missing terrain data
-            copter.failsafe_terrain_on_event();
-        }
-
-        // if we are outside the circle, point at the edge, otherwise hold yaw
-        const float dist_to_center_m = get_horizontal_distance(pos_control->get_pos_estimate_NED_m().xy().tofloat(), copter.circle_nav->get_center_NED_m().xy().tofloat());
-        // initialise yaw
-        // To-Do: reset the yaw only when the previous navigation command is not a WP.  this would allow removing the special check for ROI
-        if (auto_yaw.mode() != AutoYaw::Mode::ROI) {
-            if (dist_to_center_m > copter.circle_nav->get_radius_m() && dist_to_center_m > 5.0) {
-                auto_yaw.set_mode_to_default(false);
-            } else {
-                // vehicle is within circle so hold yaw to avoid spinning as we move to edge of circle
-                auto_yaw.set_mode(AutoYaw::Mode::HOLD);
-            }
-        }
-
-        // set the submode to move to the edge of the circle
-        set_submode(SubMode::CIRCLE_MOVE_TO_EDGE);
-    } else {
-        circle_start();
+    // initialise wpnav to move to edge of circle
+    if (!wp_nav->set_wp_destination_loc(circle_edge)) {
+        // failure to set destination can only be because of missing terrain data
+        copter.failsafe_terrain_on_event();
     }
+
+    // if we are outside the circle, point at the edge, otherwise hold yaw
+    const float dist_to_center_m = get_horizontal_distance(pos_control->get_pos_estimate_NED_m().xy().tofloat(), copter.circle_nav->get_center_NED_m().xy().tofloat());
+    // initialise yaw
+    // To-Do: reset the yaw only when the previous navigation command is not a WP.  this would allow removing the special check for ROI
+    if (auto_yaw.mode() != AutoYaw::Mode::ROI) {
+        if (dist_to_center_m > copter.circle_nav->get_radius_m() && dist_to_center_m > 5.0) {
+            auto_yaw.set_mode_to_default(false);
+        } else {
+            // vehicle is within circle so hold yaw to avoid spinning as we move to edge of circle
+            auto_yaw.set_mode(AutoYaw::Mode::HOLD);
+        }
+    }
+
+    // set the submode to move to the edge of the circle
+    set_submode(SubMode::CIRCLE_MOVE_TO_EDGE);
 }
 
-// auto_circle_start - initialises controller to fly a circle in AUTO flight mode
-//   assumes that circle_nav object has already been initialised with circle center and radius
+// auto_circle_start - begin flying a circular orbit as an S-curve waypoint leg
+//   circle_movetoedge_start has already configured circle_nav with the center, radius,
+//   altitude frame and rate; those are used here only as a parameter store.
 void ModeAuto::circle_start()
 {
-    // initialise circle controller
-    copter.circle_nav->init_NED_m(copter.circle_nav->get_center_NED_m(), copter.circle_nav->center_is_terrain_alt(), copter.circle_nav->get_rate_degs());
+    const Vector3p center_ned_m = copter.circle_nav->get_center_NED_m();
+    const float radius_m = circle_radius_m;    // commanded radius; zero selects the panorama
+    const bool is_terrain_alt = copter.circle_nav->center_is_terrain_alt();
 
-    if (auto_yaw.mode() != AutoYaw::Mode::ROI) {
-        auto_yaw.set_mode(AutoYaw::Mode::CIRCLE);
+    // orbit speed from the configured circle rate, capped by the waypoint speed
+    const float rate_rads = radians(fabsf(copter.circle_nav->get_rate_degs()));
+    float speed_ne_ms = wp_nav->get_default_speed_NE_ms();
+    if (is_positive(rate_rads) && is_positive(radius_m)) {
+        speed_ne_ms = MIN(speed_ne_ms, rate_rads * radius_m);
+    }
+
+    // start the S-curve orbit leg (origin is the current wp_nav destination, on the circle edge)
+    // for a zero radius the leg is zero length and simply holds position at the center
+    if (!wp_nav->set_circle_destination_NED_m(center_ned_m.xy().tofloat(), circle_turns_signed, center_ned_m.z, is_terrain_alt, speed_ne_ms)) {
+        // failure to set destination can only be because of missing terrain data
+        copter.failsafe_terrain_on_event();
+        return;
+    }
+
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Mission: circling %.1f turns", (double)fabsf(circle_turns_signed));
+
+    if (is_positive(radius_m)) {
+        if (auto_yaw.mode() != AutoYaw::Mode::ROI) {
+            auto_yaw.set_mode(AutoYaw::Mode::CIRCLE);
+        }
+    } else {
+        // radius-0 panorama: the zero length leg holds position while yaw spins at the circle
+        // rate; verify_circle completes the command after the requested number of turns.
+        // rate magnitude comes from the CIRCLE_RATE parameter and direction from the command
+        // (get_rate_degs() returns the raw parameter, so its sign is not the command direction)
+        const float rate_degs = fabsf(copter.circle_nav->get_rate_degs());
+        circle_panorama_start_ms = millis();
+        circle_panorama_spin_time_ms = is_positive(rate_degs) ? fabsf(circle_turns_signed) * 360.0f / rate_degs * 1000.0f : 0.0f;
+        if (auto_yaw.mode() != AutoYaw::Mode::ROI) {
+            auto_yaw.set_rate_rad(radians(rate_degs) * (is_negative(circle_turns_signed) ? -1.0f : 1.0f));
+        }
     }
 
     // set submode to circle
@@ -892,26 +920,13 @@ bool ModeAuto::do_guided(const AP_Mission::Mission_Command& cmd)
 
 float ModeAuto::wp_distance_m() const
 {
-    switch (_mode) {
-    case SubMode::CIRCLE:
-        return copter.circle_nav->get_distance_to_target_m();
-    case SubMode::WP:
-    case SubMode::CIRCLE_MOVE_TO_EDGE:
-    default:
-        return wp_nav->get_wp_distance_to_destination_m();
-    }
+    // the circle orbit is flown as an S-curve waypoint leg, so all submodes use wp_nav
+    return wp_nav->get_wp_distance_to_destination_m();
 }
 
 float ModeAuto::wp_bearing_deg() const
 {
-    switch (_mode) {
-    case SubMode::CIRCLE:
-        return degrees(copter.circle_nav->get_bearing_to_target_rad());
-    case SubMode::WP:
-    case SubMode::CIRCLE_MOVE_TO_EDGE:
-    default:
-        return degrees(wp_nav->get_wp_bearing_to_destination_rad());
-    }
+    return degrees(wp_nav->get_wp_bearing_to_destination_rad());
 }
 
 bool ModeAuto::get_wp(Location& destination) const
@@ -1130,21 +1145,6 @@ void ModeAuto::rtl_run()
 {
     // call regular rtl flight mode run function
     copter.mode_rtl.run(false);
-}
-
-// auto_circle_run - circle in AUTO flight mode
-//      called by auto_run at 100hz or more
-void ModeAuto::circle_run()
-{
-    // call circle controller
-    copter.failsafe_terrain_set_status(copter.circle_nav->update_ms());
-
-    // WP_Nav has set the vertical position control targets
-    // run the vertical position controller and set output throttle
-    pos_control->D_update_controller();
-
-    // call attitude controller with auto yaw
-    attitude_control->input_thrust_vector_heading(pos_control->get_thrust_vector(), auto_yaw.get_heading());
 }
 
 #if AC_NAV_GUIDED || AP_SCRIPTING_ENABLED
@@ -1744,20 +1744,22 @@ void ModeAuto::do_circle(const AP_Mission::Mission_Command& cmd)
     }
 
     // calculate radius
-    uint16_t circle_radius_m = HIGHBYTE(cmd.p1); // circle radius held in high byte of p1
+    uint16_t radius_m = HIGHBYTE(cmd.p1); // circle radius held in high byte of p1
     if (cmd.id == MAV_CMD_NAV_LOITER_TURNS &&
         cmd.type_specific_bits & (1U << 0)) {
         // special storage handling allows for larger radii
-        circle_radius_m *= 10;
+        radius_m *= 10;
     }
 
     // true if circle should be ccw
     const bool circle_direction_ccw = cmd.content.location.loiter_ccw;
 
-    // move to edge of circle (verify_circle) will ensure we begin circling once we reach the edge
-    circle_movetoedge_start(circle_center, circle_radius_m, circle_direction_ccw);
+    // signed number of turns for the S-curve orbit (sign selects direction, matching arc waypoints)
+    circle_turns_signed = (circle_direction_ccw ? -1.0f : 1.0f) * cmd.get_loiter_turns();
+    circle_panorama_start_ms = 0;
 
-    circle_last_num_complete = -1;
+    // move to edge of circle (verify_circle) will ensure we begin circling once we reach the edge
+    circle_movetoedge_start(circle_center, radius_m, circle_direction_ccw);
 }
 
 // do_loiter_time - initiate loitering at a point for a given time period
@@ -2324,16 +2326,16 @@ bool ModeAuto::verify_circle(const AP_Mission::Mission_Command& cmd)
         return false;
     }
 
-    const float turns = cmd.get_loiter_turns();
-
-    const auto num_circles_completed = fabsf(copter.circle_nav->get_angle_total_rad()/float(M_2PI));
-    if (int(num_circles_completed) != int(circle_last_num_complete)) {
-        circle_last_num_complete = num_circles_completed;
-        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Mission: starting circle %u/%u", unsigned(num_circles_completed)+1, unsigned(turns));
+    if (circle_panorama_start_ms != 0) {
+        // radius-0 panorama: position is held while yaw spins at the circle rate, so the
+        // command completes after the duration latched at circle_start (float comparison
+        // avoids undefined float-to-uint32 conversions for extreme turn/rate combinations)
+        return (float)(millis() - circle_panorama_start_ms) >= circle_panorama_spin_time_ms;
     }
 
-    // check if we have completed circling
-    return num_circles_completed >= turns;
+    // the orbit is a single S-curve leg spanning all requested turns; it is complete
+    // once that leg finishes
+    return copter.wp_nav->reached_wp_destination();
 }
 
 // verify_spline_wp - check if we have reached the next way point using spline

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -44,12 +44,8 @@ bool ModeAuto::init(bool ignore_checks)
         // initialise desired speed overrides
         desired_speed_override_ms = {0, 0, 0};
 
-        // initialise LOITER_TURNS orbit state
-        circle_turns_signed = 0.0f;
-        circle_radius_m = 0.0f;
-        circle_turns_reported = 0;
-        circle_panorama_start_ms = 0;
-        circle_panorama_rate_rads = 0.0f;
+        // initialise LOITER_TURNS circle state
+        circle = {};
 
         // set flag to start mission
         waiting_to_start = true;
@@ -540,11 +536,11 @@ void ModeAuto::circle_movetoedge_start(const Location &circle_center, float radi
     // set circle center
     copter.circle_nav->set_center(circle_center);
 
-    // set circle radius. The radius is read back so circle_radius_m carries AC_Circle's
+    // set circle radius. The radius is read back so circle.radius_m carries AC_Circle's
     // clamp, and a zero (panorama) radius is stored explicitly because get_radius_m() falls
     // back to the CIRCLE_RADIUS parameter when the commanded radius is zero
     copter.circle_nav->set_radius_m(radius_m);
-    circle_radius_m = is_positive(radius_m) ? copter.circle_nav->get_radius_m() : 0.0f;
+    circle.radius_m = is_positive(radius_m) ? copter.circle_nav->get_radius_m() : 0.0f;
 
     // Always fly to the exact edge of the circle first: circle_start() derives the S-curve
     // orbit's radius purely from wp_nav's current destination, with no closed-loop correction
@@ -569,7 +565,7 @@ void ModeAuto::circle_movetoedge_start(const Location &circle_center, float radi
     // initialise yaw
     // To-Do: reset the yaw only when the previous navigation command is not a WP.  this would allow removing the special check for ROI
     if (auto_yaw.mode() != AutoYaw::Mode::ROI) {
-        if (dist_to_center_m > circle_radius_m && dist_to_center_m > 5.0) {
+        if (dist_to_center_m > circle.radius_m && dist_to_center_m > 5.0) {
             auto_yaw.set_mode_to_default(false);
         } else {
             // vehicle is within circle so hold yaw to avoid spinning as we move to edge of circle
@@ -591,7 +587,7 @@ void ModeAuto::circle_start()
     // reached by the move-to-edge leg) and spin yaw at the circle rate.  No orbit leg is built,
     // rather than relying on calculate_circle_track()'s degenerate-arc guard to reject a
     // zero-radius orbit, so the hold does not depend on the origin landing exactly on the center.
-    if (!is_positive(circle_radius_m)) {
+    if (!is_positive(circle.radius_m)) {
         // a zero radius cannot encode a direction in the mission item (loiter_ccw comes from
         // param3 < 0), so CIRCLE_RATE supplies both the rate and the spin direction
         const float rate_degs = copter.circle_nav->get_rate_degs();
@@ -605,16 +601,16 @@ void ModeAuto::circle_start()
             // slew the yaw target through the requested turns at the circle rate.  FIXED is an
             // angle target, so unlike a rate command it cannot under-rotate against the yaw slew
             // limit, and it needs no teardown when the command ends
-            auto_yaw.set_fixed_yaw_rad(fabsf(circle_turns_signed) * M_2PI, rate_rads,
+            auto_yaw.set_fixed_yaw_rad(fabsf(circle.turns_signed) * M_2PI, rate_rads,
                                        is_negative(rate_degs) ? -1 : 1, true);
         }
 
         // the panorama runs for as long as the commanded turns take at that rate, the same way
         // AC_Circle's angle counter measured it
-        circle_panorama_start_ms = millis();
-        circle_panorama_rate_rads = rate_rads;
+        circle.panorama_start_ms = millis();
+        circle.panorama_rate_rads = rate_rads;
 
-        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Mission: circling %.1f turns", (double)fabsf(circle_turns_signed));
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Mission: circling %.1f turns", (double)fabsf(circle.turns_signed));
 
         // set submode to circle
         set_submode(SubMode::CIRCLE);
@@ -622,7 +618,7 @@ void ModeAuto::circle_start()
     }
 
     // no whole turn has been announced yet
-    circle_turns_reported = 0;
+    circle.turns_reported = 0;
 
     const Vector3p center_ned_m = copter.circle_nav->get_center_NED_m();
     const bool is_terrain_alt = copter.circle_nav->center_is_terrain_alt();
@@ -630,13 +626,13 @@ void ModeAuto::circle_start()
     // start the S-curve orbit leg (origin is the current wp_nav destination, on the circle edge).
     // The orbit is flown at the waypoint speed like any other leg, limited by the corner
     // acceleration through the arc radius
-    if (!wp_nav->set_circle_destination_NED_m(center_ned_m.xy().tofloat(), circle_turns_signed, center_ned_m.z, is_terrain_alt)) {
+    if (!wp_nav->set_circle_destination_NED_m(center_ned_m.xy().tofloat(), circle.turns_signed, center_ned_m.z, is_terrain_alt)) {
         // failure to set destination can only be because of missing terrain data
         copter.failsafe_terrain_on_event();
         return;
     }
 
-    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Mission: circling %.1f turns", (double)fabsf(circle_turns_signed));
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Mission: circling %.1f turns", (double)fabsf(circle.turns_signed));
 
     if (auto_yaw.mode() != AutoYaw::Mode::ROI) {
         auto_yaw.set_mode(AutoYaw::Mode::CIRCLE);
@@ -1780,7 +1776,7 @@ void ModeAuto::do_circle(const AP_Mission::Mission_Command& cmd)
     const bool circle_direction_ccw = cmd.content.location.loiter_ccw;
 
     // signed number of turns for the S-curve orbit (sign selects direction, matching arc waypoints)
-    circle_turns_signed = (circle_direction_ccw ? -1.0f : 1.0f) * cmd.get_loiter_turns();
+    circle.turns_signed = (circle_direction_ccw ? -1.0f : 1.0f) * cmd.get_loiter_turns();
 
     // move to edge of circle (verify_circle) will ensure we begin circling once we reach the edge
     circle_movetoedge_start(circle_center, radius_m);
@@ -2350,23 +2346,23 @@ bool ModeAuto::verify_circle(const AP_Mission::Mission_Command& cmd)
         return false;
     }
 
-    if (!is_positive(circle_radius_m)) {
+    if (!is_positive(circle.radius_m)) {
         // radius-0 panorama: position is held while the yaw target slews through the requested
         // turns.  The elapsed angle is counted here rather than read back from the yaw
         // controller, so anything that takes the heading away, such as an ROI, pilot yaw or
         // weathervaning, changes where the aircraft points without changing how long the
         // command runs.  AC_Circle's angle counter behaved the same way
-        const float angle_swept_rad = circle_panorama_rate_rads * (millis() - circle_panorama_start_ms) * 0.001;
-        return angle_swept_rad >= fabsf(circle_turns_signed) * M_2PI;
+        const float angle_swept_rad = circle.panorama_rate_rads * (millis() - circle.panorama_start_ms) * 0.001;
+        return angle_swept_rad >= fabsf(circle.turns_signed) * M_2PI;
     }
 
     // report each whole turn as it is completed.  The angle comes from the orbit leg itself, so
     // it tracks the path actually flown rather than an independently integrated rate
     const uint16_t turns_done = copter.wp_nav->get_circle_angle_covered_rad() / M_2PI;
-    if (turns_done > circle_turns_reported) {
-        circle_turns_reported = turns_done;
+    if (turns_done > circle.turns_reported) {
+        circle.turns_reported = turns_done;
         GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Mission: circled %u/%.1f turns",
-                      (unsigned)turns_done, (double)fabsf(circle_turns_signed));
+                      (unsigned)turns_done, (double)fabsf(circle.turns_signed));
     }
 
     // the orbit is a single S-curve leg spanning all requested turns; it is complete

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -44,6 +44,13 @@ bool ModeAuto::init(bool ignore_checks)
         // initialise desired speed overrides
         desired_speed_override_ms = {0, 0, 0};
 
+        // initialise LOITER_TURNS orbit state
+        circle_turns_signed = 0.0f;
+        circle_radius_m = 0.0f;
+        circle_turns_reported = 0;
+        circle_panorama_start_ms = 0;
+        circle_panorama_rate_rads = 0.0f;
+
         // set flag to start mission
         waiting_to_start = true;
 
@@ -122,6 +129,8 @@ void ModeAuto::run()
 
     case SubMode::WP:
     case SubMode::CIRCLE_MOVE_TO_EDGE:
+    case SubMode::CIRCLE:
+        // the circle orbit is flown as an S-curve waypoint leg
         wp_run();
         break;
 
@@ -131,10 +140,6 @@ void ModeAuto::run()
 
     case SubMode::RTL:
         rtl_run();
-        break;
-
-    case SubMode::CIRCLE:
-        circle_run();
         break;
 
     case SubMode::NAVGUIDED:
@@ -230,8 +235,6 @@ bool ModeAuto::move_vehicle_on_ekf_reset() const
     case SubMode::TAKEOFF:
     case SubMode::LAND:
     case SubMode::RTL:
-    case SubMode::CIRCLE_MOVE_TO_EDGE:
-    case SubMode::CIRCLE:
     case SubMode::NAVGUIDED:
     case SubMode::LOITER:
     case SubMode::LOITER_TO_ALT:
@@ -242,8 +245,11 @@ bool ModeAuto::move_vehicle_on_ekf_reset() const
     case SubMode::NAV_ATTITUDE_TIME:
         // these submodes reset their targets so the vehicle does not physically move
         return false;
-    case SubMode::WP:    
+    case SubMode::WP:
+    case SubMode::CIRCLE_MOVE_TO_EDGE:
+    case SubMode::CIRCLE:
         // these submodes smoothly move to maintain an absolute position
+        // (the circle orbit and the move-to-edge leg are S-curve waypoint legs, like WP)
         return true;
     }
 
@@ -529,64 +535,108 @@ void ModeAuto::land_start()
 
 // circle_movetoedge_start - initialise waypoint controller to move to edge of a circle with it's center at the specified location
 //  we assume the caller has performed all required GPS_ok checks
-void ModeAuto::circle_movetoedge_start(const Location &circle_center, float radius_m, bool ccw_turn)
+void ModeAuto::circle_movetoedge_start(const Location &circle_center, float radius_m)
 {
     // set circle center
     copter.circle_nav->set_center(circle_center);
 
-    // set circle radius
+    // set circle radius. The radius is read back so circle_radius_m carries AC_Circle's
+    // clamp, and a zero (panorama) radius is stored explicitly because get_radius_m() falls
+    // back to the CIRCLE_RADIUS parameter when the commanded radius is zero
     copter.circle_nav->set_radius_m(radius_m);
+    circle_radius_m = is_positive(radius_m) ? copter.circle_nav->get_radius_m() : 0.0f;
 
-    // set circle direction by using rate
-    float current_rate = copter.circle_nav->get_rate_degs();
-    current_rate = ccw_turn ? -fabsf(current_rate) : fabsf(current_rate);
-    copter.circle_nav->set_rate_degs(current_rate);
-
-    // check our distance from edge of circle
+    // Always fly to the exact edge of the circle first: circle_start() derives the S-curve
+    // orbit's radius purely from wp_nav's current destination, with no closed-loop correction
+    // across the orbit, so that destination must land exactly on the circle at zero speed.
+    // If the vehicle is already there this leg is short and completes within a tick or two,
+    // so this costs nothing in the common case.
     Vector3p circle_edge_ned_m;
     float dist_to_edge_m;
     copter.circle_nav->get_closest_point_on_circle_NED_m(circle_edge_ned_m, dist_to_edge_m);
 
-    // if more than 3m then fly to edge
-    if (dist_to_edge_m > 3.0) {
-        // convert circle_edge_ned_m to Location
-        Location circle_edge = Location::from_ekf_offset_NED_m(circle_edge_ned_m, Location::AltFrame::ABOVE_ORIGIN);
-
-        // convert altitude to same as command
-        circle_edge.copy_alt_from(circle_center);
-
-        // initialise wpnav to move to edge of circle
-        if (!wp_nav->set_wp_destination_loc(circle_edge)) {
-            // failure to set destination can only be because of missing terrain data
-            copter.failsafe_terrain_on_event();
-        }
-
-        // if we are outside the circle, point at the edge, otherwise hold yaw
-        const float dist_to_center_m = get_horizontal_distance(pos_control->get_pos_estimate_NED_m().xy().tofloat(), copter.circle_nav->get_center_NED_m().xy().tofloat());
-        // initialise yaw
-        // To-Do: reset the yaw only when the previous navigation command is not a WP.  this would allow removing the special check for ROI
-        if (auto_yaw.mode() != AutoYaw::Mode::ROI) {
-            if (dist_to_center_m > copter.circle_nav->get_radius_m() && dist_to_center_m > 5.0) {
-                auto_yaw.set_mode_to_default(false);
-            } else {
-                // vehicle is within circle so hold yaw to avoid spinning as we move to edge of circle
-                auto_yaw.set_mode(AutoYaw::Mode::HOLD);
-            }
-        }
-
-        // set the submode to move to the edge of the circle
-        set_submode(SubMode::CIRCLE_MOVE_TO_EDGE);
-    } else {
-        circle_start();
+    // initialise wpnav to move to edge of circle.  set_center() has already resolved the
+    // command's altitude and frame into the center, and the edge point carries the center's
+    // altitude, so the point goes straight through in NED rather than round-tripping via a
+    // Location and back
+    if (!wp_nav->set_wp_destination_NED_m(circle_edge_ned_m, copter.circle_nav->center_is_terrain_alt())) {
+        // failure to set destination can only be because of missing terrain data
+        copter.failsafe_terrain_on_event();
     }
+
+    // if we are outside the circle, point at the edge, otherwise hold yaw
+    const float dist_to_center_m = get_horizontal_distance(pos_control->get_pos_estimate_NED_m().xy().tofloat(), copter.circle_nav->get_center_NED_m().xy().tofloat());
+    // initialise yaw
+    // To-Do: reset the yaw only when the previous navigation command is not a WP.  this would allow removing the special check for ROI
+    if (auto_yaw.mode() != AutoYaw::Mode::ROI) {
+        if (dist_to_center_m > circle_radius_m && dist_to_center_m > 5.0) {
+            auto_yaw.set_mode_to_default(false);
+        } else {
+            // vehicle is within circle so hold yaw to avoid spinning as we move to edge of circle
+            auto_yaw.set_mode(AutoYaw::Mode::HOLD);
+        }
+    }
+
+    // set the submode to move to the edge of the circle
+    set_submode(SubMode::CIRCLE_MOVE_TO_EDGE);
 }
 
-// auto_circle_start - initialises controller to fly a circle in AUTO flight mode
-//   assumes that circle_nav object has already been initialised with circle center and radius
+// auto_circle_start - begin flying a circular orbit as an S-curve waypoint leg
+//   circle_movetoedge_start has already configured circle_nav with the center, radius and
+//   altitude frame; those are used here only as a parameter store.  CIRCLE_RATE is read only
+//   for the radius-0 panorama spin.
 void ModeAuto::circle_start()
 {
-    // initialise circle controller
-    copter.circle_nav->init_NED_m(copter.circle_nav->get_center_NED_m(), copter.circle_nav->center_is_terrain_alt(), copter.circle_nav->get_rate_degs());
+    // radius-0 panorama: hold the current wp_nav destination (the circle center, already
+    // reached by the move-to-edge leg) and spin yaw at the circle rate.  No orbit leg is built,
+    // rather than relying on calculate_circle_track()'s degenerate-arc guard to reject a
+    // zero-radius orbit, so the hold does not depend on the origin landing exactly on the center.
+    if (!is_positive(circle_radius_m)) {
+        // a zero radius cannot encode a direction in the mission item (loiter_ccw comes from
+        // param3 < 0), so CIRCLE_RATE supplies both the rate and the spin direction
+        const float rate_degs = copter.circle_nav->get_rate_degs();
+        // use the rate set_fixed_yaw_rad() will actually fly, which is the yaw slew limit for a
+        // zero rate and is clamped to that limit above it.  One expression feeds both the yaw
+        // command and the duration below so the two cannot disagree
+        const float slew_rate_max_rads = attitude_control->get_slew_yaw_max_rads();
+        const float rate_rads = is_positive(fabsf(rate_degs)) ? MIN(radians(fabsf(rate_degs)), slew_rate_max_rads)
+                                                              : slew_rate_max_rads;
+        if (auto_yaw.mode() != AutoYaw::Mode::ROI) {
+            // slew the yaw target through the requested turns at the circle rate.  FIXED is an
+            // angle target, so unlike a rate command it cannot under-rotate against the yaw slew
+            // limit, and it needs no teardown when the command ends
+            auto_yaw.set_fixed_yaw_rad(fabsf(circle_turns_signed) * M_2PI, rate_rads,
+                                       is_negative(rate_degs) ? -1 : 1, true);
+        }
+
+        // the panorama runs for as long as the commanded turns take at that rate, the same way
+        // AC_Circle's angle counter measured it
+        circle_panorama_start_ms = millis();
+        circle_panorama_rate_rads = rate_rads;
+
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Mission: circling %.1f turns", (double)fabsf(circle_turns_signed));
+
+        // set submode to circle
+        set_submode(SubMode::CIRCLE);
+        return;
+    }
+
+    // no whole turn has been announced yet
+    circle_turns_reported = 0;
+
+    const Vector3p center_ned_m = copter.circle_nav->get_center_NED_m();
+    const bool is_terrain_alt = copter.circle_nav->center_is_terrain_alt();
+
+    // start the S-curve orbit leg (origin is the current wp_nav destination, on the circle edge).
+    // The orbit is flown at the waypoint speed like any other leg, limited by the corner
+    // acceleration through the arc radius
+    if (!wp_nav->set_circle_destination_NED_m(center_ned_m.xy().tofloat(), circle_turns_signed, center_ned_m.z, is_terrain_alt)) {
+        // failure to set destination can only be because of missing terrain data
+        copter.failsafe_terrain_on_event();
+        return;
+    }
+
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Mission: circling %.1f turns", (double)fabsf(circle_turns_signed));
 
     if (auto_yaw.mode() != AutoYaw::Mode::ROI) {
         auto_yaw.set_mode(AutoYaw::Mode::CIRCLE);
@@ -892,26 +942,13 @@ bool ModeAuto::do_guided(const AP_Mission::Mission_Command& cmd)
 
 float ModeAuto::wp_distance_m() const
 {
-    switch (_mode) {
-    case SubMode::CIRCLE:
-        return copter.circle_nav->get_distance_to_target_m();
-    case SubMode::WP:
-    case SubMode::CIRCLE_MOVE_TO_EDGE:
-    default:
-        return wp_nav->get_wp_distance_to_destination_m();
-    }
+    // the circle orbit is flown as an S-curve waypoint leg, so all submodes use wp_nav
+    return wp_nav->get_wp_distance_to_destination_m();
 }
 
 float ModeAuto::wp_bearing_deg() const
 {
-    switch (_mode) {
-    case SubMode::CIRCLE:
-        return degrees(copter.circle_nav->get_bearing_to_target_rad());
-    case SubMode::WP:
-    case SubMode::CIRCLE_MOVE_TO_EDGE:
-    default:
-        return degrees(wp_nav->get_wp_bearing_to_destination_rad());
-    }
+    return degrees(wp_nav->get_wp_bearing_to_destination_rad());
 }
 
 bool ModeAuto::get_wp(Location& destination) const
@@ -920,6 +957,9 @@ bool ModeAuto::get_wp(Location& destination) const
     case SubMode::NAVGUIDED:
         return copter.mode_guided.get_wp(destination);
     case SubMode::WP:
+    case SubMode::CIRCLE_MOVE_TO_EDGE:
+    case SubMode::CIRCLE:
+        // the orbit and the move-to-edge leg are wp_nav legs like WP
         return wp_nav->get_oa_wp_destination(destination);
     case SubMode::RTL:
         return copter.mode_rtl.get_wp(destination);
@@ -1130,21 +1170,6 @@ void ModeAuto::rtl_run()
 {
     // call regular rtl flight mode run function
     copter.mode_rtl.run(false);
-}
-
-// auto_circle_run - circle in AUTO flight mode
-//      called by auto_run at 100hz or more
-void ModeAuto::circle_run()
-{
-    // call circle controller
-    copter.failsafe_terrain_set_status(copter.circle_nav->update_ms());
-
-    // WP_Nav has set the vertical position control targets
-    // run the vertical position controller and set output throttle
-    pos_control->D_update_controller();
-
-    // call attitude controller with auto yaw
-    attitude_control->input_thrust_vector_heading(pos_control->get_thrust_vector(), auto_yaw.get_heading());
 }
 
 #if AC_NAV_GUIDED || AP_SCRIPTING_ENABLED
@@ -1744,20 +1769,21 @@ void ModeAuto::do_circle(const AP_Mission::Mission_Command& cmd)
     }
 
     // calculate radius
-    uint16_t circle_radius_m = HIGHBYTE(cmd.p1); // circle radius held in high byte of p1
+    uint16_t radius_m = HIGHBYTE(cmd.p1); // circle radius held in high byte of p1
     if (cmd.id == MAV_CMD_NAV_LOITER_TURNS &&
         cmd.type_specific_bits & (1U << 0)) {
         // special storage handling allows for larger radii
-        circle_radius_m *= 10;
+        radius_m *= 10;
     }
 
     // true if circle should be ccw
     const bool circle_direction_ccw = cmd.content.location.loiter_ccw;
 
-    // move to edge of circle (verify_circle) will ensure we begin circling once we reach the edge
-    circle_movetoedge_start(circle_center, circle_radius_m, circle_direction_ccw);
+    // signed number of turns for the S-curve orbit (sign selects direction, matching arc waypoints)
+    circle_turns_signed = (circle_direction_ccw ? -1.0f : 1.0f) * cmd.get_loiter_turns();
 
-    circle_last_num_complete = -1;
+    // move to edge of circle (verify_circle) will ensure we begin circling once we reach the edge
+    circle_movetoedge_start(circle_center, radius_m);
 }
 
 // do_loiter_time - initiate loitering at a point for a given time period
@@ -2324,16 +2350,28 @@ bool ModeAuto::verify_circle(const AP_Mission::Mission_Command& cmd)
         return false;
     }
 
-    const float turns = cmd.get_loiter_turns();
-
-    const auto num_circles_completed = fabsf(copter.circle_nav->get_angle_total_rad()/float(M_2PI));
-    if (int(num_circles_completed) != int(circle_last_num_complete)) {
-        circle_last_num_complete = num_circles_completed;
-        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Mission: starting circle %u/%u", unsigned(num_circles_completed)+1, unsigned(turns));
+    if (!is_positive(circle_radius_m)) {
+        // radius-0 panorama: position is held while the yaw target slews through the requested
+        // turns.  The elapsed angle is counted here rather than read back from the yaw
+        // controller, so anything that takes the heading away, such as an ROI, pilot yaw or
+        // weathervaning, changes where the aircraft points without changing how long the
+        // command runs.  AC_Circle's angle counter behaved the same way
+        const float angle_swept_rad = circle_panorama_rate_rads * (millis() - circle_panorama_start_ms) * 0.001;
+        return angle_swept_rad >= fabsf(circle_turns_signed) * M_2PI;
     }
 
-    // check if we have completed circling
-    return num_circles_completed >= turns;
+    // report each whole turn as it is completed.  The angle comes from the orbit leg itself, so
+    // it tracks the path actually flown rather than an independently integrated rate
+    const uint16_t turns_done = copter.wp_nav->get_circle_angle_covered_rad() / M_2PI;
+    if (turns_done > circle_turns_reported) {
+        circle_turns_reported = turns_done;
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Mission: circled %u/%.1f turns",
+                      (unsigned)turns_done, (double)fabsf(circle_turns_signed));
+    }
+
+    // the orbit is a single S-curve leg spanning all requested turns; it is complete
+    // once that leg finishes
+    return copter.wp_nav->reached_wp_destination();
 }
 
 // verify_spline_wp - check if we have reached the next way point using spline
@@ -2404,8 +2442,10 @@ bool ModeAuto::verify_nav_attitude_time(const AP_Mission::Mission_Command& cmd)
 // pause - Prevent aircraft from progressing along the track
 bool ModeAuto::pause()
 {
-    // do not pause if not in the WP sub mode or already reached to the destination
-    if (_mode != SubMode::WP || wp_nav->reached_wp_destination()) {
+    // do not pause unless progressing along a wp_nav leg: the circle orbit and the move-to-edge
+    // leg are S-curve legs like WP, so they pause the same way
+    const bool wp_leg_active = (_mode == SubMode::WP) || (_mode == SubMode::CIRCLE_MOVE_TO_EDGE) || (_mode == SubMode::CIRCLE);
+    if (!wp_leg_active || wp_nav->reached_wp_destination()) {
         return false;
     }
 

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -17969,6 +17969,90 @@ RTL_ALT_M 111
         self.arm_vehicle()
         self.wait_disarmed()
 
+    def mission_NAV_LOITER_TURNS_zero_radius(self):
+        '''radius-0 LOITER_TURNS holds position and spins yaw at CIRCLE_RATE (panorama)'''
+        turns = 2
+        rate_degs = 20.0
+        expected_duration_s = turns * 360.0 / rate_degs
+        # a zero radius cannot encode CCW (direction rides on the radius sign), so the
+        # panorama is always commanded clockwise; a negative CIRCLE_RATE checks that the
+        # spin direction comes from the command rather than the parameter's sign
+        self.set_parameters({
+            'AUTO_OPTIONS': 3,
+            'CIRCLE_RATE': -rate_degs,
+        })
+        self.upload_simple_relhome_mission([
+            (mavutil.mavlink.MAV_CMD_NAV_TAKEOFF, 0, 0, 20),
+            self.create_MISSION_ITEM_INT(
+                mavutil.mavlink.MAV_CMD_NAV_LOITER_TURNS,
+                p1=turns,
+                p3=0,  # zero radius: panorama
+                z=20,
+                frame=mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT,
+            ),
+            (mavutil.mavlink.MAV_CMD_NAV_RETURN_TO_LAUNCH, 0, 0, 0),
+        ])
+        self.change_mode('AUTO')
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+
+        # the panorama timer starts when circle_start announces the command
+        self.wait_statustext("Mission: circling", timeout=120)
+        tstart = self.get_sim_time()
+        start_pos = self.assert_receive_message('GLOBAL_POSITION_INT', timeout=5)
+
+        # accumulate heading change and position drift until the mission moves on to RTL
+        total_angle_deg = 0.0
+        last_yaw_deg = None
+        max_drift_m = 0.0
+        while True:
+            if self.get_sim_time_cached() - tstart > expected_duration_s * 2 + 30:
+                raise AutoTestTimeoutException("panorama did not complete")
+            m = self.mav.recv_match(
+                type=['ATTITUDE', 'GLOBAL_POSITION_INT', 'MISSION_CURRENT'],
+                blocking=True,
+                timeout=5,
+            )
+            if m is None:
+                continue
+            m_type = m.get_type()
+            if m_type == 'ATTITUDE':
+                yaw_deg = math.degrees(m.yaw)
+                if last_yaw_deg is not None:
+                    delta_deg = yaw_deg - last_yaw_deg
+                    if delta_deg > 180:
+                        delta_deg -= 360
+                    elif delta_deg < -180:
+                        delta_deg += 360
+                    total_angle_deg += delta_deg
+                last_yaw_deg = yaw_deg
+            elif m_type == 'GLOBAL_POSITION_INT':
+                max_drift_m = max(max_drift_m, self.get_distance_int(start_pos, m))
+            elif m_type == 'MISSION_CURRENT':
+                if m.seq >= 3:
+                    break
+        elapsed_s = self.get_sim_time_cached() - tstart
+
+        if elapsed_s < expected_duration_s * 0.9:
+            raise NotAchievedException(
+                "Panorama completed too quickly (want>=%.1fs got %.1fs)" %
+                (expected_duration_s * 0.9, elapsed_s))
+        # spin must be clockwise (positive) through roughly the commanded total angle
+        target_angle_deg = turns * 360.0
+        if total_angle_deg < target_angle_deg - 80:
+            raise NotAchievedException(
+                "Panorama spun too little or wrong direction (want>=%.1fdeg got %.1fdeg)" %
+                (target_angle_deg - 80, total_angle_deg))
+        if total_angle_deg > target_angle_deg + 80:
+            raise NotAchievedException(
+                "Panorama spun too far (want<=%.1fdeg got %.1fdeg)" %
+                (target_angle_deg + 80, total_angle_deg))
+        if max_drift_m > 5:
+            raise NotAchievedException(
+                "Vehicle did not hold position during panorama (drift %.1fm)" % max_drift_m)
+
+        self.wait_disarmed()
+
     def AHRSAutoTrim(self):
         '''calibrate AHRS trim using RC input'''
         self.progress("Making earth frame same as body frame")  # because I'm lazy
@@ -18920,6 +19004,7 @@ return update, 1000
             self.PIDNotches,
             self.mission_NAV_LOITER_TURNS,
             self.mission_NAV_LOITER_TURNS_off_center,
+            self.mission_NAV_LOITER_TURNS_zero_radius,
             self.StaticNotches,
             self.LuaParamLockdown,
             self.RefindGPS,

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -30,6 +30,7 @@ from pysim import util
 from pysim import vehicleinfo
 from vehicle_test_suite import MAV_POS_TARGET_TYPE_MASK
 from vehicle_test_suite import AutoTestTimeoutException
+from vehicle_test_suite import Location
 from vehicle_test_suite import NotAchievedException
 from vehicle_test_suite import PreconditionFailedException
 from vehicle_test_suite import Test
@@ -18900,6 +18901,197 @@ RTL_ALT_M 111
         self.arm_vehicle()
         self.wait_disarmed()
 
+    def mission_NAV_LOITER_TURNS_speed(self):
+        '''LOITER_TURNS orbits at WP_SPD, not at CIRCLE_RATE * radius'''
+        radius = 20
+        # CIRCLE_RATE is deliberately far too low to produce this speed: the orbit must ignore
+        # it and fly at WP_SPD, bounded only by the corner acceleration.  Deriving the speed
+        # from the rate, as the orbit used to, would give radians(2) * 20 = 0.7 m/s.
+        # WP_SPD is set explicitly so the check below does not track its default.
+        self.set_parameters({
+            'AUTO_OPTIONS': 3,
+            'CIRCLE_RATE': 2,
+            'WP_SPD': 5,
+        })
+        self.upload_simple_relhome_mission([
+            (mavutil.mavlink.MAV_CMD_NAV_TAKEOFF, 0, 0, 20),
+            self.create_MISSION_ITEM_INT(
+                mavutil.mavlink.MAV_CMD_NAV_LOITER_TURNS,
+                p1=1,
+                p3=radius,
+                z=30,  # circle is 10m higher than takeoff
+                frame=mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT,
+            ),
+            (mavutil.mavlink.MAV_CMD_NAV_RETURN_TO_LAUNCH, 0, 0, 0),
+        ])
+        self.change_mode('AUTO')
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+
+        # the leg out to the circle edge also flies at WP_SPD, and ends stopped on the edge, so
+        # only sample the speed once the orbit itself has been announced
+        self.wait_statustext("Mission: circling", timeout=120)
+        tstart = self.get_sim_time()
+
+        # hold the orbit speed while still on the LOITER_TURNS command.  The minimum_duration and
+        # the seq assertion together stop a following leg from satisfying this: RTL also flies at
+        # WP_SPD, so without them an orbit that is skipped entirely still passes.
+        self.wait_groundspeed(4.0, 6.0, timeout=30, minimum_duration=5)
+        self.assert_current_waypoint(2)
+
+        # the command must also last about one circumference (2*pi*20 / 5 = 25s).  A skipped
+        # orbit reaches RTL in about a tick; the old rate-derived 0.7 m/s would take ~180s.
+        self.wait_current_waypoint(3, timeout=120)
+        orbit_time_s = self.get_sim_time_cached() - tstart
+        expected_s = 2 * math.pi * radius / 5.0
+        if orbit_time_s < expected_s * 0.6 or orbit_time_s > expected_s * 2.0:
+            raise NotAchievedException(
+                "orbit took %.1fs, expected about %.1fs" % (orbit_time_s, expected_s))
+
+        self.wait_disarmed()
+
+    def mission_NAV_LOITER_TURNS_zero_radius(self):
+        '''radius-0 LOITER_TURNS holds position and spins yaw at CIRCLE_RATE (panorama)'''
+        turns = 2
+        rate_degs = 20.0
+        expected_duration_s = turns * 360.0 / rate_degs
+        # a zero radius cannot encode a direction in the mission item (loiter_ccw comes from
+        # param3 < 0), so CIRCLE_RATE's sign is the panorama's only direction control.  A
+        # negative rate must therefore spin counter-clockwise.
+        self.set_parameters({
+            'AUTO_OPTIONS': 3,
+            'CIRCLE_RATE': -rate_degs,
+        })
+        self.upload_simple_relhome_mission([
+            (mavutil.mavlink.MAV_CMD_NAV_TAKEOFF, 0, 0, 20),
+            self.create_MISSION_ITEM_INT(
+                mavutil.mavlink.MAV_CMD_NAV_LOITER_TURNS,
+                p1=turns,
+                p3=0,  # zero radius: panorama
+                z=20,
+                frame=mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT,
+            ),
+            (mavutil.mavlink.MAV_CMD_NAV_RETURN_TO_LAUNCH, 0, 0, 0),
+        ])
+        self.change_mode('AUTO')
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+
+        # the panorama timer starts when circle_start announces the command
+        self.wait_statustext("Mission: circling", timeout=120)
+        tstart = self.get_sim_time()
+        start_pos = self.assert_receive_message('GLOBAL_POSITION_INT', timeout=5)
+
+        # accumulate heading change and position drift until the mission moves on to RTL
+        total_angle_deg = 0.0
+        last_yaw_deg = None
+        max_drift_m = 0.0
+        while True:
+            if self.get_sim_time_cached() - tstart > expected_duration_s * 2 + 30:
+                raise AutoTestTimeoutException("panorama did not complete")
+            m = self.assert_receive_message(
+                ['ATTITUDE', 'GLOBAL_POSITION_INT', 'MISSION_CURRENT'],
+                timeout=5,
+            )
+            m_type = m.get_type()
+            if m_type == 'ATTITUDE':
+                yaw_deg = math.degrees(m.yaw)
+                if last_yaw_deg is not None:
+                    delta_deg = yaw_deg - last_yaw_deg
+                    if delta_deg > 180:
+                        delta_deg -= 360
+                    elif delta_deg < -180:
+                        delta_deg += 360
+                    total_angle_deg += delta_deg
+                last_yaw_deg = yaw_deg
+            elif m_type == 'GLOBAL_POSITION_INT':
+                max_drift_m = max(max_drift_m, self.get_distance_int(start_pos, m))
+            elif m_type == 'MISSION_CURRENT':
+                if m.seq >= 3:
+                    break
+        elapsed_s = self.get_sim_time_cached() - tstart
+
+        if elapsed_s < expected_duration_s * 0.9:
+            raise NotAchievedException(
+                "Panorama completed too quickly (want>=%.1fs got %.1fs)" %
+                (expected_duration_s * 0.9, elapsed_s))
+        # CIRCLE_RATE was set negative, so the spin must be counter-clockwise through roughly
+        # the commanded total angle
+        target_angle_deg = -turns * 360.0
+        if abs(total_angle_deg - target_angle_deg) > 80:
+            raise NotAchievedException(
+                "Panorama spun %.1fdeg, expected %.1fdeg (negative CIRCLE_RATE = CCW)" %
+                (total_angle_deg, target_angle_deg))
+        if max_drift_m > 5:
+            raise NotAchievedException(
+                "Vehicle did not hold position during panorama (drift %.1fm)" % max_drift_m)
+
+        self.wait_disarmed()
+
+    def mission_NAV_LOITER_TURNS_direction(self):
+        '''LOITER_TURNS orbits the way the sign of param3 asks'''
+        radius = 20
+        self.set_parameters({
+            'AUTO_OPTIONS': 3,
+            'WP_SPD': 5,
+        })
+        self.wait_ready_to_arm()
+        circle_centre_loc = self.offset_location_ne(self.get_location(), 2 * radius, 0)
+        self.upload_simple_relhome_mission([
+            (mavutil.mavlink.MAV_CMD_NAV_TAKEOFF, 0, 0, 20),
+            self.create_MISSION_ITEM_INT(
+                mavutil.mavlink.MAV_CMD_NAV_LOITER_TURNS,
+                p1=1,
+                p3=-radius,  # a negative radius asks for a counter-clockwise orbit
+                x=int(circle_centre_loc.lat*1e7),
+                y=int(circle_centre_loc.lng*1e7),
+                z=20,
+                frame=mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT,
+            ),
+            (mavutil.mavlink.MAV_CMD_NAV_RETURN_TO_LAUNCH, 0, 0, 0),
+        ])
+        self.change_mode('AUTO')
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+
+        # only start measuring once the orbit itself has been announced, so the leg out to the
+        # circle edge does not contribute
+        self.wait_statustext("Mission: circling", timeout=120)
+        tstart = self.get_sim_time()
+
+        # accumulate the bearing from the circle centre out to the vehicle.  Going clockwise makes
+        # that bearing increase and counter-clockwise makes it decrease, so the sign of the total
+        # is the direction flown
+        total_angle_deg = 0.0
+        last_bearing_deg = None
+        while True:
+            if self.get_sim_time_cached() - tstart > 120:
+                raise AutoTestTimeoutException("orbit did not complete")
+            m = self.assert_receive_message(
+                ['GLOBAL_POSITION_INT', 'MISSION_CURRENT'],
+                timeout=5,
+            )
+            if m.get_type() == 'GLOBAL_POSITION_INT':
+                pos = Location.latlon_only(m.lat * 1e-7, m.lon * 1e-7)
+                bearing_deg = self.get_bearing(circle_centre_loc, pos)
+                if last_bearing_deg is not None:
+                    delta_deg = bearing_deg - last_bearing_deg
+                    if delta_deg > 180:
+                        delta_deg -= 360
+                    elif delta_deg < -180:
+                        delta_deg += 360
+                    total_angle_deg += delta_deg
+                last_bearing_deg = bearing_deg
+            elif m.seq >= 3:
+                break
+
+        if abs(total_angle_deg + 360) > 80:
+            raise NotAchievedException(
+                "Orbit swept %.0fdeg, expected -360deg (negative param3 = counter-clockwise)" %
+                total_angle_deg)
+
+        self.wait_disarmed()
+
     def AHRSAutoTrim(self):
         '''calibrate AHRS trim using RC input'''
         self.progress("Making earth frame same as body frame")  # because I'm lazy
@@ -19858,6 +20050,9 @@ return update, 1000
             self.PIDNotches,
             self.mission_NAV_LOITER_TURNS,
             self.mission_NAV_LOITER_TURNS_off_center,
+            self.mission_NAV_LOITER_TURNS_speed,
+            self.mission_NAV_LOITER_TURNS_zero_radius,
+            self.mission_NAV_LOITER_TURNS_direction,
             self.StaticNotches,
             self.LuaParamLockdown,
             self.RefindGPS,

--- a/libraries/AC_WPNav/AC_Circle.h
+++ b/libraries/AC_WPNav/AC_Circle.h
@@ -140,6 +140,10 @@ public:
     // See roi_at_center() for flag logic.
     bool roi_at_center() const { return (_options.get() & CircleOptions::ROI_AT_CENTER) != 0; }
 
+    // Returns true if the vehicle yaw should align with the direction of travel (tangent)
+    // rather than facing the circle center.
+    bool face_direction_of_travel() const { return (_options.get() & CircleOptions::FACE_DIRECTION_OF_TRAVEL) != 0; }
+
     // Sets rangefinder terrain offset (in centimeters) above EKF origin.
     // See set_rangefinder_terrain_U_m() for full details.
     void set_rangefinder_terrain_U_cm(bool use, bool healthy, float terrain_u_cm) { _rangefinder_available = use; _rangefinder_healthy = healthy; _rangefinder_terrain_u_m = terrain_u_cm * 0.01;}

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -449,6 +449,59 @@ bool AC_WPNav::set_wp_destination_NED_m(const Vector3p& destination_ned_m, bool 
     return true;
 }
 
+// Sets a circular-orbit destination about center_ne_m using the S-curve engine.
+// See the header for the full parameter description. The current destination is used as the
+// leg origin and must lie on the circle; the radius is derived from origin-to-center distance.
+bool AC_WPNav::set_circle_destination_NED_m(const Vector2f& center_ne_m, float turns_signed, float dest_d_m, bool is_terrain_alt, float speed_ne_ms)
+{
+    // re-initialise if previous destination has been interrupted
+    if (!is_active() || !_flags.reached_destination) {
+        wp_and_spline_init_m(_wp_desired_speed_ne_ms);
+    }
+
+    _scurve_prev_leg.init();
+
+    // use previous destination as origin; it is assumed to lie on the circle
+    _origin_ned_m = _destination_ned_m;
+
+    if (is_terrain_alt != _is_terrain_alt) {
+        // Handle transition between terrain-relative and origin-relative altitude frames
+        float terrain_d_m;
+        if (!get_terrain_D_m(terrain_d_m)) {
+            return false;
+        }
+        if (is_terrain_alt) {
+            _origin_ned_m.z -= terrain_d_m;
+            _pos_control.init_pos_terrain_D_m(terrain_d_m);
+        } else {
+            _origin_ned_m.z += terrain_d_m;
+            _pos_control.init_pos_terrain_D_m(0.0);
+        }
+    }
+
+    // build the S-curve orbit leg; net climb is applied linearly along the arc
+    const float total_angle_rad = turns_signed * M_2PI;
+    const float climb_d_m = dest_d_m - _origin_ned_m.z;
+    _scurve_this_leg.calculate_circle_track(_origin_ned_m, center_ne_m, total_angle_rad, climb_d_m,
+                                            speed_ne_ms, _pos_control.get_max_speed_up_ms(), _pos_control.get_max_speed_down_ms(),
+                                            get_wp_acceleration_mss(), get_accel_D_mss(), get_corner_acceleration_mss(),
+                                            _scurve_snap_max_mssss, _scurve_jerk_max_msss);
+
+    // the leg itself is the source of truth for where the orbit ends (for whole turns it
+    // returns to the origin's NE position). A degenerate arc leaves the origin-to-destination
+    // vector zero, so the destination stays at the origin and the leg completes in place.
+    _destination_ned_m = _origin_ned_m + _scurve_this_leg.get_origin_to_destination().topostype();
+    _is_terrain_alt = is_terrain_alt;
+
+    _this_leg_is_spline = false;
+    _scurve_next_leg.init();
+    _next_destination_ned_m.zero();
+    _flags.fast_waypoint = false;
+    _flags.reached_destination = false;
+
+    return true;
+}
+
 // Sets the next waypoint destination using a NED position vector in meters.
 // Only updates if terrain frame matches current leg.
 // Calculates trajectory preview for smoother transition into next segment.

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -449,6 +449,59 @@ bool AC_WPNav::set_wp_destination_NED_m(const Vector3p& destination_ned_m, bool 
     return true;
 }
 
+// Sets a circular-orbit destination about center_ne_m using the S-curve engine.
+// See the header for the full parameter description. The current destination is used as the
+// leg origin and must lie on the circle; the radius is derived from origin-to-center distance.
+bool AC_WPNav::set_circle_destination_NED_m(const Vector2f& center_ne_m, float turns_signed, float dest_d_m, bool is_terrain_alt)
+{
+    // re-initialise if previous destination has been interrupted
+    if (!is_active() || !_flags.reached_destination) {
+        wp_and_spline_init_m(_wp_desired_speed_ne_ms);
+    }
+
+    _scurve_prev_leg.init();
+
+    // use previous destination as origin; it is assumed to lie on the circle
+    _origin_ned_m = _destination_ned_m;
+
+    if (is_terrain_alt != _is_terrain_alt) {
+        // Handle transition between terrain-relative and origin-relative altitude frames
+        float terrain_d_m;
+        if (!get_terrain_D_m(terrain_d_m)) {
+            return false;
+        }
+        if (is_terrain_alt) {
+            _origin_ned_m.z -= terrain_d_m;
+            _pos_control.init_pos_terrain_D_m(terrain_d_m);
+        } else {
+            _origin_ned_m.z += terrain_d_m;
+            _pos_control.init_pos_terrain_D_m(0.0);
+        }
+    }
+
+    // build the S-curve orbit leg; net climb is applied linearly along the arc
+    const float total_angle_rad = turns_signed * M_2PI;
+    const float climb_d_m = dest_d_m - _origin_ned_m.z;
+    _scurve_this_leg.calculate_circle_track(_origin_ned_m, center_ne_m, total_angle_rad, climb_d_m,
+                                            _pos_control.NE_get_max_speed_ms(), _pos_control.get_max_speed_up_ms(), _pos_control.get_max_speed_down_ms(),
+                                            get_wp_acceleration_mss(), get_accel_D_mss(), get_corner_acceleration_mss(),
+                                            _scurve_snap_max_mssss, _scurve_jerk_max_msss);
+
+    // the leg itself is the source of truth for where the orbit ends (for whole turns it
+    // returns to the origin's NE position). A degenerate arc leaves the origin-to-destination
+    // vector zero, so the destination stays at the origin and the leg completes in place.
+    _destination_ned_m = _origin_ned_m + _scurve_this_leg.get_origin_to_destination().topostype();
+    _is_terrain_alt = is_terrain_alt;
+
+    _this_leg_is_spline = false;
+    _scurve_next_leg.init();
+    _next_destination_ned_m.zero();
+    _flags.fast_waypoint = false;
+    _flags.reached_destination = false;
+
+    return true;
+}
+
 // Sets the next waypoint destination using a NED position vector in meters.
 // Only updates if terrain frame matches current leg.
 // Calculates trajectory preview for smoother transition into next segment.

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -255,6 +255,7 @@ void AC_WPNav::wp_and_spline_init_m(float speed_ms, Vector3p stopping_point_ned_
     _origin_ned_m = _destination_ned_m = stopping_point_ned_m;
     _is_terrain_alt = false;
     _this_leg_is_spline = false;
+    _this_leg_is_circle = false;
 
     // initialise velocity profile for terrain margin shaping
     _offset_vel_ms = _wp_desired_speed_ne_ms;
@@ -402,23 +403,8 @@ bool AC_WPNav::set_wp_destination_NED_m(const Vector3p& destination_ned_m, bool 
             // Preserve current leg profile to enable blending with new leg
             _scurve_prev_leg = _scurve_this_leg;
         }
-    } else {
-        // Handle transition between terrain-relative and origin-relative altitude frames
-        float terrain_d_m;
-        if (!get_terrain_D_m(terrain_d_m)) {
-            return false;
-        }
-
-        // convert origin to alt-above-terrain if necessary
-        if (is_terrain_alt) {
-            // Convert origin.z to terrain-relative altitude
-            _origin_ned_m.z -= terrain_d_m;
-            _pos_control.init_pos_terrain_D_m(terrain_d_m);
-        } else {
-            // Convert origin.z to origin-relative altitude
-            _origin_ned_m.z += terrain_d_m;
-            _pos_control.init_pos_terrain_D_m(0.0);
-        }
+    } else if (!convert_origin_to_alt_frame(is_terrain_alt)) {
+        return false;
     }
 
     // update destination
@@ -441,6 +427,7 @@ bool AC_WPNav::set_wp_destination_NED_m(const Vector3p& destination_ned_m, bool 
     }
 
     _this_leg_is_spline = false;
+    _this_leg_is_circle = false;
     _scurve_next_leg.init();
     _next_destination_ned_m.zero(); // clear next destination_ned_m
     _flags.fast_waypoint = false;   // default waypoint back to slow
@@ -464,19 +451,8 @@ bool AC_WPNav::set_circle_destination_NED_m(const Vector2f& center_ne_m, float t
     // use previous destination as origin; it is assumed to lie on the circle
     _origin_ned_m = _destination_ned_m;
 
-    if (is_terrain_alt != _is_terrain_alt) {
-        // Handle transition between terrain-relative and origin-relative altitude frames
-        float terrain_d_m;
-        if (!get_terrain_D_m(terrain_d_m)) {
-            return false;
-        }
-        if (is_terrain_alt) {
-            _origin_ned_m.z -= terrain_d_m;
-            _pos_control.init_pos_terrain_D_m(terrain_d_m);
-        } else {
-            _origin_ned_m.z += terrain_d_m;
-            _pos_control.init_pos_terrain_D_m(0.0);
-        }
+    if ((is_terrain_alt != _is_terrain_alt) && !convert_origin_to_alt_frame(is_terrain_alt)) {
+        return false;
     }
 
     // build the S-curve orbit leg; net climb is applied linearly along the arc
@@ -494,6 +470,7 @@ bool AC_WPNav::set_circle_destination_NED_m(const Vector2f& center_ne_m, float t
     _is_terrain_alt = is_terrain_alt;
 
     _this_leg_is_spline = false;
+    _this_leg_is_circle = true;
     _scurve_next_leg.init();
     _next_destination_ned_m.zero();
     _flags.fast_waypoint = false;
@@ -836,6 +813,30 @@ bool AC_WPNav::get_terrain_U_m(float& terrain_u_m)
     // unreachable fallback path
     return false;
 }
+// Converts _origin_ned_m.z between the terrain-relative and origin-relative altitude frames and
+// re-seeds the position controller's terrain offset to match.  Call only when the new leg's
+// frame differs from the current one.
+// Returns false if terrain data is required but unavailable.
+bool AC_WPNav::convert_origin_to_alt_frame(bool is_terrain_alt)
+{
+    float terrain_d_m;
+    if (!get_terrain_D_m(terrain_d_m)) {
+        return false;
+    }
+
+    if (is_terrain_alt) {
+        // Convert origin.z to terrain-relative altitude
+        _origin_ned_m.z -= terrain_d_m;
+        _pos_control.init_pos_terrain_D_m(terrain_d_m);
+    } else {
+        // Convert origin.z to origin-relative altitude
+        _origin_ned_m.z += terrain_d_m;
+        _pos_control.init_pos_terrain_D_m(0.0);
+    }
+
+    return true;
+}
+
 bool AC_WPNav::get_terrain_D_m(float& terrain_d_m)
 {
         if (!get_terrain_U_m(terrain_d_m)) {
@@ -969,6 +970,7 @@ bool AC_WPNav::set_spline_destination_NED_m(const Vector3p& destination_ned_m, b
     // setup spline leg using origin and destination vectors
     _spline_this_leg.set_origin_and_destination(_origin_ned_m, _destination_ned_m, origin_vector_ned_m, destination_vector_ned_m);
     _this_leg_is_spline = true;
+    _this_leg_is_circle = false;
     _flags.reached_destination = false;
 
     return true;

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -197,6 +197,15 @@ public:
     // arc_rad specifies the signed arc angle in radians for an ARC_WAYPOINT segment (0 for straight path)
     bool set_wp_destination_next_NED_m(const Vector3p& destination_ned_m, bool is_terrain_alt = false, float arc_rad = 0.0);
 
+    // Sets a circular-orbit destination about center_ne_m using the S-curve engine.
+    // The current destination (used as the leg origin) must lie on the circle; the radius is the
+    // distance from that origin to the center. turns_signed is the signed number of turns (its sign
+    // selects direction and its magnitude may exceed 1 for multiple turns). dest_d_m is the altitude
+    // (NED down) at the end of the orbit and is_terrain_alt selects the altitude frame. speed_ne_ms is
+    // the desired horizontal orbit speed (further limited by the corner acceleration).
+    // Returns false if a terrain-frame transition is required but terrain data is unavailable.
+    bool set_circle_destination_NED_m(const Vector2f& center_ne_m, float turns_signed, float dest_d_m, bool is_terrain_alt, float speed_ne_ms);
+
     // Computes the horizontal stopping point in NE frame, returned in centimeters.
     // See get_wp_stopping_point_NE_m() for full details.
     void get_wp_stopping_point_NE_cm(Vector2f& stopping_point_ne_cm) const;

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -197,6 +197,20 @@ public:
     // arc_rad specifies the signed arc angle in radians for an ARC_WAYPOINT segment (0 for straight path)
     bool set_wp_destination_next_NED_m(const Vector3p& destination_ned_m, bool is_terrain_alt = false, float arc_rad = 0.0);
 
+    // Sets a circular-orbit destination about center_ne_m using the S-curve engine.
+    // The current destination (used as the leg origin) must lie on the circle; the radius is the
+    // distance from that origin to the center. turns_signed is the signed number of turns (its sign
+    // selects direction and its magnitude may exceed 1 for multiple turns). dest_d_m is the altitude
+    // (NED down) at the end of the orbit and is_terrain_alt selects the altitude frame. The orbit is
+    // flown at the waypoint speed, limited by the corner acceleration through the arc radius.
+    // Returns false if a terrain-frame transition is required but terrain data is unavailable.
+    bool set_circle_destination_NED_m(const Vector2f& center_ne_m, float turns_signed, float dest_d_m, bool is_terrain_alt);
+
+    // Returns the angle swept around the current circular-orbit leg so far, in radians.
+    // Unsigned and unwrapped, so it grows past 2*pi on a multi-turn orbit.
+    // Returns zero unless the current leg was set by set_circle_destination_NED_m().
+    float get_circle_angle_covered_rad() const { return _this_leg_is_circle ? _scurve_this_leg.get_arc_angle_covered_rad() : 0.0; }
+
     // Computes the horizontal stopping point in NE frame, returned in centimeters.
     // See get_wp_stopping_point_NE_m() for full details.
     void get_wp_stopping_point_NE_cm(Vector2f& stopping_point_ne_cm) const;

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -405,10 +405,8 @@ protected:
 
     // path type flags
     bool _this_leg_is_spline;       // true if the current leg uses spline trajectory
-    // true if the current leg is a circular orbit built by set_circle_destination_NED_m.
-    // initialised here because it gates object avoidance, so it must be valid before the first leg is set
-    bool _this_leg_is_circle = false;
     bool _next_leg_is_spline;       // true if the next leg will use spline trajectory
+    bool _this_leg_is_circle;       // true if the current leg is a circular orbit built by set_circle_destination_NED_m
 
     // waypoint navigation state
     uint32_t _wp_last_update_ms;         // timestamp of the last update_wpnav() call (milliseconds)

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -50,6 +50,12 @@ public:
     bool get_terrain_U_m(float& terrain_u_m);
     bool get_terrain_D_m(float& terrain_d_m);
 
+    // Converts _origin_ned_m.z between the terrain-relative and origin-relative altitude frames
+    // and re-seeds the position controller's terrain offset to match.  Call only when the new
+    // leg's frame differs from the current one.
+    // Returns false if terrain data is required but unavailable.
+    bool convert_origin_to_alt_frame(bool is_terrain_alt);
+
     // Returns the terrain following altitude margin in meters.
     // Vehicle will stop if distance from target altitude exceeds this margin.
     float get_terrain_margin_m() const { return MAX(_terrain_margin_m, 0.1); }
@@ -204,6 +210,9 @@ public:
     // (NED down) at the end of the orbit and is_terrain_alt selects the altitude frame. The orbit is
     // flown at the waypoint speed, limited by the corner acceleration through the arc radius.
     // Returns false if a terrain-frame transition is required but terrain data is unavailable.
+    // Not virtual: AC_WPNav_OA holds its avoidance state inactive for the whole orbit in
+    // update_wpnav() instead of overriding here, which lets the linker drop this and the
+    // S-curve arc builder behind it from vehicles that never fly an orbit.
     bool set_circle_destination_NED_m(const Vector2f& center_ne_m, float turns_signed, float dest_d_m, bool is_terrain_alt);
 
     // Returns the angle swept around the current circular-orbit leg so far, in radians.
@@ -396,6 +405,9 @@ protected:
 
     // path type flags
     bool _this_leg_is_spline;       // true if the current leg uses spline trajectory
+    // true if the current leg is a circular orbit built by set_circle_destination_NED_m.
+    // initialised here because it gates object avoidance, so it must be valid before the first leg is set
+    bool _this_leg_is_circle = false;
     bool _next_leg_is_spline;       // true if the next leg will use spline trajectory
 
     // waypoint navigation state

--- a/libraries/AC_WPNav/AC_WPNav_OA.cpp
+++ b/libraries/AC_WPNav/AC_WPNav_OA.cpp
@@ -103,9 +103,21 @@ bool AC_WPNav_OA::reached_wp_destination() const
 }
 
 // Runs the waypoint navigation update loop, including OA path planning logic.
-// Delegates to parent class if OA is not active or not required.
+// Delegates to parent class if the leg is a circular orbit, or if OA is not active or not required.
 bool AC_WPNav_OA::update_wpnav()
 {
+    // Object avoidance does not run on a circular orbit leg.  The path planners are given a
+    // straight origin-to-destination segment, which for an orbit is the chord back to the entry
+    // point rather than the arc being flown, so they would both miss obstacles on the arc and,
+    // on deactivating, rebuild the leg as a straight line to the entry point, discarding the
+    // turns not yet flown.  Holding the state inactive keeps every other override here falling
+    // through to the base class for the whole orbit, in particular reached_wp_destination(),
+    // which would otherwise never report the orbit complete
+    if (_this_leg_is_circle) {
+        _oa_state = AP_OAPathPlanner::OA_NOT_REQUIRED;
+        return AC_WPNav::update_wpnav();
+    }
+
     // Run path planning logic using the active OA planner
     AP_OAPathPlanner *oa_ptr = AP_OAPathPlanner::get_singleton();
     Location current_loc;

--- a/libraries/AC_WPNav/AC_WPNav_OA.h
+++ b/libraries/AC_WPNav/AC_WPNav_OA.h
@@ -51,7 +51,7 @@ public:
     bool reached_wp_destination() const override;
 
     // Runs the waypoint navigation update loop, including OA path planning logic.
-    // Delegates to parent class if OA is not active or not required.
+    // Delegates to parent class if the leg is a circular orbit, or if OA is not active or not required.
     bool update_wpnav() override;
 
 protected:

--- a/libraries/AP_Math/SCurve.cpp
+++ b/libraries/AP_Math/SCurve.cpp
@@ -82,52 +82,29 @@ void SCurve::calculate_track(const Vector3p &origin, const Vector3p &destination
         return;
     }
 
+    // convert the origin, destination and arc angle into the canonical arc/straight geometry
     const Vector2f chord = seg_delta.xy();
-    const float chord_length = seg_delta.xy().length();
+    const float chord_length = chord.length();
     if (!is_positive(chord_length) || fabsf(wrap_PI(arc_ang_rad)) < radians(1.0f)) {
-        // straight segment
-        is_arc_segment = false;
-        arc.angle_rad = 0.0f;
-        arc.length_ne = chord_length;
-        arc.radius_ne = 0.0f;
-        arc.center_ne = Vector2f();
-        seg_length = seg_delta.length();
+        set_straight_geometry();
     } else {
         // arc segment. The outer condition guarantees chord_length > 0 and
-        // |sin(arc_ang_rad/2)| >= sin(0.5 deg), so both divisions below are safe and
-        // arc.radius_ne is always positive (>= chord_length/2).
-        is_arc_segment = true;
-        arc.angle_rad = arc_ang_rad;
-        arc.radius_ne = fabsf(chord_length / (2.0f * fabsf(sinf(arc.angle_rad * 0.5f))));
-        const float center_offset = safe_sqrt(sq(arc.radius_ne) - sq(chord_length * 0.5f)); // perpendicular offset from chord to circle center
-        const float turn_dir = is_negative(arc.angle_rad) ? -1.0f : 1.0f; // -1 for CCW, 1 for CW
-        const float center_side = (is_positive(wrap_PI(fabsf(arc.angle_rad)))) ? 1.0f : -1.0f; // 1 for |angle| < PI, -1 for |angle| > PI
-        arc.center_ne = chord * 0.5f + Vector2f(-chord.y, chord.x) * (center_side * turn_dir * center_offset / chord_length);
-        arc.length_ne = arc.radius_ne * fabsf(arc.angle_rad);
-        seg_length = safe_sqrt(sq(seg_delta.z) + sq(arc.length_ne));
-        accel_c = is_positive(accel_c) ? accel_c : accel_xy;
-        speed_xy = MIN(speed_xy, safe_sqrt(accel_c * arc.radius_ne));
+        // |sin(arc_ang_rad/2)| >= sin(0.5 deg), so radius is positive (>= chord_length/2)
+        // and both divisions below are safe.
+        const float radius = fabsf(chord_length / (2.0f * fabsf(sinf(arc_ang_rad * 0.5f))));
+        const float center_offset = safe_sqrt(sq(radius) - sq(chord_length * 0.5f)); // perpendicular offset from chord to circle center
+        const float turn_dir = is_negative(arc_ang_rad) ? -1.0f : 1.0f; // -1 for CCW, 1 for CW
+        const float center_side = (is_positive(wrap_PI(fabsf(arc_ang_rad)))) ? 1.0f : -1.0f; // 1 for |angle| < PI, -1 for |angle| > PI
+        const Vector2f center_ne = chord * 0.5f + Vector2f(-chord.y, chord.x) * (center_side * turn_dir * center_offset / chord_length);
+        set_arc_geometry(center_ne, radius, arc_ang_rad);
     }
     if (is_zero(seg_length)) {
         seg_delta.zero();
         return;
     }
 
-    // set snap_max and jerk max
-    snap_max = snap_maximum;
-    jerk_max = jerk_maximum;
-
-    // Set speed and acceleration limits from the path that is actually flown: the
-    // horizontal extent is the arc length (equal to the chord for a straight
-    // segment) and the vertical extent is seg_delta.z. Using the straight-line
-    // chord here would understate a climbing arc's horizontal travel and needlessly
-    // throttle it against the vertical speed limit.
-    vel_max = kinematic_limit(arc.length_ne, seg_delta.z, speed_xy, speed_up, speed_down);
-    accel_max = kinematic_limit(arc.length_ne, seg_delta.z, accel_xy, accel_z, accel_z);
-    accel_z_max = accel_z;
-
-    // validate limits, build the segment profile and verify the result
-    finalise_path(seg_length);
+    // build the jerk-limited profile from the configured geometry and limits
+    generate_path(speed_xy, speed_up, speed_down, accel_xy, accel_z, accel_c, snap_maximum, jerk_maximum);
 }
 
 // generate a 3D trigonometric track that follows a circular arc about center_ne.
@@ -160,40 +137,74 @@ void SCurve::calculate_circle_track(const Vector3p &origin, const Vector2f &cent
         return;
     }
 
-    // configure the arc geometry directly from the circle parameters
-    is_arc_segment = true;
-    arc.angle_rad = total_angle_rad;
-    arc.radius_ne = radius;
-    arc.center_ne = origin_to_center_ne;
-    arc.length_ne = radius * fabsf(total_angle_rad);
-
-    // seg_delta must hold the true origin-to-destination displacement (not just the net
-    // vertical change): SCurve::move_to_pos_vel_accel() relies on it to exactly cancel a
-    // finished leg's contribution when that leg is preserved as another leg's prev_leg for
-    // corner blending (see AC_WPNav::set_wp_destination_NED_m). For a closed arc the endpoint
-    // is the origin rotated about the center by the swept angle, so the NE displacement is
-    // the origin-to-center vector minus that same vector rotated by the swept angle -- zero
-    // for whole turns, but not in general.
+    // seg_delta must hold the true origin-to-destination displacement (not just the climb):
+    // SCurve::move_to_pos_vel_accel() relies on it to exactly cancel a finished leg's
+    // contribution when that leg is preserved as another leg's prev_leg for corner blending
+    // (see AC_WPNav::set_wp_destination_NED_m), and AC_WPNav derives the leg destination
+    // from it via get_origin_to_destination(). For a closed arc the endpoint is the origin
+    // rotated about the center by the swept angle, so the NE displacement is the
+    // origin-to-center vector minus that same vector rotated by the swept angle -- zero for
+    // whole turns, but not in general.
     Vector2f end_offset_ne = origin_to_center_ne;
     end_offset_ne.rotate(total_angle_rad);
     seg_delta = Vector3f(origin_to_center_ne - end_offset_ne, climb_d_m);
-    seg_length = safe_sqrt(sq(climb_d_m) + sq(arc.length_ne));
+    set_arc_geometry(origin_to_center_ne, radius, total_angle_rad);
     if (is_zero(seg_length)) {
         seg_delta.zero();
         return;
     }
 
-    // limit horizontal speed so centripetal acceleration stays within the corner acceleration limit
-    accel_c = is_positive(accel_c) ? accel_c : accel_xy;
-    speed_xy = MIN(speed_xy, safe_sqrt(accel_c * radius));
+    // build the jerk-limited profile from the configured geometry and limits
+    generate_path(speed_xy, speed_up, speed_down, accel_xy, accel_z, accel_c, snap_maximum, jerk_maximum);
+}
+
+// populate the canonical straight-segment geometry from seg_delta (the net
+// start-to-end displacement). The arc fields are cleared and the path length is
+// the full 3D chord length.
+void SCurve::set_straight_geometry()
+{
+    is_arc_segment = false;
+    arc.angle_rad = 0.0f;
+    arc.length_ne = seg_delta.xy().length();
+    arc.radius_ne = 0.0f;
+    arc.center_ne = Vector2f();
+    seg_length = seg_delta.length();
+}
+
+// populate the canonical arc geometry (center relative to the origin, radius and
+// signed swept angle) and the resulting path length. seg_delta must already hold the
+// net start-to-end displacement; its vertical component sets the constant climb.
+void SCurve::set_arc_geometry(const Vector2f &center_ne_rel, float radius, float angle_rad)
+{
+    is_arc_segment = true;
+    arc.angle_rad = angle_rad;
+    arc.radius_ne = radius;
+    arc.center_ne = center_ne_rel;
+    arc.length_ne = radius * fabsf(angle_rad);
+    seg_length = safe_sqrt(sq(seg_delta.z) + sq(arc.length_ne));
+}
+
+// build the jerk-limited S-curve profile for the already-configured geometry
+// (is_arc_segment, arc.*, seg_delta, seg_length). Applies the corner-acceleration
+// speed limit for arcs, derives the speed and acceleration limits from the path
+// actually flown (arc length plus vertical component), and calls finalise_path().
+void SCurve::generate_path(float speed_xy, float speed_up, float speed_down,
+                           float accel_xy, float accel_z, float accel_c,
+                           float snap_maximum, float jerk_maximum)
+{
+    if (is_arc_segment) {
+        // limit horizontal speed so centripetal acceleration stays within the corner acceleration limit
+        accel_c = is_positive(accel_c) ? accel_c : accel_xy;
+        speed_xy = MIN(speed_xy, safe_sqrt(accel_c * arc.radius_ne));
+    }
 
     // set snap and jerk maxima
     snap_max = snap_maximum;
     jerk_max = jerk_maximum;
 
-    // set speed and acceleration limits from the horizontal arc length and vertical component.
-    // NOTE: set_kinematic_limits(origin, destination) cannot be used here because for a closed
-    // circle destination == origin, giving a zero direction and a zero speed limit.
+    // set speed and acceleration limits from the path actually flown: the horizontal
+    // extent is the arc length (equal to the chord for a straight segment) and the
+    // vertical extent is seg_delta.z
     vel_max = kinematic_limit(arc.length_ne, seg_delta.z, speed_xy, speed_up, speed_down);
     accel_max = kinematic_limit(arc.length_ne, seg_delta.z, accel_xy, accel_z, accel_z);
     accel_z_max = accel_z;
@@ -545,7 +556,7 @@ bool SCurve::advance_target_along_track(SCurve &prev_leg, SCurve &next_leg, floa
         ) {
 
         // Calculate the position, velocity and acceleration at the turn mid point
-        Vector3p turn_pos = -get_track().topostype();
+        Vector3p turn_pos = -get_origin_to_destination().topostype();
         Vector3f turn_vel, turn_accel;
         move_from_time_pos_vel_accel(get_time_elapsed() + time_to_destination * 0.5f, turn_pos, turn_vel, turn_accel);
         next_leg.move_from_time_pos_vel_accel(time_to_destination * 0.5f, turn_pos, turn_vel, turn_accel);

--- a/libraries/AP_Math/SCurve.cpp
+++ b/libraries/AP_Math/SCurve.cpp
@@ -148,6 +148,96 @@ void SCurve::calculate_track(const Vector3p &origin, const Vector3p &destination
     }
 }
 
+// generate a 3D trigonometric track that follows a circular arc about center_ne.
+// total_angle_rad is the signed swept angle (may exceed 2*pi for multiple turns);
+// its sign sets direction. climb_d_m is the net D-axis change applied linearly
+// along the arc. The radius is the distance from origin to center so the origin
+// lies on the circle. Includes speed, acceleration and jerk limits.
+void SCurve::calculate_circle_track(const Vector3p &origin, const Vector2f &center_ne,
+                                    float total_angle_rad, float climb_d_m,
+                                    float speed_xy, float speed_up, float speed_down,
+                                    float accel_xy, float accel_z, float accel_c,
+                                    float snap_maximum, float jerk_maximum)
+{
+    init();
+
+    // ensure limit arguments are positive
+    speed_xy = fabsf(speed_xy);
+    speed_up = fabsf(speed_up);
+    speed_down = fabsf(speed_down);
+    accel_xy = fabsf(accel_xy);
+    accel_z = fabsf(accel_z);
+
+    // the arc radius is the distance from the origin to the circle center, so the origin lies on the circle
+    const Vector2f origin_to_center_ne = center_ne - origin.xy().tofloat();
+    const float radius = origin_to_center_ne.length();
+
+    // leave track as zero length if the radius or swept angle is too small to form an arc
+    if (!is_positive(radius) || fabsf(total_angle_rad) < radians(1.0f)) {
+        seg_delta.zero();
+        return;
+    }
+
+    // configure the arc geometry directly from the circle parameters
+    is_arc_segment = true;
+    arc.angle_rad = total_angle_rad;
+    arc.radius_ne = radius;
+    arc.center_ne = origin_to_center_ne;
+    arc.length_ne = radius * fabsf(total_angle_rad);
+
+    // seg_delta must hold the true origin-to-destination displacement (not just the net
+    // vertical change): SCurve::move_to_pos_vel_accel() relies on it to exactly cancel a
+    // finished leg's contribution when that leg is preserved as another leg's prev_leg for
+    // corner blending (see AC_WPNav::set_wp_destination_NED_m). For a closed arc the endpoint
+    // is the origin rotated about the center by the swept angle, so the NE displacement is
+    // the origin-to-center vector minus that same vector rotated by the swept angle -- zero
+    // for whole turns, but not in general.
+    Vector2f end_offset_ne = origin_to_center_ne;
+    end_offset_ne.rotate(total_angle_rad);
+    seg_delta = Vector3f(origin_to_center_ne - end_offset_ne, climb_d_m);
+    seg_length = safe_sqrt(sq(climb_d_m) + sq(arc.length_ne));
+    if (is_zero(seg_length)) {
+        seg_delta.zero();
+        return;
+    }
+
+    // limit horizontal speed so centripetal acceleration stays within the corner acceleration limit
+    accel_c = is_positive(accel_c) ? accel_c : accel_xy;
+    speed_xy = MIN(speed_xy, safe_sqrt(accel_c * radius));
+
+    // set snap and jerk maxima
+    snap_max = snap_maximum;
+    jerk_max = jerk_maximum;
+
+    // set speed and acceleration limits from the horizontal arc length and vertical component.
+    // NOTE: set_kinematic_limits(origin, destination) cannot be used here because for a closed
+    // circle destination == origin, giving a zero direction and a zero speed limit.
+    vel_max = kinematic_limit(arc.length_ne, seg_delta.z, speed_xy, speed_up, speed_down);
+    accel_max = kinematic_limit(arc.length_ne, seg_delta.z, accel_xy, accel_z, accel_z);
+    accel_z_max = accel_z;
+
+    // avoid divide-by zeros. Path will be left as a zero length path
+    if (!is_positive(snap_max) || !is_positive(jerk_max) || !is_positive(accel_max) || !is_positive(vel_max)) {
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+        ::printf("SCurve::calculate_circle_track created zero length path\n");
+#endif
+        INTERNAL_ERROR(AP_InternalError::error_t::invalid_arg_or_result);
+        return;
+    }
+
+    add_segments(seg_length);
+
+    // catch calculation errors
+    if (!valid()) {
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+        ::printf("SCurve::calculate_circle_track invalid path\n");
+        debug();
+#endif
+        INTERNAL_ERROR(AP_InternalError::error_t::invalid_arg_or_result);
+        init();
+    }
+}
+
 // set maximum velocity and re-calculate the path using these limits
 void SCurve::set_speed_max(float speed_xy, float speed_up, float speed_down)
 {

--- a/libraries/AP_Math/SCurve.cpp
+++ b/libraries/AP_Math/SCurve.cpp
@@ -126,26 +126,8 @@ void SCurve::calculate_track(const Vector3p &origin, const Vector3p &destination
     accel_max = kinematic_limit(arc.length_ne, seg_delta.z, accel_xy, accel_z, accel_z);
     accel_z_max = accel_z;
 
-    // avoid divide-by zeros. Path will be left as a zero length path
-    if (!is_positive(snap_max) || !is_positive(jerk_max) || !is_positive(accel_max) || !is_positive(vel_max)) {
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-        ::printf("SCurve::calculate_track created zero length path\n");
-#endif
-        INTERNAL_ERROR(AP_InternalError::error_t::invalid_arg_or_result);
-        return;
-    }
-
-    add_segments(seg_length);
-
-    // catch calculation errors
-    if (!valid()) {
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-        ::printf("SCurve::calculate_track invalid path\n");
-        debug();
-#endif
-        INTERNAL_ERROR(AP_InternalError::error_t::invalid_arg_or_result);
-        init();
-    }
+    // validate limits, build the segment profile and verify the result
+    finalise_path(seg_length);
 }
 
 // generate a 3D trigonometric track that follows a circular arc about center_ne.
@@ -216,26 +198,8 @@ void SCurve::calculate_circle_track(const Vector3p &origin, const Vector2f &cent
     accel_max = kinematic_limit(arc.length_ne, seg_delta.z, accel_xy, accel_z, accel_z);
     accel_z_max = accel_z;
 
-    // avoid divide-by zeros. Path will be left as a zero length path
-    if (!is_positive(snap_max) || !is_positive(jerk_max) || !is_positive(accel_max) || !is_positive(vel_max)) {
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-        ::printf("SCurve::calculate_circle_track created zero length path\n");
-#endif
-        INTERNAL_ERROR(AP_InternalError::error_t::invalid_arg_or_result);
-        return;
-    }
-
-    add_segments(seg_length);
-
-    // catch calculation errors
-    if (!valid()) {
-#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-        ::printf("SCurve::calculate_circle_track invalid path\n");
-        debug();
-#endif
-        INTERNAL_ERROR(AP_InternalError::error_t::invalid_arg_or_result);
-        init();
-    }
+    // validate limits, build the segment profile and verify the result
+    finalise_path(seg_length);
 }
 
 // set maximum velocity and re-calculate the path using these limits
@@ -1184,6 +1148,35 @@ void SCurve::add_segment(uint8_t &index, float end_time, SegmentType seg_type, f
     segment[index].end_vel = end_vel;
     segment[index].end_pos = end_pos;
     index++;
+}
+
+// validate the configured limits, build the S-curve segment profile over the
+// given path length, and verify the result. snap_max, jerk_max, vel_max,
+// accel_max and accel_z_max must already be set. On error the path is left
+// zero length.
+void SCurve::finalise_path(float path_length)
+{
+    // avoid divide-by zeros. Path will be left as a zero length path
+    if (!is_positive(snap_max) || !is_positive(jerk_max) || !is_positive(accel_max) || !is_positive(vel_max)) {
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+        ::printf("SCurve::finalise_path created zero length path\n");
+#endif
+        INTERNAL_ERROR(AP_InternalError::error_t::invalid_arg_or_result);
+        init();
+        return;
+    }
+
+    add_segments(path_length);
+
+    // catch calculation errors
+    if (!valid()) {
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+        ::printf("SCurve::finalise_path invalid path\n");
+        debug();
+#endif
+        INTERNAL_ERROR(AP_InternalError::error_t::invalid_arg_or_result);
+        init();
+    }
 }
 
 // return true if the curve is valid.  Used to identify and protect against code errors

--- a/libraries/AP_Math/SCurve.cpp
+++ b/libraries/AP_Math/SCurve.cpp
@@ -48,6 +48,7 @@ void SCurve::init()
     snap_max = 0.0f;
     jerk_max = 0.0f;
     accel_max = 0.0f;
+    accel_c_max = 0.0f;
     vel_max = 0.0f;
     time = 0.0f;
     num_segs = SEG_INIT;
@@ -194,8 +195,8 @@ void SCurve::generate_path(float speed_xy, float speed_up, float speed_down,
 {
     if (is_arc_segment) {
         // limit horizontal speed so centripetal acceleration stays within the corner acceleration limit
-        accel_c = is_positive(accel_c) ? accel_c : accel_xy;
-        speed_xy = MIN(speed_xy, safe_sqrt(accel_c * arc.radius_ne));
+        accel_c_max = is_positive(accel_c) ? accel_c : accel_xy;
+        speed_xy = MIN(speed_xy, safe_sqrt(accel_c_max * arc.radius_ne));
     }
 
     // set snap and jerk maxima
@@ -224,6 +225,11 @@ void SCurve::set_speed_max(float speed_xy, float speed_up, float speed_down)
     // return immediately if zero length path
     if (num_segs != segments_max) {
         return;
+    }
+
+    if (is_arc_segment) {
+        // limit horizontal speed so centripetal acceleration stays within the corner acceleration limit
+        speed_xy = MIN(speed_xy, safe_sqrt(accel_c_max * arc.radius_ne));
     }
 
     // segment accelerations can not be changed after segment creation.

--- a/libraries/AP_Math/SCurve.cpp
+++ b/libraries/AP_Math/SCurve.cpp
@@ -50,6 +50,7 @@ void SCurve::init()
     accel_max = 0.0f;
     accel_c_max = 0.0f;
     vel_max = 0.0f;
+    vel_xy_max = 0.0f;
     time = 0.0f;
     num_segs = SEG_INIT;
     add_segment(num_segs, 0.0f, SegmentType::CONSTANT_JERK, 0.0f, 0.0f, 0.0f, 0.0f);
@@ -155,6 +156,12 @@ void SCurve::calculate_circle_track(const Vector3p &origin, const Vector2f &cent
         return;
     }
 
+    // Remember the caller's horizontal speed limit. An orbit's speed comes from the commanded
+    // turn rate, not from the waypoint speed, so unlike a straight or arc leg it must not be
+    // raised back to the position controller's limit when the speed limits are later updated
+    // (see set_speed_max).
+    vel_xy_max = speed_xy;
+
     // build the jerk-limited profile from the configured geometry and limits
     generate_path(speed_xy, speed_up, speed_down, accel_xy, accel_z, accel_c, snap_maximum, jerk_maximum);
 }
@@ -230,6 +237,12 @@ void SCurve::set_speed_max(float speed_xy, float speed_up, float speed_down)
     if (is_arc_segment) {
         // limit horizontal speed so centripetal acceleration stays within the corner acceleration limit
         speed_xy = MIN(speed_xy, safe_sqrt(accel_c_max * arc.radius_ne));
+    }
+
+    if (is_positive(vel_xy_max)) {
+        // re-apply the leg's own horizontal speed limit so a later speed change can slow the
+        // leg but never raise it above the speed the leg was created with
+        speed_xy = MIN(speed_xy, vel_xy_max);
     }
 
     // segment accelerations can not be changed after segment creation.

--- a/libraries/AP_Math/SCurve.cpp
+++ b/libraries/AP_Math/SCurve.cpp
@@ -48,6 +48,7 @@ void SCurve::init()
     snap_max = 0.0f;
     jerk_max = 0.0f;
     accel_max = 0.0f;
+    accel_c_max = 0.0f;
     vel_max = 0.0f;
     time = 0.0f;
     num_segs = SEG_INIT;
@@ -195,8 +196,8 @@ void SCurve::generate_path(float speed_xy, float speed_up, float speed_down,
 {
     if (is_arc_segment) {
         // limit horizontal speed so centripetal acceleration stays within the corner acceleration limit
-        accel_c = is_positive(accel_c) ? accel_c : accel_xy;
-        speed_xy = MIN(speed_xy, safe_sqrt(accel_c * arc.radius_ne));
+        accel_c_max = is_positive(accel_c) ? accel_c : accel_xy;
+        speed_xy = MIN(speed_xy, safe_sqrt(accel_c_max * arc.radius_ne));
     }
 
     // set snap and jerk maxima
@@ -244,6 +245,11 @@ void SCurve::set_speed_max(float speed_xy, float speed_up, float speed_down)
     // return immediately if zero length path
     if (num_segs != segments_max) {
         return;
+    }
+
+    if (is_arc_segment) {
+        // limit horizontal speed so centripetal acceleration stays within the corner acceleration limit
+        speed_xy = MIN(speed_xy, safe_sqrt(accel_c_max * arc.radius_ne));
     }
 
     // segment accelerations can not be changed after segment creation.

--- a/libraries/AP_Math/SCurve.cpp
+++ b/libraries/AP_Math/SCurve.cpp
@@ -82,46 +82,130 @@ void SCurve::calculate_track(const Vector3p &origin, const Vector3p &destination
         return;
     }
 
+    // convert the origin, destination and arc angle into the canonical arc/straight geometry
     const Vector2f chord = seg_delta.xy();
-    const float chord_length = seg_delta.xy().length();
+    const float chord_length = chord.length();
     if (!is_positive(chord_length) || fabsf(wrap_PI(arc_ang_rad)) < radians(1.0f)) {
-        // straight segment
-        is_arc_segment = false;
-        arc.angle_rad = 0.0f;
-        arc.length_ne = chord_length;
-        arc.radius_ne = 0.0f;
-        arc.center_ne = Vector2f();
-        seg_length = seg_delta.length();
+        set_straight_geometry();
     } else {
         // arc segment. The outer condition guarantees chord_length > 0 and
-        // |sin(arc_ang_rad/2)| >= sin(0.5 deg), so both divisions below are safe and
-        // arc.radius_ne is always positive (>= chord_length/2).
-        is_arc_segment = true;
-        arc.angle_rad = arc_ang_rad;
-        arc.radius_ne = fabsf(chord_length / (2.0f * fabsf(sinf(arc.angle_rad * 0.5f))));
-        const float center_offset = safe_sqrt(sq(arc.radius_ne) - sq(chord_length * 0.5f)); // perpendicular offset from chord to circle center
-        const float turn_dir = is_negative(arc.angle_rad) ? -1.0f : 1.0f; // -1 for CCW, 1 for CW
-        const float center_side = (is_positive(wrap_PI(fabsf(arc.angle_rad)))) ? 1.0f : -1.0f; // 1 for |angle| < PI, -1 for |angle| > PI
-        arc.center_ne = chord * 0.5f + Vector2f(-chord.y, chord.x) * (center_side * turn_dir * center_offset / chord_length);
-        arc.length_ne = arc.radius_ne * fabsf(arc.angle_rad);
-        seg_length = safe_sqrt(sq(seg_delta.z) + sq(arc.length_ne));
-        accel_c = is_positive(accel_c) ? accel_c : accel_xy;
-        speed_xy = MIN(speed_xy, safe_sqrt(accel_c * arc.radius_ne));
+        // |sin(arc_ang_rad/2)| >= sin(0.5 deg), so radius is positive (>= chord_length/2)
+        // and both divisions below are safe.
+        const float radius = fabsf(chord_length / (2.0f * fabsf(sinf(arc_ang_rad * 0.5f))));
+        const float center_offset = safe_sqrt(sq(radius) - sq(chord_length * 0.5f)); // perpendicular offset from chord to circle center
+        const float turn_dir = is_negative(arc_ang_rad) ? -1.0f : 1.0f; // -1 for CCW, 1 for CW
+        const float center_side = (is_positive(wrap_PI(fabsf(arc_ang_rad)))) ? 1.0f : -1.0f; // 1 for |angle| < PI, -1 for |angle| > PI
+        const Vector2f center_ne = chord * 0.5f + Vector2f(-chord.y, chord.x) * (center_side * turn_dir * center_offset / chord_length);
+        set_arc_geometry(center_ne, radius, arc_ang_rad);
     }
     if (is_zero(seg_length)) {
         seg_delta.zero();
         return;
     }
 
-    // set snap_max and jerk max
+    // build the jerk-limited profile from the configured geometry and limits
+    generate_path(speed_xy, speed_up, speed_down, accel_xy, accel_z, accel_c, snap_maximum, jerk_maximum);
+}
+
+// generate a 3D trigonometric track that follows a circular arc about center_ne.
+// total_angle_rad is the signed swept angle (may exceed 2*pi for multiple turns);
+// its sign sets direction. climb_d_m is the net D-axis change applied linearly
+// along the arc. The radius is the distance from origin to center so the origin
+// lies on the circle. Includes speed, acceleration and jerk limits.
+void SCurve::calculate_circle_track(const Vector3p &origin, const Vector2f &center_ne,
+                                    float total_angle_rad, float climb_d_m,
+                                    float speed_xy, float speed_up, float speed_down,
+                                    float accel_xy, float accel_z, float accel_c,
+                                    float snap_maximum, float jerk_maximum)
+{
+    init();
+
+    // ensure limit arguments are positive
+    speed_xy = fabsf(speed_xy);
+    speed_up = fabsf(speed_up);
+    speed_down = fabsf(speed_down);
+    accel_xy = fabsf(accel_xy);
+    accel_z = fabsf(accel_z);
+
+    // the arc radius is the distance from the origin to the circle center, so the origin lies on the circle
+    const Vector2f origin_to_center_ne = center_ne - origin.xy().tofloat();
+    const float radius = origin_to_center_ne.length();
+
+    // leave track as zero length if the radius or swept angle is too small to form an arc
+    if (!is_positive(radius) || fabsf(total_angle_rad) < radians(1.0f)) {
+        seg_delta.zero();
+        return;
+    }
+
+    // seg_delta must hold the true origin-to-destination displacement (not just the climb):
+    // SCurve::move_to_pos_vel_accel() relies on it to exactly cancel a finished leg's
+    // contribution when that leg is preserved as another leg's prev_leg for corner blending
+    // (see AC_WPNav::set_wp_destination_NED_m), and AC_WPNav derives the leg destination
+    // from it via get_origin_to_destination(). For a closed arc the endpoint is the origin
+    // rotated about the center by the swept angle, so the NE displacement is the
+    // origin-to-center vector minus that same vector rotated by the swept angle -- zero for
+    // whole turns, but not in general.
+    Vector2f end_offset_ne = origin_to_center_ne;
+    end_offset_ne.rotate(total_angle_rad);
+    seg_delta = Vector3f(origin_to_center_ne - end_offset_ne, climb_d_m);
+    set_arc_geometry(origin_to_center_ne, radius, total_angle_rad);
+    if (is_zero(seg_length)) {
+        seg_delta.zero();
+        return;
+    }
+
+    // build the jerk-limited profile from the configured geometry and limits
+    generate_path(speed_xy, speed_up, speed_down, accel_xy, accel_z, accel_c, snap_maximum, jerk_maximum);
+}
+
+// populate the canonical straight-segment geometry from seg_delta (the net
+// start-to-end displacement). The arc fields are cleared and the path length is
+// the full 3D chord length.
+void SCurve::set_straight_geometry()
+{
+    is_arc_segment = false;
+    arc.angle_rad = 0.0f;
+    arc.length_ne = seg_delta.xy().length();
+    arc.radius_ne = 0.0f;
+    arc.center_ne = Vector2f();
+    seg_length = seg_delta.length();
+}
+
+// populate the canonical arc geometry (center relative to the origin, radius and
+// signed swept angle) and the resulting path length. seg_delta must already hold the
+// net start-to-end displacement; its vertical component sets the constant climb.
+void SCurve::set_arc_geometry(const Vector2f &center_ne_rel, float radius, float angle_rad)
+{
+    is_arc_segment = true;
+    arc.angle_rad = angle_rad;
+    arc.radius_ne = radius;
+    arc.center_ne = center_ne_rel;
+    arc.length_ne = radius * fabsf(angle_rad);
+    seg_length = safe_sqrt(sq(seg_delta.z) + sq(arc.length_ne));
+}
+
+// build the jerk-limited S-curve profile for the already-configured geometry
+// (is_arc_segment, arc.*, seg_delta, seg_length). Applies the corner-acceleration
+// speed limit for arcs, derives the speed and acceleration limits from the path
+// actually flown (arc length plus vertical component), then builds and verifies the
+// segment profile. On error the path is left zero length.
+void SCurve::generate_path(float speed_xy, float speed_up, float speed_down,
+                           float accel_xy, float accel_z, float accel_c,
+                           float snap_maximum, float jerk_maximum)
+{
+    if (is_arc_segment) {
+        // limit horizontal speed so centripetal acceleration stays within the corner acceleration limit
+        accel_c = is_positive(accel_c) ? accel_c : accel_xy;
+        speed_xy = MIN(speed_xy, safe_sqrt(accel_c * arc.radius_ne));
+    }
+
+    // set snap and jerk maxima
     snap_max = snap_maximum;
     jerk_max = jerk_maximum;
 
-    // Set speed and acceleration limits from the path that is actually flown: the
-    // horizontal extent is the arc length (equal to the chord for a straight
-    // segment) and the vertical extent is seg_delta.z. Using the straight-line
-    // chord here would understate a climbing arc's horizontal travel and needlessly
-    // throttle it against the vertical speed limit.
+    // set speed and acceleration limits from the path actually flown: the horizontal
+    // extent is the arc length (equal to the chord for a straight segment) and the
+    // vertical extent is seg_delta.z
     vel_max = kinematic_limit(arc.length_ne, seg_delta.z, speed_xy, speed_up, speed_down);
     accel_max = kinematic_limit(arc.length_ne, seg_delta.z, accel_xy, accel_z, accel_z);
     accel_z_max = accel_z;
@@ -129,9 +213,10 @@ void SCurve::calculate_track(const Vector3p &origin, const Vector3p &destination
     // avoid divide-by zeros. Path will be left as a zero length path
     if (!is_positive(snap_max) || !is_positive(jerk_max) || !is_positive(accel_max) || !is_positive(vel_max)) {
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-        ::printf("SCurve::calculate_track created zero length path\n");
+        ::printf("SCurve::generate_path created zero length path\n");
 #endif
         INTERNAL_ERROR(AP_InternalError::error_t::invalid_arg_or_result);
+        init();
         return;
     }
 
@@ -140,7 +225,7 @@ void SCurve::calculate_track(const Vector3p &origin, const Vector3p &destination
     // catch calculation errors
     if (!valid()) {
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-        ::printf("SCurve::calculate_track invalid path\n");
+        ::printf("SCurve::generate_path invalid path\n");
         debug();
 #endif
         INTERNAL_ERROR(AP_InternalError::error_t::invalid_arg_or_result);
@@ -491,7 +576,7 @@ bool SCurve::advance_target_along_track(SCurve &prev_leg, SCurve &next_leg, floa
         ) {
 
         // Calculate the position, velocity and acceleration at the turn mid point
-        Vector3p turn_pos = -get_track().topostype();
+        Vector3p turn_pos = -get_origin_to_destination().topostype();
         Vector3f turn_vel, turn_accel;
         move_from_time_pos_vel_accel(get_time_elapsed() + time_to_destination * 0.5f, turn_pos, turn_vel, turn_accel);
         next_leg.move_from_time_pos_vel_accel(time_to_destination * 0.5f, turn_pos, turn_vel, turn_accel);
@@ -519,6 +604,26 @@ bool SCurve::advance_target_along_track(SCurve &prev_leg, SCurve &next_leg, floa
 bool SCurve::finished() const
 {
     return time >= time_end();
+}
+
+// return the angle swept around the arc so far, in radians, unsigned and unwrapped so it grows
+// past 2*pi on a multi-turn arc.  returns zero for a straight segment
+float SCurve::get_arc_angle_covered_rad() const
+{
+    if (!is_arc_segment || !is_positive(seg_length)) {
+        return 0.0;
+    }
+
+    // distance travelled along the track.  This is the 3D path length, so the fraction of the
+    // track covered is used rather than dividing by the arc radius: seg_length carries the
+    // climb applied over the arc, which the horizontal arc length does not
+    float scurve_P1 = 0.0f;
+    float scurve_V1, scurve_A1, scurve_J1;
+    get_jerk_accel_vel_pos_at_time(time, scurve_J1, scurve_A1, scurve_V1, scurve_P1);
+
+    // this is the rotation project_scurve_onto_track() applies, so the angle reported is the
+    // angle flown by construction
+    return fabsf(arc.angle_rad) * (scurve_P1 / seg_length);
 }
 
 // increment time pointer and return the position, velocity and acceleration vectors relative to the origin

--- a/libraries/AP_Math/SCurve.h
+++ b/libraries/AP_Math/SCurve.h
@@ -93,6 +93,10 @@ public:
     // time has reached the end of the sequence
     bool finished() const WARN_IF_UNUSED;
 
+    // return the vector from the origin to the destination
+    // (for an arc segment this is the chord between the endpoints, not the path flown)
+    const Vector3f& get_origin_to_destination() const WARN_IF_UNUSED { return seg_delta; };
+
     // calculate the segment times for the trigonometric S-Curve path defined by:
     // Sm - maximum value of the snap profile
     // Jm - maximum value of the raised cosine jerk profile
@@ -128,9 +132,6 @@ private:
 
     // get desired maximum acceleration along track
     float get_accel_z_max() const WARN_IF_UNUSED { return accel_z_max; }
-
-    // return the change in position from origin to destination
-    const Vector3f& get_track() const WARN_IF_UNUSED { return seg_delta; };
 
     // return the current time elapsed
     float get_time_elapsed() const WARN_IF_UNUSED { return time; }
@@ -188,6 +189,18 @@ private:
 
     // fill segment[first..last] with zero-delta constant-jerk segments anchored to segment[src]
     void fill_empty_segments(uint8_t first, uint8_t last, uint8_t src);
+
+    // populate the canonical straight-segment geometry from seg_delta
+    void set_straight_geometry();
+
+    // populate the canonical arc geometry (center relative to origin, radius and signed swept angle)
+    // seg_delta (its vertical component) must already be set
+    void set_arc_geometry(const Vector2f &center_ne_rel, float radius, float angle_rad);
+
+    // build the jerk-limited profile from the already-configured geometry and the given limits
+    void generate_path(float speed_xy, float speed_up, float speed_down,
+                        float accel_xy, float accel_z, float accel_c,
+                        float snap_maximum, float jerk_maximum);
 
     // validate the configured limits, build the segment profile over path_length and verify the result
     // snap_max, jerk_max, vel_max, accel_max and accel_z_max must already be set

--- a/libraries/AP_Math/SCurve.h
+++ b/libraries/AP_Math/SCurve.h
@@ -59,6 +59,16 @@ public:
                          float accel_xy, float accel_z, float accel_c,
                          float snap_maximum, float jerk_maximum);
 
+    // generate a trigonometric track that follows a circular arc about center_ne
+    // total_angle_rad is the signed swept angle and may exceed 2*pi for multiple turns
+    // climb_d_m is the net change along the down (D) axis, applied linearly over the arc
+    // the arc radius is taken as the distance from origin to center, so the origin lies on the circle
+    void calculate_circle_track(const Vector3p &origin, const Vector2f &center_ne,
+                                float total_angle_rad, float climb_d_m,
+                                float speed_xy, float speed_up, float speed_down,
+                                float accel_xy, float accel_z, float accel_c,
+                                float snap_maximum, float jerk_maximum);
+
     // set maximum velocity and re-calculate the path using these limits
     void set_speed_max(float speed_xy, float speed_up, float speed_down);
 

--- a/libraries/AP_Math/SCurve.h
+++ b/libraries/AP_Math/SCurve.h
@@ -189,6 +189,10 @@ private:
     // fill segment[first..last] with zero-delta constant-jerk segments anchored to segment[src]
     void fill_empty_segments(uint8_t first, uint8_t last, uint8_t src);
 
+    // validate the configured limits, build the segment profile over path_length and verify the result
+    // snap_max, jerk_max, vel_max, accel_max and accel_z_max must already be set
+    void finalise_path(float path_length);
+
     // return true if the curve is valid.  Used to identify and protect against code errors
     bool valid() const WARN_IF_UNUSED;
 

--- a/libraries/AP_Math/SCurve.h
+++ b/libraries/AP_Math/SCurve.h
@@ -228,7 +228,8 @@ private:
     float snap_max;     // maximum snap magnitude
     float jerk_max;     // maximum jerk magnitude
     float accel_max;    // maximum acceleration magnitude
-    float accel_z_max;    // maximum acceleration magnitude
+    float accel_c_max;  // maximum cornering acceleration magnitude
+    float accel_z_max;  // maximum acceleration magnitude
     float vel_max;      // maximum velocity magnitude
     float time;         // time that defines position on the path
 

--- a/libraries/AP_Math/SCurve.h
+++ b/libraries/AP_Math/SCurve.h
@@ -231,6 +231,7 @@ private:
     float accel_c_max;  // maximum cornering acceleration magnitude
     float accel_z_max;  // maximum acceleration magnitude
     float vel_max;      // maximum velocity magnitude
+    float vel_xy_max;   // horizontal speed limit intrinsic to this leg, re-applied by set_speed_max (0 if the leg has none)
     float time;         // time that defines position on the path
 
     // segment 0 is the initial segment and holds the vehicle's initial position and velocity

--- a/libraries/AP_Math/SCurve.h
+++ b/libraries/AP_Math/SCurve.h
@@ -59,6 +59,16 @@ public:
                          float accel_xy, float accel_z, float accel_c,
                          float snap_maximum, float jerk_maximum);
 
+    // generate a trigonometric track that follows a circular arc about center_ne
+    // total_angle_rad is the signed swept angle and may exceed 2*pi for multiple turns
+    // climb_d_m is the net change along the down (D) axis, applied linearly over the arc
+    // the arc radius is taken as the distance from origin to center, so the origin lies on the circle
+    void calculate_circle_track(const Vector3p &origin, const Vector2f &center_ne,
+                                float total_angle_rad, float climb_d_m,
+                                float speed_xy, float speed_up, float speed_down,
+                                float accel_xy, float accel_z, float accel_c,
+                                float snap_maximum, float jerk_maximum);
+
     // set maximum velocity and re-calculate the path using these limits
     void set_speed_max(float speed_xy, float speed_up, float speed_down);
 
@@ -82,6 +92,14 @@ public:
 
     // time has reached the end of the sequence
     bool finished() const WARN_IF_UNUSED;
+
+    // return the vector from the origin to the destination
+    // (for an arc segment this is the chord between the endpoints, not the path flown)
+    const Vector3f& get_origin_to_destination() const WARN_IF_UNUSED { return seg_delta; };
+
+    // return the angle swept around the arc so far, in radians, unsigned and unwrapped so it
+    // grows past 2*pi on a multi-turn arc.  returns zero for a straight segment
+    float get_arc_angle_covered_rad() const WARN_IF_UNUSED;
 
     // calculate the segment times for the trigonometric S-Curve path defined by:
     // Sm - maximum value of the snap profile
@@ -118,9 +136,6 @@ private:
 
     // get desired maximum acceleration along track
     float get_accel_z_max() const WARN_IF_UNUSED { return accel_z_max; }
-
-    // return the change in position from origin to destination
-    const Vector3f& get_track() const WARN_IF_UNUSED { return seg_delta; };
 
     // return the current time elapsed
     float get_time_elapsed() const WARN_IF_UNUSED { return time; }
@@ -178,6 +193,18 @@ private:
 
     // fill segment[first..last] with zero-delta constant-jerk segments anchored to segment[src]
     void fill_empty_segments(uint8_t first, uint8_t last, uint8_t src);
+
+    // populate the canonical straight-segment geometry from seg_delta
+    void set_straight_geometry();
+
+    // populate the canonical arc geometry (center relative to origin, radius and signed swept angle)
+    // seg_delta (its vertical component) must already be set
+    void set_arc_geometry(const Vector2f &center_ne_rel, float radius, float angle_rad);
+
+    // build the jerk-limited profile from the already-configured geometry and the given limits
+    void generate_path(float speed_xy, float speed_up, float speed_down,
+                        float accel_xy, float accel_z, float accel_c,
+                        float snap_maximum, float jerk_maximum);
 
     // return true if the curve is valid.  Used to identify and protect against code errors
     bool valid() const WARN_IF_UNUSED;

--- a/libraries/AP_Math/tests/test_scurve.cpp
+++ b/libraries/AP_Math/tests/test_scurve.cpp
@@ -248,13 +248,15 @@ TEST(SCurveCalcPath, constraints)
 // calculate_track: arc speed limit must come from the arc length, not the chord
 // ---------------------------------------------------------------------------
 
-// Runaway guard for the drive loops below. Both legs complete in well under this
-// (roughly 8k iterations), so it only bounds a regression that never reports
-// completion. 50000 iterations is 125 s of simulated time at 400 Hz.
+// Runaway guard for every drive loop below. All of them complete in well under this: the
+// straight and arc legs in roughly 8k iterations, the longest circle (3.5 turns) in roughly
+// 20k, so it only bounds a regression that never reports completion. 50000 iterations is
+// 125 s of simulated time at 400 Hz.
 static const uint32_t MAX_DRIVE_ITERS = 50000;
 
-// drive a prepared leg to completion, returning the peak horizontal and vertical target speed
-struct LegPeak { float speed_xy; float speed_z; bool finished; };
+// drive a prepared leg to completion, returning the peak horizontal and vertical
+// target speed and the final target position
+struct LegPeak { float speed_xy; float speed_z; Vector3p final_pos; bool finished; };
 static LegPeak drive_leg(SCurve &leg, const Vector3p &origin)
 {
     SCurve prev, next;
@@ -273,8 +275,33 @@ static LegPeak drive_leg(SCurve &leg, const Vector3p &origin)
         r.speed_xy = MAX(r.speed_xy, vel.xy().length());
         r.speed_z = MAX(r.speed_z, fabsf(vel.z));
     }
+    r.final_pos = pos;
     r.finished = done;
     return r;
+}
+
+// A level straight leg reaches the full horizontal speed, has no vertical motion, and
+// finishes at the destination. Covers the set_straight_geometry / generate_path path
+// for a non-arc segment.
+TEST(SCurveTrack, straight_leg)
+{
+    const Vector3p origin{0, 0, -50};
+    const Vector3p dest{50, 0, -50};    // 50 m north, level
+    const float speed_xy = 5.0f;
+
+    SCurve leg;
+    leg.calculate_track(origin, dest, 0.0f,   // arc angle 0 -> straight segment
+                        speed_xy, 3.0f, 2.0f,
+                        2.0f, 2.0f, 2.0f,
+                        60.0f, 10.0f);
+
+    const LegPeak p = drive_leg(leg, origin);
+    EXPECT_TRUE(p.finished);
+    EXPECT_NEAR(p.speed_xy, speed_xy, 0.05f);   // reaches the horizontal speed
+    EXPECT_LE(p.speed_z, 0.02f);                // stays level
+    EXPECT_NEAR((float)p.final_pos.x, 50.0f, 0.05f);
+    EXPECT_NEAR((float)p.final_pos.y, 0.0f, 0.05f);
+    EXPECT_NEAR((float)p.final_pos.z, -50.0f, 0.05f);
 }
 
 // A climbing arc must take its speed limit from the path it actually flies (the arc
@@ -342,6 +369,173 @@ TEST(SCurveTrack, arc_velocity_matches_position_derivative)
     // finite difference matches the reported velocity to O(dt); a large gap means the reported
     // velocity is not tangent to the path actually flown
     EXPECT_LT(max_err, 0.05f);
+}
+
+// ---------------------------------------------------------------------------
+// calculate_circle_track: full-circle / multi-turn arc geometry
+// ---------------------------------------------------------------------------
+
+// result of driving one circle leg to completion, sampling the target path
+struct CircleResult {
+    float max_radius_err;   // largest deviation of the target from radius R
+    float peak_speed_ne;    // largest horizontal target speed (what the centripetal clamp bounds)
+    Vector3p final_pos;     // target position at completion
+    float first_east;       // east position ~1 s after start (direction check)
+    bool finished;          // leg reported completion
+};
+
+// build a circle leg and advance it to completion, exactly as AC_WPNav drives a leg
+static CircleResult run_circle(const Vector3p &origin, const Vector2f &center,
+                               float total_angle_rad, float climb_d_m,
+                               float speed_xy, float accel_c)
+{
+    SCurve prev, leg, next;
+    prev.init();
+    next.init();
+    leg.calculate_circle_track(origin, center, total_angle_rad, climb_d_m,
+                               speed_xy, 3.0f, 2.0f,   // speed xy, up, down
+                               2.0f, 2.0f, accel_c,    // accel xy, z, corner
+                               60.0f, 10.0f);          // snap, jerk
+
+    const float R = (center - origin.xy().tofloat()).length();
+    const float dt = 0.0025f;
+
+    CircleResult r {};
+    Vector3p pos;
+    Vector3f vel, accel;
+    bool done = false;
+    for (uint32_t i = 0; i < MAX_DRIVE_ITERS && !done; i++) {
+        // target_pos must be reset to the leg origin before each advance (see AC_WPNav)
+        pos = origin;
+        vel.zero();
+        accel.zero();
+        done = leg.advance_target_along_track(prev, next, 2.0f, accel_c, false, dt, pos, vel, accel);
+        r.max_radius_err = MAX(r.max_radius_err, fabsf((pos.xy().tofloat() - center).length() - R));
+        r.peak_speed_ne = MAX(r.peak_speed_ne, vel.xy().length());
+        if (i == 400) {
+            r.first_east = pos.y;
+        }
+    }
+    r.final_pos = pos;
+    r.finished = done;
+    return r;
+}
+
+TEST(SCurveCircle, geometry)
+{
+    const Vector3p origin{10, 0, -50};   // 10 m north of center, 50 m up
+    const Vector2f center{0, 0};
+    const float R = 10.0f;
+    const float accel_c = 2.0f;
+    // horizontal speed is clamped so centripetal accel v^2/R stays within accel_c
+    const float vmax_expect = MIN(5.0f, safe_sqrt(accel_c * R));
+
+    struct Case { const char *name; float turns; float climb; };
+    const Case cases[] = {
+        {"full_cw",    1.0f,   0.0f},
+        {"half_cw",    0.5f,   0.0f},
+        {"multi_cw",   3.5f,   0.0f},
+        {"climb_cw",   2.0f,  -5.0f},
+        {"full_ccw",  -1.0f,   0.0f},
+        {"multi_ccw", -2.5f,   0.0f},
+    };
+
+    for (const auto &c : cases) {
+        const float angle = c.turns * M_2PI;
+        const CircleResult r = run_circle(origin, center, angle, c.climb, 5.0f, accel_c);
+
+        EXPECT_TRUE(r.finished) << c.name;
+
+        // target never leaves the circle
+        EXPECT_LT(r.max_radius_err, 0.05f) << "radius drift: " << c.name
+            << " err=" << r.max_radius_err;
+
+        // never exceeds the clamped speed (verifies the centripetal limit)
+        EXPECT_LE(r.peak_speed_ne, vmax_expect + 0.05f) << "overspeed: " << c.name
+            << " peak=" << r.peak_speed_ne;
+
+        // reaches the commanded net climb
+        EXPECT_NEAR((float)r.final_pos.z, (float)origin.z + c.climb, 0.10f) << "climb: " << c.name;
+
+        // NE endpoint matches the swept angle applied to the entry offset
+        Vector2f rel = origin.xy().tofloat() - center;
+        rel.rotate(angle);
+        const Vector2f end_expect = center + rel;
+        EXPECT_NEAR((float)r.final_pos.x, end_expect.x, 0.15f) << "end north: " << c.name;
+        EXPECT_NEAR((float)r.final_pos.y, end_expect.y, 0.15f) << "end east: " << c.name;
+
+        // direction: positive angle sweeps toward +east, negative toward -east
+        if (angle > 0) {
+            EXPECT_GT(r.first_east, 0.0f) << "expected CW: " << c.name;
+        } else {
+            EXPECT_LT(r.first_east, 0.0f) << "expected CCW: " << c.name;
+        }
+    }
+}
+
+// Regression test: AC_WPNav's corner-blending mechanism used to corrupt the position target of
+// the leg immediately following a fractional-turn circle. This replicates exactly what
+// AC_WPNav does when a plain WP leg follows a circle leg: the finished circle is preserved as
+// the new leg's _scurve_prev_leg for corner blending (see AC_WPNav::set_wp_destination_NED_m),
+// and advance_target_along_track() unconditionally calls prev_leg.move_to_pos_vel_accel() every
+// tick, which subtracts get_origin_to_destination() to cancel a finished leg's contribution
+// to zero.
+TEST(SCurveCircle, prev_leg_handoff)
+{
+    const Vector3p O{10, 0, -50};
+    const Vector2f center{0, 0};
+    const float turns = 0.5f;          // fractional turns -> destination != origin
+
+    SCurve circle;
+    circle.calculate_circle_track(O, center, turns * M_2PI, 0.0f,
+                                  5.0f, 3.0f, 2.0f,
+                                  2.0f, 2.0f, 2.0f,
+                                  60.0f, 10.0f);
+
+    // drive the circle leg to completion (mirrors run_circle() above)
+    {
+        SCurve prev, next;
+        prev.init();
+        next.init();
+        Vector3p pos;
+        Vector3f vel, accel;
+        bool done = false;
+        for (uint32_t i = 0; i < MAX_DRIVE_ITERS && !done; i++) {
+            pos = O;
+            vel.zero();
+            accel.zero();
+            done = circle.advance_target_along_track(prev, next, 2.0f, 2.0f, false, 0.0025f, pos, vel, accel);
+        }
+        ASSERT_TRUE(done);
+    }
+
+    // the orbit destination (AC_WPNav derives this from the leg's get_origin_to_destination();
+    // computed independently here from the endpoint rotation so the test does not trust
+    // seg_delta)
+    Vector2f origin_to_end_ne = O.xy().tofloat() - center;
+    origin_to_end_ne.rotate(turns * M_2PI);
+    const Vector3p D(center.x + origin_to_end_ne.x, center.y + origin_to_end_ne.y, O.z);
+
+    // new leg: origin = D (AC_WPNav sets _origin_ned_m = _destination_ned_m), a straight hop north
+    SCurve new_leg;
+    new_leg.calculate_track(D, D + Vector3p(20, 0, 0), 0.0f,
+                            5.0f, 3.0f, 2.0f,
+                            2.0f, 2.0f, 2.0f,
+                            60.0f, 10.0f);
+
+    // AC_WPNav preserves the finished circle as _scurve_prev_leg for the new leg
+    SCurve scurve_next_leg;
+    scurve_next_leg.init();
+
+    Vector3p target_pos = D;
+    Vector3f target_vel, target_accel;
+    // one tick into a 20 m leg definitely isn't finished; this also exercises the return value
+    EXPECT_FALSE(new_leg.advance_target_along_track(circle, scurve_next_leg, 2.0f, 2.0f, false, 0.0025f, target_pos, target_vel, target_accel));
+
+    // the first tick of the new leg must start at (essentially) its own origin D
+    EXPECT_NEAR((float)target_pos.x, (float)D.x, 0.05f);
+    EXPECT_NEAR((float)target_pos.y, (float)D.y, 0.05f);
+    EXPECT_NEAR((float)target_pos.z, (float)D.z, 0.05f);
 }
 
 AP_GTEST_MAIN()

--- a/libraries/AP_Math/tests/test_scurve.cpp
+++ b/libraries/AP_Math/tests/test_scurve.cpp
@@ -248,9 +248,10 @@ TEST(SCurveCalcPath, constraints)
 // calculate_track: arc speed limit must come from the arc length, not the chord
 // ---------------------------------------------------------------------------
 
-// Runaway guard for the drive loops below. Both legs complete in well under this
-// (roughly 8k iterations), so it only bounds a regression that never reports
-// completion. 50000 iterations is 125 s of simulated time at 400 Hz.
+// Runaway guard for every drive loop below. All of them complete in well under this: the
+// straight and arc legs in roughly 8k iterations, the longest circle (3.5 turns) in roughly
+// 20k, so it only bounds a regression that never reports completion. 50000 iterations is
+// 125 s of simulated time at 400 Hz.
 static const uint32_t MAX_DRIVE_ITERS = 50000;
 
 // drive a prepared leg to completion, returning the peak horizontal and vertical target speed
@@ -342,6 +343,171 @@ TEST(SCurveTrack, arc_velocity_matches_position_derivative)
     // finite difference matches the reported velocity to O(dt); a large gap means the reported
     // velocity is not tangent to the path actually flown
     EXPECT_LT(max_err, 0.05f);
+}
+
+// ---------------------------------------------------------------------------
+// calculate_circle_track: full-circle / multi-turn arc geometry
+// ---------------------------------------------------------------------------
+
+// result of driving one circle leg to completion, sampling the target path
+struct CircleResult {
+    float max_radius_err;   // largest deviation of the target from radius R
+    float peak_speed;       // largest target speed magnitude
+    Vector3p final_pos;     // target position at completion
+    float first_east;       // east position ~1 s after start (direction check)
+    bool finished;          // leg reported completion
+};
+
+// build a circle leg and advance it to completion, exactly as AC_WPNav drives a leg
+static CircleResult run_circle(const Vector3p &origin, const Vector2f &center,
+                               float total_angle_rad, float climb_d_m,
+                               float speed_xy, float accel_c)
+{
+    SCurve prev, leg, next;
+    prev.init();
+    next.init();
+    leg.calculate_circle_track(origin, center, total_angle_rad, climb_d_m,
+                               speed_xy, 3.0f, 2.0f,   // speed xy, up, down
+                               2.0f, 2.0f, accel_c,    // accel xy, z, corner
+                               60.0f, 10.0f);          // snap, jerk
+
+    const float R = (center - origin.xy().tofloat()).length();
+    const float dt = 0.0025f;
+
+    CircleResult r {};
+    Vector3p pos;
+    Vector3f vel, accel;
+    bool done = false;
+    for (uint32_t i = 0; i < MAX_DRIVE_ITERS && !done; i++) {
+        // target_pos must be reset to the leg origin before each advance (see AC_WPNav)
+        pos = origin;
+        vel.zero();
+        accel.zero();
+        done = leg.advance_target_along_track(prev, next, 2.0f, accel_c, false, dt, pos, vel, accel);
+        r.max_radius_err = MAX(r.max_radius_err, fabsf((pos.xy().tofloat() - center).length() - R));
+        r.peak_speed = MAX(r.peak_speed, vel.length());
+        if (i == 400) {
+            r.first_east = pos.y;
+        }
+    }
+    r.final_pos = pos;
+    r.finished = done;
+    return r;
+}
+
+TEST(SCurveCircle, geometry)
+{
+    const Vector3p origin{10, 0, -50};   // 10 m north of center, 50 m up
+    const Vector2f center{0, 0};
+    const float R = 10.0f;
+    const float accel_c = 2.0f;
+    // horizontal speed is clamped so centripetal accel v^2/R stays within accel_c
+    const float vmax_expect = MIN(5.0f, safe_sqrt(accel_c * R));
+
+    struct Case { const char *name; float turns; float climb; };
+    const Case cases[] = {
+        {"full_cw",    1.0f,   0.0f},
+        {"half_cw",    0.5f,   0.0f},
+        {"multi_cw",   3.5f,   0.0f},
+        {"climb_cw",   2.0f,  -5.0f},
+        {"full_ccw",  -1.0f,   0.0f},
+        {"multi_ccw", -2.5f,   0.0f},
+    };
+
+    for (const auto &c : cases) {
+        const float angle = c.turns * M_2PI;
+        const CircleResult r = run_circle(origin, center, angle, c.climb, 5.0f, accel_c);
+
+        EXPECT_TRUE(r.finished) << c.name;
+
+        // target never leaves the circle
+        EXPECT_LT(r.max_radius_err, 0.05f) << "radius drift: " << c.name
+            << " err=" << r.max_radius_err;
+
+        // never exceeds the clamped speed (verifies the centripetal limit)
+        EXPECT_LE(r.peak_speed, vmax_expect + 0.05f) << "overspeed: " << c.name
+            << " peak=" << r.peak_speed;
+
+        // reaches the commanded net climb
+        EXPECT_NEAR((float)r.final_pos.z, (float)origin.z + c.climb, 0.10f) << "climb: " << c.name;
+
+        // NE endpoint matches the swept angle applied to the entry offset
+        Vector2f rel = origin.xy().tofloat() - center;
+        rel.rotate(angle);
+        const Vector2f end_expect = center + rel;
+        EXPECT_NEAR((float)r.final_pos.x, end_expect.x, 0.15f) << "end north: " << c.name;
+        EXPECT_NEAR((float)r.final_pos.y, end_expect.y, 0.15f) << "end east: " << c.name;
+
+        // direction: positive angle sweeps toward +east, negative toward -east
+        if (angle > 0) {
+            EXPECT_GT(r.first_east, 0.0f) << "expected CW: " << c.name;
+        } else {
+            EXPECT_LT(r.first_east, 0.0f) << "expected CCW: " << c.name;
+        }
+    }
+}
+
+// Regression test: AC_WPNav's corner-blending mechanism used to corrupt the position target of
+// the leg immediately following a fractional-turn circle. This replicates exactly what
+// AC_WPNav does when a plain WP leg follows a circle leg: the finished circle is preserved as
+// the new leg's _scurve_prev_leg for corner blending (see AC_WPNav::set_wp_destination_NED_m),
+// and advance_target_along_track() unconditionally calls prev_leg.move_to_pos_vel_accel() every
+// tick, which subtracts get_track() to cancel a finished leg's contribution to zero.
+TEST(SCurveCircle, prev_leg_handoff)
+{
+    const Vector3p O{10, 0, -50};
+    const Vector2f center{0, 0};
+    const float turns = 0.5f;          // fractional turns -> destination != origin
+
+    SCurve circle;
+    circle.calculate_circle_track(O, center, turns * M_2PI, 0.0f,
+                                  5.0f, 3.0f, 2.0f,
+                                  2.0f, 2.0f, 2.0f,
+                                  60.0f, 10.0f);
+
+    // drive the circle leg to completion (mirrors run_circle() above)
+    {
+        SCurve prev, next;
+        prev.init();
+        next.init();
+        Vector3p pos;
+        Vector3f vel, accel;
+        bool done = false;
+        for (uint32_t i = 0; i < MAX_DRIVE_ITERS && !done; i++) {
+            pos = O;
+            vel.zero();
+            accel.zero();
+            done = circle.advance_target_along_track(prev, next, 2.0f, 2.0f, false, 0.0025f, pos, vel, accel);
+        }
+        ASSERT_TRUE(done);
+    }
+
+    // the orbit destination, computed independently here from the endpoint rotation so the
+    // test does not trust seg_delta
+    Vector2f origin_to_end_ne = O.xy().tofloat() - center;
+    origin_to_end_ne.rotate(turns * M_2PI);
+    const Vector3p D(center.x + origin_to_end_ne.x, center.y + origin_to_end_ne.y, O.z);
+
+    // new leg: origin = D (AC_WPNav sets _origin_ned_m = _destination_ned_m), a straight hop north
+    SCurve new_leg;
+    new_leg.calculate_track(D, D + Vector3p(20, 0, 0), 0.0f,
+                            5.0f, 3.0f, 2.0f,
+                            2.0f, 2.0f, 2.0f,
+                            60.0f, 10.0f);
+
+    // AC_WPNav preserves the finished circle as _scurve_prev_leg for the new leg
+    SCurve scurve_next_leg;
+    scurve_next_leg.init();
+
+    Vector3p target_pos = D;
+    Vector3f target_vel, target_accel;
+    // one tick into a 20 m leg definitely isn't finished; this also exercises the return value
+    EXPECT_FALSE(new_leg.advance_target_along_track(circle, scurve_next_leg, 2.0f, 2.0f, false, 0.0025f, target_pos, target_vel, target_accel));
+
+    // the first tick of the new leg must start at (essentially) its own origin D
+    EXPECT_NEAR((float)target_pos.x, (float)D.x, 0.05f);
+    EXPECT_NEAR((float)target_pos.y, (float)D.y, 0.05f);
+    EXPECT_NEAR((float)target_pos.z, (float)D.z, 0.05f);
 }
 
 AP_GTEST_MAIN()

--- a/libraries/AP_Math/tests/test_scurve.cpp
+++ b/libraries/AP_Math/tests/test_scurve.cpp
@@ -254,8 +254,9 @@ TEST(SCurveCalcPath, constraints)
 // 125 s of simulated time at 400 Hz.
 static const uint32_t MAX_DRIVE_ITERS = 50000;
 
-// drive a prepared leg to completion, returning the peak horizontal and vertical target speed
-struct LegPeak { float speed_xy; float speed_z; bool finished; };
+// drive a prepared leg to completion, returning the peak horizontal and vertical
+// target speed and the final target position
+struct LegPeak { float speed_xy; float speed_z; Vector3p final_pos; bool finished; };
 static LegPeak drive_leg(SCurve &leg, const Vector3p &origin)
 {
     SCurve prev, next;
@@ -274,8 +275,33 @@ static LegPeak drive_leg(SCurve &leg, const Vector3p &origin)
         r.speed_xy = MAX(r.speed_xy, vel.xy().length());
         r.speed_z = MAX(r.speed_z, fabsf(vel.z));
     }
+    r.final_pos = pos;
     r.finished = done;
     return r;
+}
+
+// A level straight leg reaches the full horizontal speed, has no vertical motion, and
+// finishes at the destination. Covers the set_straight_geometry / generate_path path
+// for a non-arc segment.
+TEST(SCurveTrack, straight_leg)
+{
+    const Vector3p origin{0, 0, -50};
+    const Vector3p dest{50, 0, -50};    // 50 m north, level
+    const float speed_xy = 5.0f;
+
+    SCurve leg;
+    leg.calculate_track(origin, dest, 0.0f,   // arc angle 0 -> straight segment
+                        speed_xy, 3.0f, 2.0f,
+                        2.0f, 2.0f, 2.0f,
+                        60.0f, 10.0f);
+
+    const LegPeak p = drive_leg(leg, origin);
+    EXPECT_TRUE(p.finished);
+    EXPECT_NEAR(p.speed_xy, speed_xy, 0.05f);   // reaches the horizontal speed
+    EXPECT_LE(p.speed_z, 0.02f);                // stays level
+    EXPECT_NEAR((float)p.final_pos.x, 50.0f, 0.05f);
+    EXPECT_NEAR((float)p.final_pos.y, 0.0f, 0.05f);
+    EXPECT_NEAR((float)p.final_pos.z, -50.0f, 0.05f);
 }
 
 // A climbing arc must take its speed limit from the path it actually flies (the arc
@@ -452,7 +478,8 @@ TEST(SCurveCircle, geometry)
 // AC_WPNav does when a plain WP leg follows a circle leg: the finished circle is preserved as
 // the new leg's _scurve_prev_leg for corner blending (see AC_WPNav::set_wp_destination_NED_m),
 // and advance_target_along_track() unconditionally calls prev_leg.move_to_pos_vel_accel() every
-// tick, which subtracts get_track() to cancel a finished leg's contribution to zero.
+// tick, which subtracts get_origin_to_destination() to cancel a finished leg's contribution
+// to zero.
 TEST(SCurveCircle, prev_leg_handoff)
 {
     const Vector3p O{10, 0, -50};
@@ -482,8 +509,9 @@ TEST(SCurveCircle, prev_leg_handoff)
         ASSERT_TRUE(done);
     }
 
-    // the orbit destination, computed independently here from the endpoint rotation so the
-    // test does not trust seg_delta
+    // the orbit destination (AC_WPNav derives this from the leg's get_origin_to_destination();
+    // computed independently here from the endpoint rotation so the test does not trust
+    // seg_delta)
     Vector2f origin_to_end_ne = O.xy().tofloat() - center;
     origin_to_end_ne.rotate(turns * M_2PI);
     const Vector3p D(center.x + origin_to_end_ne.x, center.y + origin_to_end_ne.y, O.z);

--- a/libraries/AP_Math/tests/test_scurve.cpp
+++ b/libraries/AP_Math/tests/test_scurve.cpp
@@ -538,5 +538,56 @@ TEST(SCurveCircle, prev_leg_handoff)
     EXPECT_NEAR((float)target_pos.z, (float)D.z, 0.05f);
 }
 
+// A circular orbit's speed comes from the commanded turn rate, not from the waypoint speed, so a
+// later speed update must be able to slow the orbit but never raise it. Regression: set_speed_max()
+// re-derived the leg speed purely from the limits handed to it, which discarded the orbit speed and
+// let an unrelated WPNAV_SPEED/WPNAV_SPEED_UP/WPNAV_SPEED_DN change accelerate the circle.
+TEST(SCurveCircle, speed_update_cannot_raise_orbit_speed)
+{
+    const Vector3p origin{10, 0, -50};
+    const Vector2f center{0, 0};
+    const float orbit_speed = 1.5f;     // well below both the waypoint speed and the centripetal cap
+    const float accel_c = 2.0f;         // centripetal cap at radius 10 is sqrt(2 * 10) = 4.47 m/s
+
+    // a speed increase must not be applied to the orbit
+    {
+        SCurve leg;
+        leg.calculate_circle_track(origin, center, M_2PI, 0.0f,
+                                   orbit_speed, 3.0f, 2.0f,
+                                   2.0f, 2.0f, accel_c,
+                                   60.0f, 10.0f);
+        leg.set_speed_max(5.0f, 3.0f, 2.0f);
+        const LegPeak p = drive_leg(leg, origin);
+        EXPECT_TRUE(p.finished);
+        EXPECT_NEAR(p.speed_xy, orbit_speed, 0.05f);
+    }
+
+    // a speed reduction must still be applied
+    {
+        SCurve leg;
+        leg.calculate_circle_track(origin, center, M_2PI, 0.0f,
+                                   orbit_speed, 3.0f, 2.0f,
+                                   2.0f, 2.0f, accel_c,
+                                   60.0f, 10.0f);
+        leg.set_speed_max(1.0f, 3.0f, 2.0f);
+        const LegPeak p = drive_leg(leg, origin);
+        EXPECT_TRUE(p.finished);
+        EXPECT_NEAR(p.speed_xy, 1.0f, 0.05f);
+    }
+
+    // contrast: a straight leg carries no intrinsic speed limit, so a speed increase still applies
+    {
+        SCurve leg;
+        leg.calculate_track(origin, origin + Vector3p(50, 0, 0), 0.0f,
+                            orbit_speed, 3.0f, 2.0f,
+                            2.0f, 2.0f, 2.0f,
+                            60.0f, 10.0f);
+        leg.set_speed_max(3.0f, 3.0f, 2.0f);
+        const LegPeak p = drive_leg(leg, origin);
+        EXPECT_TRUE(p.finished);
+        EXPECT_NEAR(p.speed_xy, 3.0f, 0.05f);
+    }
+}
+
 AP_GTEST_MAIN()
 int hal = 0; //weirdly the build will fail without this


### PR DESCRIPTION
### Summary

Flies Copter's CIRCLE mission item (MAV_CMD_NAV_LOITER_TURNS) as a single jerk-limited S-curve orbit leg on the waypoint engine, instead of the separate AC_Circle controller, so a circle accelerates, cruises and decelerates with the same S-curve profile as straight, arc and spline waypoints.

### Classification & Testing (check all that apply and add your own)

- [ ] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

SITL: mission_NAV_LOITER_TURNS and mission_NAV_LOITER_TURNS_off_center pass (fly-to-edge and start-on-edge entry). Standalone Circle mode is unchanged and regression-clean: ModeCircle, SuperSimpleCircle, CircleSpeed. Straight/arc/spline waypoint regression also clean: CopterMission, WPArcs, SplineLastWaypoint. New AP_Math gtest SCurveCircle.geometry checks the orbit holds radius, respects the centripetal speed limit, closes, and sweeps the correct direction across full/fractional/multi-turn/climbing/CW/CCW cases.

### Description

Replaces AC_Circle for the Auto CIRCLE mission item with a single S-curve waypoint leg, in three layers:

- AP_Math (SCurve): calculate_circle_track() builds one closed arc leg about a center for a signed number of turns (may exceed 2*pi) with an optional net climb, reusing the existing arc projection (a circle is just an arc that sweeps >= 360 deg). Also factors the shared setup into set_arc_geometry/set_straight_geometry/generate_path/finalise_path, used by both the chord-derived (calculate_track) and center-derived (calculate_circle_track) paths.

- AC_WPNav: set_circle_destination_NED_m()/_loc() set up the orbit leg (origin taken as the current destination, which lies on the circle) and expose the orbit center for yaw.

- ArduCopter (ModeAuto/AutoYaw): after the existing move-to-edge step, the orbit runs through wp_run() and verify_circle() completes on reached_wp_destination(). Yaw faces the circle center via an AutoYaw::Mode::CIRCLE fallback that reads the wp_nav orbit center, honoring CIRCLE_OPTIONS FACE_DIRECTION_OF_TRAVEL. AC_Circle and the standalone CIRCLE flight mode are unchanged; Auto still uses circle_nav only as the move-to-edge geometry/parameter store. move_vehicle_on_ekf_reset() now groups CIRCLE with WP (MoveVehicle) since the orbit is a wp_nav leg.

Builds on the S-curve climbing-arc fixes (submitted separately): arc kinematic limits from arc length not chord, the velocity/acceleration projection fix, and removal of the unreachable arc degeneracy guard.
