### PR TITLE
Plane: Quadplane: add a loiter stage in VTOL land approach with a loiter time of `Q_RTL_PAUSE_TIME`

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -572,6 +572,13 @@ const AP_Param::GroupInfo QuadPlane::var_info2[] = {
     // @Bitmask: 1: Disable thrust loss detection in transtions and fixed wing modes. Thrust loss detection will only run in VTOL modes.
     AP_GROUPINFO("THRST_LOSS_OPT", 42, QuadPlane, thrust_loss.options, 0),
 
+    // @Param: RTL_PAUSE_TIME
+    // @DisplayName: Q RTL pause time.
+    // @Description: Time (in seconds) to pause in a VTOL loiter above landing point before starting final descent. Zero disables. This applies in VTOL landing in auto mode and QRTL mode.
+    // @Units: s
+    // @Range: 0 10
+    AP_GROUPINFO("RTL_PAUSE_TIME", 43, QuadPlane, qrtl_pause_time, 0),
+
     AP_GROUPEND
 };
 
@@ -2719,6 +2726,7 @@ void QuadPlane::vtol_position_controller(void)
     }
 
     case QPOS_POSITION2:
+    case QPOS_PAUSE:
     case QPOS_LAND_ABORT:
     case QPOS_LAND_DESCEND: {
         setup_target_position();
@@ -2866,6 +2874,12 @@ void QuadPlane::vtol_position_controller(void)
         } else {
             set_climb_rate_ms(0);
         }
+        break;
+    }
+
+    case QPOS_PAUSE: {
+        // Hold zero climb rate for the duration of the pause
+        set_climb_rate_ms(0);
         break;
     }
 
@@ -3613,6 +3627,9 @@ bool QuadPlane::verify_vtol_land(void)
         return true;
     }
 
+    // True if land descent should be started
+    bool start_descend = false;
+
     if (poscontrol.get_state() == QPOS_POSITION2) {
         // see if we should move onto the descend stage of landing
         const float descend_dist_threshold_m = 2.0;
@@ -3633,24 +3650,40 @@ bool QuadPlane::verify_vtol_land(void)
         
         if (reached_position &&
             (vel_ned_ms.xy() - approach_vel_ne_ms).length() < descend_speed_threshold_ms) {
-            poscontrol.set_state(QPOS_LAND_DESCEND);
-            poscontrol.pilot_correction_done = false;
             pos_control->set_lean_angle_max_cd(0);
             poscontrol.correction_ne_m.zero();
 #if AP_LANDINGGEAR_ENABLED
             plane.g2.landing_gear.deploy_for_landing();
 #endif
-            last_land_final_agl_m = plane.relative_ground_altitude(RangeFinderUse::TAKEOFF_LANDING);
-            gcs().send_text(MAV_SEVERITY_INFO,"Land descend started");
-            if (plane.control_mode == &plane.mode_auto) {
-                // set height to mission height, so we can use the mission
-                // WP height for triggering land final if no rangefinder
-                // available
-                plane.set_next_WP(plane.mission.get_current_nav_cmd().content.location);
+            // Start loitering if loiter time is set else go directly to descent
+            if (is_positive(qrtl_pause_time.get())) {
+                poscontrol.set_state(QPOS_PAUSE);
+                gcs().send_text(MAV_SEVERITY_INFO,"Land loiter started");
             } else {
-                plane.set_next_WP(plane.next_WP_loc);
-                plane.next_WP_loc.copy_alt_from(ahrs.get_home());
+                start_descend = true;
             }
+        }
+    }
+
+    // Check if loiter time has passed
+    if ((poscontrol.get_state() == QPOS_PAUSE) &&
+        (poscontrol.time_since_state_start_ms() > (qrtl_pause_time.get() * 1000)))  {
+        start_descend = true;
+    }
+
+    // Move onto land descend state
+    if (start_descend) {
+        poscontrol.set_state(QPOS_LAND_DESCEND);
+        last_land_final_agl_m = plane.relative_ground_altitude(RangeFinderUse::TAKEOFF_LANDING);
+        gcs().send_text(MAV_SEVERITY_INFO,"Land descend started");
+        if (plane.control_mode == &plane.mode_auto) {
+            // set height to mission height, so we can use the mission
+            // WP height for triggering land final if no rangefinder
+            // available
+            plane.set_next_WP(plane.mission.get_current_nav_cmd().content.location);
+        } else {
+            plane.set_next_WP(plane.next_WP_loc);
+            plane.next_WP_loc.copy_alt_from(ahrs.get_home());
         }
     }
 
@@ -4226,16 +4259,24 @@ void QuadPlane::update_throttle_mix(void)
 bool QuadPlane::in_vtol_land_approach(void) const
 {
     if (plane.control_mode == &plane.mode_qrtl &&
-        poscontrol.get_state() <= QPOS_POSITION2) {
+        poscontrol.get_state() <= QPOS_PAUSE) {
         return true;
     }
-    if (in_vtol_auto()) {
-        if (is_vtol_land(plane.mission.get_current_nav_cmd().id) &&
-            (poscontrol.get_state() == QPOS_APPROACH ||
-             poscontrol.get_state() == QPOS_AIRBRAKE ||
-             poscontrol.get_state() == QPOS_POSITION1 ||
-             poscontrol.get_state() == QPOS_POSITION2)) {
-            return true;
+    if (in_vtol_auto() && is_vtol_land(plane.mission.get_current_nav_cmd().id)) {
+        switch (poscontrol.get_state()) {
+            case QPOS_APPROACH:
+            case QPOS_AIRBRAKE:
+            case QPOS_POSITION1:
+            case QPOS_POSITION2:
+            case QPOS_PAUSE:
+                return true;
+
+            case QPOS_NONE:
+            case QPOS_LAND_DESCEND:
+            case QPOS_LAND_ABORT:
+            case QPOS_LAND_FINAL:
+            case QPOS_LAND_COMPLETE:
+                break;
         }
     }
     return false;

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3624,10 +3624,10 @@ bool QuadPlane::verify_vtol_land(void)
 #if AP_LANDINGGEAR_ENABLED
             plane.g2.landing_gear.deploy_for_landing();
 #endif
-            // Start loitering if loiter time is set else go directly to descent
+            // Start loitering if pause time is set else go directly to descent
             if (is_positive(qrtl_pause_time.get())) {
                 poscontrol.set_state(QPOS_PAUSE);
-                gcs().send_text(MAV_SEVERITY_INFO,"Land loiter started");
+                gcs().send_text(MAV_SEVERITY_INFO,"Land pause started");
             } else {
                 start_descend = true;
             }
@@ -3636,7 +3636,7 @@ bool QuadPlane::verify_vtol_land(void)
 
     // Check if loiter time has passed
     if ((poscontrol.get_state() == QPOS_PAUSE) &&
-        (poscontrol.time_since_state_start_ms() > (qrtl_pause_time.get() * 1000)))  {
+        (poscontrol.time_since_state_start_ms() > (qrtl_pause_time.get() * 1000))) {
         start_descend = true;
     }
 

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2244,29 +2244,46 @@ void QuadPlane::PosControlState::set_state(enum position_control_state s)
         auto &qp = plane.quadplane;
         pilot_correction_done = false;
         // handle resets needed for when the state changes
-        if (s == QPOS_POSITION1) {
+        switch (s) {
+        case QPOS_POSITION1: {
             reached_wp_speed = false;
             // never do a rate reset, if attitude control is not active it will be automatically reset before running, see: last_att_control_ms
             // if it is active then the rate control should not be reset at all
             qp.attitude_control->reset_yaw_target_and_rate(false);
             pos1_speed_limit_ms = plane.ahrs.groundspeed_vector().length();
             done_accel_init = false;
-        } else if (s == QPOS_AIRBRAKE) {
+            break;
+        }
+        case QPOS_AIRBRAKE: {
             // start with zero integrator on vertical throttle
             qp.pos_control->D_get_accel_pid().set_integrator(0);
-        } else if (s == QPOS_LAND_DESCEND) {
+            break;
+        }
+        case QPOS_PAUSE:
+        case QPOS_LAND_DESCEND: {
             // reset throttle descent control
             qp.thr_ctrl_land = false;
             qp.land_descend_start_alt_m = plane.current_loc.alt*0.01;
             last_override_descent_ms = 0;
-        } else if (s == QPOS_LAND_ABORT) {
+            break;
+        }
+        case QPOS_LAND_ABORT: {
             // reset throttle descent control
             qp.thr_ctrl_land = false;
-        } else if (s == QPOS_LAND_FINAL) {
+            break;
+        }
+        case QPOS_LAND_FINAL: {
             // remember last pos reset to handle GPS glitch in LAND_FINAL
             ahrs_position_NE_reset_count = plane.ahrs.get_position_NE_reset_count();
             qp.landing_detect.land_start_ms = 0;
             qp.landing_detect.lower_limit_start_ms = 0;
+            break;
+        }
+        case QPOS_NONE:
+        case QPOS_APPROACH:
+        case QPOS_POSITION2:
+        case QPOS_LAND_COMPLETE:
+            break;
         }
         // double log to capture the state change
 #if HAL_LOGGING_ENABLED
@@ -4856,7 +4873,10 @@ bool QuadPlane::abort_landing(void)
         plane.in_auto_mission_id(MAV_CMD_NAV_PAYLOAD_PLACE) &&
         poscontrol.get_state() == QPOS_LAND_COMPLETE;
 
-    if (!payload_place_landed && !in_vtol_land_descent()) {
+    // Approach complete and paused before starting descent
+    const bool approach_pause = in_vtol_land_approach() && (poscontrol.get_state() == QPOS_PAUSE);
+
+    if (!payload_place_landed && !in_vtol_land_descent() && !approach_pause) {
         return false;
     }
     poscontrol.set_state(QuadPlane::QPOS_LAND_ABORT);

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -572,6 +572,13 @@ const AP_Param::GroupInfo QuadPlane::var_info2[] = {
     // @Bitmask: 1: Disable thrust loss detection in transtions and fixed wing modes. Thrust loss detection will only run in VTOL modes.
     AP_GROUPINFO("THRST_LOSS_OPT", 42, QuadPlane, thrust_loss.options, 0),
 
+    // @Param: RTL_PAUSE_TIME
+    // @DisplayName: Q RTL pause time.
+    // @Description: Time (in seconds) to pause in a VTOL loiter above landing point before starting final descent. Zero disables. This applies in VTOL landing in auto mode and QRTL mode.
+    // @Units: s
+    // @Range: 0 10
+    AP_GROUPINFO("RTL_PAUSE_TIME", 43, QuadPlane, qrtl_pause_time, 0),
+
     AP_GROUPEND
 };
 
@@ -2671,6 +2678,7 @@ void QuadPlane::vtol_position_controller(void)
     }
 
     case QPOS_POSITION2:
+    case QPOS_PAUSE:
     case QPOS_LAND_ABORT:
     case QPOS_LAND_DESCEND: {
         setup_target_position();
@@ -2818,6 +2826,12 @@ void QuadPlane::vtol_position_controller(void)
         } else {
             set_climb_rate_ms(0);
         }
+        break;
+    }
+
+    case QPOS_PAUSE: {
+        // Hold zero climb rate for the duration of the pause
+        set_climb_rate_ms(0);
         break;
     }
 
@@ -3565,6 +3579,9 @@ bool QuadPlane::verify_vtol_land(void)
         return true;
     }
 
+    // True if land descent should be started
+    bool start_descend = false;
+
     if (poscontrol.get_state() == QPOS_POSITION2) {
         // see if we should move onto the descend stage of landing
         const float descend_dist_threshold_m = 2.0;
@@ -3585,24 +3602,40 @@ bool QuadPlane::verify_vtol_land(void)
         
         if (reached_position &&
             (vel_ned_ms.xy() - approach_vel_ne_ms).length() < descend_speed_threshold_ms) {
-            poscontrol.set_state(QPOS_LAND_DESCEND);
-            poscontrol.pilot_correction_done = false;
             pos_control->set_lean_angle_max_cd(0);
             poscontrol.correction_ne_m.zero();
 #if AP_LANDINGGEAR_ENABLED
             plane.g2.landing_gear.deploy_for_landing();
 #endif
-            last_land_final_agl_m = plane.relative_ground_altitude(RangeFinderUse::TAKEOFF_LANDING);
-            gcs().send_text(MAV_SEVERITY_INFO,"Land descend started");
-            if (plane.control_mode == &plane.mode_auto) {
-                // set height to mission height, so we can use the mission
-                // WP height for triggering land final if no rangefinder
-                // available
-                plane.set_next_WP(plane.mission.get_current_nav_cmd().content.location);
+            // Start loitering if loiter time is set else go directly to descent
+            if (is_positive(qrtl_pause_time.get())) {
+                poscontrol.set_state(QPOS_PAUSE);
+                gcs().send_text(MAV_SEVERITY_INFO,"Land loiter started");
             } else {
-                plane.set_next_WP(plane.next_WP_loc);
-                plane.next_WP_loc.copy_alt_from(ahrs.get_home());
+                start_descend = true;
             }
+        }
+    }
+
+    // Check if loiter time has passed
+    if ((poscontrol.get_state() == QPOS_PAUSE) &&
+        (poscontrol.time_since_state_start_ms() > (qrtl_pause_time.get() * 1000)))  {
+        start_descend = true;
+    }
+
+    // Move onto land descend state
+    if (start_descend) {
+        poscontrol.set_state(QPOS_LAND_DESCEND);
+        last_land_final_agl_m = plane.relative_ground_altitude(RangeFinderUse::TAKEOFF_LANDING);
+        gcs().send_text(MAV_SEVERITY_INFO,"Land descend started");
+        if (plane.control_mode == &plane.mode_auto) {
+            // set height to mission height, so we can use the mission
+            // WP height for triggering land final if no rangefinder
+            // available
+            plane.set_next_WP(plane.mission.get_current_nav_cmd().content.location);
+        } else {
+            plane.set_next_WP(plane.next_WP_loc);
+            plane.next_WP_loc.copy_alt_from(ahrs.get_home());
         }
     }
 
@@ -4178,16 +4211,24 @@ void QuadPlane::update_throttle_mix(void)
 bool QuadPlane::in_vtol_land_approach(void) const
 {
     if (plane.control_mode == &plane.mode_qrtl &&
-        poscontrol.get_state() <= QPOS_POSITION2) {
+        poscontrol.get_state() <= QPOS_PAUSE) {
         return true;
     }
-    if (in_vtol_auto()) {
-        if (is_vtol_land(plane.mission.get_current_nav_cmd().id) &&
-            (poscontrol.get_state() == QPOS_APPROACH ||
-             poscontrol.get_state() == QPOS_AIRBRAKE ||
-             poscontrol.get_state() == QPOS_POSITION1 ||
-             poscontrol.get_state() == QPOS_POSITION2)) {
-            return true;
+    if (in_vtol_auto() && is_vtol_land(plane.mission.get_current_nav_cmd().id)) {
+        switch (poscontrol.get_state()) {
+            case QPOS_APPROACH:
+            case QPOS_AIRBRAKE:
+            case QPOS_POSITION1:
+            case QPOS_POSITION2:
+            case QPOS_PAUSE:
+                return true;
+
+            case QPOS_NONE:
+            case QPOS_LAND_DESCEND:
+            case QPOS_LAND_ABORT:
+            case QPOS_LAND_FINAL:
+            case QPOS_LAND_COMPLETE:
+                break;
         }
     }
     return false;

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -342,7 +342,10 @@ private:
     // QRTL start altitude, meters
     AP_Int16 qrtl_alt_m;
     AP_Int16 qrtl_alt_min_m;
-    
+
+    // QRTL pause time in seconds
+    AP_Float qrtl_pause_time;
+
     // alt to switch to QLAND_FINAL
     AP_Float land_final_alt_m;
     AP_Float vel_forward_alt_cutoff_m;
@@ -492,6 +495,7 @@ private:
         QPOS_AIRBRAKE,
         QPOS_POSITION1,
         QPOS_POSITION2,
+        QPOS_PAUSE,
         QPOS_LAND_DESCEND,
         QPOS_LAND_ABORT,
         QPOS_LAND_FINAL,

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -189,7 +189,9 @@ static const struct AP_Param::defaults_table_struct defaults_table_tailsitter[] 
     { "Q_P_NE_VEL_P",        1.0},
     { "Q_P_NE_VEL_I",        0.5},
     { "Q_P_NE_VEL_D",        0.25},
-    
+    // Control surface tailsitters don't like descending fast, especially if they are still moving.
+    // A 5 second pause before descent gives them a chance to stabilize
+    { "Q_RTL_PAUSE_TIME",     5.0},
 };
 
 Tailsitter::Tailsitter(QuadPlane& _quadplane, AP_MotorsMulticopter*& _motors):quadplane(_quadplane),motors(_motors)

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -3393,6 +3393,53 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         })
         self.do_RTL()
 
+    def RTLPauseTime(self):
+        '''test Q_RTL_PAUSE_TIME - pause above landing point before descent'''
+
+        def fly_to_fw_and_away():
+            '''take off in VTOL, transition to FW and fly 400m+ from home'''
+            self.zero_throttle()
+            self.takeoff(15, 'QHOVER')
+            self.change_mode("FBWA")
+            self.set_rc(3, 1900)
+            self.wait_distance_to_home(400, 1000, timeout=60)
+            self.set_rc(3, 1500)
+
+        # Sub-test 1: Q_RTL_PAUSE_TIME=0 should skip the loiter phase entirely
+        self.progress("Testing Q_RTL_PAUSE_TIME=0 - no loiter expected")
+        self.context_push()
+        self.set_parameter('Q_RTL_PAUSE_TIME', 0)
+        fly_to_fw_and_away()
+        self.context_collect('STATUSTEXT')
+        self.change_mode('QRTL')
+        self.wait_statustext('Land descend started', timeout=120)
+        if self.statustext_in_collections('Land loiter started'):
+            raise NotAchievedException(
+                "Got unexpected 'Land loiter started' with Q_RTL_PAUSE_TIME=0")
+        self.wait_disarmed(timeout=120)
+        self.context_pop()
+
+        # Sub-test 2: Q_RTL_PAUSE_TIME=5 should delay descent by ~5 seconds
+        loiter_time_s = 5
+        tolerance_s = 0.5
+        self.progress("Testing Q_RTL_PAUSE_TIME=%d - loiter expected" % loiter_time_s)
+        self.context_push()
+        self.set_parameter('Q_RTL_PAUSE_TIME', loiter_time_s)
+        fly_to_fw_and_away()
+        self.change_mode('QRTL')
+        self.wait_statustext('Land loiter started', timeout=120)
+        t_loiter_start = self.get_sim_time_cached()
+        self.wait_statustext('Land descend started', timeout=60)
+        t_descend_start = self.get_sim_time_cached()
+        delta = t_descend_start - t_loiter_start
+        self.progress("Loiter lasted %.1fs (expected %.1fs)" % (delta, loiter_time_s))
+        if abs(delta - loiter_time_s) > tolerance_s:
+            raise NotAchievedException(
+                "Loiter duration incorrect: got %.1fs expected %.1fs" %
+                (delta, loiter_time_s))
+        self.wait_disarmed(timeout=120)
+        self.context_pop()
+
     def tests(self):
         '''return list of all tests'''
 
@@ -3446,6 +3493,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             self.DCMClimbRate,
             self.RTL_AUTOLAND_1,  # as in fly-home then go to landing sequence
             self.RTL_AUTOLAND_1_FROM_GUIDED,  # as in fly-home then go to landing sequence
+            self.RTLPauseTime,
             self.AHRSFlyForwardFlag,
             self.DoRepositionTerrain,
             self.DoRepositionTerrain2,

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -3897,6 +3897,53 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
                                       (field, instance, value, ref))
                         break
 
+    def RTLPauseTime(self):
+        '''test Q_RTL_PAUSE_TIME - pause above landing point before descent'''
+
+        def fly_to_fw_and_away():
+            '''take off in VTOL, transition to FW and fly 400m+ from home'''
+            self.zero_throttle()
+            self.takeoff(15, 'QHOVER')
+            self.change_mode("FBWA")
+            self.set_rc(3, 1900)
+            self.wait_distance_to_home(400, 1000, timeout=60)
+            self.set_rc(3, 1500)
+
+        # Sub-test 1: Q_RTL_PAUSE_TIME=0 should skip the loiter phase entirely
+        self.progress("Testing Q_RTL_PAUSE_TIME=0 - no loiter expected")
+        self.context_push()
+        self.set_parameter('Q_RTL_PAUSE_TIME', 0)
+        fly_to_fw_and_away()
+        self.context_collect('STATUSTEXT')
+        self.change_mode('QRTL')
+        self.wait_statustext('Land descend started', timeout=120)
+        if self.statustext_in_collections('Land loiter started'):
+            raise NotAchievedException(
+                "Got unexpected 'Land loiter started' with Q_RTL_PAUSE_TIME=0")
+        self.wait_disarmed(timeout=120)
+        self.context_pop()
+
+        # Sub-test 2: Q_RTL_PAUSE_TIME=5 should delay descent by ~5 seconds
+        loiter_time_s = 5
+        tolerance_s = 0.5
+        self.progress("Testing Q_RTL_PAUSE_TIME=%d - loiter expected" % loiter_time_s)
+        self.context_push()
+        self.set_parameter('Q_RTL_PAUSE_TIME', loiter_time_s)
+        fly_to_fw_and_away()
+        self.change_mode('QRTL')
+        self.wait_statustext('Land loiter started', timeout=120)
+        t_loiter_start = self.get_sim_time_cached()
+        self.wait_statustext('Land descend started', timeout=60)
+        t_descend_start = self.get_sim_time_cached()
+        delta = t_descend_start - t_loiter_start
+        self.progress("Loiter lasted %.1fs (expected %.1fs)" % (delta, loiter_time_s))
+        if abs(delta - loiter_time_s) > tolerance_s:
+            raise NotAchievedException(
+                "Loiter duration incorrect: got %.1fs expected %.1fs" %
+                (delta, loiter_time_s))
+        self.wait_disarmed(timeout=120)
+        self.context_pop()
+
     def tests(self):
         '''return list of all tests'''
 
@@ -3952,6 +3999,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             self.DCMClimbRate,
             self.RTL_AUTOLAND_1,  # as in fly-home then go to landing sequence
             self.RTL_AUTOLAND_1_FROM_GUIDED,  # as in fly-home then go to landing sequence
+            self.RTLPauseTime,
             self.AHRSFlyForwardFlag,
             self.DoRepositionTerrain,
             self.DoRepositionTerrain2,

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -3944,6 +3944,63 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.wait_disarmed(timeout=120)
         self.context_pop()
 
+    def VTOLLandGoAround(self):
+        '''test MAV_CMD_DO_GO_AROUND is rejected early in a VTOL landing but
+        accepted once paused or descending'''
+        # Enable pause phase so it can also be checked
+        self.set_parameter('Q_RTL_PAUSE_TIME', 10)
+
+        # takeoff, fly out to the waypoint then approach a landing point back
+        # near home, giving a full VTOL land approach. The DO_JUMP
+        # returns us to the waypoint after each aborted landing so we can test
+        # a go-around in several phases within a single flight.
+        self.upload_simple_relhome_mission([
+            (mavutil.mavlink.MAV_CMD_NAV_VTOL_TAKEOFF, 0, 0, 20),
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 700, 0, 40),
+            # Small offset so its not converted into "land at current location"
+            (mavutil.mavlink.MAV_CMD_NAV_VTOL_LAND, 0.1, 0, 0),
+            # jump back to the waypoint forever
+            self.create_MISSION_ITEM_INT(
+                mavutil.mavlink.MAV_CMD_DO_JUMP,
+                p1=2,
+                p2=-1,
+            ),
+        ])
+
+        self.change_mode('AUTO')
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+
+        def go_around(want_result):
+            self.run_cmd(mavutil.mavlink.MAV_CMD_DO_GO_AROUND, want_result=want_result)
+
+        # First landing attempt: the go-around should be rejected in the
+        # approach and position phases, but accepted once we start the loiter
+        # pause (before the abort_landing pause handling this was rejected).
+        self.start_subtest("Go-around rejected during approach")
+        self.wait_statustext('VTOL approach', timeout=180)
+        go_around(mavutil.mavlink.MAV_RESULT_FAILED)
+
+        self.start_subtest("Go-around rejected during position2")
+        self.wait_statustext('VTOL position2 started', timeout=90)
+        go_around(mavutil.mavlink.MAV_RESULT_FAILED)
+
+        self.start_subtest("Go-around accepted during loiter pause")
+        self.wait_statustext('Land loiter started', timeout=60)
+        go_around(mavutil.mavlink.MAV_RESULT_ACCEPTED)
+        # the abort continues the mission (DO_JUMP) back to the waypoint
+        self.wait_current_waypoint(2, timeout=30)
+
+        # Second landing attempt: let the pause expire and abort the descent
+        self.start_subtest("Go-around accepted during descent")
+        self.wait_statustext('Land descend started', timeout=180)
+        go_around(mavutil.mavlink.MAV_RESULT_ACCEPTED)
+        self.wait_current_waypoint(2, timeout=30)
+
+        # Third landing attempt: let it land for real
+        self.start_subtest("Landing completes when not aborted")
+        self.wait_disarmed(timeout=300)
+
     def tests(self):
         '''return list of all tests'''
 
@@ -4000,6 +4057,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             self.RTL_AUTOLAND_1,  # as in fly-home then go to landing sequence
             self.RTL_AUTOLAND_1_FROM_GUIDED,  # as in fly-home then go to landing sequence
             self.RTLPauseTime,
+            self.VTOLLandGoAround,
             self.AHRSFlyForwardFlag,
             self.DoRepositionTerrain,
             self.DoRepositionTerrain2,

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -3917,9 +3917,9 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.context_collect('STATUSTEXT')
         self.change_mode('QRTL')
         self.wait_statustext('Land descend started', timeout=120)
-        if self.statustext_in_collections('Land loiter started'):
+        if self.statustext_in_collections('Land pause started'):
             raise NotAchievedException(
-                "Got unexpected 'Land loiter started' with Q_RTL_PAUSE_TIME=0")
+                "Got unexpected 'Land pause started' with Q_RTL_PAUSE_TIME=0")
         self.wait_disarmed(timeout=120)
         self.context_pop()
 
@@ -3931,7 +3931,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.set_parameter('Q_RTL_PAUSE_TIME', loiter_time_s)
         fly_to_fw_and_away()
         self.change_mode('QRTL')
-        self.wait_statustext('Land loiter started', timeout=120)
+        self.wait_statustext('Land pause started', timeout=120)
         t_loiter_start = self.get_sim_time_cached()
         self.wait_statustext('Land descend started', timeout=60)
         t_descend_start = self.get_sim_time_cached()
@@ -3986,7 +3986,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         go_around(mavutil.mavlink.MAV_RESULT_FAILED)
 
         self.start_subtest("Go-around accepted during loiter pause")
-        self.wait_statustext('Land loiter started', timeout=60)
+        self.wait_statustext('Land pause started', timeout=60)
         go_around(mavutil.mavlink.MAV_RESULT_ACCEPTED)
         # the abort continues the mission (DO_JUMP) back to the waypoint
         self.wait_current_waypoint(2, timeout=30)


### PR DESCRIPTION
### Summary

This adds a param for a delay above the landing location before the landing decent is started. By default it is 0 so there is no change in behavior.

<!-- Put a one or two line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->

The default is set to 5 seconds for tailsitters which replaces https://github.com/ArduPilot/ardupilot/pull/26417 and fixes https://github.com/ArduPilot/ardupilot/issues/25771 and https://github.com/ArduPilot/ardupilot/issues/29943