### PR TITLE
AP_Mount: Add delta_yaw and delta_yaw_velocity support for AP_Mount_MAVLink

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -8181,6 +8181,39 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 raise NotAchievedException(
                     f"compid {compid} focus wrong: want={want_focus} got={got}")
 
+    def MountAVTCM62DeltaYaw(self):
+        '''check autopilot forwards gimbal-reported delta_yaw in GIMBAL_DEVICE_ATTITUDE_STATUS'''
+        self.set_parameters({
+            "MNT1_TYPE": 6,         # MAVLink
+            "CAM1_TYPE": 4,         # Mount
+            "SERIAL5_PROTOCOL": 2,  # MAVLink2
+        })
+        self.customise_SITL_commandline(["--serial5=sim:avt_cm62_gimbal:"])
+        self.wait_ready_to_arm()
+
+        tstart = self.get_sim_time()
+        while True:
+            if self.get_sim_time_cached() - tstart > 60:
+                raise NotAchievedException("autopilot never forwarded non-NaN delta_yaw")
+            m = self.assert_receive_message('GIMBAL_DEVICE_ATTITUDE_STATUS', timeout=10)
+            if m.get_srcComponent() != 1:
+                # message from the simulated gimbal itself, not the autopilot
+                continue
+            if math.isnan(m.delta_yaw):
+                # backend hasn't latched delta support yet
+                continue
+            break
+
+        sim = self.assert_receive_message('SIMSTATE')
+        err_deg = abs(math.degrees(m.delta_yaw - sim.yaw))
+        if err_deg > 180:
+            err_deg = 360 - err_deg
+        if err_deg > 1:
+            raise NotAchievedException(
+                "forwarded delta_yaw %f deg does not match vehicle yaw %f deg" %
+                (math.degrees(m.delta_yaw), math.degrees(sim.yaw)))
+        self.progress("delta_yaw forwarded correctly")
+
     def assert_mount_rpy(self, r, p, y, tolerance=1):
         '''assert mount atttiude in degrees'''
         got_r, got_p, got_y, yaw_is_absolute = self.get_mount_roll_pitch_yaw_deg()
@@ -18860,6 +18893,7 @@ return update, 1000
             self.MountAVTCM62,
             self.MountAVTCM62Dual,
             self.MountAVTCM62DualMission,
+            self.MountAVTCM62DeltaYaw,
             self.MountRCFailAngle,
             self.MountRCFailRate,
             self.FlyMissionTwice,

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -700,6 +700,17 @@ bool AP_Mount::get_attitude_euler(uint8_t instance, float& roll_deg, float& pitc
     return true;
 }
 
+// get mount's current delta yaw and delta yaw velocity in rad and rad/s.
+// returns true on success
+bool AP_Mount::get_attitude_deltas(uint8_t instance, float &delta_yaw, float& delta_yaw_velocity)
+{
+    auto *backend = get_instance(instance);
+    if (backend == nullptr) {
+        return false;
+    }
+    return backend->get_attitude_deltas(delta_yaw, delta_yaw_velocity);
+}
+
 // run pre-arm check.  returns false on failure and fills in failure_msg
 // any failure_msg returned will not include a prefix
 bool AP_Mount::pre_arm_checks(char *failure_msg, uint8_t failure_msg_len)

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -248,6 +248,10 @@ public:
     // returns true on success
     bool get_attitude_euler(uint8_t instance, float& roll_deg, float& pitch_deg, float& yaw_bf_deg);
 
+    // get mount's current delta yaw and delta yaw velocity in rad and rad/s.
+    // returns true on success
+    bool get_attitude_deltas(uint8_t instance, float &delta_yaw, float& delta_yaw_velocity);
+
     // run pre-arm check.  returns false on failure and fills in failure_msg
     // any failure_msg returned will not include a prefix
     bool pre_arm_checks(char *failure_msg, uint8_t failure_msg_len);

--- a/libraries/AP_Mount/AP_Mount_Backend.cpp
+++ b/libraries/AP_Mount/AP_Mount_Backend.cpp
@@ -456,6 +456,9 @@ void AP_Mount_Backend::send_gimbal_device_attitude_status(mavlink_channel_t chan
     Vector3f ang_velocity { nanf(""), nanf(""), nanf("") };
     IGNORE_RETURN(get_angular_velocity(ang_velocity));
 
+    float delta_yaw, delta_yaw_velocity;
+    const bool has_deltas = get_attitude_deltas(delta_yaw, delta_yaw_velocity);
+
     // construct quaternion array
     const float quat_array[4] = {att_quat.q1, att_quat.q2, att_quat.q3, att_quat.q4};
 
@@ -469,8 +472,8 @@ void AP_Mount_Backend::send_gimbal_device_attitude_status(mavlink_channel_t chan
                                                    ang_velocity.y,    // pitch axis angular velocity (NaN for unknown)
                                                    ang_velocity.z,    // yaw axis angular velocity (NaN for unknown)
                                                    0,                                           // failure flags (not supported)
-                                                   std::numeric_limits<double>::quiet_NaN(),    // delta_yaw (NaN for unknonw)
-                                                   std::numeric_limits<double>::quiet_NaN(),    // delta_yaw_velocity (NaN for unknonw)
+                                                   has_deltas ? delta_yaw : std::numeric_limits<double>::quiet_NaN(),    // delta_yaw (NaN for unknown)
+                                                   has_deltas ? delta_yaw_velocity : std::numeric_limits<double>::quiet_NaN(),    // delta_yaw_velocity (NaN for unknown)
                                                    _instance + 1);  // gimbal_device_id
 }
 #endif

--- a/libraries/AP_Mount/AP_Mount_Backend.h
+++ b/libraries/AP_Mount/AP_Mount_Backend.h
@@ -69,6 +69,10 @@ public:
     // yaw is in body-frame.
     virtual bool get_attitude_quaternion(Quaternion& att_quat) = 0;
 
+    // get mount's current delta yaw and delta yaw velocity in rad and rad/s. Only available on some backends
+    // returns true on success
+    virtual bool get_attitude_deltas(float& delta_yaw, float& delta_yaw_velocity) { return false; }
+
     // get angular velocity of mount. Only available on some backends
     virtual bool get_angular_velocity(Vector3f& rates) { return false; }
 

--- a/libraries/AP_Mount/AP_Mount_MAVLink.cpp
+++ b/libraries/AP_Mount/AP_Mount_MAVLink.cpp
@@ -64,6 +64,20 @@ bool AP_Mount_MAVLink::get_attitude_quaternion(Quaternion& att_quat)
     return true;
 }
 
+// get mount's current delta yaw and delta yaw velocity in rad and rad/s.
+// returns true on success
+bool AP_Mount_MAVLink::get_attitude_deltas(float &delta_yaw, float& delta_yaw_velocity)
+{
+    if (!_found_deltas ||
+        isnan(_gimbal_device_attitude_status.delta_yaw) ||
+        isnan(_gimbal_device_attitude_status.delta_yaw_velocity)) {
+        return false;
+    }
+    delta_yaw = _gimbal_device_attitude_status.delta_yaw;
+    delta_yaw_velocity = _gimbal_device_attitude_status.delta_yaw_velocity;
+    return true;
+}
+
 // search for gimbal in GCS_MAVLink routing table
 void AP_Mount_MAVLink::find_gimbal()
 {
@@ -165,6 +179,12 @@ void AP_Mount_MAVLink::handle_gimbal_device_attitude_status(const mavlink_messag
     // take copy of message so it can be forwarded onto GCS later
     mavlink_msg_gimbal_device_attitude_status_decode(&msg, &_gimbal_device_attitude_status);
     _last_attitude_status_ms = AP_HAL::millis();
+
+    // Check if gimbal provides extended delta yaw and delta yaw rate information. (Will always be 0 if not provided)
+    if (!is_zero(_gimbal_device_attitude_status.delta_yaw) ||
+    !is_zero(_gimbal_device_attitude_status.delta_yaw_velocity)) {
+        _found_deltas = true;
+    }
 }
 
 // request GIMBAL_DEVICE_INFORMATION message

--- a/libraries/AP_Mount/AP_Mount_MAVLink.h
+++ b/libraries/AP_Mount/AP_Mount_MAVLink.h
@@ -63,6 +63,10 @@ protected:
     // get attitude as a quaternion.  returns true on success
     bool get_attitude_quaternion(Quaternion& att_quat) override;
 
+    // get mount's current delta yaw and delta yaw velocity in rad and rad/s.
+    // returns true on success
+    bool get_attitude_deltas(float &delta_yaw, float& delta_yaw_velocity) override;
+
 private:
 
     // returns true if the camera is reporting that it has the
@@ -101,6 +105,7 @@ private:
     uint8_t _sysid;                 // sysid of gimbal
     uint8_t _compid;                // component id of gimbal
     mavlink_gimbal_device_attitude_status_t _gimbal_device_attitude_status;  // copy of most recently received gimbal status
+    bool _found_deltas = false; // true if gimbal has provided delta yaw and delta yaw rate in GIMBAL_DEVICE_ATTITUDE_STATUS
     uint32_t _last_attitude_status_ms;  // system time last attitude status was received (used for health reporting)
     char vendor_name[MAVLINK_MSG_GIMBAL_DEVICE_INFORMATION_FIELD_VENDOR_NAME_LEN];  // vendor name
     char model_name[MAVLINK_MSG_GIMBAL_DEVICE_INFORMATION_FIELD_MODEL_NAME_LEN];  // model name

--- a/libraries/SITL/SIM_MAVLinkGimbalv2.cpp
+++ b/libraries/SITL/SIM_MAVLinkGimbalv2.cpp
@@ -292,6 +292,9 @@ void MAVLinkGimbalv2::send_attitude_status()
         q.from_rotation_matrix(body_to_gimbal);
     }
 
+    float veh_roll, veh_pitch, veh_yaw;
+    _vehicle_dcm.to_euler(&veh_roll, &veh_pitch, &veh_yaw);
+
     mavlink_gimbal_device_attitude_status_t status {};
     status.target_system    = _vehicle_system_id;
     status.target_component = _vehicle_component_id;
@@ -305,6 +308,8 @@ void MAVLinkGimbalv2::send_attitude_status()
     status.angular_velocity_y = 0.0f;
     status.angular_velocity_z = 0.0f;
     status.failure_flags = 0;
+    status.delta_yaw = veh_yaw;
+    status.delta_yaw_velocity = 0.0f;
 
     mavlink_message_t msg;
     mavlink_msg_gimbal_device_attitude_status_encode_status(


### PR DESCRIPTION
### Summary

<!-- Put a one or two line summary of what your PR does here -->
Added delta_yaw and delta_yaw_velocity support in `AP_Mount` and added an `AP_Mount_MAVLink` implementation, for `GIMBAL_DEVICE_ATTITUDE_STATUS`.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->
Tested on cube blue with Gremsy Pixy LR payload (v7.8.7) (with ArduCopter).

### Description

<!-- Describe the PR's content here -->
1. Added `get_attitude_deltas` to AP_Mount.h and AP_Mount_Backend.h
2. In `send_gimbal_device_attitude_status`, if we are able to `get_attitude_deltas`, attach it as part of the MAVLink message.
3. Added `AP_Mount_MAVLink` implementation of `get_attitude_deltas`. Only true if we ever receive a non-zero value for either of them (indicating the gimbal sends the extended value).

**Rationale:** A gimbal device maintains its own yaw estimate, which can differ from the vehicle's heading. The difference may be small (separate compass with different calibration) or arbitrarily large (some gimbals reference yaw to an arbitrary zero, such as their power-on direction, rather than to north). Some gimbals, such as the Gremsy Pixy LR, report their attitude quaternion in vehicle frame in both follow and lock modes (`GIMBAL_DEVICE_FLAGS_YAW_IN_VEHICLE_FRAME`), so a consumer must always add a vehicle heading to compute the gimbal's earth-frame azimuth.

ArduPilot currently always sends NaN for `delta_yaw` and `delta_yaw_velocity` in `GIMBAL_DEVICE_ATTITUDE_STATUS`, even when the gimbal reports them. A GCS therefore has to either use the autopilot's vehicle heading, which is offset from the gimbal's own estimate, or bypass the gimbal manager and listen for `GIMBAL_DEVICE_ATTITUDE_STATUS` directly from the gimbal device's component, contrary to the intent of the gimbal protocol v2, and impossible when the gimbal is not visible on the GCS link. The offset produces real failures: on the Pixy LR, switching from follow to lock commands an azimuth computed from vehicle heading, which the gimbal executes against its own heading estimate, so the gimbal visibly slews by the difference (in testing, sometimes more than 180 degrees, with the size of the error depending on vehicle heading).

`delta_yaw` exists in the spec for exactly this: it is the vehicle heading as estimated by the gimbal itself. Converting between body and earth frames with the gimbal's own estimate makes the round trip self-consistent, so the frame offset cancels regardless of its cause or size. With this change, when the gimbal reports `delta_yaw`, ArduPilot forwards it in `GIMBAL_DEVICE_ATTITUDE_STATUS`, so a GCS can do that conversion without relying on vehicle heading. Vehicle heading and gimbal attitude also arrive at different rates, so using the gimbal's own value avoids mixing estimates sampled at different times.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
