### PR TITLE
hwdef: enable bootloader flashing on ARKV6X and ARK_PI6X

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/ARKV6X/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ARKV6X/hwdef.dat
@@ -345,6 +345,3 @@ ROMFS io_firmware.bin Tools/IO_Firmware/iofirmware_lowpolh.bin
 # note that if firmware is build with --secure-bl then DFU is
 # disabled
 ENABLE_DFU_BOOT 1
-
-# bootloader embedding / bootloader flashing not available
-define AP_BOOTLOADER_FLASHING_ENABLED 0

--- a/libraries/AP_HAL_ChibiOS/hwdef/ARK_PI6X/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ARK_PI6X/hwdef.dat
@@ -155,6 +155,3 @@ DMA_PRIORITY SDMMC* SPI*
 
 # enable FAT filesystem support (needs a microSD defined via SDMMC)
 define HAL_OS_FATFS_IO 1
-
-# bootloader embedding / bootloader flashing not available
-define AP_BOOTLOADER_FLASHING_ENABLED 0


### PR DESCRIPTION
## Summary

Both boards set `AP_BOOTLOADER_FLASHING_ENABLED 0` despite having a bootloader binary in `Tools/bootloaders`.

Without it, `AP_OpenDroneID`'s persistent UAS ID (`DID_OPTIONS` bit 2) is a silent no-op — it calls `Util::flash_bootloader()` to store `DID_UAS_ID` in the bootloader sector, which resolves to the `AP_HAL::Util` stub, so the ID is lost on every reboot.
