### PR TITLE
Camera: Add 3D trigger distance

### DIFF
--- a/libraries/AP_Camera/AP_Camera_Backend.cpp
+++ b/libraries/AP_Camera/AP_Camera_Backend.cpp
@@ -94,15 +94,24 @@ void AP_Camera_Backend::update()
         last_location = current_loc;
         return;
     }
-    if (last_location.lat == current_loc.lat && last_location.lng == current_loc.lng) {
-        // we haven't moved - this can happen as update() may
-        // be called without a new GPS fix
+    // check if vehicle has moved
+    if (last_location.lat == current_loc.lat &&
+        last_location.lng == current_loc.lng &&
+        (!_params.trigg_dist_3d || last_location.alt == current_loc.alt)) {
+        // we haven't moved
+        // this can happen as update() may be called without a new GPS fix
         return;
     }
-
     // check vehicle has moved at least trigg_dist meters
-    if (current_loc.get_distance(last_location) < _params.trigg_dist) {
-        return;
+    if (_params.trigg_dist_3d > 0) {
+        const Vector3f ned = current_loc.get_distance_NED_alt_frame(last_location);
+        if (norm(ned.x, ned.y, ned.z) < _params.trigg_dist) {
+            return;
+        }
+    } else {
+        if (current_loc.get_distance(last_location) < _params.trigg_dist) {
+            return;
+        }
     }
 
     take_picture();

--- a/libraries/AP_Camera/AP_Camera_Params.cpp
+++ b/libraries/AP_Camera/AP_Camera_Params.cpp
@@ -44,6 +44,13 @@ const AP_Param::GroupInfo AP_Camera_Params::var_info[] = {
     // @Range: 0 1000
     AP_GROUPINFO("_TRIGG_DIST", 5, AP_Camera_Params, trigg_dist, 0),
 
+    // @Param: _TRIGG_3D
+    // @DisplayName: Camera trigger distance 3D
+    // @Description: Enable 3D distance calculation for camera trigger distance. When disabled the camera triggers based on the horizontal distance between the current and last trigger location. When enabled the camera triggers based on the 3D distance including North, East and vertical/Down displacement.
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Standard
+    AP_GROUPINFO("_TRIGG_3D", 14, AP_Camera_Params, trigg_dist_3d, 0),
+
     // @Param: _RELAY_ON
     // @DisplayName: Camera relay ON value
     // @Description: This sets whether the relay goes high or low when it triggers. Note that you should also set RELAY_DEFAULT appropriately for your camera

--- a/libraries/AP_Camera/AP_Camera_Params.h
+++ b/libraries/AP_Camera/AP_Camera_Params.h
@@ -19,6 +19,7 @@ public:
     AP_Int16 servo_on_pwm;      // PWM value to move servo to when shutter is activated
     AP_Int16 servo_off_pwm;     // PWM value to move servo to when shutter is deactivated
     AP_Float trigg_dist;        // distance between trigger points (meters)
+    AP_Int8 trigg_dist_3d;      // enable 3D distance calculation for trigg_dist
     AP_Int8 relay_on;           // relay value to trigger camera
     AP_Float interval_min;      // minimum time (in seconds) between shots required by camera
     AP_Int8 options;            // whether to start recording when armed and stop when disarmed


### PR DESCRIPTION
## Summary

Add an option to calculate camera trigger distance using 3D position instead of only horizontal distance.

The existing camera trigger distance calculation uses latitude/longitude distance, which only considers horizontal movement. As a result, vertical-only movement does not contribute to the camera trigger distance.

## Changes

- Add `CAM1_TRIGG_DIST_3D` parameter to enable 3D distance calculation.
- Preserve the existing 2D distance calculation when disabled.
- Calculate 3D distance using NED position when enabled.
- Consider altitude changes when checking whether the vehicle has moved.

The 3D distance is calculated as:

`distance = sqrt(North² + East² + Down²)`

## Behavior

When `CAM1_TRIGG_DIST_3D = 0`, existing 2D behavior is retained.

When `CAM1_TRIGG_DIST_3D = 1`, horizontal and vertical movement contribute to the trigger distance.

This allows camera triggering to work correctly during missions containing vertical movement.

## Testing

Tested in SITL with Mission Planner for:

- 2D horizontal distance triggering
- 3D distance triggering
- Vertical-only movement
- Horizontal-only movement
- Combined horizontal and vertical movement
- Movement below and above the configured trigger distance
- 3D triggering disabled to confirm existing behavior is preserved

Fixes #33546