### PR TITLE
QuadPlane: fix QLoiter backtransitions

### DIFF
--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -817,6 +817,11 @@ protected:
     bool _enter() override;
     uint32_t last_target_loc_set_ms;
 
+    // entered with a stale attitude target: drive it level before
+    // initialising the loiter controller
+    bool entry_leveling;
+    uint32_t entry_leveling_start_ms;
+
 #if AP_QUICKTUNE_ENABLED
     bool supports_quicktune() const override { return true; }
 #endif

--- a/ArduPlane/mode_qloiter.cpp
+++ b/ArduPlane/mode_qloiter.cpp
@@ -5,6 +5,13 @@
 
 bool ModeQLoiter::_enter()
 {
+    // entering from fixed-wing flight: the VTOL attitude controller's
+    // target is stale, frozen since VTOL was last active, and the loiter
+    // controller initializes its acceleration target from it.  Drive the
+    // target level before initializing.
+    entry_leveling = AP_HAL::millis() - quadplane.last_att_control_ms > 100;
+    entry_leveling_start_ms = AP_HAL::millis();
+
     // initialise loiter
     loiter_nav->clear_pilot_desired_acceleration();
     loiter_nav->init_target();
@@ -92,6 +99,30 @@ void ModeQLoiter::run()
     }
     if (!quadplane.motors->armed()) {
         plane.mode_qloiter._enter();
+    }
+
+    if (entry_leveling) {
+        // attitude target angle below which the target is considered level for
+        // handing over to the loiter controller. This bounds the acceleration
+        // the loiter controller initializes with to a trivial ~0.5 m/s^2
+        constexpr float level_angle_rad = 0.05;
+        constexpr uint32_t level_timeout_ms = 3000;
+        const Vector3f &att_target = attitude_control->get_att_target_euler_rad();
+        if ((fabsf(att_target.x) > level_angle_rad || fabsf(att_target.y) > level_angle_rad) &&
+            now - entry_leveling_start_ms < level_timeout_ms) {
+            // drive the attitude target level
+            quadplane.set_desired_spool_state(AP_Motors::DesiredSpoolState::THROTTLE_UNLIMITED);
+            attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw_cd(0, 0, 0);
+            quadplane.set_climb_rate_ms(0);
+            quadplane.run_z_controller();
+            plane.stabilize_roll();
+            plane.stabilize_pitch();
+            return;
+        }
+        entry_leveling = false;
+        // initialise the loiter controller from the driven level target
+        loiter_nav->clear_pilot_desired_acceleration();
+        loiter_nav->init_target();
     }
 
     if (quadplane.should_relax()) {

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -19,7 +19,9 @@ from pymavlink.rotmat import Vector3
 
 import vehicle_test_suite
 
+from vehicle_test_suite import AltFrame
 from vehicle_test_suite import AutoTestTimeoutException
+from vehicle_test_suite import Location
 from vehicle_test_suite import NotAchievedException
 from vehicle_test_suite import PreconditionFailedException
 from vehicle_test_suite import Test
@@ -2310,6 +2312,182 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
 
         self.fly_home_land_and_disarm()
 
+    def QLandPositionHold(self, turning_transition=False, straight_entry=False):
+        '''check position hold during a QLAND from fixed-wing flight
+
+        Take off in QLOITER, then transition to fixed-wing in GUIDED -
+        on a long straight leg by default, or banked around a point one
+        loiter radius abeam with turning_transition=True, which leaves
+        the VTOL attitude controller's last target frozen mid-turn.
+        Every flavor then establishes the same guided circle and waits
+        for a due-east ground course.  QLAND is commanded straight off
+        the circle, or with straight_entry=True after ten seconds
+        settled on a long straight eastbound leg, which takes the turn
+        out of the entry and leaves only the fixed-wing to VTOL
+        handover.  The vehicle must brake to a stop without hunting in
+        every case.
+        '''
+        alt = 30
+        self.takeoff(30, mode='QLOITER')
+        radius = self.get_parameter('WP_LOITER_RAD')
+        if turning_transition:
+            # transition while circling a point one loiter radius
+            # abeam, freezing a banked VTOL attitude target
+            trans_loc = self.offset_location_ne(self.home_position_as_location(), 0, radius)
+        else:
+            # transition on a long straight leg, freezing a level
+            # VTOL attitude target
+            trans_loc = self.offset_location_ne(self.home_position_as_location(), 500, 0)
+        trans_loc.set_alt_m(alt, AltFrame.ABOVE_HOME)
+        self.send_do_reposition(trans_loc, change_mode=True)
+        self.wait_statustext('Transition done', timeout=60)
+        self.delay_sim_time(5, reason="transition tail freezes the VTOL attitude target")
+
+        # both flavors converge on the same circle for the QLAND entry
+        circle_loc = self.offset_location_ne(self.home_position_as_location(), 500, 0)
+        circle_loc.set_alt_m(alt, AltFrame.ABOVE_HOME)
+        self.send_do_reposition(circle_loc)
+        self.wait_altitude(alt-5, alt+5, relative=True, timeout=180)
+        # L1 tracks somewhat outside WP_LOITER_RAD, so allow a generous
+        # margin; we only care that a stable circle is established
+        self.wait_circling_point_with_radius(circle_loc, radius, epsilon=15,
+                                             min_circle_time=10, timeout=300)
+
+        # trigger QLAND when ground course is due east
+        tstart = self.get_sim_time()
+        while True:
+            if self.get_sim_time_cached() - tstart > 300:
+                raise AutoTestTimeoutException("Did not reach eastbound trigger point")
+            m = self.assert_receive_message('GLOBAL_POSITION_INT')
+            course_deg = math.degrees(math.atan2(m.vy, m.vx))
+            if abs(course_deg - 90) <= 3:
+                break
+
+        if straight_entry:
+            # leave the circle for a long straight eastbound leg, so
+            # the vehicle is rolled out and settled when QLAND is
+            # commanded rather than merely pointing east for an instant
+            run_loc = self.offset_location_ne(
+                Location.latlon_only(m.lat * 1.0e-7, m.lon * 1.0e-7), 0, 10000)
+            run_loc.set_alt_m(alt, AltFrame.ABOVE_HOME)
+            self.send_do_reposition(run_loc)
+            self.delay_sim_time(10, reason="settle wings-level on the eastbound leg")
+            m = self.assert_receive_message('GLOBAL_POSITION_INT')
+
+        # ATTITUDE_TARGET carries the demanded yaw; it is not in the
+        # default streams
+        self.set_message_rate_hz('ATTITUDE_TARGET', 10)
+        self.change_mode('QLAND')
+        entry_loc = Location.latlon_only(m.lat * 1.0e-7, m.lon * 1.0e-7)
+
+        # sample position, attitude and demanded attitude from mode
+        # entry until nearly landed
+        samples = []
+        coord = []
+        yaw_deg = None
+        vel_ms = None
+        tstart = self.get_sim_time()
+        while True:
+            now = self.get_sim_time_cached()
+            if now - tstart > 180:
+                raise AutoTestTimeoutException("Did not descend to sampling floor")
+            m = self.assert_receive_message(
+                ['GLOBAL_POSITION_INT', 'ATTITUDE', 'ATTITUDE_TARGET'])
+            mtype = m.get_type()
+            if mtype == 'ATTITUDE':
+                yaw_deg = math.degrees(m.yaw)
+                continue
+            if mtype == 'ATTITUDE_TARGET':
+                if yaw_deg is None or vel_ms is None:
+                    continue
+                qw, qx, qy, qz = m.q
+                yaw_des_deg = math.degrees(
+                    math.atan2(2 * (qw * qz + qx * qy), 1 - 2 * (qy * qy + qz * qz)))
+                yaw_err_deg = abs((yaw_deg - yaw_des_deg + 180) % 360 - 180)
+                course_deg = math.degrees(math.atan2(vel_ms[1], vel_ms[0]))
+                crossflow_ms = abs(math.hypot(vel_ms[0], vel_ms[1]) *
+                                   math.sin(math.radians(course_deg - yaw_des_deg)))
+                coord.append((now, yaw_err_deg, crossflow_ms))
+                continue
+            if m.relative_alt * 0.001 < 2:
+                break
+            vel_ms = (m.vx * 0.01, m.vy * 0.01)
+            samples.append((now, Location.latlon_only(m.lat * 1.0e-7, m.lon * 1.0e-7)))
+        if len(samples) < 20 or len(coord) < 20:
+            raise NotAchievedException(
+                "Insufficient samples (%u position, %u attitude)" %
+                (len(samples), len(coord)))
+
+        # final stopping position: average of the last 5 seconds
+        tail = [s for s in samples if s[0] > samples[-1][0] - 5]
+        final_loc = Location.latlon_only(
+            sum(s[1].lat for s in tail) / len(tail),
+            sum(s[1].lng for s in tail) / len(tail),
+        )
+        dist = [(s[0], self.get_distance(final_loc, s[1])) for s in samples]
+
+        # retreat: once the vehicle starts closing on its resting
+        # point it must keep closing - track the largest rise in
+        # distance back above the closest approach so far
+        min_d = dist[0][1]
+        retreat_m = 0.0
+        for t, d in dist:
+            min_d = min(min_d, d)
+            retreat_m = max(retreat_m, d - min_d)
+
+        # settling: time from first coming within 20m of the final
+        # position until permanently within 3m of it.  The inner band
+        # sits above the ~2m wobble of a normal descent so a clean
+        # hover cannot straddle it.
+        t20 = next(t for t, d in dist if d < 20)
+        settle_s = max((t for t, d in dist if d > 3), default=t20) - t20
+
+        # coordination: the deceleration must not fight the airframe's
+        # aerodynamic stability. Judged on commanded crossflow: the controller
+        # must not demand a yaw that would put the airframe into a crossflow
+        # greater than the maximum loiter speed. Additionally judged on
+        # sustained yaw error.
+        yaw_err_s = sum(b[0] - a[0] for a, b in zip(coord, coord[1:]) if a[1] > 20)
+        crossflow_peak = max(c[2] for c in coord)
+
+        self.progress(
+            "QLAND hold: %u samples, entry->final %.2fm, retreat %.2fm, settle %.2fs" %
+            (len(samples), self.get_distance(entry_loc, final_loc), retreat_m, settle_s))
+        self.progress("QLAND coordination: %.2fs with yaw error >20deg, "
+                      "peak commanded crossflow %.2fm/s" %
+                      (yaw_err_s, crossflow_peak))
+
+        failures = []
+        if retreat_m > 5.0:
+            failures.append(
+                "retreated %.2fm from closest approach to stopping point (want <5m)" % retreat_m)
+        if settle_s > 6.0:
+            failures.append("took %.2fs to settle from 20m out (want <6s)" % settle_s)
+        if yaw_err_s > 1.0:
+            failures.append(
+                "held >20deg of yaw error for %.2fs (want <1s)" % yaw_err_s)
+        max_loiter_spd = self.get_parameter('Q_LOIT_SPEED_MS')
+        if crossflow_peak > max_loiter_spd:
+            failures.append(
+                "peak commanded crossflow %.2fm/s exceeds max loiter speed %.1fm/s" %
+                (crossflow_peak, max_loiter_spd))
+        if failures:
+            raise NotAchievedException("QLAND misbehaved: " + "; ".join(failures))
+
+        self.wait_disarmed(timeout=180)
+
+    def QLandPositionHoldTurningTransition(self):
+        '''check QLAND position hold after a mid-turn transition'''
+        self.QLandPositionHold(turning_transition=True)
+
+    def QLandPositionHoldStraightEntry(self):
+        '''check QLAND position hold entered off a straight leg'''
+        self.QLandPositionHold(straight_entry=True)
+
+    def QLandPositionHoldTurningTransitionStraightEntry(self):
+        '''check QLAND position hold off a straight leg after a mid-turn transition'''
+        self.QLandPositionHold(turning_transition=True, straight_entry=True)
+
     def WindEstimateConsistency(self):
         '''test that DCM and EKF3 roughly agree on wind speed and direction'''
         self.set_parameters({
@@ -3445,6 +3623,10 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             self.DCMClimbRate,
             self.RTL_AUTOLAND_1,  # as in fly-home then go to landing sequence
             self.RTL_AUTOLAND_1_FROM_GUIDED,  # as in fly-home then go to landing sequence
+            self.QLandPositionHold,
+            self.QLandPositionHoldTurningTransition,
+            self.QLandPositionHoldStraightEntry,
+            self.QLandPositionHoldTurningTransitionStraightEntry,
             self.AHRSFlyForwardFlag,
             self.DoRepositionTerrain,
             self.DoRepositionTerrain2,

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -8858,12 +8858,14 @@ class TestSuite(abc.ABC):
             self.delay_sim_time(0.2, "let RC inputs settle")
             self.context_pop()
 
-    def send_do_reposition(self, loc, frame=None):
+    def send_do_reposition(self, loc, frame=None, change_mode=False):
         '''send a DO_REPOSITION command for a location.  loc is ideally
         a (frame-aware) Location, in which case the MAV_FRAME comes
         from the Location itself and frame must be left None.  Passing
         a mavutil.location and a frame is deprecated, as the object's
-        altitude frame can silently contradict the passed frame'''
+        altitude frame can silently contradict the passed frame.
+        change_mode requests a switch to GUIDED; without it the
+        command is rejected unless already in GUIDED'''
         if isinstance(loc, Location):
             if frame is not None:
                 raise ValueError("frame comes from the Location; do not pass one")
@@ -8872,10 +8874,11 @@ class TestSuite(abc.ABC):
             if frame is None:
                 frame = mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT
             alt = loc.alt
+        flags = mavutil.mavlink.MAV_DO_REPOSITION_FLAGS_CHANGE_MODE if change_mode else 0
         self.run_cmd_int(
             mavutil.mavlink.MAV_CMD_DO_REPOSITION,
             0,
-            0,
+            flags,
             0,
             0,
             int(loc.lat*1e7), # lat* 1e7


### PR DESCRIPTION
### Summary

Fix a bug that can cause excessive position hunting when switching to QLoiter/QLand from fixed-wing.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Currently, the stopping behavior when switching to QLoiter depends on state that accumulated during your transition to fixed-wing flight. This bug is long-standing (tested back to 4.5). Below are two screenshots from a test on master.

<img width="1026" height="795" alt="image" src="https://github.com/user-attachments/assets/b48041a0-e86b-43db-9be2-1006d916d6b2" />

<img width="892" height="855" alt="image" src="https://github.com/user-attachments/assets/c0cbecad-1dad-4bb7-b96b-8b025be68864" />

If you don't do your outbound transition perfectly straight with wings level, you get this weird hard bank when you switch into QLoiter/QLand.

The fix I'm proposing in this PR is to initialize the loiter at the current position, re-seeding the velocity PID integrator for a pure brake (only when initializing from a period of position controller inactivity). The vehicle now rolls wings level and pitches back to a stop from any entry attitude, regardless of the state of the forwar-transition, stopping in ~6s from 25m/s and remaining within 2m of the final landing point, where it previously wallowed for 13s and wandered around more than 10m.

Screenshot of ground tracks before/after my fix:

<img width="1080" height="810" alt="image" src="https://github.com/user-attachments/assets/a68f9f7d-52cb-411d-a0db-a25325a1d236" />

My only issue is that the code for my fix *looks* a tad hacky with the `vel_pid` stuff I'm doing, but I think the idea is sound, and I believe this is the cleanest way to achieve it. @lthall (or anyone else) if you have any opinions on a better shape of this, I'd be happy to hear them. Or if you just wanna swipe my autotest and fix this a different way in a superseding PR, I'm totally fine with that.

The new autotest reliably fails, on all 4 criteria, before the fix, and reliably passes after. Plenty of headroom.

### Turning transition (transition tail freezes a banked attitude target)

| criterion | bound | master (3 runs) | with fix (3 runs) |
| --------- | ----- | --------------- | ----------------- |
| retreat from closest approach to stopping point | < 5 m | **10.03 / 9.37 / 11.98** | 1.89 / 1.90 / 1.88 |
| settle from 20 m out to within 2 m | < 8 s | **11.60 / 11.30 / 12.60** | 2.10 / 2.10 / 2.10 |
| ground-course winding above 3 m/s | < 60° | **318 / 314 / 338** | 18.0 / 18.0 / 17.9 |
| N/S displacement of stopping point from entry | < 25 m | **43.3 / 44.8 / 42.5** | 16.9 / 17.0 / 17.0 |

Every master run fails all four criteria; every fixed run passes all four.

### Straight transition (control: transition tail freezes a level attitude target)

| criterion | bound | master (3 runs) | with fix (3 runs) |
| --------- | ----- | --------------- | ----------------- |
| retreat from closest approach to stopping point | < 5 m | 1.86 / 1.84 / 1.84 | 1.89 / 1.89 / 1.88 |
| settle from 20 m out to within 2 m | < 8 s | 2.10 / 2.10 / 2.10 | 2.10 / 2.10 / 2.10 |
| ground-course winding above 3 m/s | < 60° | 14.4 / 14.4 / 14.4 | 9.4 / 17.5 / 17.7 |
| N/S displacement of stopping point from entry | < 25 m | 13.2 / 13.2 / 13.2 | 17.5 / 17.4 / 14.9 |

Master already passes when its stale attitude target happens to be level, the same code and thresholds, demonstrating the expectation is realistic and the fix simply makes the happy case the only case.