### PR TITLE
AP_Bootloader: Reserve IDs 1940-1949 for Agam Robotics

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -429,6 +429,9 @@ AP_HW_A2M6X                          1850
 AP_HW_A2M6X_NANO                     1855
 AP_HW_A2M6X_V2                       1860
 
+# IDs 1940–1949 reserved for Agam Robotics
+AP_HW_AGAM_MEGH7                     1940
+
 # IDs 1950-1979 reserved for HC Robotics
 AP_HW_HCR-504                        1950
 AP_HW_HCR-506                        1951


### PR DESCRIPTION
Reserved IDs for Agam Robotics in board_types.txt

### Summary

Reserve IDs 1940-1949 for Agam Robotics

### Classification & Testing (check all that apply and add your own)

- [ ] Checked by a human programmer
- [x] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

