### PR TITLE
AC_PrecLand: resolve QURT compile warning

### DIFF
--- a/libraries/AC_PrecLand/AC_PrecLand_StateMachine.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand_StateMachine.cpp
@@ -198,8 +198,8 @@ AC_PrecLand_StateMachine::Status AC_PrecLand_StateMachine::retry_landing(Vector3
         if (!AP::ahrs().get_relative_position_NED_origin(pos)) {
             return Status::ERROR;
         }
-        const float dist_to_target = (go_to_pos-pos).length();
-        if ((dist_to_target < MAX_POS_ERROR_M)) {
+        const float dist_to_target = (go_to_pos-pos).tofloat().length();
+        if (dist_to_target < MAX_POS_ERROR_M) {
             // we have approx reached landing location previously detected
             _retry_state = RetryLanding::DESCEND;
         }
@@ -216,7 +216,7 @@ AC_PrecLand_StateMachine::Status AC_PrecLand_StateMachine::retry_landing(Vector3
         // z_target is in "D" frame
         const float z_target = go_to_pos.z + RETRY_OFFSET_ALT_M;
         retry_pos_m = Vector3p{pos.x, pos.y, z_target};
-        if (fabsf(pos.z - retry_pos_m.z) < MAX_POS_ERROR_M) {
+        if (fabsf(float(pos.z) - float(retry_pos_m.z)) < MAX_POS_ERROR_M) {
             // we have descended to the original height where we started the climb from
             _retry_state = RetryLanding::COMPLETE;
             GCS_SEND_TEXT(MAV_SEVERITY_INFO, "PrecLand: Retry Completed");


### PR DESCRIPTION
### Summary

This attempts to resolve one of the compiler warnings that led to PR https://github.com/ArduPilot/ardupilot/pull/28897

I do not have the ability to compile the QURT boards but CI does so we can use it to verify if this has worked.  We can do that by opening the [Checks tab](https://github.com/ArduPilot/ardupilot/pull/33857/checks) just above this description, then expand QURT Build and then further expand the "Waf Build" above "'copter' finished successfully".

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
