### PR TITLE
GCS_MAVLink: only stream AVAILABLE_MODES_MONITOR after modes actually change

### DIFF
--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -1114,9 +1114,15 @@ private:
         // Note these start at 1
         uint8_t requested_index;
         uint8_t next_index;
+        // set once a GCS has requested AVAILABLE_MODES; used to decide whether
+        // to start streaming AVAILABLE_MODES_MONITOR once modes actually change
+        bool monitor_requested;
     } available_modes;
     bool send_available_modes();
     bool send_available_mode_monitor();
+    // start streaming AVAILABLE_MODES_MONITOR to this channel if it previously
+    // requested AVAILABLE_MODES and the mode set has now actually changed
+    void available_modes_now_changed();
 
 };
 
@@ -1313,7 +1319,10 @@ public:
     // Sequence number should be incremented when available modes changes
     // Sent in AVAILABLE_MODES_MONITOR msg
     uint8_t get_available_modes_sequence() const { return available_modes_sequence; }
-    void available_modes_changed() { available_modes_sequence += 1; }
+    // call whenever the set of available modes actually changes; increments the
+    // sequence number and kicks off AVAILABLE_MODES_MONITOR streaming on any
+    // channel that previously requested AVAILABLE_MODES
+    void available_modes_changed();
 
 protected:
 

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3281,6 +3281,20 @@ uint8_t GCS::get_channel_from_port_number(uint8_t port_num)
     return UINT8_MAX;
 }
 
+void GCS::available_modes_changed()
+{
+    available_modes_sequence += 1;
+
+    // Now that the modes have really changed, start streaming
+    // AVAILABLE_MODES_MONITOR on any channel that asked for the mode list
+    for (uint8_t i=0; i<num_gcs(); i++) {
+        GCS_MAVLINK *link = chan(i);
+        if (link != nullptr) {
+            link->available_modes_now_changed();
+        }
+    }
+}
+
 MAV_RESULT GCS_MAVLINK::handle_command_request_message(const mavlink_command_int_t &packet)
 {
     const uint32_t mavlink_id = (uint32_t)packet.param1;
@@ -3301,9 +3315,13 @@ MAV_RESULT GCS_MAVLINK::handle_command_request_message(const mavlink_command_int
         available_modes.next_index = 1;
         available_modes.requested_index = (uint8_t)packet.param2;
 
-        // After the first request sequnece is streamed in the AVAILABLE_MODES_MONITOR message
-        // This allows the GCS to re-request modes if there is a change
-        set_ap_message_interval(MSG_AVAILABLE_MODES_MONITOR, 5000);
+        // Per the MAVLink standard modes spec, AVAILABLE_MODES_MONITOR should only
+        // start streaming once the set of available modes actually changes for the
+        // first time, not immediately on a GCS's initial request. Remember that
+        // this channel is interested; available_modes_now_changed() (called from
+        // GCS::available_modes_changed() when a real change happens) will start
+        // the stream.
+        available_modes.monitor_requested = true;
         break;
 
 #if AP_CAMERA_ENABLED
@@ -6593,6 +6611,16 @@ bool GCS_MAVLINK::send_available_modes()
     }
 
     return true;
+}
+
+void GCS_MAVLINK::available_modes_now_changed()
+{
+    if (!available_modes.monitor_requested) {
+        // this channel has never asked for the available modes, don't stream
+        // the monitor message at it
+        return;
+    }
+    set_ap_message_interval(MSG_AVAILABLE_MODES_MONITOR, 5000);
 }
 
 bool GCS_MAVLINK::send_available_mode_monitor()


### PR DESCRIPTION
## Summary

Fixes #33811

`AVAILABLE_MODES_MONITOR` was streamed unconditionally as soon as a GCS requested `AVAILABLE_MODES`, even when the set of available modes had never changed. Per the [MAVLink standard modes spec](https://mavlink.io/en/services/standard_modes.html), this message should only be emitted — and then streamed at low rate — once the mode set *actually* changes. PX4 follows this; ArduPilot did not.

Because a spec-compliant GCS (e.g. QGroundControl) treats any monitor message as "modes may have changed, re-download the list", the old behaviour caused an unnecessary duplicate download of the full mode list on every connection.

## Root cause

In `GCS_MAVLINK::handle_command_request_message()` (`libraries/GCS_MAVLink/GCS_Common.cpp`), the `MSG_AVAILABLE_MODES` case called:

```cpp
set_ap_message_interval(MSG_AVAILABLE_MODES_MONITOR, 5000);
```

unconditionally, at *request* time rather than at *change* time.

The change-detection infrastructure was already correct and in place — `GCS::available_modes_changed()` is called only on genuine mode-set changes, from `AP_Vehicle::one_Hz_loop()` (bitmask comparison of `get_available_mode_enabled_mask()`) and from `Copter::mode_guided_custom_*` when scripting registers a custom mode. The only problem was where the stream got started.

## Changes

Confined to `libraries/GCS_MAVLink` (one commit):

- `GCS.h`: added `bool monitor_requested` to the per-channel `available_modes` struct, recording that this channel has asked for the mode list.
- `GCS_Common.cpp`: `handle_command_request_message()` now sets `available_modes.monitor_requested = true` instead of starting the stream.
- `GCS_Common.cpp`: new `GCS_MAVLINK::available_modes_now_changed()` starts the 0.2 Hz stream on a channel, but only if that channel previously requested `AVAILABLE_MODES`.
- `GCS.h` / `GCS_Common.cpp`: `GCS::available_modes_changed()` moved out of the header; it still increments `available_modes_sequence` and now also fans out to every channel's `available_modes_now_changed()`.

No flight-control logic touched — this only affects telemetry emitted to the GCS.

Note: `monitor_requested` needs no explicit initialisation because ArduPilot globally overrides `operator new` to zero-fill (`libraries/AP_Common/c++.cpp`); this is the same guarantee the adjacent `should_send` field already relies on.

## Testing

SITL (`ArduCopter`, `sim_vehicle.py --no-mavproxy`), driven by a pymavlink script that:

1. **Phase 1** — sends `MAV_CMD_REQUEST_MESSAGE` for `AVAILABLE_MODES`, then listens 20 s with no mode change. The monitor stream is 0.2 Hz, so ~4 messages arrive if it is (incorrectly) streaming.
2. **Phase 2** — triggers a *real* mode-set change by setting `FLTMODE_GCSBLOCK=512` (blocks FLIP from GCS selection, which changes `get_available_mode_enabled_mask()`), then listens 20 s again.

### Before (unpatched master)

```
[BEFORE] === PHASE 1: request AVAILABLE_MODES, then observe with NO mode change ===
[BEFORE] AVAILABLE_MODES received: 1 (mode_count=25)
[BEFORE] AVAILABLE_MODES_MONITOR received in 20s with no mode change: 4
[BEFORE]     MONITOR seq=0
[BEFORE]     MONITOR seq=0
[BEFORE]     MONITOR seq=0
[BEFORE]     MONITOR seq=0
[BEFORE] PHASE 1 FAIL: expected 0 monitor messages, got 4
[BEFORE] === PHASE 2: trigger a real available-modes change (FLTMODE_GCSBLOCK) ===
[BEFORE] FLTMODE_GCSBLOCK set to 512.0
[BEFORE] AVAILABLE_MODES_MONITOR received in 20s after a real mode-set change: 4
[BEFORE]     MONITOR seq=1
[BEFORE] PHASE 2 PASS
[BEFORE] seq before change = 0, seq after change = 1
[BEFORE] RESULT phase1(no-stream-before-change)=FAIL phase2(stream-after-change)=PASS
```

The 4 monitor messages at `seq=0` are the bug: nothing had changed, yet a GCS is being told to re-download.

### After (this PR)

```
[AFTER] === PHASE 1: request AVAILABLE_MODES, then observe with NO mode change ===
[AFTER] AVAILABLE_MODES received: 1 (mode_count=25)
[AFTER] AVAILABLE_MODES_MONITOR received in 20s with no mode change: 0
[AFTER] PHASE 1 PASS: expected 0 monitor messages, got 0
[AFTER] === PHASE 2: trigger a real available-modes change (FLTMODE_GCSBLOCK) ===
[AFTER] FLTMODE_GCSBLOCK set to 512.0
[AFTER] AVAILABLE_MODES_MONITOR received in 20s after a real mode-set change: 4
[AFTER]     MONITOR seq=1
[AFTER]     MONITOR seq=1
[AFTER]     MONITOR seq=1
[AFTER]     MONITOR seq=1
[AFTER] PHASE 2 PASS: expected >0 monitor messages after change, got 4
[AFTER] RESULT phase1(no-stream-before-change)=PASS phase2(stream-after-change)=PASS
```

Mode list still downloads correctly (25 modes), the monitor stays quiet until something really changes, and once it does the stream starts at 0.2 Hz with an incremented `seq`.

### Regression / build

- `Tools/autotest/autotest.py build.Copter test.Copter.ScriptingFlipMode` — **PASSED** (this is the test that exercises scripting registering a custom mode, i.e. a real `available_modes_changed()` path).
- SITL builds clean for `copter`, `plane`, `rover`, `sub`, `blimp`, `antennatracker`.
- No test in `Tools/` references `AVAILABLE_MODES_MONITOR`, so nothing depended on the old immediate-stream behaviour.
