### PR TITLE
FFT notch tune: persist the tracking mode and name the notch used

### DIFF
--- a/libraries/AP_GyroFFT/AP_GyroFFT.cpp
+++ b/libraries/AP_GyroFFT/AP_GyroFFT.cpp
@@ -786,7 +786,8 @@ void AP_GyroFFT::stop_notch_tune()
     }
 
 #if AP_INERTIALSENSOR_HARMONICNOTCH_ENABLED
-    if (!_ins->setup_throttle_gyro_harmonic_notch(harmonic, (float)_fft_min_hz.get(), _avg_throttle_out, harmonics)) {
+    uint8_t notch_idx = 0;
+    if (!_ins->setup_throttle_gyro_harmonic_notch(harmonic, (float)_fft_min_hz.get(), _avg_throttle_out, harmonics, &notch_idx)) {
         GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "FFT: Unable to set throttle notch with %.1fHz/%.2f",
             harmonic, _avg_throttle_out);
         AP_Notify::events.autotune_failed = true;
@@ -794,7 +795,9 @@ void AP_GyroFFT::stop_notch_tune()
         _throttle_ref.set(_avg_throttle_out);
         _freq_hover_hz.set(harmonic);
     } else {
-        GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "FFT: Notch frequency %.1fHz and ref %.2f selected", harmonic, _avg_throttle_out);
+        // name the notch, it is not necessarily the first one
+        GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "FFT: Notch %u freq %.1fHz ref %.2f selected",
+            unsigned(notch_idx + 1), harmonic, _avg_throttle_out);
         AP_Notify::events.autotune_complete = true;
     }
 #endif  // AP_INERTIALSENSOR_HARMONICNOTCH_ENABLED

--- a/libraries/AP_GyroFFT/AP_GyroFFT.cpp
+++ b/libraries/AP_GyroFFT/AP_GyroFFT.cpp
@@ -786,7 +786,8 @@ void AP_GyroFFT::stop_notch_tune()
     }
 
 #if AP_INERTIALSENSOR_HARMONICNOTCH_ENABLED
-    if (!_ins->setup_throttle_gyro_harmonic_notch(harmonic, (float)_fft_min_hz.get(), _avg_throttle_out, harmonics)) {
+    uint8_t notch_idx = 0;
+    if (!_ins->setup_throttle_gyro_harmonic_notch(harmonic, (float)_fft_min_hz.get(), _avg_throttle_out, harmonics, &notch_idx)) {
         GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "FFT: Unable to set throttle notch with %.1fHz/%.2f",
             harmonic, _avg_throttle_out);
         AP_Notify::events.autotune_failed = true;
@@ -794,7 +795,9 @@ void AP_GyroFFT::stop_notch_tune()
         _throttle_ref.set(_avg_throttle_out);
         _freq_hover_hz.set(harmonic);
     } else {
-        GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "FFT: Notch frequency %.1fHz and ref %.2f selected", harmonic, _avg_throttle_out);
+        // name the notch by its parameter prefix, it is not necessarily the first one
+        GCS_SEND_TEXT(MAV_SEVERITY_NOTICE, "FFT: INS_HNTC%c freq %.1fHz ref %.2f selected",
+            notch_idx == 0 ? 'H' : char('1' + notch_idx), harmonic, _avg_throttle_out);
         AP_Notify::events.autotune_complete = true;
     }
 #endif  // AP_INERTIALSENSOR_HARMONICNOTCH_ENABLED

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -2392,7 +2392,7 @@ void AP_InertialSensor::HarmonicNotch::update_frequencies_hz(uint8_t num_freqs, 
 }
 
 // setup the notch for throttle based tracking, called from FFT based tuning
-bool AP_InertialSensor::setup_throttle_gyro_harmonic_notch(float center_freq_hz, float lower_freq_hz, float ref, uint8_t harmonics)
+bool AP_InertialSensor::setup_throttle_gyro_harmonic_notch(float center_freq_hz, float lower_freq_hz, float ref, uint8_t harmonics, uint8_t *notch_idx)
 {
     for (auto &notch : harmonic_notches) {
         if (notch.params.tracking_mode() != HarmonicNotchDynamicMode::UpdateThrottle) {
@@ -2405,7 +2405,10 @@ bool AP_InertialSensor::setup_throttle_gyro_harmonic_notch(float center_freq_hz,
         notch.params.set_freq_min_ratio(lower_freq_hz / center_freq_hz);
         notch.params.set_harmonics(harmonics);
         notch.params.save_params();
-        // only enable the first notch
+        if (notch_idx != nullptr) {
+            *notch_idx = &notch - &harmonic_notches[0];
+        }
+        // only enable the first throttle notch
         return true;
     }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -2392,7 +2392,7 @@ void AP_InertialSensor::HarmonicNotch::update_frequencies_hz(uint8_t num_freqs, 
 }
 
 // setup the notch for throttle based tracking, called from FFT based tuning
-bool AP_InertialSensor::setup_throttle_gyro_harmonic_notch(float center_freq_hz, float lower_freq_hz, float ref, uint8_t harmonics)
+bool AP_InertialSensor::setup_throttle_gyro_harmonic_notch(float center_freq_hz, float lower_freq_hz, float ref, uint8_t harmonics, uint8_t *notch_idx)
 {
     for (auto &notch : harmonic_notches) {
         if (notch.params.tracking_mode() != HarmonicNotchDynamicMode::UpdateThrottle) {
@@ -2405,6 +2405,9 @@ bool AP_InertialSensor::setup_throttle_gyro_harmonic_notch(float center_freq_hz,
         notch.params.set_freq_min_ratio(lower_freq_hz / center_freq_hz);
         notch.params.set_harmonics(harmonics);
         notch.params.save_params();
+        if (notch_idx != nullptr) {
+            *notch_idx = &notch - &harmonic_notches[0];
+        }
         // only enable the first notch
         return true;
     }

--- a/libraries/AP_InertialSensor/AP_InertialSensor.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.h
@@ -243,8 +243,8 @@ public:
     uint16_t get_accel_filter_hz(void) const { return _accel_filter_cutoff; }
 
 #if AP_INERTIALSENSOR_HARMONICNOTCH_ENABLED
-    // setup the notch for throttle based tracking
-    bool setup_throttle_gyro_harmonic_notch(float center_freq_hz, float lower_freq_hz, float ref, uint8_t harmonics);
+    // setup the notch for throttle based tracking, returning the notch used in notch_idx
+    bool setup_throttle_gyro_harmonic_notch(float center_freq_hz, float lower_freq_hz, float ref, uint8_t harmonics, uint8_t *notch_idx = nullptr);
 
     // write out harmonic notch log messages
     void write_notch_log_messages() const;

--- a/libraries/Filter/HarmonicNotchFilter.cpp
+++ b/libraries/Filter/HarmonicNotchFilter.cpp
@@ -539,13 +539,16 @@ void HarmonicNotchFilterParams::init()
  */
 void HarmonicNotchFilterParams::save_params()
 {
-    _enable.save();
-    _center_freq_hz.save();
-    _bandwidth_hz.save();
+    // force the tuned values into storage, a value that matches the parameter
+    // default is not saved and the notch would move if that default ever changed
+    _enable.save(true);
+    _center_freq_hz.save(true);
+    _bandwidth_hz.save(true);
     _attenuation_dB.save();
-    _harmonics.save();
-    _reference.save();
-    _freq_min_ratio.save();
+    _harmonics.save(true);
+    _reference.save(true);
+    _freq_min_ratio.save(true);
+    _tracking_mode.save(true);
 }
 
 

--- a/libraries/Filter/HarmonicNotchFilter.cpp
+++ b/libraries/Filter/HarmonicNotchFilter.cpp
@@ -546,6 +546,9 @@ void HarmonicNotchFilterParams::save_params()
     _harmonics.save();
     _reference.save();
     _freq_min_ratio.save();
+    // force the tracking mode into storage, otherwise the tuned notch is left
+    // relying on the parameter default and changes source if that default moves
+    _tracking_mode.save(true);
 }
 
 


### PR DESCRIPTION
### Summary

Two problems with the notch the FFT tune configures.

`save_params()` left the tracking mode out. The mode normally sits at its parameter default, and `save()` does not write a value that equals its default, so the tuned notch was left relying on that default never moving. It does move: the pre-4.2 fixed notch conversion made `INS_HNTC2_MODE` default to 0 while HNTC2 was disabled and 1 once it was enabled (fixed separately in #33878), which is exactly the failure this guards against.

`setup_throttle_gyro_harmonic_notch()` takes the first notch in throttle mode, which is not necessarily the first notch. A static or RPM-tracking first notch is skipped and a later one is enabled instead, and the tune reported success without saying which notch it had touched.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)

`test.Copter.GyroFFTAverage` passes.

Flown in SITL with `INS_HNTCH_MODE 0` supplied as a default, so the first notch is static and the tune has to move on:

```
AP: FFT: Notch 2 freq 148.8Hz ref 0.39 selected
eeprom: INS_HNTCH_MODE <not in eeprom>   INS_HNTC2_MODE 1
```

With only the `_tracking_mode` save removed and the same flight repeated, `INS_HNTC2_MODE` is absent from the eeprom. `INS_HNTCH_MODE` stays out of storage in both cases, so the forced save is scoped to the notch the tune actually configured.

### Description

The retargeting itself is reasonable behaviour - it preserves a deliberately configured static notch and uses the next available one - so this keeps it and just makes it visible rather than refusing to tune. The message needed shortening (`frequency` -> `freq`) because adding the notch number pushed the old string to 52 characters and MAVLink truncated it at 50.

`notch_idx` is an optional out-param rather than a changed return type so that the AP_InertialSensor commit still compiles on its own.

Note `save_params()` still uses a plain `save()` for `_enable`, which has the same latent issue if a board's `defaults.parm` sets `INS_HNTCH_ENABLE 1`. Left alone here as it is a separate change.
