### PR TITLE
APM_Control: fix last-run-ticks compiler warning

### DIFF
--- a/libraries/APM_Control/AP_FW_Controller.h
+++ b/libraries/APM_Control/AP_FW_Controller.h
@@ -124,6 +124,8 @@ protected:
 
 private:
 
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
     // Ticks tracking to check that the controller is called once per loop and no more
     uint32_t last_run_ticks;
+#endif
 };


### PR DESCRIPTION
### Summary

This attempts to resolve a compiler warning in AP_FW_Controller that led to PR https://github.com/ArduPilot/ardupilot/pull/28897

I do not have the ability to compile the QURT boards but CI does so we can use it to verify if this has worked.  We can do that by opening the Checks tab above, then expand QURT Build and then further expand the "Waf Build" above "'copter' finished successfully".

Update: this does seem to resolve the warning

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request