### PR TITLE
AP_Mission: zero-initialize ChangeDetector command buffers

### DIFF
--- a/libraries/AP_Mission/AP_Mission_ChangeDetector.cpp
+++ b/libraries/AP_Mission/AP_Mission_ChangeDetector.cpp
@@ -35,7 +35,7 @@ bool AP_Mission_ChangeDetector::check_for_mission_change()
     // retrieve cmds from mission and compare with mis_change_detect
     uint8_t num_cmds = 0;
     uint16_t cmd_idx = curr_cmd_idx;
-    AP_Mission::Mission_Command cmd[mis_change_detect_cmd_max];
+    AP_Mission::Mission_Command cmd[mis_change_detect_cmd_max] {};
     while ((num_cmds < ARRAY_SIZE(cmd)) && mission->get_next_nav_cmd(cmd_idx, cmd[num_cmds])) {
         num_cmds++;
         if ((num_cmds > mis_change_detect.cmd_count) || (cmd[num_cmds-1] != mis_change_detect.cmd[num_cmds-1])) {

--- a/libraries/AP_Mission/AP_Mission_ChangeDetector.h
+++ b/libraries/AP_Mission/AP_Mission_ChangeDetector.h
@@ -35,7 +35,7 @@ private:
         uint16_t curr_cmd_index;            // local copy of AP_Mission's current command index
         uint8_t cmd_count;                  // number of commands in the cmd array
         AP_Mission::Mission_Command cmd[mis_change_detect_cmd_max]; // local copy of the next few mission commands
-    } mis_change_detect;
+    } mis_change_detect {};
 };
 
 #endif // AP_MISSION_ENABLED


### PR DESCRIPTION
### Summary

Zero-initialize the two `Mission_Command` buffers that `AP_Mission_ChangeDetector`
feeds into a whole-struct `memcmp`, fixing the Valgrind uninitialised-variable
errors reported in #31495.

### Classification & Testing (check all that apply and add your own)

- [ ] Checked by a human programmer
- [x] Bug fix
- [x] Tested manually, description below

Builds clean for SITL (`./waf configure --board sitl && ./waf copter`).
Not yet run under Valgrind locally — Valgrind does not support macOS/ARM, so the
before/after check with the Arc-waypoint autotests from #31492
(`Tools/autotest ... --valgrind`) needs a Linux host or this PR's CI. Happy to
set that up if a maintainer can't easily trigger it.

### Description

`Mission_Command::operator==` is a `memcmp` over the entire struct, and its own
comment acknowledges the contract: it "relies on all bytes in the structure even
if they may not be used". That contract makes every byte that reaches the
comparison significant — including union bytes the active command type never
touches and compiler padding.

`AP_Mission_ChangeDetector::check_for_mission_change()` violates that contract
in two places:

- `mis_change_detect` (header) — the persistent copy of the upcoming commands,
  a plain member struct with no initializer. It is compared against and
  partially updated on every call. Today's instances happen to live inside
  statically-allocated vehicle objects, but nothing about the class guarantees
  zeroed storage.
- `cmd[mis_change_detect_cmd_max]` (local, stack) — filled by
  `get_next_nav_cmd()`, then compared element-wise against the stored copy.
  `read_cmd_from_storage()` zeroes the command it writes (`cmd = {}`), but that
  defined-ness has to survive two struct assignments on the way back up, and
  padding bytes are not guaranteed to be preserved by member-wise copies.

Zero-initializing both buffers at their definitions makes every byte that
`memcmp` reads start defined, whatever the allocation context or copy path.
Two lines, no behavioral change for correctly-detected missions; it also
removes the (rare) possibility of a spurious change detection caused by
garbage bytes differing between two otherwise-identical commands.

Fixes #31495
