### PR TITLE
AP_Airspeed: Add missing devids for analog and SITL

### DIFF
--- a/Tools/scripts/decode_devid.py
+++ b/Tools/scripts/decode_devid.py
@@ -45,6 +45,7 @@ bustypes = {
     4: "SITL",
     5: "MSP",
     6: "SERIAL",
+    7: "WSPI",
 }
 
 compass_types = {

--- a/libraries/AP_Airspeed/AP_Airspeed_SITL.h
+++ b/libraries/AP_Airspeed/AP_Airspeed_SITL.h
@@ -7,6 +7,7 @@
 
 #if AP_AIRSPEED_SITL_ENABLED
 
+#include <AP_HAL/AP_HAL.h>
 #include "AP_Airspeed_Backend.h"
 
 class AP_Airspeed_SITL : public AP_Airspeed_Backend
@@ -16,6 +17,12 @@ public:
     using AP_Airspeed_Backend::AP_Airspeed_Backend;
 
     bool init(void) override {
+        set_bus_id(AP_HAL::Device::make_bus_id(
+            AP_HAL::Device::BUS_TYPE_SITL,
+            0,
+            0,
+            uint8_t(DevType::SITL)
+        ));
         return true;
     }
 

--- a/libraries/AP_Airspeed/AP_Airspeed_analog.cpp
+++ b/libraries/AP_Airspeed/AP_Airspeed_analog.cpp
@@ -38,6 +38,12 @@ AP_Airspeed_Analog::AP_Airspeed_Analog(AP_Airspeed &_frontend, uint8_t _instance
 
 bool AP_Airspeed_Analog::init()
 {
+    set_bus_id(AP_HAL::Device::make_bus_id(
+        AP_HAL::Device::BUS_TYPE_UNKNOWN,
+        0,
+        0,
+        uint8_t(DevType::ANALOG)
+    ));
     return _source != nullptr;
 }
 


### PR DESCRIPTION
### Summary

I saw a log with the dev ID of a DroneCAN sensor but with the type set to analog, this is because analog was not setting the dev ID at all.

<!-- Put a one or two line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->

`DEVTYPE_AIRSPEED_SITL`, and `DEVTYPE_AIRSPEED_ANALOG` already exist in the decode script. This also adds the missing WSPI from the decode script, this was added in https://github.com/ArduPilot/ardupilot/pull/21439

Tested in SITL:
```
./Tools/scripts/decode_devid.py -A 524288
bus_type:UNKNOWN(0)  bus:0 address:0(0x0) devtype:8(0x8) DEVTYPE_AIRSPEED_ANALOG
 ./Tools/scripts/decode_devid.py -A 65540
bus_type:SITL(4)  bus:0 address:0(0x0) devtype:1(0x1) DEVTYPE_AIRSPEED_SITL
```

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
