### PR TITLE
autotest: fix flaky QuadPlane cliff fence tests

### DIFF
--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -16403,6 +16403,16 @@ SERIAL5_BAUD 128
         # ridge (~206 m AMSL) while staying 10 m below both tests' max
         # fence altitude (225 m AMSL), so use the higher of the current
         # altitude and 215 m AMSL.
+        # north_m must be generous: on QuadPlane the reposition flies as
+        # fixed-wing GUIDED, which orbits the target at ~60-70 m
+        # (WP_LOITER_RAD plus tracking error), so arrival is accepted at
+        # 100 m -- a tighter radius is only ever satisfied transiently
+        # while joining the orbit.  The wait can therefore fire ~100 m
+        # short of the target, and the back-transition carries the
+        # aircraft tens of metres further, so the actual descent point
+        # must still be well past the cliff edge for the min-alt fence
+        # floor (~150 m AMSL in both cliff tests) to sit clearly above
+        # the terrain below.
         reposition_alt_amsl = max(current_loc.alt, 215.0)
 
         # fly to target using GUIDED mode waypoint navigation
@@ -16417,7 +16427,7 @@ SERIAL5_BAUD 128
             reposition_alt_amsl,
             frame=mavutil.mavlink.MAV_FRAME_GLOBAL,
         )
-        self.wait_location(target_loc, accuracy=50, height_accuracy=None,
+        self.wait_location(target_loc, accuracy=100, height_accuracy=None,
                            timeout=timeout)
 
         # switch back to loiter mode and descend to breach the fence floor
@@ -16597,7 +16607,7 @@ SERIAL5_BAUD 128
         self.takeoff(25, mode=self.FenceRelative_TakeoffMode())
         self.do_fence_enable()
         self.assert_mode_is(self.FenceRelative_TakeoffMode())
-        self.FenceRelative_fly_north_then_descend(150)
+        self.FenceRelative_fly_north_then_descend(300)
         self.wait_mode('RTL', timeout=120)
         expected_breach_alt = offset_home.alt + fence_alt_min
         self.assert_altitude(expected_breach_alt, accuracy=10)
@@ -16765,7 +16775,7 @@ SERIAL5_BAUD 128
         self.takeoff(20, mode=self.FenceRelative_TakeoffMode())
         self.do_fence_enable()
         self.assert_mode_is(self.FenceRelative_TakeoffMode())
-        self.FenceRelative_fly_north_then_descend(150)
+        self.FenceRelative_fly_north_then_descend(300)
         self.wait_mode('RTL', timeout=120)
         expected_breach_alt = fence_min_below_arming
         self.assert_altitude(expected_breach_alt, accuracy=10)


### PR DESCRIPTION
### Summary

Fix flaky QuadPlane cliff fence autotests (FenceRelativeToAMSLCliff, FenceRelativeToHomeCliff): fly far enough past the cliff edge before descending, and accept reposition arrival at the fixed-wing GUIDED orbit radius.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)

Repeated SITL runs before and after the change:
- Before: test.QuadPlane.FenceRelativeToAMSLCliff passed 3 of 5 runs, failing with `WaitModeTimeout('Did not change mode')`.
- After: test.QuadPlane.FenceRelativeToAMSLCliff passed 5/5, test.QuadPlane.FenceRelativeToHomeCliff passed 3/3, and test.Copter.FenceRelativeToAMSLCliff / test.Copter.FenceRelativeToHomeCliff both pass.
- Dataflash logs confirm the min-alt breach now fires with over 130 m of ground clearance, where previously it fired 1-2 m above touchdown (or not at all).

### Description

FenceRelativeToAMSLCliff failed about half its runs on QuadPlane: the fixed-wing GUIDED reposition orbits the target at 60-70 m (WP_LOITER_RAD plus tracking error), arrives short and the back-transition drifts laterally, leaving the descent point over terrain 1-2 m above the min-alt fence floor. The aircraft landed before breaching and `wait_mode('RTL')` timed out. FenceRelativeToHomeCliff shares the same floor and geometry, so it was equally at risk.

Two changes to fix it:

1. Fly 300 m north instead of 150 m, so the descent point is well past the cliff edge and the fence floor (~150 m AMSL in both tests) sits far above the terrain below.
2. Accept reposition arrival at 100 m instead of 50 m. A radius tighter than the GUIDED orbit is only ever satisfied transiently while joining it; with the longer leg the aircraft often settled into a stable ~69 m orbit and `wait_location` timed out with "Failed to attain location".

A comment in `FenceRelative_fly_north_then_descend` now documents both constraints so the distances don't get shrunk back later. Copter uses the same helper and was re-verified.
