### PR TITLE
AP_Math: SCurve: remove redundant arc path_unit normalization

### DIFF
--- a/libraries/AP_Math/SCurve.cpp
+++ b/libraries/AP_Math/SCurve.cpp
@@ -587,8 +587,8 @@ void SCurve::project_scurve_onto_track(float scurve_A1, float scurve_V1, float s
         Vector2f arc_tangent_ne = Vector2f(-center_to_pos_ne.y, center_to_pos_ne.x) * turn_dir;
         arc_tangent_ne /= arc.radius_ne;
         const float horiz_ds = arc.length_ne / seg_length;
-        Vector3f path_unit(arc_tangent_ne.x * horiz_ds, arc_tangent_ne.y * horiz_ds, dz_ds);
-        path_unit.normalize();
+        // unit length by construction: |arc_tangent_ne| = 1 and horiz_ds^2 + dz_ds^2 = 1 from the seg_length definition
+        const Vector3f path_unit(arc_tangent_ne.x * horiz_ds, arc_tangent_ne.y * horiz_ds, dz_ds);
 
         // velocity & tangential accel
         vel += path_unit * scurve_V1;


### PR DESCRIPTION
### Summary

Remove a redundant normalize() of the arc-projection path unit vector in SCurve. The vector is unit length by construction, so the call only redid work already guaranteed by the geometry setup.

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] Tested manually, description below (e.g. SITL)

<!-- Put additional testing description for this PR's changes here -->

### Description

In project_scurve_onto_track() the arc branch builds path_unit from the arc tangent and the vertical gradient, then normalizes it. The normalization is redundant.

The magnitude of arc.center_ne equals radius_ne exactly. Its chord-midpoint and perpendicular-offset components are orthogonal, and the offset is defined as sqrt(radius^2 - (chord/2)^2). Rotation preserves magnitude, so arc_tangent_ne is unit length after dividing by radius_ne.

The 3D combination is also unit length. seg_length is defined as sqrt(length_ne^2 + dz^2), so horiz_ds^2 + dz_ds^2 = 1.

The normalize() therefore only corrected single-precision rounding on the order of 1 ulp, comparable to the rounding its own sqrt and division reintroduced. This change removes the call, documents the invariant with a comment, and makes path_unit const. Output velocity and acceleration can differ from master only at the last-bit level.
