### PR TITLE
AP_Mission: fix get_next_nav_cmd

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -5449,6 +5449,111 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                      timeout=1,
                      want_result=mavutil.mavlink.MAV_RESULT_DENIED)
 
+    def fly_jump_loop_mission(self, name, items, loop_end_wp, loop_centre):
+        '''fly items and check the vehicle keeps to the loop the jump creates
+
+        items must jump back forever over a leg centred on loop_centre.
+        loop_end_wp is the sequence number of the last waypoint of that leg,
+        reached just before the jump is taken.
+        '''
+        self.progress("Jump case: %s" % name)
+        self.start_flying_simple_relhome_mission(items)
+
+        # reach the end of the looped leg for the first time
+        self.wait_current_waypoint(loop_end_wp, timeout=120)
+
+        # the jump goes back to the start of the leg, so the vehicle should
+        # orbit it.  Position is checked rather than the reported current
+        # waypoint, which advances correctly even when the lookahead does not
+        tstart = self.get_sim_time()
+        while self.get_sim_time() - tstart < 45:
+            dist = self.get_distance(loop_centre, self.get_location())
+            if dist > 100:
+                raise NotAchievedException(
+                    "%s: vehicle left the loop after the jump, %.0fm from its centre" % (name, dist))
+            self.delay_sim_time(1, "checking the vehicle stays on the loop")
+
+        self.progress("%s: stayed on the loop" % name)
+        self.do_RTL()
+
+    def JumpNextNavResolution(self):
+        '''Verify the next-nav-command lookahead follows jumps of every shape'''
+
+        # the lookahead used to shape the path must resolve the same next nav
+        # command the mission goes on to execute.  It did not whenever a jump
+        # landed on anything other than a nav command (issues 31021 and 21534),
+        # so cover each combination of jump type and target.  In every case the
+        # vehicle must orbit the wpA <-> wpB leg; the waypoints 300m south of
+        # it are reachable only by discarding the jump
+        alt = 20
+        loop_centre = self.offset_location_ne(self.home_position_as_location(), 7, 22)
+
+        takeoff_and_approach = [
+            (mavutil.mavlink.MAV_CMD_NAV_TAKEOFF, 0, 0, alt),
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 19, -57, alt),
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 35, -17, alt),
+        ]
+        wpA = (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 23, 14, alt)
+        wpB = (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, -8, 30, alt)
+        beyond_the_jump = [
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, -300, 30, alt),
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, -350, 30, alt),
+        ]
+        # a do command that Copter's AUTO handles and that needs no hardware
+        roi_none = mavutil.mavlink.MAV_CMD_DO_SET_ROI_NONE
+
+        # the target is a do command, so the scan has to carry on past it to
+        # reach wpA.  This is the general form of the bug, tags aside
+        self.fly_jump_loop_mission(
+            "jump to do command",
+            takeoff_and_approach + [
+                self.create_MISSION_ITEM_INT(roi_none),                                      # 4 jump target
+                wpA,                                                                         # 5
+                wpB,                                                                         # 6
+                self.create_MISSION_ITEM_INT(mavutil.mavlink.MAV_CMD_DO_JUMP, p1=4, p2=-1),  # 7
+            ] + beyond_the_jump,
+            loop_end_wp=6,
+            loop_centre=loop_centre)
+
+        # the target is a nav command, which the scan returns immediately.
+        # This shape always worked, and is here to keep it that way
+        self.fly_jump_loop_mission(
+            "jump to nav command",
+            takeoff_and_approach + [
+                wpA,                                                                         # 4 jump target
+                wpB,                                                                         # 5
+                self.create_MISSION_ITEM_INT(mavutil.mavlink.MAV_CMD_DO_JUMP, p1=4, p2=-1),  # 6
+            ] + beyond_the_jump,
+            loop_end_wp=5,
+            loop_centre=loop_centre)
+
+        # a tag jump always lands on the tag marker, which is never a nav
+        # command, so this shape was broken for every mission that used tags
+        self.fly_jump_loop_mission(
+            "jump tag to nav command",
+            takeoff_and_approach + [
+                self.create_MISSION_ITEM_INT(mavutil.mavlink.MAV_CMD_JUMP_TAG, p1=1),            # 4 tag 1
+                wpA,                                                                             # 5
+                wpB,                                                                             # 6
+                self.create_MISSION_ITEM_INT(mavutil.mavlink.MAV_CMD_DO_JUMP_TAG, p1=1, p2=-1),  # 7
+            ] + beyond_the_jump,
+            loop_end_wp=6,
+            loop_centre=loop_centre)
+
+        # tag marker then a do command: the scan has to step over two non-nav
+        # commands before it reaches wpA
+        self.fly_jump_loop_mission(
+            "jump tag to do command",
+            takeoff_and_approach + [
+                self.create_MISSION_ITEM_INT(mavutil.mavlink.MAV_CMD_JUMP_TAG, p1=2),            # 4 tag 2
+                self.create_MISSION_ITEM_INT(roi_none),                                          # 5
+                wpA,                                                                             # 6
+                wpB,                                                                             # 7
+                self.create_MISSION_ITEM_INT(mavutil.mavlink.MAV_CMD_DO_JUMP_TAG, p1=2, p2=-1),  # 8
+            ] + beyond_the_jump,
+            loop_end_wp=7,
+            loop_centre=loop_centre)
+
     def GPSViconSwitching(self):
         """Fly GPS and Vicon switching test"""
         """Setup parameters including switching to EKF3"""
@@ -16228,6 +16333,12 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         '''
 
         self.upload_simple_relhome_mission(items)
+        # start from the beginning of the mission.  Copter resets the
+        # mission on disarm, so this usually changes nothing, but a test
+        # that moves the index without ever arming leaves it pointing
+        # mid-mission.  This must follow the upload, as setting the index
+        # while no mission is loaded is silently ignored:
+        self.set_current_waypoint(0, check_afterwards=False)
 
         self.set_parameter("AUTO_OPTIONS", 3)
         self.change_mode('AUTO')
@@ -18991,6 +19102,7 @@ return update, 1000
             self.FlyMissionTwiceWithReset,
             self.MissionIndexValidity,
             self.InvalidJumpTags,
+            self.JumpNextNavResolution,
             self.IMUConsistency,
             self.AHRSTrimLand,
             self.IBus,

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -5950,6 +5950,32 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             want_result=mavutil.mavlink.MAV_RESULT_FAILED,
         )
 
+    def MAV_CMD_DO_SET_MISSION_CURRENT_no_nav_command(self):
+        '''Test setting the current command in a mission whose loop holds no nav command'''
+
+        # setting the current command searches forward for a nav command to
+        # load, following jumps as it goes.  A forever jump over nothing but
+        # do commands never runs out of repeats and never reaches a nav
+        # command, so the search has nothing to terminate on and locks up the
+        # main loop, taking the vehicle with it
+        self.upload_simple_relhome_mission([
+            self.create_MISSION_ITEM_INT(mavutil.mavlink.MAV_CMD_DO_SET_ROI_NONE),       # 1
+            self.create_MISSION_ITEM_INT(mavutil.mavlink.MAV_CMD_DO_JUMP, p1=1, p2=-1),  # 2 jump to 1 forever
+        ])
+
+        # the vehicle must answer.  A missing ack here means it never came back
+        # from the search, not that it declined the command
+        self.run_cmd(
+            mavutil.mavlink.MAV_CMD_DO_SET_MISSION_CURRENT,
+            p1=1,
+            timeout=10,
+            want_result=mavutil.mavlink.MAV_RESULT_FAILED,
+        )
+
+        # and must still be talking to us afterwards
+        self.wait_heartbeat()
+        self.wait_heartbeat()
+
     def FlashStorage(self):
         '''Test flash storage (for parameters etc)'''
         self.set_parameter("LOG_BITMASK", 1)
@@ -7490,6 +7516,7 @@ return update()
             self.SET_POSITION_TARGET_LOCAL_NED,
             self.MAV_CMD_DO_SET_MISSION_CURRENT,
             self.MAV_CMD_DO_SET_MISSION_CURRENT_looped_mission,
+            self.MAV_CMD_DO_SET_MISSION_CURRENT_no_nav_command,
             self.MAV_CMD_DO_CHANGE_SPEED,
             self.MAV_CMD_MISSION_START,
             self.Button,

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -2218,7 +2218,7 @@ void AP_Mission::advance_current_do_cmd()
 ///     returns true if found, false if not found (i.e. mission complete)
 ///     accounts for do_jump commands
 ///     increment_jump_num_times_if_found should be set to true if advancing the active navigation command
-bool AP_Mission::get_next_cmd(uint16_t start_index, Mission_Command& cmd, bool increment_jump_num_times_if_found, bool send_gcs_msg, jump_tracking_struct *jump_state)
+bool AP_Mission::get_next_cmd(uint16_t start_index, Mission_Command& cmd, bool increment_jump_num_times_if_found, jump_tracking_struct *jump_state)
 {
     // default to the live jump tracking; callers may pass a private cursor to look ahead without side effects
     if (jump_state == nullptr) {
@@ -2274,7 +2274,7 @@ bool AP_Mission::get_next_cmd(uint16_t start_index, Mission_Command& cmd, bool i
                 get_jump_times_run(temp_cmd, jump_state) < temp_cmd.content.jump.num_times) {
                 // update the record of the number of times run
                 if (increment_jump_num_times_if_found && !_flags.resuming_mission) {
-                    increment_jump_times_run(temp_cmd, send_gcs_msg, jump_state);
+                    increment_jump_times_run(temp_cmd, jump_state);
                 }
                 // continue searching from jump target
                 cmd_index = temp_cmd.content.jump.target;
@@ -2421,12 +2421,16 @@ int16_t AP_Mission::get_jump_times_run(const Mission_Command& cmd, jump_tracking
 }
 
 /// increment_jump_times_run - increments the recorded number of times the jump command has been run
-void AP_Mission::increment_jump_times_run(Mission_Command& cmd, bool send_gcs_msg, jump_tracking_struct *jump_state)
+void AP_Mission::increment_jump_times_run(Mission_Command& cmd, jump_tracking_struct *jump_state)
 {
     // default to the live jump tracking; callers may pass a private cursor to look ahead without side effects
     if (jump_state == nullptr) {
         jump_state = _jump_tracking;
     }
+
+    // only the running mission takes the jumps recorded in the live counters, so only those are
+    // worth telling the GCS about; a look-ahead on a private cursor stays quiet
+    const bool send_gcs_msg = (jump_state == _jump_tracking);
 
     // exit immediately if cmd is not a do-jump command
     if (cmd.id != MAV_CMD_DO_JUMP) {
@@ -2695,7 +2699,7 @@ bool AP_Mission::distance_to_landing(uint16_t index, float &tot_distance, Locati
         // search until the end of the mission command list
         for (uint16_t cmd_index = index; cmd_index < (unsigned)_cmd_total; cmd_index++) {
             // get next command
-            if (!get_next_cmd(cmd_index, temp_cmd, true, false, jump_state)) {
+            if (!get_next_cmd(cmd_index, temp_cmd, true, jump_state)) {
                 // we got to the end of the mission
                 return false;
             }
@@ -2745,7 +2749,7 @@ bool AP_Mission::distance_to_mission_leg(uint16_t start_index, uint16_t &search_
     for (; search_remaining > 0; search_remaining--) {
         // search until the end of the mission command list
         for (uint16_t cmd_index = index; cmd_index <= (unsigned)_cmd_total; cmd_index++) {
-            if (get_next_cmd(cmd_index, temp_cmd, true, false, jump_state)) {
+            if (get_next_cmd(cmd_index, temp_cmd, true, jump_state)) {
                 break;
             } else {
                 // got to the end of the mission

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -2685,28 +2685,25 @@ bool AP_Mission::distance_to_landing(uint16_t index, float &tot_distance, Locati
 {
     Mission_Command temp_cmd;
     tot_distance = 0.0f;
-    bool ret = false;  // reached end of loop without getting to a landing
 
-    // back up jump tracking to reset after distance calculation
-    jump_tracking_struct _jump_tracking_backup[AP_MISSION_MAX_NUM_DO_JUMP_COMMANDS];
-    for (uint8_t i=0; i<AP_MISSION_MAX_NUM_DO_JUMP_COMMANDS; i++) {
-        _jump_tracking_backup[i] = _jump_tracking[i];
-    }
+    // look ahead on a private copy of the jump tracking so the running mission's jump counters are untouched
+    jump_tracking_struct jump_state[AP_MISSION_MAX_NUM_DO_JUMP_COMMANDS];
+    memcpy(jump_state, _jump_tracking, sizeof(jump_state));
 
     // run through remainder of mission to approximate a distance to landing
     for (uint8_t i=0; i<UINT8_MAX; i++) {
         // search until the end of the mission command list
         for (uint16_t cmd_index = index; cmd_index < (unsigned)_cmd_total; cmd_index++) {
             // get next command
-            if (!get_next_cmd(cmd_index, temp_cmd, true, false)) {
+            if (!get_next_cmd(cmd_index, temp_cmd, true, false, jump_state)) {
                 // we got to the end of the mission
-                goto reset_do_jump_tracking;
+                return false;
             }
             if (temp_cmd.id == MAV_CMD_NAV_WAYPOINT || temp_cmd.id == MAV_CMD_NAV_SPLINE_WAYPOINT || is_landing_type_cmd(temp_cmd.id)) {
                 break;
             } else if (is_nav_cmd(temp_cmd) || temp_cmd.id == MAV_CMD_CONDITION_DELAY) {
                 // if we receive a nav command that we dont handle then give up as cant measure the distance e.g. MAV_CMD_NAV_LOITER_UNLIM
-                goto reset_do_jump_tracking;
+                return false;
             }
         }
         index = temp_cmd.index+1;
@@ -2722,17 +2719,11 @@ bool AP_Mission::distance_to_landing(uint16_t index, float &tot_distance, Locati
 
         if (is_landing_type_cmd(temp_cmd.id)) {
             // reached a landing!
-            ret = true;
-            goto reset_do_jump_tracking;
+            return true;
         }
     }
 
-reset_do_jump_tracking:
-    for (uint8_t i=0; i<AP_MISSION_MAX_NUM_DO_JUMP_COMMANDS; i++) {
-        _jump_tracking[i] = _jump_tracking_backup[i];
-    }
-
-    return ret;
+    return false;
 }
 
 // Approximate the distance travelled to return to the mission path. DO_JUMP commands are observed in look forward.
@@ -2745,22 +2736,20 @@ bool AP_Mission::distance_to_mission_leg(uint16_t start_index, uint16_t &search_
     rejoin_index = -1;
     bool ret = false;
 
-    // back up jump tracking to reset after distance calculation
-    jump_tracking_struct _jump_tracking_backup[AP_MISSION_MAX_NUM_DO_JUMP_COMMANDS];
-    for (uint8_t i=0; i<AP_MISSION_MAX_NUM_DO_JUMP_COMMANDS; i++) {
-        _jump_tracking_backup[i] = _jump_tracking[i];
-    }
+    // look ahead on a private copy of the jump tracking so the running mission's jump counters are untouched
+    jump_tracking_struct jump_state[AP_MISSION_MAX_NUM_DO_JUMP_COMMANDS];
+    memcpy(jump_state, _jump_tracking, sizeof(jump_state));
 
     // run through remainder of mission to approximate a distance to landing
     uint16_t index = start_index;
     for (; search_remaining > 0; search_remaining--) {
         // search until the end of the mission command list
         for (uint16_t cmd_index = index; cmd_index <= (unsigned)_cmd_total; cmd_index++) {
-            if (get_next_cmd(cmd_index, temp_cmd, true, false)) {
+            if (get_next_cmd(cmd_index, temp_cmd, true, false, jump_state)) {
                 break;
             } else {
                 // got to the end of the mission
-                goto reset_do_jump_tracking;
+                return ret;
             }
         }
         index = temp_cmd.index + 1;
@@ -2805,18 +2794,12 @@ bool AP_Mission::distance_to_mission_leg(uint16_t start_index, uint16_t &search_
 
         if (is_landing_type_cmd(temp_cmd.id) || (temp_cmd.id == MAV_CMD_DO_LAND_START)) {
             // reached a landing!
-            goto reset_do_jump_tracking;
+            return ret;
         }
     }
+
     // reached end of loop without getting to a landing or DO_LAND_START
-    ret = false;
-
-reset_do_jump_tracking:
-    for (uint8_t i=0; i<AP_MISSION_MAX_NUM_DO_JUMP_COMMANDS; i++) {
-        _jump_tracking[i] = _jump_tracking_backup[i];
-    }
-
-    return ret;
+    return false;
 }
 
 // check if command is a landing type command.

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -196,10 +196,12 @@ bool AP_Mission::is_takeoff_next(uint16_t cmd_index)
     Mission_Command cmd = {};
     // check a maximum of 16 items, remembering that missions can have
     // loops in them
-    for (uint8_t i=0; i<16; i++, cmd_index++) {
+    for (uint8_t i=0; i<16; i++) {
         if (!get_next_nav_cmd(cmd_index, cmd)) {
             return false;
         }
+        // resume the search after the command found, which a jump may have moved
+        cmd_index = cmd.index + 1;
         switch (cmd.id) {
         // any of these are considered a takeoff command:
         case MAV_CMD_NAV_VTOL_TAKEOFF:
@@ -581,9 +583,6 @@ bool AP_Mission::get_next_nav_cmd(uint16_t start_index, Mission_Command& cmd)
         if (is_nav_cmd(cmd)) {
             return true;
         }
-        // resume from the command the scan resolved to.  A jump moves the scan elsewhere in the
-        // mission, so stepping our own index instead would silently discard it
-        cmd_index = cmd.index + 1;
     }
 
     // reached the end of the command list or the loop guard without finding a nav command
@@ -691,8 +690,6 @@ bool AP_Mission::set_current_cmd(uint16_t index)
                     _flags.do_cmd_loaded = true;
                 }
             }
-            // move onto next command
-            index = cmd.index+1;
         }
 
         // if we have not found a do command then set flag to show there are no do-commands to be run before nav command completes
@@ -2178,8 +2175,6 @@ bool AP_Mission::advance_current_nav_cmd(uint16_t starting_index)
                 start_command(_do_cmd);
             }
         }
-        // move onto next command
-        cmd_index = cmd.index+1;
     }
 
     if (max_loops == 0) {
@@ -2229,25 +2224,29 @@ void AP_Mission::advance_current_do_cmd()
     start_command(_do_cmd);
 }
 
-/// get_next_cmd - gets next command found at or after start_index
+/// get_next_cmd - gets next command found at or after scan_index
 ///     returns true if found, false if not found (i.e. mission complete)
 ///     accounts for do_jump commands
+///     scan_index is the caller's position in the mission, and is advanced by this function: on
+///     success it is left pointing at the command to resume the scan from, which is the index
+///     after the one returned, not after the index the scan was asked to start at.  Following a
+///     jump moves the scan elsewhere in the mission, so a caller that steps its own index instead
+///     would silently discard the jump.  Its value is unspecified on failure
 ///     increment_jump_num_times_if_found should be set to true if advancing the active navigation command
-bool AP_Mission::get_next_cmd(uint16_t start_index, Mission_Command& cmd, bool increment_jump_num_times_if_found, jump_tracking_struct *jump_state)
+bool AP_Mission::get_next_cmd(uint16_t &scan_index, Mission_Command& cmd, bool increment_jump_num_times_if_found, jump_tracking_struct *jump_state)
 {
     // default to the live jump tracking; callers may pass a private cursor to look ahead without side effects
     if (jump_state == nullptr) {
         jump_state = _jump_tracking;
     }
-    uint16_t cmd_index = start_index;
     Mission_Command temp_cmd;
     uint16_t jump_index = AP_MISSION_CMD_INDEX_NONE;
 
     // search until the end of the mission command list
     uint8_t max_loops = 64;
-    while (cmd_index < (unsigned)_cmd_total) {
+    while (scan_index < (unsigned)_cmd_total) {
         // load the next command
-        if (!read_cmd_from_storage(cmd_index, temp_cmd)) {
+        if (!read_cmd_from_storage(scan_index, temp_cmd)) {
             // this should never happen because of check above but just in case
             return false;
         }
@@ -2273,7 +2272,7 @@ bool AP_Mission::get_next_cmd(uint16_t start_index, Mission_Command& cmd, bool i
             }
 
             // check for endless loops
-            if (!increment_jump_num_times_if_found && jump_index == cmd_index) {
+            if (!increment_jump_num_times_if_found && jump_index == scan_index) {
                 // we have somehow reached this jump command twice and there is no chance it will complete
                 // To-Do: log an error?
                 return false;
@@ -2281,7 +2280,7 @@ bool AP_Mission::get_next_cmd(uint16_t start_index, Mission_Command& cmd, bool i
 
             // record this command so we can check for endless loops
             if (jump_index == AP_MISSION_CMD_INDEX_NONE) {
-                jump_index = cmd_index;
+                jump_index = scan_index;
             }
 
             // get number of times jump command has already been run
@@ -2292,7 +2291,7 @@ bool AP_Mission::get_next_cmd(uint16_t start_index, Mission_Command& cmd, bool i
                     increment_jump_times_run(temp_cmd, jump_state);
                 }
                 // continue searching from jump target
-                cmd_index = temp_cmd.content.jump.target;
+                scan_index = temp_cmd.content.jump.target;
             } else {
                 if (increment_jump_num_times_if_found && !option_is_set(Option::DONT_ZERO_COUNTER)) {
                     /*
@@ -2301,18 +2300,19 @@ bool AP_Mission::get_next_cmd(uint16_t start_index, Mission_Command& cmd, bool i
                       they get the count again
                     */
                     for (uint8_t i=0; i<AP_MISSION_MAX_NUM_DO_JUMP_COMMANDS; i++) {
-                        if (jump_state[i].index == cmd_index) {
+                        if (jump_state[i].index == scan_index) {
                             jump_state[i].num_times_run = 0;
                             break;
                         }
                     }
                 }
                 // jump has been run specified number of times so move search to next command in mission
-                cmd_index++;
+                scan_index++;
             }
         } else {
-            // this is a non-jump command so return it
+            // this is a non-jump command so return it, leaving the scan positioned after it
             cmd = temp_cmd;
+            scan_index = temp_cmd.index + 1;
             return true;
         }
     }
@@ -2334,8 +2334,9 @@ bool AP_Mission::get_next_do_cmd(uint16_t start_index, Mission_Command& cmd)
         return false;
     }
 
-    // get next command
-    if (!get_next_cmd(start_index, temp_cmd, false)) {
+    // get next command; the scan position is discarded, only the single command is wanted
+    uint16_t scan_index = start_index;
+    if (!get_next_cmd(scan_index, temp_cmd, false)) {
         // no more commands so return failure
         return false;
     } else if (is_nav_cmd(temp_cmd)) {
@@ -2711,21 +2712,27 @@ bool AP_Mission::distance_to_landing(uint16_t index, float &tot_distance, Locati
 
     // run through remainder of mission to approximate a distance to landing
     for (uint8_t i=0; i<UINT8_MAX; i++) {
-        // search until the end of the mission command list
-        for (uint16_t cmd_index = index; cmd_index < (unsigned)_cmd_total; cmd_index++) {
+        // search for the next command that contributes to the distance, stepping over the
+        // do-commands in between.  get_next_cmd advances index, so jumps taken on the way are kept
+        bool found = false;
+        for (uint8_t j=0; j<UINT8_MAX && index < (unsigned)_cmd_total; j++) {
             // get next command
-            if (!get_next_cmd(cmd_index, temp_cmd, true, jump_state)) {
-                // we got to the end of the mission
+            if (!get_next_cmd(index, temp_cmd, true, jump_state)) {
+                // reached the end of the mission without finding a landing
                 return false;
             }
             if (temp_cmd.id == MAV_CMD_NAV_WAYPOINT || temp_cmd.id == MAV_CMD_NAV_SPLINE_WAYPOINT || is_landing_type_cmd(temp_cmd.id)) {
+                found = true;
                 break;
             } else if (is_nav_cmd(temp_cmd) || temp_cmd.id == MAV_CMD_CONDITION_DELAY) {
                 // if we receive a nav command that we dont handle then give up as cant measure the distance e.g. MAV_CMD_NAV_LOITER_UNLIM
                 return false;
             }
         }
-        index = temp_cmd.index+1;
+        if (!found) {
+            // ran out of mission, or out of look-ahead, without reaching a command we can measure to
+            return false;
+        }
 
         if (!(temp_cmd.content.location.lat == 0 && temp_cmd.content.location.lng == 0)) {
             // add distance to running total
@@ -2762,16 +2769,11 @@ bool AP_Mission::distance_to_mission_leg(uint16_t start_index, uint16_t &search_
     // run through remainder of mission to approximate a distance to landing
     uint16_t index = start_index;
     for (; search_remaining > 0; search_remaining--) {
-        // search until the end of the mission command list
-        for (uint16_t cmd_index = index; cmd_index <= (unsigned)_cmd_total; cmd_index++) {
-            if (get_next_cmd(cmd_index, temp_cmd, true, jump_state)) {
-                break;
-            } else {
-                // got to the end of the mission
-                return ret;
-            }
+        // get the next command; get_next_cmd advances index past it, following any jump taken
+        if (!get_next_cmd(index, temp_cmd, true, jump_state)) {
+            // got to the end of the mission
+            return ret;
         }
-        index = temp_cmd.index + 1;
 
         if (stored_in_location(temp_cmd.id) && temp_cmd.content.location.initialised()) {
             if (prev_loc.lat == 0 && prev_loc.lng == 0) {

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -555,13 +555,25 @@ bool AP_Mission::is_nav_cmd(const Mission_Command& cmd)
 
 /// get_next_nav_cmd - gets next "navigation" command found at or after start_index
 ///     returns true if found, false if not found (i.e. reached end of mission command list)
-///     accounts for do_jump commands but never increments the jump's num_times_run (advance_current_nav_cmd is responsible for this)
+///     follows do_jump commands on a private copy of the jump tracking, so the live mission's
+///     num_times_run counters are left untouched (advance_current_nav_cmd owns those)
 bool AP_Mission::get_next_nav_cmd(uint16_t start_index, Mission_Command& cmd)
 {
+    // advance a private copy of the jump tracking, seeded from the live state, so the look-ahead
+    // follows jumps exactly as execution would (and terminates on finite jumps) without mutating
+    // the running mission's counters
+    jump_tracking_struct jump_state[AP_MISSION_MAX_NUM_DO_JUMP_COMMANDS];
+    memcpy(jump_state, _jump_tracking, sizeof(jump_state));
+
+    // avoid endless loops, as advance_current_nav_cmd does: a DO_JUMP loop containing no nav
+    // command (e.g. a forever jump back over only do-commands) would otherwise spin here
+    uint8_t max_loops = 255;
+
     // search until the end of the mission command list
-    for (uint16_t cmd_index = start_index; cmd_index < (unsigned)_cmd_total; cmd_index++) {
-        // get next command
-        if (!get_next_cmd(cmd_index, cmd, false)) {
+    uint16_t cmd_index = start_index;
+    while (cmd_index < (unsigned)_cmd_total && max_loops-- > 0) {
+        // get next command, following jumps on the private cursor
+        if (!get_next_cmd(cmd_index, cmd, true, jump_state)) {
             // no more commands so return failure
             return false;
         }
@@ -569,9 +581,12 @@ bool AP_Mission::get_next_nav_cmd(uint16_t start_index, Mission_Command& cmd)
         if (is_nav_cmd(cmd)) {
             return true;
         }
+        // resume from the command the scan resolved to.  A jump moves the scan elsewhere in the
+        // mission, so stepping our own index instead would silently discard it
+        cmd_index = cmd.index + 1;
     }
 
-    // if we got this far we did not find a navigation command
+    // reached the end of the command list or the loop guard without finding a nav command
     return false;
 }
 

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -2218,8 +2218,12 @@ void AP_Mission::advance_current_do_cmd()
 ///     returns true if found, false if not found (i.e. mission complete)
 ///     accounts for do_jump commands
 ///     increment_jump_num_times_if_found should be set to true if advancing the active navigation command
-bool AP_Mission::get_next_cmd(uint16_t start_index, Mission_Command& cmd, bool increment_jump_num_times_if_found, bool send_gcs_msg)
+bool AP_Mission::get_next_cmd(uint16_t start_index, Mission_Command& cmd, bool increment_jump_num_times_if_found, bool send_gcs_msg, jump_tracking_struct *jump_state)
 {
+    // default to the live jump tracking; callers may pass a private cursor to look ahead without side effects
+    if (jump_state == nullptr) {
+        jump_state = _jump_tracking;
+    }
     uint16_t cmd_index = start_index;
     Mission_Command temp_cmd;
     uint16_t jump_index = AP_MISSION_CMD_INDEX_NONE;
@@ -2267,10 +2271,10 @@ bool AP_Mission::get_next_cmd(uint16_t start_index, Mission_Command& cmd, bool i
 
             // get number of times jump command has already been run
             if (temp_cmd.content.jump.num_times == AP_MISSION_JUMP_REPEAT_FOREVER ||
-                get_jump_times_run(temp_cmd) < temp_cmd.content.jump.num_times) {
+                get_jump_times_run(temp_cmd, jump_state) < temp_cmd.content.jump.num_times) {
                 // update the record of the number of times run
                 if (increment_jump_num_times_if_found && !_flags.resuming_mission) {
-                    increment_jump_times_run(temp_cmd, send_gcs_msg);
+                    increment_jump_times_run(temp_cmd, send_gcs_msg, jump_state);
                 }
                 // continue searching from jump target
                 cmd_index = temp_cmd.content.jump.target;
@@ -2282,8 +2286,8 @@ bool AP_Mission::get_next_cmd(uint16_t start_index, Mission_Command& cmd, bool i
                       they get the count again
                     */
                     for (uint8_t i=0; i<AP_MISSION_MAX_NUM_DO_JUMP_COMMANDS; i++) {
-                        if (_jump_tracking[i].index == cmd_index) {
-                            _jump_tracking[i].num_times_run = 0;
+                        if (jump_state[i].index == cmd_index) {
+                            jump_state[i].num_times_run = 0;
                             break;
                         }
                     }
@@ -2386,8 +2390,13 @@ void AP_Mission::init_jump_tracking()
 }
 
 /// get_jump_times_run - returns number of times the jump command has been run
-int16_t AP_Mission::get_jump_times_run(const Mission_Command& cmd)
+int16_t AP_Mission::get_jump_times_run(const Mission_Command& cmd, jump_tracking_struct *jump_state)
 {
+    // default to the live jump tracking; callers may pass a private cursor to look ahead without side effects
+    if (jump_state == nullptr) {
+        jump_state = _jump_tracking;
+    }
+
     // exit immediately if cmd is not a do-jump command or target is invalid
     if ((cmd.id != MAV_CMD_DO_JUMP) || (cmd.content.jump.target >= (unsigned)_cmd_total) || (cmd.content.jump.target == 0)) {
         // To-Do: log an error?
@@ -2396,12 +2405,12 @@ int16_t AP_Mission::get_jump_times_run(const Mission_Command& cmd)
 
     // search through jump_tracking array for this cmd
     for (uint8_t i=0; i<AP_MISSION_MAX_NUM_DO_JUMP_COMMANDS; i++) {
-        if (_jump_tracking[i].index == cmd.index) {
-            return _jump_tracking[i].num_times_run;
-        } else if (_jump_tracking[i].index == AP_MISSION_CMD_INDEX_NONE) {
-            // we've searched through all known jump commands and haven't found it so allocate new space in _jump_tracking array
-            _jump_tracking[i].index = cmd.index;
-            _jump_tracking[i].num_times_run = 0;
+        if (jump_state[i].index == cmd.index) {
+            return jump_state[i].num_times_run;
+        } else if (jump_state[i].index == AP_MISSION_CMD_INDEX_NONE) {
+            // we've searched through all known jump commands and haven't found it so allocate new space in jump_state array
+            jump_state[i].index = cmd.index;
+            jump_state[i].num_times_run = 0;
             return 0;
         }
     }
@@ -2412,8 +2421,13 @@ int16_t AP_Mission::get_jump_times_run(const Mission_Command& cmd)
 }
 
 /// increment_jump_times_run - increments the recorded number of times the jump command has been run
-void AP_Mission::increment_jump_times_run(Mission_Command& cmd, bool send_gcs_msg)
+void AP_Mission::increment_jump_times_run(Mission_Command& cmd, bool send_gcs_msg, jump_tracking_struct *jump_state)
 {
+    // default to the live jump tracking; callers may pass a private cursor to look ahead without side effects
+    if (jump_state == nullptr) {
+        jump_state = _jump_tracking;
+    }
+
     // exit immediately if cmd is not a do-jump command
     if (cmd.id != MAV_CMD_DO_JUMP) {
         // To-Do: log an error?
@@ -2422,20 +2436,20 @@ void AP_Mission::increment_jump_times_run(Mission_Command& cmd, bool send_gcs_ms
 
     // search through jump_tracking array for this cmd
     for (uint8_t i=0; i<AP_MISSION_MAX_NUM_DO_JUMP_COMMANDS; i++) {
-        if (_jump_tracking[i].index == cmd.index) {
-            _jump_tracking[i].num_times_run++;
+        if (jump_state[i].index == cmd.index) {
+            jump_state[i].num_times_run++;
             if (send_gcs_msg) {
                 if (cmd.content.jump.num_times == AP_MISSION_JUMP_REPEAT_FOREVER) {
-                    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Mission: %u Jump %i/unlimited", _jump_tracking[i].index, _jump_tracking[i].num_times_run);
+                    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Mission: %u Jump %i/unlimited", jump_state[i].index, jump_state[i].num_times_run);
                 } else {
-                    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Mission: %u Jump %i/%i", _jump_tracking[i].index, _jump_tracking[i].num_times_run, cmd.content.jump.num_times);
+                    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Mission: %u Jump %i/%i", jump_state[i].index, jump_state[i].num_times_run, cmd.content.jump.num_times);
                 }
             }
             return;
-        } else if (_jump_tracking[i].index == AP_MISSION_CMD_INDEX_NONE) {
-            // we've searched through all known jump commands and haven't found it so allocate new space in _jump_tracking array
-            _jump_tracking[i].index = cmd.index;
-            _jump_tracking[i].num_times_run = 1;
+        } else if (jump_state[i].index == AP_MISSION_CMD_INDEX_NONE) {
+            // we've searched through all known jump commands and haven't found it so allocate new space in jump_state array
+            jump_state[i].index = cmd.index;
+            jump_state[i].num_times_run = 1;
             return;
         }
     }

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -670,8 +670,18 @@ bool AP_Mission::set_current_cmd(uint16_t index)
     // if the mission is stopped or completed move the nav_cmd index to the specified point and set the state to stopped
     // so that if the user resumes the mission it will begin at the specified index
     if (_flags.state != MISSION_RUNNING) {
+        // avoid endless loops: a jump loop that holds no nav command, such as a
+        // forever DO_JUMP over do commands, never runs out of repeats and never
+        // reaches a nav command, so the search below would never finish
+        uint8_t max_loops = 255;
+
         // search until we find next nav command or reach end of command list
         while (!_flags.nav_cmd_loaded) {
+            if (max_loops-- == 0) {
+                _nav_cmd.index = AP_MISSION_CMD_INDEX_NONE;
+                return false;
+            }
+
             // get next command
             if (!get_next_cmd(index, cmd, true)) {
                 _nav_cmd.index = AP_MISSION_CMD_INDEX_NONE;

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -870,15 +870,18 @@ private:
     ///     returns true if successfully advanced (can it ever be unsuccessful?)
     void advance_current_do_cmd();
 
-    /// get_next_cmd - gets next command found at or after start_index
+    /// get_next_cmd - gets next command found at or after scan_index
     ///     returns true if found, false if not found (i.e. mission complete)
     ///     accounts for do_jump commands
+    ///     scan_index is the caller's position in the mission, and is advanced by this function to
+    ///     the command the scan should resume from, so that a scan continued through this function
+    ///     follows jumps the same way the running mission does; unspecified on failure
     ///     increment_jump_num_times_if_found should be set to true if advancing the active navigation command
     ///     jump_state, when supplied, is used in place of the live _jump_tracking so callers can look
     ///     ahead without disturbing the running mission's jump counters; nullptr uses _jump_tracking.
     ///     A look-ahead on a private cursor is not taking the jumps it follows, so it does not
     ///     report them to the GCS either
-    bool get_next_cmd(uint16_t start_index, Mission_Command& cmd, bool increment_jump_num_times_if_found, jump_tracking_struct *jump_state = nullptr);
+    bool get_next_cmd(uint16_t &scan_index, Mission_Command& cmd, bool increment_jump_num_times_if_found, jump_tracking_struct *jump_state = nullptr);
 
     /// get_next_do_cmd - gets next "do" or "conditional" command after start_index
     ///     returns true if found, false if not found

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -875,8 +875,10 @@ private:
     ///     accounts for do_jump commands
     ///     increment_jump_num_times_if_found should be set to true if advancing the active navigation command
     ///     jump_state, when supplied, is used in place of the live _jump_tracking so callers can look
-    ///     ahead without disturbing the running mission's jump counters; nullptr uses _jump_tracking
-    bool get_next_cmd(uint16_t start_index, Mission_Command& cmd, bool increment_jump_num_times_if_found, bool send_gcs_msg = true, jump_tracking_struct *jump_state = nullptr);
+    ///     ahead without disturbing the running mission's jump counters; nullptr uses _jump_tracking.
+    ///     A look-ahead on a private cursor is not taking the jumps it follows, so it does not
+    ///     report them to the GCS either
+    bool get_next_cmd(uint16_t start_index, Mission_Command& cmd, bool increment_jump_num_times_if_found, jump_tracking_struct *jump_state = nullptr);
 
     /// get_next_do_cmd - gets next "do" or "conditional" command after start_index
     ///     returns true if found, false if not found
@@ -896,8 +898,9 @@ private:
     int16_t get_jump_times_run(const Mission_Command& cmd, jump_tracking_struct *jump_state = nullptr);
 
     /// increment_jump_times_run - increments the recorded number of times the jump command has been run
-    ///     jump_state, when supplied, is used in place of the live _jump_tracking; nullptr uses _jump_tracking
-    void increment_jump_times_run(Mission_Command& cmd, bool send_gcs_msg = true, jump_tracking_struct *jump_state = nullptr);
+    ///     jump_state, when supplied, is used in place of the live _jump_tracking; nullptr uses _jump_tracking.
+    ///     The jump is reported to the GCS only when the live counters are the ones being advanced
+    void increment_jump_times_run(Mission_Command& cmd, jump_tracking_struct *jump_state = nullptr);
 
     /// check_eeprom_version - checks version of missions stored in eeprom matches this library
     /// command list will be cleared if they do not match

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -818,6 +818,13 @@ private:
 
     static bool stored_in_location(uint16_t id);
 
+    // record of how many times a do-jump command has been run. The mission keeps one set of these
+    // in _jump_tracking; look-aheads scan on a copy so the running mission is unaffected
+    struct jump_tracking_struct {
+        uint16_t index;                 // index of do-jump commands in mission
+        int16_t num_times_run;          // number of times this jump command has been run
+    };
+
     struct {
         uint16_t age;   // a value of 0 means we have never seen a tag. Once a tag is seen, age will increment every time the mission index changes.
         uint16_t tag;   // most recent tag that was successfully jumped to. Only valid if age > 0
@@ -867,7 +874,9 @@ private:
     ///     returns true if found, false if not found (i.e. mission complete)
     ///     accounts for do_jump commands
     ///     increment_jump_num_times_if_found should be set to true if advancing the active navigation command
-    bool get_next_cmd(uint16_t start_index, Mission_Command& cmd, bool increment_jump_num_times_if_found, bool send_gcs_msg = true);
+    ///     jump_state, when supplied, is used in place of the live _jump_tracking so callers can look
+    ///     ahead without disturbing the running mission's jump counters; nullptr uses _jump_tracking
+    bool get_next_cmd(uint16_t start_index, Mission_Command& cmd, bool increment_jump_num_times_if_found, bool send_gcs_msg = true, jump_tracking_struct *jump_state = nullptr);
 
     /// get_next_do_cmd - gets next "do" or "conditional" command after start_index
     ///     returns true if found, false if not found
@@ -883,10 +892,12 @@ private:
 
     /// get_jump_times_run - returns number of times the jump command has been run
     ///     return is signed to be consistent with do-jump cmd's repeat count which can be -1 (to signify to repeat forever)
-    int16_t get_jump_times_run(const Mission_Command& cmd);
+    ///     jump_state, when supplied, is used in place of the live _jump_tracking; nullptr uses _jump_tracking
+    int16_t get_jump_times_run(const Mission_Command& cmd, jump_tracking_struct *jump_state = nullptr);
 
     /// increment_jump_times_run - increments the recorded number of times the jump command has been run
-    void increment_jump_times_run(Mission_Command& cmd, bool send_gcs_msg = true);
+    ///     jump_state, when supplied, is used in place of the live _jump_tracking; nullptr uses _jump_tracking
+    void increment_jump_times_run(Mission_Command& cmd, bool send_gcs_msg = true, jump_tracking_struct *jump_state = nullptr);
 
     /// check_eeprom_version - checks version of missions stored in eeprom matches this library
     /// command list will be cleared if they do not match
@@ -941,10 +952,7 @@ private:
     Location         _exit_position;  // the position in the mission that the mission was exited
 
     // jump related variables
-    struct jump_tracking_struct {
-        uint16_t index;                 // index of do-jump commands in mission
-        int16_t num_times_run;          // number of times this jump command has been run
-    } _jump_tracking[AP_MISSION_MAX_NUM_DO_JUMP_COMMANDS];
+    jump_tracking_struct    _jump_tracking[AP_MISSION_MAX_NUM_DO_JUMP_COMMANDS];
 
     // last time that mission changed
     uint32_t _last_change_time_ms;


### PR DESCRIPTION
### Summary

- Fixes the broken DO_JUMP_TAG in copter (#31021).
- Fixes an issue with tangent exit from loiters in plane when followed by a DO_JUMP_TAG (#21534, #32029)
- This also contains a drive-by fix of an existing bug where loading a mission with an infinite loop of do commands would lock up the autopilot.

### Classification & Testing

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

This supersedes PRs #32029 and #31038

On Copter, the next nav command is fetched before it is executed: `get_next_nav_cmd` supplies the target the S-curve calculations are shaped through, and `advance_current_nav_cmd` later loads what actually runs. Nothing guaranteed the two resolved the mission the same way, and around jumps they did not (as reported in #21534), causing Copter to claim it was flying to one waypoint (after it advances it) while flying to a different one (the one it fetched before). On Plane, we don't pre-fetch the next waypoint, so this bug has less dramatic impact.

They disagreed because `get_next_nav_cmd` never actually followed a jump. The scan handed `get_next_cmd` a linearly incremented index each pass, so a jump's target was only glanced at (accepted if it happened to be a nav command directly, discarded otherwise) until the index walked past the jump and the scan continued in the linear sequence beyond it, reporting a nav command the vehicle may not fly next (and in fact, may *never* fly if that was an infinite jump).

A jump tag is never a nav command, so `DO_JUMP_TAG` missions tripped this every time, but tags are just the common case of jumping to a non-nav command; a `DO_JUMP` which targets any non-nav command fails the same way.

The fix builds on a small mechanism: the jump-resolving look-ups (`get_next_cmd`, `get_jump_times_run`, `increment_jump_times_run`) gain an optional jump cursor, a private copy of the do-jump counters, so a caller can scan ahead following jumps exactly as execution would, without spending the running mission's counters. **Fetch and execute now walk the same resolution path, differing only in whose counters they spend, so they cannot disagree.** That cursor replaces the two workarounds that existed for the same problem: the backup/restore-through-goto dance in the distance scans, and the `send_gcs_msg` flag (a jump is now reported to the GCS exactly when the live counters are the ones being advanced). `get_next_cmd` also takes over advancing the caller's scan position, so the resume-from-the-resolved-index rule is written once instead of six times: previously two of those six were wrong, including `distance_to_landing`'s inner scan (couldn't find anyone reporting any bugs from that, but that could have in theory messed with the logic for finding the closest landing on Plane).

While bounding these searches, `set_current_cmd` turned out to have an unbounded one: a jump loop containing no nav command (a forever `DO_JUMP` over do commands) never terminates the search and hangs the main loop. It's now bounded the same way `advance_current_nav_cmd` bounds its own, failing the command instead. New autotests cover the four jump shapes (`DO_JUMP` and `DO_JUMP_TAG`, each landing on a nav and on a do command) by checking the vehicle's actual position rather than the reported waypoint, plus the set-current hang on Rover.