### PR TITLE
autotest: close dataflash log filehandles

### DIFF
--- a/Tools/Replay/check_replay.py
+++ b/Tools/Replay/check_replay.py
@@ -8,6 +8,7 @@ check that replay produced identical results
 
 def check_log(logfile, progress=print, ekf2_only=False, ekf3_only=False, verbose=False, accuracy=0.0, ignores=set()):
     '''check replay log for matching output'''
+    from contextlib import closing
     from pymavlink import mavutil
     progress("Processing log %s" % logfile)
     failure = 0
@@ -16,8 +17,6 @@ def check_log(logfile, progress=print, ekf2_only=False, ekf3_only=False, verbose
     base_count = 0
     counts = {}
     base_counts = {}
-
-    mlog = mavutil.mavlink_connection(logfile)
 
     ek2_list = ['NKF1','NKF2','NKF3','NKF4','NKF5','NKF0','NKQ', 'NKY0', 'NKY1']
     ek3_list = ['XKF1','XKF2','XKF3','XKF4','XKF5','XKFA','XKF0','XKFS','XKQ','XKFD','XKV1','XKV2','XKY0','XKY1']
@@ -33,46 +32,47 @@ def check_log(logfile, progress=print, ekf2_only=False, ekf3_only=False, verbose
     for m in mlist:
         base[m] = {}
 
-    while True:
-        m = mlog.recv_match(type=mlist)
-        if m is None:
-            break
-        if not hasattr(m,'C'):
-            continue
-        mtype = m.get_type()
-        if mtype not in counts:
-            counts[mtype] = 0
-            base_counts[mtype] = 0
-        core = m.C
-        if core < 100:
-            base[mtype][core] = m
-            base_count += 1
-            base_counts[mtype] += 1
-            continue
-        mb = base[mtype][core-100]
-        count += 1
-        counts[mtype] += 1
-        mismatch = False
-        for f in m._fieldnames:
-            if f == 'C':
+    with closing(mavutil.mavlink_connection(logfile)) as mlog:
+        while True:
+            m = mlog.recv_match(type=mlist)
+            if m is None:
+                break
+            if not hasattr(m,'C'):
                 continue
-            if "%s.%s" % (mtype, f) in ignores:
+            mtype = m.get_type()
+            if mtype not in counts:
+                counts[mtype] = 0
+                base_counts[mtype] = 0
+            core = m.C
+            if core < 100:
+                base[mtype][core] = m
+                base_count += 1
+                base_counts[mtype] += 1
                 continue
-            v1 = getattr(m,f)
-            v2 = getattr(mb,f)
-            ok = v1 == v2
-            if not ok and accuracy > 0:
-                avg = (v1+v2)*0.5
-                margin = accuracy*0.01*avg
-                if abs(v1-v2) <= abs(margin):
-                    ok = True
-            if not ok:
-                mismatch = True
-                errors += 1
-                progress("Mismatch in field %s.%s: %s %s" % (mtype, f, str(v1), str(v2)))
-        if mismatch:
-            progress(mb)
-            progress(m)
+            mb = base[mtype][core-100]
+            count += 1
+            counts[mtype] += 1
+            mismatch = False
+            for f in m._fieldnames:
+                if f == 'C':
+                    continue
+                if "%s.%s" % (mtype, f) in ignores:
+                    continue
+                v1 = getattr(m,f)
+                v2 = getattr(mb,f)
+                ok = v1 == v2
+                if not ok and accuracy > 0:
+                    avg = (v1+v2)*0.5
+                    margin = accuracy*0.01*avg
+                    if abs(v1-v2) <= abs(margin):
+                        ok = True
+                if not ok:
+                    mismatch = True
+                    errors += 1
+                    progress("Mismatch in field %s.%s: %s %s" % (mtype, f, str(v1), str(v2)))
+            if mismatch:
+                progress(mb)
+                progress(m)
     progress("Processed %u/%u messages, %u errors" % (count, base_count, errors))
     if verbose:
         for mtype in counts.keys():

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -2192,6 +2192,9 @@ class TestSuite(abc.ABC):
         self.max_set_rc_timeout = 0
         self.last_wp_load = 0
         self.forced_post_test_sitl_reboots = 0
+        # DFReaders handed out by dfreader_for_path(); closed after each
+        # test by close_dfreaders()
+        self.dfreaders = []
         self.run_tests_called = False
         self._show_test_timings = _show_test_timings
         self.test_timings = dict()
@@ -9724,6 +9727,9 @@ Also, ignores heartbeats not from our target system'''
                 if h not in start_message_hooks:
                     self.message_hooks.remove(h)
             hooks_removed = True
+        # the test is done with any log it opened; release the
+        # filehandles rather than holding them for the life of the run:
+        self.close_dfreaders()
         self.test_timings[desc] = time.time() - start_time
         reset_needed = any(ctx.sitl_commandline_customised for ctx in self.contexts[old_contexts_length:])
 
@@ -13381,8 +13387,20 @@ switch value'''
         return latest
 
     def dfreader_for_path(self, path):
-        return DFReader.DFReader_binary(path,
-                                        zero_time_base=True)
+        '''return a DFReader for path.  The reader holds an open filehandle
+        (and an mmap) on the log until it is closed, so stash it for
+        close_dfreaders() to release at the end of the test rather than
+        leaking it for the life of the process.'''
+        ret = DFReader.DFReader_binary(path,
+                                       zero_time_base=True)
+        self.dfreaders.append(ret)
+        return ret
+
+    def close_dfreaders(self):
+        '''close all readers handed out by dfreader_for_path()'''
+        for dfreader in self.dfreaders:
+            dfreader.close()
+        self.dfreaders = []
 
     def assert_log_dsf_no_drops(self, path):
         """Assert that DSF.Dp (write-buffer drop count) is zero in the given log file"""


### PR DESCRIPTION
### Summary

Close the `pymavlink` dataflash log readers leaked by the autotest suite and the Replay log checker. Fixes #32533.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Tested manually, description below

`DFReader` parses real dataflash logs. I verified with a Claude script that
counts open descriptors around each call path rather than with a full SITL run. A control case reproduces the pre-fix leak so a pass can't be a false negative.

```
CONTROL pre-fix pattern (should leak)                before=7 after=17 delta=+10  OK
FIX dfreader_for_path + close_dfreaders              before=17 after=17 delta=+0  OK
FIX check_replay.check_log                           before=17 after=17 delta=+0  OK
```

### Description

#### What

Two sites hand out a `pymavlink` log reader and never close it. Both are on the
path that produced the stray `ArduPlane-Replay-*.BIN` handles in the report.

- `Tools/Replay/check_replay.py`, `check_log()` — opened the log with
  `mavutil.mavlink_connection()` and dropped it. Now wrapped in
  `contextlib.closing`.
- `Tools/autotest/vehicle_test_suite.py`, `dfreader_for_path()` — returned a
  `DFReader_binary` that nothing ever closed. Readers are now registered as
  they are handed out and released by a new `close_dfreaders()` called from
  `run_one_test_attempt()` once the test body has finished.

#### Why

`DFReader_binary.__init__` does `open(filename, 'rb')` and then `mmap`s that
descriptor, so a reader pins a filehandle until `close()` is called. It has a
`close()` method but no `__enter__`, so it cannot be used as a context manager
without an upstream pymavlink change — hence `contextlib.closing` rather than a
plain `with`.

`dfreader_for_path()` and `dfreader_for_current_onboard_log()` have about 43
call sites across `vehicle_test_suite.py`, `arduplane.py`, `arducopter.py`,
`quadplane.py`, `ardusub.py` and `antennatracker.py`. Closing at the single
point where the readers are created and released, rather than editing every
call site, keeps the diff small and means new tests get the cleanup for free.
The release point is after the test body's `try`/`except`, so it also runs when
a test fails, and it happens before `check_logs()` moves the binary logs aside.

Nothing holds a reader across tests, so end-of-test is a safe point to close.

#### Relationship to #32559

This PR only touches the reader lifetime. In `vehicle_test_suite.py` the
closest hunk in the two PRs are 13 lines apart, so they should merge in either
order.
