### PR TITLE
RTL cleanup

### DIFF
--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1534,8 +1534,8 @@ public:
     enum class SubMode : uint8_t {
         STARTING,
         INITIAL_CLIMB,
-        RETURN_HOME,
-        LOITER_AT_HOME,
+        FLY_TO_RETURN_POINT,
+        HOLD_AT_RETURN_POINT,
         FINAL_DESCENT,
         LAND
     };
@@ -1589,8 +1589,8 @@ private:
     void climb_start();
     void return_start();
     void climb_return_run();
-    void loiterathome_start();
-    void loiterathome_run();
+    void hold_at_return_point_start();
+    void hold_at_return_point_run();
     void build_path();
     void compute_return_target();
 
@@ -1600,7 +1600,7 @@ private:
     AP_Float alt_final_m;
     AP_Float climb_min_m;
 
-    SubMode _state = SubMode::INITIAL_CLIMB;  // records state of rtl (initial climb, returning home, etc)
+    SubMode _state = SubMode::INITIAL_CLIMB;  // records state of rtl (initial climb, returning, etc)
     bool _state_complete = false; // set to true if the current state is completed
 
     struct {
@@ -1618,8 +1618,8 @@ private:
         TERRAINDATABASE = 2
     };
 
-    // Loiter timer - Records how long we have been in loiter
-    uint32_t _loiter_start_time;
+    // Hold timer - Records how long we have been holding at the return point
+    uint32_t _hold_start_time;
 
     bool terrain_following_allowed;
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1687,11 +1687,11 @@ protected:
 
 private:
 
+    void set_submode(SubMode submode);
     void wait_cleanup_run();
     void path_follow_run();
     void pre_land_position_run();
-    void land();
-    SubMode smart_rtl_state = SubMode::PATH_FOLLOW;
+    SubMode smart_rtl_state = SubMode::WAIT_FOR_PATH_CLEANUP;
 
     // keep track of how long we have failed to get another return
     // point while following our path home.  If we take too long we

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1586,8 +1586,14 @@ protected:
 
 private:
 
+    // advance_state - move to the next stage when the current one is complete
+    void advance_state();
+
+    // set_submode - performs all normal stage changes; sets _state, clears _state_complete and runs the stage's entry init
+    void set_submode(SubMode submode);
+
     void climb_start();
-    void return_start();
+    bool return_start();
     void climb_return_run();
     void hold_at_return_point_start();
     void hold_at_return_point_run();
@@ -1600,7 +1606,7 @@ private:
     AP_Float alt_final_m;
     AP_Float climb_min_m;
 
-    SubMode _state = SubMode::INITIAL_CLIMB;  // records state of rtl (initial climb, returning, etc)
+    SubMode _state = SubMode::STARTING;
     bool _state_complete = false; // set to true if the current state is completed
 
     struct {
@@ -1618,8 +1624,8 @@ private:
         TERRAINDATABASE = 2
     };
 
-    // Hold timer - Records how long we have been holding at the return point
-    uint32_t _hold_start_time;
+    // time the current stage was entered (set by set_submode); used by the hold timer
+    uint32_t _stage_start_ms;
 
     bool terrain_following_allowed;
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1595,6 +1595,7 @@ private:
 
     void climb_start();
     bool return_start();
+    bool run_wp_controllers();
     void climb_return_run();
     void hold_at_return_point_start();
     void hold_at_return_point_run();

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1539,10 +1539,11 @@ public:
         FINAL_DESCENT,
         LAND
     };
-    SubMode state() { return _state; }
-
-    // this should probably not be exposed
-    bool state_complete() const { return _state_complete; }
+    
+    // true once RTL has completed its final stage: the final descent has reached
+    // RTL_ALT_FINAL, or the vehicle has landed and spooled to ground idle;
+    // used by ModeAuto::verify_RTL
+    bool is_complete() const;
 
     virtual bool is_landing() const override;
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1597,8 +1597,14 @@ protected:
 
 private:
 
+    // advance_state - move to the next stage when the current one is complete
+    void advance_state();
+
+    // set_submode - performs all normal stage changes; sets _state, clears _state_complete and runs the stage's entry init
+    void set_submode(SubMode submode);
+
     void climb_start();
-    void return_start();
+    bool return_start();
     void climb_return_run();
     void hold_at_return_point_start();
     void hold_at_return_point_run();
@@ -1611,7 +1617,7 @@ private:
     AP_Float alt_final_m;
     AP_Float climb_min_m;
 
-    SubMode _state = SubMode::INITIAL_CLIMB;  // records state of rtl (initial climb, returning, etc)
+    SubMode _state = SubMode::STARTING;
     bool _state_complete = false; // set to true if the current state is completed
 
     struct {
@@ -1629,8 +1635,8 @@ private:
         TERRAINDATABASE = 2
     };
 
-    // Hold timer - Records how long we have been holding at the return point
-    uint32_t _hold_start_time;
+    // time the current stage was entered (set by set_submode); used by the hold timer
+    uint32_t _stage_start_ms;
 
     bool terrain_following_allowed;
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1545,8 +1545,8 @@ public:
     enum class SubMode : uint8_t {
         STARTING,
         INITIAL_CLIMB,
-        RETURN_HOME,
-        LOITER_AT_HOME,
+        FLY_TO_RETURN_POINT,
+        HOLD_AT_RETURN_POINT,
         FINAL_DESCENT,
         LAND
     };
@@ -1600,8 +1600,8 @@ private:
     void climb_start();
     void return_start();
     void climb_return_run();
-    void loiterathome_start();
-    void loiterathome_run();
+    void hold_at_return_point_start();
+    void hold_at_return_point_run();
     void build_path();
     void compute_return_target();
 
@@ -1611,7 +1611,7 @@ private:
     AP_Float alt_final_m;
     AP_Float climb_min_m;
 
-    SubMode _state = SubMode::INITIAL_CLIMB;  // records state of rtl (initial climb, returning home, etc)
+    SubMode _state = SubMode::INITIAL_CLIMB;  // records state of rtl (initial climb, returning, etc)
     bool _state_complete = false; // set to true if the current state is completed
 
     struct {
@@ -1629,8 +1629,8 @@ private:
         TERRAINDATABASE = 2
     };
 
-    // Loiter timer - Records how long we have been in loiter
-    uint32_t _loiter_start_time;
+    // Hold timer - Records how long we have been holding at the return point
+    uint32_t _hold_start_time;
 
     bool terrain_following_allowed;
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1606,6 +1606,7 @@ private:
 
     void climb_start();
     bool return_start();
+    bool run_wp_controllers();
     void climb_return_run();
     void hold_at_return_point_start();
     void hold_at_return_point_run();

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1550,10 +1550,11 @@ public:
         FINAL_DESCENT,
         LAND
     };
-    SubMode state() { return _state; }
-
-    // this should probably not be exposed
-    bool state_complete() const { return _state_complete; }
+    
+    // true once RTL has completed its final stage: the final descent has reached
+    // RTL_ALT_FINAL, or the vehicle has landed and spooled to ground idle;
+    // used by ModeAuto::verify_RTL
+    bool is_complete() const;
 
     virtual bool is_landing() const override;
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1698,11 +1698,11 @@ protected:
 
 private:
 
+    void set_submode(SubMode submode);
     void wait_cleanup_run();
     void path_follow_run();
     void pre_land_position_run();
-    void land();
-    SubMode smart_rtl_state = SubMode::PATH_FOLLOW;
+    SubMode smart_rtl_state = SubMode::WAIT_FOR_PATH_CLEANUP;
 
     // keep track of how long we have failed to get another return
     // point while following our path home.  If we take too long we

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -2234,8 +2234,8 @@ bool ModeAuto::verify_loiter_to_alt() const
 bool ModeAuto::verify_RTL()
 {
     return (copter.mode_rtl.state_complete() && 
-            (copter.mode_rtl.state() == ModeRTL::SubMode::FINAL_DESCENT || copter.mode_rtl.state() == ModeRTL::SubMode::LAND) &&
-            (motors->get_spool_state() == AP_Motors::SpoolState::GROUND_IDLE));
+            ((copter.mode_rtl.state() == ModeRTL::SubMode::FINAL_DESCENT) ||
+             (copter.mode_rtl.state() == ModeRTL::SubMode::LAND && motors->get_spool_state() == AP_Motors::SpoolState::GROUND_IDLE)));
 }
 
 /********************************************************************************/

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -2233,9 +2233,7 @@ bool ModeAuto::verify_loiter_to_alt() const
 // returns true with RTL has completed successfully
 bool ModeAuto::verify_RTL()
 {
-    return (copter.mode_rtl.state_complete() && 
-            ((copter.mode_rtl.state() == ModeRTL::SubMode::FINAL_DESCENT) ||
-             (copter.mode_rtl.state() == ModeRTL::SubMode::LAND && motors->get_spool_state() == AP_Motors::SpoolState::GROUND_IDLE)));
+    return copter.mode_rtl.is_complete();
 }
 
 /********************************************************************************/

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -2254,23 +2254,7 @@ bool ModeAuto::verify_loiter_to_alt() const
 // do_RTL should have been called once first to initialise all variables
 bool ModeAuto::verify_RTL()
 {
-    // return immediately if RTL's current state has not completed
-    if (!copter.mode_rtl.state_complete()) {
-        return false;
-    }
-
-    switch (copter.mode_rtl.state()) {
-        case ModeRTL::SubMode::FINAL_DESCENT:
-            return true;
-        case ModeRTL::SubMode::LAND:
-            // if landing ensure motors have spooled down
-            return motors->get_spool_state() == AP_Motors::SpoolState::GROUND_IDLE;
-        default:
-            break;
-    }
-
-    // RTL has not completed
-    return false;
+    return copter.mode_rtl.is_complete();
 }
 
 /********************************************************************************/

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -144,9 +144,11 @@ void ModeRTL::run(bool disarm_on_land)
     switch (_state) {
 
     case SubMode::STARTING:
-        // should not be reached:
-        _state = SubMode::INITIAL_CLIMB;
-        FALLTHROUGH;
+        // reached only after an in-cycle restart_without_terrain(); hold on the
+        // current target this loop and let advance_state() rebuild the path next loop
+        climb_return_run();
+        _state_complete = true;
+        break;
 
     case SubMode::INITIAL_CLIMB:
     case SubMode::FLY_TO_RETURN_POINT:

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -252,14 +252,14 @@ bool ModeRTL::return_start()
     return destination_set;
 }
 
-// climb_return_run - runs the initial climb and return portions of RTL, both of which rely on the wp controller
-//      called by rtl_run at 100hz or more
-void ModeRTL::climb_return_run()
+// run_wp_controllers - run the wp_nav horizontal, vertical and attitude controllers shared by
+//   the climb, return and hold stages.  Returns false when disarmed/landed (caller returns).
+bool ModeRTL::run_wp_controllers()
 {
     // if not armed set throttle to zero and exit immediately
     if (is_disarmed_or_landed()) {
         make_safe_ground_handling();
-        return;
+        return false;
     }
 
     // set motors to full range
@@ -274,6 +274,17 @@ void ModeRTL::climb_return_run()
 
     // call attitude controller with auto yaw
     attitude_control->input_thrust_vector_heading(pos_control->get_thrust_vector(), auto_yaw.get_heading());
+
+    return true;
+}
+
+// climb_return_run - runs the initial climb and return portions of RTL, both of which rely on the wp controller
+//      called by rtl_run at 100hz or more
+void ModeRTL::climb_return_run()
+{
+    if (!run_wp_controllers()) {
+        return;
+    }
 
     // check if we've completed this stage of RTL
     _state_complete = wp_nav->reached_wp_destination();
@@ -294,24 +305,9 @@ void ModeRTL::hold_at_return_point_start()
 //      called by rtl_run at 100hz or more
 void ModeRTL::hold_at_return_point_run()
 {
-    // if not armed set throttle to zero and exit immediately
-    if (is_disarmed_or_landed()) {
-        make_safe_ground_handling();
+    if (!run_wp_controllers()) {
         return;
     }
-
-    // set motors to full range
-    motors->set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
-
-    // run waypoint controller
-    copter.failsafe_terrain_set_status(wp_nav->update_wpnav());
-
-    // WP_Nav has set the vertical position control targets
-    // run the vertical position controller and set output throttle
-    pos_control->D_update_controller();
-
-    // call attitude controller with auto yaw
-    attitude_control->input_thrust_vector_heading(pos_control->get_thrust_vector(), auto_yaw.get_heading());
 
     // check if we've completed this stage of RTL
     const uint32_t hold_elapsed_ms = millis() - _stage_start_ms;

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -135,36 +135,12 @@ void ModeRTL::run(bool disarm_on_land)
         return;
     }
 
-    // check if we need to move to next state
+    // advance the state machine at most one stage per loop
     if (_state_complete) {
-        switch (_state) {
-        case SubMode::STARTING:
-            build_path();
-            climb_start();
-            break;
-        case SubMode::INITIAL_CLIMB:
-            return_start();
-            break;
-        case SubMode::FLY_TO_RETURN_POINT:
-            hold_at_return_point_start();
-            break;
-        case SubMode::HOLD_AT_RETURN_POINT:
-            if (rtl_path.land || copter.failsafe.radio) {
-                land_start();
-            } else {
-                descent_start();
-            }
-            break;
-        case SubMode::FINAL_DESCENT:
-            // do nothing
-            break;
-        case SubMode::LAND:
-            // do nothing - rtl_land_run will take care of disarming motors
-            break;
-        }
+        advance_state();
     }
 
-    // call the correct run function
+    // run the controller for the current stage
     switch (_state) {
 
     case SubMode::STARTING:
@@ -191,12 +167,65 @@ void ModeRTL::run(bool disarm_on_land)
     }
 }
 
+// advance_state - move to the next stage when the current one is complete
+void ModeRTL::advance_state()
+{
+    switch (_state) {
+    case SubMode::STARTING:
+        build_path();
+        set_submode(SubMode::INITIAL_CLIMB);
+        break;
+    case SubMode::INITIAL_CLIMB:
+        set_submode(SubMode::FLY_TO_RETURN_POINT);
+        break;
+    case SubMode::FLY_TO_RETURN_POINT:
+        set_submode(SubMode::HOLD_AT_RETURN_POINT);
+        break;
+    case SubMode::HOLD_AT_RETURN_POINT:
+        set_submode((rtl_path.land || copter.failsafe.radio) ? SubMode::LAND : SubMode::FINAL_DESCENT);
+        break;
+    case SubMode::FINAL_DESCENT:
+    case SubMode::LAND:
+        // terminal stages
+        break;
+    }
+}
+
+// set_submode - performs all normal stage changes; sets _state, clears _state_complete and runs the stage's entry init
+void ModeRTL::set_submode(SubMode submode)
+{
+    _state = submode;
+    _state_complete = false;
+    _stage_start_ms = millis();
+
+    switch (submode) {
+    case SubMode::STARTING:
+        // path (re)build handled by advance_state(); nothing to init here
+        break;
+    case SubMode::INITIAL_CLIMB:
+        climb_start();
+        break;
+    case SubMode::FLY_TO_RETURN_POINT:
+        if (!return_start()) {
+            // terrain data missing: rebuild the path with terrain following off
+            restart_without_terrain();
+        }
+        break;
+    case SubMode::HOLD_AT_RETURN_POINT:
+        hold_at_return_point_start();
+        break;
+    case SubMode::FINAL_DESCENT:
+        descent_start();
+        break;
+    case SubMode::LAND:
+        land_start();
+        break;
+    }
+}
+
 // climb_start - initialise climb to RTL altitude
 void ModeRTL::climb_start()
 {
-    _state = SubMode::INITIAL_CLIMB;
-    _state_complete = false;
-
     // set the destination
     if (!wp_nav->set_wp_destination_loc(rtl_path.climb_target) || !wp_nav->set_wp_destination_next_loc(rtl_path.return_target)) {
         // this should not happen because build_path will have checked terrain data was available
@@ -211,18 +240,16 @@ void ModeRTL::climb_start()
 }
 
 // return_start - initialise the return to the return point (home or nearest rally point)
-void ModeRTL::return_start()
+//   returns false if the destination could not be set (missing terrain data)
+bool ModeRTL::return_start()
 {
-    _state = SubMode::FLY_TO_RETURN_POINT;
-    _state_complete = false;
-
-    if (!wp_nav->set_wp_destination_loc(rtl_path.return_target)) {
-        // failure must be caused by missing terrain data, restart RTL
-        restart_without_terrain();
-    }
+    // failure to set the destination must be caused by missing terrain data
+    const bool destination_set = wp_nav->set_wp_destination_loc(rtl_path.return_target);
 
     // initialise yaw to point at the return point (maybe)
     auto_yaw.set_mode_to_default(true);
+
+    return destination_set;
 }
 
 // climb_return_run - runs the initial climb and return portions of RTL, both of which rely on the wp controller
@@ -255,10 +282,6 @@ void ModeRTL::climb_return_run()
 // hold_at_return_point_start - initialise the hold over the return point (home or nearest rally point)
 void ModeRTL::hold_at_return_point_start()
 {
-    _state = SubMode::HOLD_AT_RETURN_POINT;
-    _state_complete = false;
-    _hold_start_time = millis();
-
     // yaw back to initial take-off heading yaw unless pilot has already overridden yaw
     if (auto_yaw.default_mode(true) != AutoYaw::Mode::HOLD) {
         auto_yaw.set_mode(AutoYaw::Mode::RESET_TO_ARMED_YAW);
@@ -291,7 +314,8 @@ void ModeRTL::hold_at_return_point_run()
     attitude_control->input_thrust_vector_heading(pos_control->get_thrust_vector(), auto_yaw.get_heading());
 
     // check if we've completed this stage of RTL
-    if ((millis() - _hold_start_time) >= (uint32_t)g.rtl_loiter_time.get()) {
+    const uint32_t hold_elapsed_ms = millis() - _stage_start_ms;
+    if (hold_elapsed_ms >= (uint32_t)g.rtl_loiter_time.get()) {
         if (auto_yaw.mode() == AutoYaw::Mode::RESET_TO_ARMED_YAW) {
             // check if heading is within 2 degrees of heading when vehicle was armed
             // todo: Use the target heading instead of the actual heading to allow landing even if yaw control is lost.
@@ -308,9 +332,6 @@ void ModeRTL::hold_at_return_point_run()
 // descent_start - initialise descent to final alt
 void ModeRTL::descent_start()
 {
-    _state = SubMode::FINAL_DESCENT;
-    _state_complete = false;
-
     // initialise altitude target to stopping point
     pos_control->D_init_controller_stopping_point();
 
@@ -384,9 +405,6 @@ void ModeRTL::descent_run()
 // land_start - initialise controllers to hold over the return point
 void ModeRTL::land_start()
 {
-    _state = SubMode::LAND;
-    _state_complete = false;
-
     // set horizontal speed and acceleration limits
     pos_control->NE_set_max_speed_accel_m(wp_nav->get_default_speed_NE_ms(), wp_nav->get_wp_acceleration_mss());
     pos_control->NE_set_correction_speed_accel_m(wp_nav->get_default_speed_NE_ms(), wp_nav->get_wp_acceleration_mss());

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -77,7 +77,7 @@ void ModeRTL::convert_params()
  * and the lower implementation of the waypoint or landing controllers within those states
  */
 
-// rtl_init - initialise rtl controller
+// init - initialise rtl controller
 bool ModeRTL::init(bool ignore_checks)
 {
     if (!ignore_checks) {
@@ -127,7 +127,7 @@ ModeRTL::RTLAltType ModeRTL::get_alt_type() const
     return RTLAltType::RELATIVE;
 }
 
-// rtl_run - runs the return-to-launch controller
+// run - runs the return-to-launch controller
 // should be called at 100hz or more
 void ModeRTL::run(bool disarm_on_land)
 {
@@ -145,10 +145,10 @@ void ModeRTL::run(bool disarm_on_land)
         case SubMode::INITIAL_CLIMB:
             return_start();
             break;
-        case SubMode::RETURN_HOME:
-            loiterathome_start();
+        case SubMode::FLY_TO_RETURN_POINT:
+            hold_at_return_point_start();
             break;
-        case SubMode::LOITER_AT_HOME:
+        case SubMode::HOLD_AT_RETURN_POINT:
             if (rtl_path.land || copter.failsafe.radio) {
                 land_start();
             } else {
@@ -173,12 +173,12 @@ void ModeRTL::run(bool disarm_on_land)
         FALLTHROUGH;
 
     case SubMode::INITIAL_CLIMB:
-    case SubMode::RETURN_HOME:
+    case SubMode::FLY_TO_RETURN_POINT:
         climb_return_run();
         break;
 
-    case SubMode::LOITER_AT_HOME:
-        loiterathome_run();
+    case SubMode::HOLD_AT_RETURN_POINT:
+        hold_at_return_point_run();
         break;
 
     case SubMode::FINAL_DESCENT:
@@ -191,7 +191,7 @@ void ModeRTL::run(bool disarm_on_land)
     }
 }
 
-// rtl_climb_start - initialise climb to RTL altitude
+// climb_start - initialise climb to RTL altitude
 void ModeRTL::climb_start()
 {
     _state = SubMode::INITIAL_CLIMB;
@@ -199,7 +199,7 @@ void ModeRTL::climb_start()
 
     // set the destination
     if (!wp_nav->set_wp_destination_loc(rtl_path.climb_target) || !wp_nav->set_wp_destination_next_loc(rtl_path.return_target)) {
-        // this should not happen because rtl_build_path will have checked terrain data was available
+        // this should not happen because build_path will have checked terrain data was available
         gcs().send_text(MAV_SEVERITY_CRITICAL,"RTL: unexpected error setting climb target");
         LOGGER_WRITE_ERROR(LogErrorSubsystem::NAVIGATION, LogErrorCode::FAILED_TO_SET_DESTINATION);
         copter.set_mode(Mode::Number::LAND, ModeReason::TERRAIN_FAILSAFE);
@@ -210,10 +210,10 @@ void ModeRTL::climb_start()
     auto_yaw.set_mode(AutoYaw::Mode::HOLD);
 }
 
-// rtl_return_start - initialise return to home
+// return_start - initialise the return to the return point (home or nearest rally point)
 void ModeRTL::return_start()
 {
-    _state = SubMode::RETURN_HOME;
+    _state = SubMode::FLY_TO_RETURN_POINT;
     _state_complete = false;
 
     if (!wp_nav->set_wp_destination_loc(rtl_path.return_target)) {
@@ -221,11 +221,11 @@ void ModeRTL::return_start()
         restart_without_terrain();
     }
 
-    // initialise yaw to point home (maybe)
+    // initialise yaw to point at the return point (maybe)
     auto_yaw.set_mode_to_default(true);
 }
 
-// rtl_climb_return_run - implements the initial climb, return home and descent portions of RTL which all rely on the wp controller
+// climb_return_run - runs the initial climb and return portions of RTL, both of which rely on the wp controller
 //      called by rtl_run at 100hz or more
 void ModeRTL::climb_return_run()
 {
@@ -252,12 +252,12 @@ void ModeRTL::climb_return_run()
     _state_complete = wp_nav->reached_wp_destination();
 }
 
-// loiterathome_start - initialise return to home
-void ModeRTL::loiterathome_start()
+// hold_at_return_point_start - initialise the hold over the return point (home or nearest rally point)
+void ModeRTL::hold_at_return_point_start()
 {
-    _state = SubMode::LOITER_AT_HOME;
+    _state = SubMode::HOLD_AT_RETURN_POINT;
     _state_complete = false;
-    _loiter_start_time = millis();
+    _hold_start_time = millis();
 
     // yaw back to initial take-off heading yaw unless pilot has already overridden yaw
     if (auto_yaw.default_mode(true) != AutoYaw::Mode::HOLD) {
@@ -267,9 +267,9 @@ void ModeRTL::loiterathome_start()
     }
 }
 
-// rtl_climb_return_descent_run - implements the initial climb, return home and descent portions of RTL which all rely on the wp controller
+// hold_at_return_point_run - holds over the return point until RTL_LOIT_TIME elapses (and the armed heading is reached, if realigning yaw)
 //      called by rtl_run at 100hz or more
-void ModeRTL::loiterathome_run()
+void ModeRTL::hold_at_return_point_run()
 {
     // if not armed set throttle to zero and exit immediately
     if (is_disarmed_or_landed()) {
@@ -291,7 +291,7 @@ void ModeRTL::loiterathome_run()
     attitude_control->input_thrust_vector_heading(pos_control->get_thrust_vector(), auto_yaw.get_heading());
 
     // check if we've completed this stage of RTL
-    if ((millis() - _loiter_start_time) >= (uint32_t)g.rtl_loiter_time.get()) {
+    if ((millis() - _hold_start_time) >= (uint32_t)g.rtl_loiter_time.get()) {
         if (auto_yaw.mode() == AutoYaw::Mode::RESET_TO_ARMED_YAW) {
             // check if heading is within 2 degrees of heading when vehicle was armed
             // todo: Use the target heading instead of the actual heading to allow landing even if yaw control is lost.
@@ -299,13 +299,13 @@ void ModeRTL::loiterathome_run()
                 _state_complete = true;
             }
         } else {
-            // we have loitered long enough
+            // we have held long enough
             _state_complete = true;
         }
     }
 }
 
-// rtl_descent_start - initialise descent to final alt
+// descent_start - initialise descent to final alt
 void ModeRTL::descent_start()
 {
     _state = SubMode::FINAL_DESCENT;
@@ -323,7 +323,7 @@ void ModeRTL::descent_start()
 #endif
 }
 
-// rtl_descent_run - implements the final descent to the RTL_ALT_M
+// descent_run - implements the final descent to the RTL_ALT_M
 //      called by rtl_run at 100hz or more
 void ModeRTL::descent_run()
 {
@@ -381,7 +381,7 @@ void ModeRTL::descent_run()
     _state_complete = fabsf(rtl_path.descent_target.alt * 0.01 - pos_control->get_pos_estimate_U_m()) < 0.2;
 }
 
-// land_start - initialise controllers to loiter over home
+// land_start - initialise controllers to hold over the return point
 void ModeRTL::land_start()
 {
     _state = SubMode::LAND;
@@ -391,7 +391,7 @@ void ModeRTL::land_start()
     pos_control->NE_set_max_speed_accel_m(wp_nav->get_default_speed_NE_ms(), wp_nav->get_wp_acceleration_mss());
     pos_control->NE_set_correction_speed_accel_m(wp_nav->get_default_speed_NE_ms(), wp_nav->get_wp_acceleration_mss());
 
-    // initialise loiter target destination
+    // initialise the horizontal position controller
     if (!pos_control->NE_is_active()) {
         pos_control->NE_init_controller();
     }
@@ -588,8 +588,8 @@ bool ModeRTL::get_wp(Location& destination) const
     switch (_state) {
     case SubMode::STARTING:
     case SubMode::INITIAL_CLIMB:
-    case SubMode::RETURN_HOME:
-    case SubMode::LOITER_AT_HOME:
+    case SubMode::FLY_TO_RETURN_POINT:
+    case SubMode::HOLD_AT_RETURN_POINT:
     case SubMode::FINAL_DESCENT:
         return wp_nav->get_oa_wp_destination(destination);
     case SubMode::LAND:

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -433,6 +433,16 @@ bool ModeRTL::is_landing() const
     return _state == SubMode::LAND;
 }
 
+// true once RTL has completed its final stage: the final descent has reached RTL_ALT_FINAL,
+// or (when landing) the vehicle has touched down and spooled to ground idle.
+// Used by ModeAuto::verify_RTL.
+bool ModeRTL::is_complete() const
+{
+    return _state_complete &&
+           ((_state == SubMode::FINAL_DESCENT) ||
+            (_state == SubMode::LAND && motors->get_spool_state() == AP_Motors::SpoolState::GROUND_IDLE));
+}
+
 // land_run - run the landing controllers to put the aircraft on the ground
 // called by rtl_run at 100hz or more
 void ModeRTL::land_run(bool disarm_on_land)

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -77,7 +77,7 @@ void ModeRTL::convert_params()
  * and the lower implementation of the waypoint or landing controllers within those states
  */
 
-// rtl_init - initialise rtl controller
+// init - initialise rtl controller
 bool ModeRTL::init(bool ignore_checks)
 {
     if (!ignore_checks) {
@@ -127,7 +127,7 @@ ModeRTL::RTLAltType ModeRTL::get_alt_type() const
     return RTLAltType::RELATIVE;
 }
 
-// rtl_run - runs the return-to-launch controller
+// run - runs the return-to-launch controller
 // should be called at 100hz or more
 void ModeRTL::run(bool disarm_on_land)
 {
@@ -145,10 +145,10 @@ void ModeRTL::run(bool disarm_on_land)
         case SubMode::INITIAL_CLIMB:
             return_start();
             break;
-        case SubMode::RETURN_HOME:
-            loiterathome_start();
+        case SubMode::FLY_TO_RETURN_POINT:
+            hold_at_return_point_start();
             break;
-        case SubMode::LOITER_AT_HOME:
+        case SubMode::HOLD_AT_RETURN_POINT:
             if (rtl_path.land || copter.failsafe.radio) {
                 land_start();
             } else {
@@ -173,12 +173,12 @@ void ModeRTL::run(bool disarm_on_land)
         FALLTHROUGH;
 
     case SubMode::INITIAL_CLIMB:
-    case SubMode::RETURN_HOME:
+    case SubMode::FLY_TO_RETURN_POINT:
         climb_return_run();
         break;
 
-    case SubMode::LOITER_AT_HOME:
-        loiterathome_run();
+    case SubMode::HOLD_AT_RETURN_POINT:
+        hold_at_return_point_run();
         break;
 
     case SubMode::FINAL_DESCENT:
@@ -191,7 +191,7 @@ void ModeRTL::run(bool disarm_on_land)
     }
 }
 
-// rtl_climb_start - initialise climb to RTL altitude
+// climb_start - initialise climb to RTL altitude
 void ModeRTL::climb_start()
 {
     _state = SubMode::INITIAL_CLIMB;
@@ -199,7 +199,7 @@ void ModeRTL::climb_start()
 
     // set the destination
     if (!wp_nav->set_wp_destination_loc(rtl_path.climb_target) || !wp_nav->set_wp_destination_next_loc(rtl_path.return_target)) {
-        // this should not happen because rtl_build_path will have checked terrain data was available
+        // this should not happen because build_path will have checked terrain data was available
         gcs().send_text(MAV_SEVERITY_CRITICAL,"RTL: unexpected error setting climb target");
         LOGGER_WRITE_ERROR(LogErrorSubsystem::NAVIGATION, LogErrorCode::FAILED_TO_SET_DESTINATION);
         copter.set_mode(Mode::Number::LAND, ModeReason::TERRAIN_FAILSAFE);
@@ -210,10 +210,10 @@ void ModeRTL::climb_start()
     auto_yaw.set_mode(AutoYaw::Mode::HOLD);
 }
 
-// rtl_return_start - initialise return to home
+// return_start - initialise the return to the return point (home or nearest rally point)
 void ModeRTL::return_start()
 {
-    _state = SubMode::RETURN_HOME;
+    _state = SubMode::FLY_TO_RETURN_POINT;
     _state_complete = false;
 
     if (!wp_nav->set_wp_destination_loc(rtl_path.return_target)) {
@@ -221,11 +221,11 @@ void ModeRTL::return_start()
         restart_without_terrain();
     }
 
-    // initialise yaw to point home (maybe)
+    // initialise yaw to point at the return point (maybe)
     auto_yaw.set_mode_to_default(true);
 }
 
-// rtl_climb_return_run - implements the initial climb, return home and descent portions of RTL which all rely on the wp controller
+// climb_return_run - runs the initial climb and return portions of RTL, both of which rely on the wp controller
 //      called by rtl_run at 100hz or more
 void ModeRTL::climb_return_run()
 {
@@ -252,12 +252,12 @@ void ModeRTL::climb_return_run()
     _state_complete = wp_nav->reached_wp_destination();
 }
 
-// loiterathome_start - initialise return to home
-void ModeRTL::loiterathome_start()
+// hold_at_return_point_start - initialise the hold over the return point (home or nearest rally point)
+void ModeRTL::hold_at_return_point_start()
 {
-    _state = SubMode::LOITER_AT_HOME;
+    _state = SubMode::HOLD_AT_RETURN_POINT;
     _state_complete = false;
-    _loiter_start_time = millis();
+    _hold_start_time = millis();
 
     // yaw back to initial take-off heading yaw unless pilot has already overridden yaw
     if (auto_yaw.default_mode(true) != AutoYaw::Mode::HOLD) {
@@ -267,9 +267,9 @@ void ModeRTL::loiterathome_start()
     }
 }
 
-// rtl_climb_return_descent_run - implements the initial climb, return home and descent portions of RTL which all rely on the wp controller
+// hold_at_return_point_run - holds over the return point until RTL_LOIT_TIME elapses (and the armed heading is reached, if realigning yaw)
 //      called by rtl_run at 100hz or more
-void ModeRTL::loiterathome_run()
+void ModeRTL::hold_at_return_point_run()
 {
     // if not armed set throttle to zero and exit immediately
     if (is_disarmed_or_landed()) {
@@ -291,7 +291,7 @@ void ModeRTL::loiterathome_run()
     attitude_control->input_thrust_vector_heading(pos_control->get_thrust_vector(), auto_yaw.get_heading());
 
     // check if we've completed this stage of RTL
-    if ((millis() - _loiter_start_time) >= (uint32_t)g.rtl_loiter_time.get()) {
+    if ((millis() - _hold_start_time) >= (uint32_t)g.rtl_loiter_time.get()) {
         if (auto_yaw.mode() == AutoYaw::Mode::RESET_TO_ARMED_YAW) {
             // check if heading is within 2 degrees of heading when vehicle was armed
             // todo: Use the target heading instead of the actual heading to allow landing even if yaw control is lost.
@@ -299,13 +299,13 @@ void ModeRTL::loiterathome_run()
                 _state_complete = true;
             }
         } else {
-            // we have loitered long enough
+            // we have held long enough
             _state_complete = true;
         }
     }
 }
 
-// rtl_descent_start - initialise descent to final alt
+// descent_start - initialise descent to final alt
 void ModeRTL::descent_start()
 {
     _state = SubMode::FINAL_DESCENT;
@@ -323,7 +323,7 @@ void ModeRTL::descent_start()
 #endif
 }
 
-// rtl_descent_run - implements the final descent to the RTL_ALT_M
+// descent_run - implements the final descent to the RTL_ALT_M
 //      called by rtl_run at 100hz or more
 void ModeRTL::descent_run()
 {
@@ -380,7 +380,7 @@ void ModeRTL::descent_run()
     _state_complete = fabsf(rtl_path.descent_target.alt * 0.01 - pos_control->get_pos_estimate_U_m()) < 0.2;
 }
 
-// land_start - initialise controllers to loiter over home
+// land_start - initialise controllers to hold over the return point
 void ModeRTL::land_start()
 {
     _state = SubMode::LAND;
@@ -390,7 +390,7 @@ void ModeRTL::land_start()
     pos_control->NE_set_max_speed_accel_m(wp_nav->get_default_speed_NE_ms(), wp_nav->get_wp_acceleration_mss());
     pos_control->NE_set_correction_speed_accel_m(wp_nav->get_default_speed_NE_ms(), wp_nav->get_wp_acceleration_mss());
 
-    // initialise loiter target destination
+    // initialise the horizontal position controller
     if (!pos_control->NE_is_active()) {
         pos_control->NE_init_controller();
     }
@@ -587,8 +587,8 @@ bool ModeRTL::get_wp(Location& destination) const
     switch (_state) {
     case SubMode::STARTING:
     case SubMode::INITIAL_CLIMB:
-    case SubMode::RETURN_HOME:
-    case SubMode::LOITER_AT_HOME:
+    case SubMode::FLY_TO_RETURN_POINT:
+    case SubMode::HOLD_AT_RETURN_POINT:
     case SubMode::FINAL_DESCENT:
         return wp_nav->get_oa_wp_destination(destination);
     case SubMode::LAND:

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -432,6 +432,16 @@ bool ModeRTL::is_landing() const
     return _state == SubMode::LAND;
 }
 
+// true once RTL has completed its final stage: the final descent has reached RTL_ALT_FINAL,
+// or (when landing) the vehicle has touched down and spooled to ground idle.
+// Used by ModeAuto::verify_RTL.
+bool ModeRTL::is_complete() const
+{
+    return _state_complete &&
+           ((_state == SubMode::FINAL_DESCENT) ||
+            (_state == SubMode::LAND && motors->get_spool_state() == AP_Motors::SpoolState::GROUND_IDLE));
+}
+
 // land_run - run the landing controllers to put the aircraft on the ground
 // called by rtl_run at 100hz or more
 void ModeRTL::land_run(bool disarm_on_land)

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -135,36 +135,12 @@ void ModeRTL::run(bool disarm_on_land)
         return;
     }
 
-    // check if we need to move to next state
+    // advance the state machine at most one stage per loop
     if (_state_complete) {
-        switch (_state) {
-        case SubMode::STARTING:
-            build_path();
-            climb_start();
-            break;
-        case SubMode::INITIAL_CLIMB:
-            return_start();
-            break;
-        case SubMode::FLY_TO_RETURN_POINT:
-            hold_at_return_point_start();
-            break;
-        case SubMode::HOLD_AT_RETURN_POINT:
-            if (rtl_path.land || copter.failsafe.radio) {
-                land_start();
-            } else {
-                descent_start();
-            }
-            break;
-        case SubMode::FINAL_DESCENT:
-            // do nothing
-            break;
-        case SubMode::LAND:
-            // do nothing - rtl_land_run will take care of disarming motors
-            break;
-        }
+        advance_state();
     }
 
-    // call the correct run function
+    // run the controller for the current stage
     switch (_state) {
 
     case SubMode::STARTING:
@@ -191,12 +167,65 @@ void ModeRTL::run(bool disarm_on_land)
     }
 }
 
+// advance_state - move to the next stage when the current one is complete
+void ModeRTL::advance_state()
+{
+    switch (_state) {
+    case SubMode::STARTING:
+        build_path();
+        set_submode(SubMode::INITIAL_CLIMB);
+        break;
+    case SubMode::INITIAL_CLIMB:
+        set_submode(SubMode::FLY_TO_RETURN_POINT);
+        break;
+    case SubMode::FLY_TO_RETURN_POINT:
+        set_submode(SubMode::HOLD_AT_RETURN_POINT);
+        break;
+    case SubMode::HOLD_AT_RETURN_POINT:
+        set_submode((rtl_path.land || copter.failsafe.radio) ? SubMode::LAND : SubMode::FINAL_DESCENT);
+        break;
+    case SubMode::FINAL_DESCENT:
+    case SubMode::LAND:
+        // terminal stages
+        break;
+    }
+}
+
+// set_submode - performs all normal stage changes; sets _state, clears _state_complete and runs the stage's entry init
+void ModeRTL::set_submode(SubMode submode)
+{
+    _state = submode;
+    _state_complete = false;
+    _stage_start_ms = millis();
+
+    switch (submode) {
+    case SubMode::STARTING:
+        // path (re)build handled by advance_state(); nothing to init here
+        break;
+    case SubMode::INITIAL_CLIMB:
+        climb_start();
+        break;
+    case SubMode::FLY_TO_RETURN_POINT:
+        if (!return_start()) {
+            // terrain data missing: rebuild the path with terrain following off
+            restart_without_terrain();
+        }
+        break;
+    case SubMode::HOLD_AT_RETURN_POINT:
+        hold_at_return_point_start();
+        break;
+    case SubMode::FINAL_DESCENT:
+        descent_start();
+        break;
+    case SubMode::LAND:
+        land_start();
+        break;
+    }
+}
+
 // climb_start - initialise climb to RTL altitude
 void ModeRTL::climb_start()
 {
-    _state = SubMode::INITIAL_CLIMB;
-    _state_complete = false;
-
     // set the destination
     if (!wp_nav->set_wp_destination_loc(rtl_path.climb_target) || !wp_nav->set_wp_destination_next_loc(rtl_path.return_target)) {
         // this should not happen because build_path will have checked terrain data was available
@@ -211,18 +240,16 @@ void ModeRTL::climb_start()
 }
 
 // return_start - initialise the return to the return point (home or nearest rally point)
-void ModeRTL::return_start()
+//   returns false if the destination could not be set (missing terrain data)
+bool ModeRTL::return_start()
 {
-    _state = SubMode::FLY_TO_RETURN_POINT;
-    _state_complete = false;
-
-    if (!wp_nav->set_wp_destination_loc(rtl_path.return_target)) {
-        // failure must be caused by missing terrain data, restart RTL
-        restart_without_terrain();
-    }
+    // failure to set the destination must be caused by missing terrain data
+    const bool destination_set = wp_nav->set_wp_destination_loc(rtl_path.return_target);
 
     // initialise yaw to point at the return point (maybe)
     auto_yaw.set_mode_to_default(true);
+
+    return destination_set;
 }
 
 // climb_return_run - runs the initial climb and return portions of RTL, both of which rely on the wp controller
@@ -255,10 +282,6 @@ void ModeRTL::climb_return_run()
 // hold_at_return_point_start - initialise the hold over the return point (home or nearest rally point)
 void ModeRTL::hold_at_return_point_start()
 {
-    _state = SubMode::HOLD_AT_RETURN_POINT;
-    _state_complete = false;
-    _hold_start_time = millis();
-
     // yaw back to initial take-off heading yaw unless pilot has already overridden yaw
     if (auto_yaw.default_mode(true) != AutoYaw::Mode::HOLD) {
         auto_yaw.set_mode(AutoYaw::Mode::RESET_TO_ARMED_YAW);
@@ -291,7 +314,8 @@ void ModeRTL::hold_at_return_point_run()
     attitude_control->input_thrust_vector_heading(pos_control->get_thrust_vector(), auto_yaw.get_heading());
 
     // check if we've completed this stage of RTL
-    if ((millis() - _hold_start_time) >= (uint32_t)g.rtl_loiter_time.get()) {
+    const uint32_t hold_elapsed_ms = millis() - _stage_start_ms;
+    if (hold_elapsed_ms >= (uint32_t)g.rtl_loiter_time.get()) {
         if (auto_yaw.mode() == AutoYaw::Mode::RESET_TO_ARMED_YAW) {
             // check if heading is within 2 degrees of heading when vehicle was armed
             // todo: Use the target heading instead of the actual heading to allow landing even if yaw control is lost.
@@ -308,9 +332,6 @@ void ModeRTL::hold_at_return_point_run()
 // descent_start - initialise descent to final alt
 void ModeRTL::descent_start()
 {
-    _state = SubMode::FINAL_DESCENT;
-    _state_complete = false;
-
     // initialise altitude target to stopping point
     pos_control->D_init_controller_stopping_point();
 
@@ -383,9 +404,6 @@ void ModeRTL::descent_run()
 // land_start - initialise controllers to hold over the return point
 void ModeRTL::land_start()
 {
-    _state = SubMode::LAND;
-    _state_complete = false;
-
     // set horizontal speed and acceleration limits
     pos_control->NE_set_max_speed_accel_m(wp_nav->get_default_speed_NE_ms(), wp_nav->get_wp_acceleration_mss());
     pos_control->NE_set_correction_speed_accel_m(wp_nav->get_default_speed_NE_ms(), wp_nav->get_wp_acceleration_mss());

--- a/ArduCopter/mode_smart_rtl.cpp
+++ b/ArduCopter/mode_smart_rtl.cpp
@@ -31,11 +31,36 @@ bool ModeSmartRTL::init(bool ignore_checks)
         auto_yaw.set_mode_to_default(true);
 
         // wait for cleanup of return path
-        smart_rtl_state = SubMode::WAIT_FOR_PATH_CLEANUP;
+        set_submode(SubMode::WAIT_FOR_PATH_CLEANUP);
         return true;
     }
 
     return false;
+}
+
+// set_submode - the only writer of smart_rtl_state; runs the stage's entry init
+void ModeSmartRTL::set_submode(SubMode submode)
+{
+    smart_rtl_state = submode;
+
+    switch (submode) {
+    case SubMode::WAIT_FOR_PATH_CLEANUP:
+        // initialised in init()
+        break;
+    case SubMode::PATH_FOLLOW:
+        path_follow_last_pop_fail_ms = 0;
+        break;
+    case SubMode::PRELAND_POSITION:
+        // wp destination is data-dependent and set by the caller
+        break;
+    case SubMode::DESCEND:
+        set_descent_target_alt(get_alt_final_m() * 100);
+        descent_start();
+        break;
+    case SubMode::LAND:
+        land_start();
+        break;
+    }
 }
 
 // perform cleanup required when leaving smart_rtl
@@ -88,8 +113,7 @@ void ModeSmartRTL::wait_cleanup_run()
 
     // check if return path is computed and if yes, begin journey home
     if (g2.smart_rtl.request_thorough_cleanup()) {
-        path_follow_last_pop_fail_ms = 0;
-        smart_rtl_state = SubMode::PATH_FOLLOW;
+        set_submode(SubMode::PATH_FOLLOW);
     }
 }
 
@@ -111,7 +135,7 @@ void ModeSmartRTL::path_follow_run()
             if (g2.smart_rtl.get_num_points() == 0) {
                 // this is the very last point, add 2m to the target alt and move to pre-land state
                 dest_NED.z -= 2.0f;
-                smart_rtl_state = SubMode::PRELAND_POSITION;
+                set_submode(SubMode::PRELAND_POSITION);
                 wp_nav->set_wp_destination_NED_m(dest_NED);
             } else {
                 // peek at the next point.  this can fail if the IO task currently has the path semaphore
@@ -134,7 +158,7 @@ void ModeSmartRTL::path_follow_run()
             // We should never get here; should always have at least
             // two points and the "zero points left" is handled above.
             INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
-            smart_rtl_state = SubMode::PRELAND_POSITION;
+            set_submode(SubMode::PRELAND_POSITION);
         } else if (path_follow_last_pop_fail_ms == 0) {
             // first time we've failed to pop off (ever, or after a success)
             path_follow_last_pop_fail_ms = AP_HAL::millis();
@@ -142,7 +166,7 @@ void ModeSmartRTL::path_follow_run()
             // we failed to pop a point off for 10 seconds.  This is
             // almost certainly a bug.
             INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
-            smart_rtl_state = SubMode::PRELAND_POSITION;
+            set_submode(SubMode::PRELAND_POSITION);
         }
     }
 
@@ -161,12 +185,9 @@ void ModeSmartRTL::pre_land_position_run()
     if (wp_nav->reached_wp_destination()) {
         // choose descend and hold, or land based on user parameter rtl_alt_final_cm
         if (get_alt_final_m() <= 0 || copter.failsafe.radio) {
-            land_start();
-            smart_rtl_state = SubMode::LAND;
+            set_submode(SubMode::LAND);
         } else {
-            set_descent_target_alt(get_alt_final_m() * 100);
-            descent_start();
-            smart_rtl_state = SubMode::DESCEND;
+            set_submode(SubMode::DESCEND);
         }
     }
 


### PR DESCRIPTION
### Summary

Restructures Copter's RTL state machine so all stage transitions run through one
function, and fixes a latent hang in the terrain-restart path.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

RTL's stage transitions were spread across `run()`, the `*_start()` functions and`restart_without_terrain()`, each writing `_state` and `_state_complete` directly. The first five commits are behaviour neutral; the last is a fix.

1. **rename stages and functions** — `RETURN_HOME` → `FLY_TO_RETURN_POINT`, `LOITER_AT_HOME` → `HOLD_AT_RETURN_POINT`, handlers and timer to match. Compiled `.text` of `mode_rtl.cpp.o` is byte-identical.
2. **state machine restructured** — transition graph moves into `advance_state()`; all stage changes go through `set_submode()`, which sets the state, clears the completion flag, stamps entry time and runs the stage's init.
3. **encapsulation cleanup** — `state()`/`state_complete()` replaced by `is_complete()`, moving `ModeAuto::verify_RTL`'s test into `ModeRTL`. The condition is unchanged, including the `RTL_ALT_FINAL` behaviour.
4. **remove duplicated run-body** — the control block shared by `climb_return_run()` and `hold_at_return_point_run()` moves into `run_wp_controllers()`. Smart RTL's similar blocks are left alone; they differ.
5. **Smart RTL state handling** — writes routed through its own `set_submode()`; corrects the initialiser and drops the declaration-only `land()`.
6. **fix latent hang in the in-cycle terrain restart path** — the one behavioural change. `restart_without_terrain()` sets the stage to `STARTING` so the path is rebuilt without terrain following, but `run()`'s `STARTING` case overwrote it with `INITIAL_CLIMB` and fell through, bypassing the `build_path()` in `advance_state()`. The path was never rebuilt, so `return_start()` could fail on the same missing terrain data and cycle without progressing. `STARTING` now  holds the current target for the loop and marks the stage complete.
