### PR TITLE
Tools: allowed_subsystems.py fix to support AC_PosControl

### DIFF
--- a/Tools/scripts/allowed_subsystems.py
+++ b/Tools/scripts/allowed_subsystems.py
@@ -70,11 +70,6 @@ class AllowedSubsystems(object):
         'Replay',
         'AP_Periph',
         'AP_Bootloader',
-        # class / sub-library prefixes in common use that are not their own
-        # libraries/ directory
-        'AC_PosControl',
-        'AC_Circle',
-        'AP_MotorsHeli',
         'mavlink',
     }
 
@@ -101,6 +96,14 @@ class AllowedSubsystems(object):
         ('Tools/bootloaders/', ['bootloaders']),
         ('Tools/Replay/', ['Replay']),
     ]
+
+    # prefixes that are used but do not match the directory they are in
+    # list includes the directory name and alternative prefixes that may be used
+    SPECIAL_SUBSYSTEMS = {
+        'AC_AttitudeControl': ['AC_PosControl'],
+        'AC_WPNav': ['AC_Circle'],
+        'AP_Motors': ['AP_MotorsHeli'],
+    }
 
     # Top-level directory (other than vehicles, libraries and the special cases
     # above) -> ordered candidate subsystems.
@@ -171,8 +174,14 @@ class AllowedSubsystems(object):
         created_dirs is an iterable of libraries/ subdirectory names that a
         commit creates; they are allowed even if they do not yet exist on disk.
         '''
+        special_subsystems = {
+            sub_prefix
+            for sub_prefixes in self.SPECIAL_SUBSYSTEMS.values()
+            for sub_prefix in sub_prefixes
+        }
         return (self.library_dirs()
                 | set(self.CURATED_SUBSYSTEMS)
+                | special_subsystems
                 | set(created_dirs))
 
     def subsystems_for_path(self, path):
@@ -203,6 +212,11 @@ class AllowedSubsystems(object):
             # libraries/<HAL>/hwdef/... belongs to hwdef as well as the HAL
             if len(parts) >= 4 and parts[2] == 'hwdef':
                 return [lib, 'hwdef']
+            # allow special prefixes from SPECIAL_SUBSYSTEMS
+            filename = parts[-1]
+            for sub_prefix in self.SPECIAL_SUBSYSTEMS.get(lib, []):
+                if filename.startswith(sub_prefix):
+                    return [lib, sub_prefix]
             return [lib]
 
         # most-specific-first special directory rules


### PR DESCRIPTION
### Summary

This fixes an issue with the allowed_subsystems.py script used in the "Test for Malformed Commits in PR Branch"

This has been lightly tested against the branch used in PR https://github.com/ArduPilot/ardupilot/pull/33843 by running, "./Tools/scripts/check_branch_conventions.py" before and after this change.

Before:
```
Checking 10 commit(s) since 2b5cebb933d91e92f7bab768268e41c2960b6ae4...

✓ No merge commits.
✓ No fixup! commits.
✓ All commit messages have well-formed subsystem tags.
✗ 496fce85d131 libraries/AC_AttitudeControl/AC_PosControl.cpp is not part of subsystem 'AC_PosControl'; it belongs to: AC_AttitudeControl
✓ All commit subject lines within 160 characters.
✓ No unacceptable author emails.
✓ All submodule updates are isolated in their own commits.
~ Submodule reference check only applies to master-targeting PRs.
✓ board_types.txt not changed (board ID check).
✓ No changed source files lose their trailing newline.
✓ No markdown files changed.
✓ No markdown files changed (RST markup check).
✓ No markdown files changed (underline heading check).
```

After:

```
Checking 11 commit(s) since 2b5cebb933d91e92f7bab768268e41c2960b6ae4...

✓ No merge commits.
✓ No fixup! commits.
✓ All commit messages have well-formed subsystem tags.
✓ All commits touch a single allowed subsystem.
✓ All commit subject lines within 160 characters.
✓ No unacceptable author emails.
✓ All submodule updates are isolated in their own commits.
~ Submodule reference check only applies to master-targeting PRs.
✓ board_types.txt not changed (board ID check).
✓ No changed source files lose their trailing newline.
✓ No markdown files changed.
✓ No markdown files changed (RST markup check).
✓ No markdown files changed (underline heading check).
```


### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
