### PR TITLE
Refactor decode_devid to be callable by python code

### DIFF
--- a/Tools/scripts/decode_devid.py
+++ b/Tools/scripts/decode_devid.py
@@ -1,45 +1,26 @@
 #!/usr/bin/env python3
 
-# flake8: noqa
-
-'''
-decode a device ID, such as used for COMPASS_DEV_ID, INS_ACC_ID etc
+"""
+Decode a device ID such as used for COMPASS_DEV_ID, INS_ACC_ID etc
 
 To understand the devtype you should look at the backend headers for
 the sensor library, such as libraries/AP_Compass/AP_Compass_Backend.h
-'''
 
-import sys
+AP_FLAKE8_CLEAN
+
+SPDX-FileCopyrightText: 2024-2026 ArduPilot developers
+
+SPDX-License-Identifier: GPL-3.0-or-later
+
+"""
+
 import optparse
+import sys
 
-def num(s):
-    try:
-        return int(s)
-    except ValueError:
-        return int(s, 16)
+from typing import Union
 
-
-parser = optparse.OptionParser("decode_devid.py")
-parser.add_option("-C", "--compass", action='store_true', help='decode compass IDs')
-parser.add_option("-I", "--imu", action='store_true', help='decode IMU IDs')
-parser.add_option("-B", "--baro", action='store_true', help='decode barometer IDs')
-parser.add_option("-A", "--airspeed", action='store_true', help='decode airspeed IDs')
-parser.add_option("-M", "--mavlink", action='store_true', help='decode MAVLink channel IDs')
-
-opts, args = parser.parse_args()
-
-if len(args) == 0:
-    print("Please supply a device ID")
-    sys.exit(1)
-
-devid=num(args[0])
-
-bus_type=devid & 0x07
-bus=(devid>>3) & 0x1F
-address=(devid>>8)&0xFF
-devtype=(devid>>16)
-
-bustypes = {
+# Device type lookup tables
+BUSTYPES = {
     1: "I2C",
     2: "SPI",
     3: "DRONECAN",
@@ -49,149 +30,258 @@ bustypes = {
     7: "WSPI",
 }
 
-compass_types = {
-    0x01 : "DEVTYPE_HMC5883_OLD",
-    0x07 : "DEVTYPE_HMC5883",
-    0x02 : "DEVTYPE_LSM303D",
-    0x04 : "DEVTYPE_AK8963 ",
-    0x05 : "DEVTYPE_BMM150 ",
-    0x06 : "DEVTYPE_LSM9DS1",
-    0x08 : "DEVTYPE_LIS3MDL",
-    0x09 : "DEVTYPE_AK0991x",
-    0x0A : "DEVTYPE_IST8310",
-    0x0B : "DEVTYPE_ICM20948",
-    0x0C : "DEVTYPE_MMC3416",
-    0x0D : "DEVTYPE_QMC5883L",
-    0x0E : "DEVTYPE_MAG3110",
-    0x0F : "DEVTYPE_SITL",
-    0x10 : "DEVTYPE_IST8308",
-    0x11 : "DEVTYPE_RM3100_OLD",
-    0x12 : "DEVTYPE_RM3100",
-    0x13 : "DEVTYPE_MMC5883",
-    0x14 : "DEVTYPE_AK09918",
-    0x15 : "DEVTYPE_AK09915",
-    0x16 : "DEVTYPE_QMC5883P",
-    0x17 : "DEVTYPE_BMM350",
-    0x18 : "DEVTYPE_IIS2MDC",
-    0x19 : "DEVTYPE_LIS2MDL",  # unused except on pre-release firmware
-    0x1A : "DEVTYPE_AF9838",
+COMPASS_TYPES = {
+    0x01: "DEVTYPE_HMC5883_OLD",
+    0x07: "DEVTYPE_HMC5883",
+    0x02: "DEVTYPE_LSM303D",
+    0x04: "DEVTYPE_AK8963 ",
+    0x05: "DEVTYPE_BMM150 ",
+    0x06: "DEVTYPE_LSM9DS1",
+    0x08: "DEVTYPE_LIS3MDL",
+    0x09: "DEVTYPE_AK0991x",
+    0x0A: "DEVTYPE_IST8310",
+    0x0B: "DEVTYPE_ICM20948",
+    0x0C: "DEVTYPE_MMC3416",
+    0x0D: "DEVTYPE_QMC5883L",
+    0x0E: "DEVTYPE_MAG3110",
+    0x0F: "DEVTYPE_SITL",
+    0x10: "DEVTYPE_IST8308",
+    0x11: "DEVTYPE_RM3100_OLD",
+    0x12: "DEVTYPE_RM3100",
+    0x13: "DEVTYPE_MMC5883",
+    0x14: "DEVTYPE_AK09918",
+    0x15: "DEVTYPE_AK09915",
+    0x16: "DEVTYPE_QMC5883P",
+    0x17: "DEVTYPE_BMM350",
+    0x18: "DEVTYPE_IIS2MDC",
+    0x19: "DEVTYPE_LIS2MDL",  # unused except on pre-release firmware
+    0x1A: "DEVTYPE_AF9838",
 }
 
-imu_types = {
-    0x09 : "DEVTYPE_BMI160",
-    0x10 : "DEVTYPE_L3G4200D",
-    0x11 : "DEVTYPE_ACC_LSM303D",
-    0x12 : "DEVTYPE_ACC_BMA180",
-    0x13 : "DEVTYPE_ACC_MPU6000",
-    0x16 : "DEVTYPE_ACC_MPU9250",
-    0x17 : "DEVTYPE_ACC_IIS328DQ",
-    0x21 : "DEVTYPE_GYR_MPU6000",
-    0x22 : "DEVTYPE_GYR_L3GD20",
-    0x24 : "DEVTYPE_GYR_MPU9250",
-    0x25 : "DEVTYPE_GYR_I3G4250D",
-    0x26 : "DEVTYPE_GYR_LSM9DS1",
-    0x27 : "DEVTYPE_INS_ICM20789",
-    0x28 : "DEVTYPE_INS_ICM20689",
-    0x29 : "DEVTYPE_INS_BMI055",
-    0x2A : "DEVTYPE_SITL",
-    0x2B : "DEVTYPE_INS_BMI088",
-    0x2C : "DEVTYPE_INS_ICM20948",
-    0x2D : "DEVTYPE_INS_ICM20648",
-    0x2E : "DEVTYPE_INS_ICM20649",
-    0x2F : "DEVTYPE_INS_ICM20602",
-    0x30 : "DEVTYPE_INS_ICM20601",
-    0x31 : "DEVTYPE_INS_ADIS1647x",
-    0x32 : "DEVTYPE_INS_SERIAL",
-    0x33 : "DEVTYPE_INS_ICM40609",
-    0x34 : "DEVTYPE_INS_ICM42688",
-    0x35 : "DEVTYPE_INS_ICM42605",
-    0x36 : "DEVTYPE_INS_ICM40605",
-    0x37 : "DEVTYPE_INS_IIM42652",
-    0x38 : "DEVTYPE_INS_BMI270",
-    0x39 : "DEVTYPE_INS_BMI085",
-    0x3A : "DEVTYPE_INS_ICM42670",
-    0x3B : "DEVTYPE_INS_ICM45686",
-    0x3C : "DEVTYPE_INS_SCHA63T",
-    0x3D : "DEVTYPE_INS_IIM42653",
-    0x3E : "DEVTYPE_INS_LSM6DSV16X",
-    0x3F : "DEVTYPE_INS_ASM330",
-    0x40 : "DEVTYPE_INS_ADIS16607",
-    0x42 : "DEVTYPE_INS_LSM6DSV32X",
-    0x43 : "DEVTYPE_INS_LSM6DSK320X",
+IMU_TYPES = {
+    0x09: "DEVTYPE_BMI160",
+    0x10: "DEVTYPE_L3G4200D",
+    0x11: "DEVTYPE_ACC_LSM303D",
+    0x12: "DEVTYPE_ACC_BMA180",
+    0x13: "DEVTYPE_ACC_MPU6000",
+    0x16: "DEVTYPE_ACC_MPU9250",
+    0x17: "DEVTYPE_ACC_IIS328DQ",
+    0x21: "DEVTYPE_GYR_MPU6000",
+    0x22: "DEVTYPE_GYR_L3GD20",
+    0x24: "DEVTYPE_GYR_MPU9250",
+    0x25: "DEVTYPE_GYR_I3G4250D",
+    0x26: "DEVTYPE_GYR_LSM9DS1",
+    0x27: "DEVTYPE_INS_ICM20789",
+    0x28: "DEVTYPE_INS_ICM20689",
+    0x29: "DEVTYPE_INS_BMI055",
+    0x2A: "DEVTYPE_SITL",
+    0x2B: "DEVTYPE_INS_BMI088",
+    0x2C: "DEVTYPE_INS_ICM20948",
+    0x2D: "DEVTYPE_INS_ICM20648",
+    0x2E: "DEVTYPE_INS_ICM20649",
+    0x2F: "DEVTYPE_INS_ICM20602",
+    0x30: "DEVTYPE_INS_ICM20601",
+    0x31: "DEVTYPE_INS_ADIS1647x",
+    0x32: "DEVTYPE_INS_SERIAL",
+    0x33: "DEVTYPE_INS_ICM40609",
+    0x34: "DEVTYPE_INS_ICM42688",
+    0x35: "DEVTYPE_INS_ICM42605",
+    0x36: "DEVTYPE_INS_ICM40605",
+    0x37: "DEVTYPE_INS_IIM42652",
+    0x38: "DEVTYPE_INS_BMI270",
+    0x39: "DEVTYPE_INS_BMI085",
+    0x3A: "DEVTYPE_INS_ICM42670",
+    0x3B: "DEVTYPE_INS_ICM45686",
+    0x3C: "DEVTYPE_INS_SCHA63T",
+    0x3D: "DEVTYPE_INS_IIM42653",
+    0x3E: "DEVTYPE_INS_LSM6DSV16X",
+    0x3F: "DEVTYPE_INS_ASM330",
+    0x40: "DEVTYPE_INS_ADIS16607",
+    0x42: "DEVTYPE_INS_LSM6DSV32X",
+    0x43: "DEVTYPE_INS_LSM6DSK320X",
 }
 
-baro_types = {
-    0x01 : "DEVTYPE_BARO_SITL",
-    0x02 : "DEVTYPE_BARO_BMP085",
-    0x03 : "DEVTYPE_BARO_BMP280",
-    0x04 : "DEVTYPE_BARO_BMP388",
-    0x05 : "DEVTYPE_BARO_DPS280",
-    0x06 : "DEVTYPE_BARO_DPS310",
-    0x07 : "DEVTYPE_BARO_FBM320",
-    0x08 : "DEVTYPE_BARO_ICM20789",
-    0x09 : "DEVTYPE_BARO_KELLERLD",
-    0x0A : "DEVTYPE_BARO_LPS2XH",
-    0x0B : "DEVTYPE_BARO_MS5611",
-    0x0C : "DEVTYPE_BARO_SPL06",
-    0x0D : "DEVTYPE_BARO_DRONECAN",
-    0x0E : "DEVTYPE_BARO_MSP",
-    0x0F : "DEVTYPE_BARO_ICP101XX",
-    0x10 : "DEVTYPE_BARO_ICP201XX",
-    0x11 : "DEVTYPE_BARO_MS5607",
-    0x12 : "DEVTYPE_BARO_MS5837_30BA",
-    0x13 : "DEVTYPE_BARO_MS5637",
-    0x14 : "DEVTYPE_BARO_BMP390",
-    0x15 : "DEVTYPE_BARO_BMP581",
-    0x16 : "DEVTYPE_BARO_SPA06",
-    0x17 : "DEVTYPE_BARO_AUAV",
-    0x18 : "DEVTYPE_BARO_MS5837_02BA",
+BARO_TYPES = {
+    0x01: "DEVTYPE_BARO_SITL",
+    0x02: "DEVTYPE_BARO_BMP085",
+    0x03: "DEVTYPE_BARO_BMP280",
+    0x04: "DEVTYPE_BARO_BMP388",
+    0x05: "DEVTYPE_BARO_DPS280",
+    0x06: "DEVTYPE_BARO_DPS310",
+    0x07: "DEVTYPE_BARO_FBM320",
+    0x08: "DEVTYPE_BARO_ICM20789",
+    0x09: "DEVTYPE_BARO_KELLERLD",
+    0x0A: "DEVTYPE_BARO_LPS2XH",
+    0x0B: "DEVTYPE_BARO_MS5611",
+    0x0C: "DEVTYPE_BARO_SPL06",
+    0x0D: "DEVTYPE_BARO_DRONECAN",
+    0x0E: "DEVTYPE_BARO_MSP",
+    0x0F: "DEVTYPE_BARO_ICP101XX",
+    0x10: "DEVTYPE_BARO_ICP201XX",
+    0x11: "DEVTYPE_BARO_MS5607",
+    0x12: "DEVTYPE_BARO_MS5837_30BA",
+    0x13: "DEVTYPE_BARO_MS5637",
+    0x14: "DEVTYPE_BARO_BMP390",
+    0x15: "DEVTYPE_BARO_BMP581",
+    0x16: "DEVTYPE_BARO_SPA06",
+    0x17: "DEVTYPE_BARO_AUAV",
+    0x18: "DEVTYPE_BARO_MS5837_02BA",
 }
 
-airspeed_types = {
-    0x01 : "DEVTYPE_AIRSPEED_SITL",
-    0x02 : "DEVTYPE_AIRSPEED_MS4525",
-    0x03 : "DEVTYPE_AIRSPEED_MS5525",
-    0x04 : "DEVTYPE_AIRSPEED_DLVR",
-    0x05 : "DEVTYPE_AIRSPEED_MSP",
-    0x06 : "DEVTYPE_AIRSPEED_SDP3X",
-    0x07 : "DEVTYPE_AIRSPEED_DRONECAN",
-    0x08 : "DEVTYPE_AIRSPEED_ANALOG",
-    0x09 : "DEVTYPE_AIRSPEED_NMEA",
-    0x0A : "DEVTYPE_AIRSPEED_ASP5033",
-    0x0B : "DEVTYPE_AIRSPEED_AUAV",
-    0x0C : "DEVTYPE_AIRSPEED_SCRIPTING",
+AIRSPEED_TYPES = {
+    0x01: "DEVTYPE_AIRSPEED_SITL",
+    0x02: "DEVTYPE_AIRSPEED_MS4525",
+    0x03: "DEVTYPE_AIRSPEED_MS5525",
+    0x04: "DEVTYPE_AIRSPEED_DLVR",
+    0x05: "DEVTYPE_AIRSPEED_MSP",
+    0x06: "DEVTYPE_AIRSPEED_SDP3X",
+    0x07: "DEVTYPE_AIRSPEED_DRONECAN",
+    0x08: "DEVTYPE_AIRSPEED_ANALOG",
+    0x09: "DEVTYPE_AIRSPEED_NMEA",
+    0x0A: "DEVTYPE_AIRSPEED_ASP5033",
+    0x0B: "DEVTYPE_AIRSPEED_AUAV",
+    0x0C: "DEVTYPE_AIRSPEED_SCRIPTING",
 }
 
-mavlink_types = {
-    0x01 : "DEVTYPE_MAVLINK_UART",
-    0x02 : "DEVTYPE_MAVLINK_NETWORKING",
-    0x03 : "DEVTYPE_MAVLINK_CAN",
-    0x04 : "DEVTYPE_MAVLINK_SCRIPTING",
+MAVLINK_TYPES = {
+    0x01: "DEVTYPE_MAVLINK_UART",
+    0x02: "DEVTYPE_MAVLINK_NETWORKING",
+    0x03: "DEVTYPE_MAVLINK_CAN",
+    0x04: "DEVTYPE_MAVLINK_SCRIPTING",
 }
 
-decoded_devname = ""
+def parse_device_id(device_id_str: str) -> int:
+    """Parse device ID from string (decimal or hex)."""
+    try:
+        return int(device_id_str)
+    except ValueError:
+        return int(device_id_str, 16)
 
-if opts.compass:
-    decoded_devname = compass_types.get(devtype, "UNKNOWN")
 
-if opts.imu:
-    decoded_devname = imu_types.get(devtype, "UNKNOWN")
+def decode_device_id(device_id: int) -> dict[str, Union[int, str, bool]]:
+    """
+    Decode an ArduPilot device ID into its components.
 
-if opts.baro:
-    decoded_devname = baro_types.get(devtype, "UNKNOWN")
+    Args:
+        device_id: Device ID as integer (can be decimal or hex)
 
-if opts.airspeed:
-    decoded_devname = airspeed_types.get(devtype, "UNKNOWN")
+    Returns:
+        Dictionary with keys:
+            - bus_type_value: Bus type numeric value
+            - bus_type_name: Bus type name (I2C, SPI, etc.)
+            - bus: Bus number
+            - address: Device address
+            - devtype: Device type numeric value
+            - is_dronecan: Whether this is DRONECAN bus type
 
-if opts.mavlink:
-    decoded_devname = mavlink_types.get(devtype, "UNKNOWN")
+    """
+    bus_type = device_id & 0x07
+    bus = (device_id >> 3) & 0x1F
+    address = (device_id >> 8) & 0xFF
+    devtype = device_id >> 16
 
-if bus_type == 3:
-    #dronecan devtype represents sensor_id
-    print("bus_type:%s(%u)  bus:%u address:%u(0x%x) sensor_id:%u(0x%x) %s" % (
-        bustypes.get(bus_type,"UNKNOWN"), bus_type,
-        bus, address, address, devtype-1, devtype-1, decoded_devname))
-else:
-    print("bus_type:%s(%u)  bus:%u address:%u(0x%x) devtype:%u(0x%x) %s" % (
-        bustypes.get(bus_type,"UNKNOWN"), bus_type,
-        bus, address, address, devtype, devtype, decoded_devname))
+    return {
+        "bus_type_value": bus_type,
+        "bus_type_name": BUSTYPES.get(bus_type, "UNKNOWN"),
+        "bus": bus,
+        "address": address,
+        "devtype": devtype,
+        "is_dronecan": bus_type == 3,
+    }
+
+
+def get_device_type_name(devtype: int, device_category: str) -> str:
+    """
+    Look up device type name based on device category.
+
+    Args:
+        devtype: Device type numeric value
+        device_category: One of 'compass', 'imu', 'baro', 'airspeed'
+
+    Returns:
+        Device type name string, or 'UNKNOWN' if not found
+
+    """
+    category_map = {
+        "compass": COMPASS_TYPES,
+        "imu": IMU_TYPES,
+        "baro": BARO_TYPES,
+        "airspeed": AIRSPEED_TYPES,
+        "mavlink": MAVLINK_TYPES,
+    }
+
+    type_dict = category_map.get(device_category.lower())
+    if type_dict is None:
+        return "UNKNOWN"
+
+    return type_dict.get(devtype, "UNKNOWN")
+
+
+def format_device_info(decode_info: dict, device_type_name: str = "") -> str:
+    """
+    Format decoded device info as a readable string.
+
+    Args:
+        decode_info: Dictionary returned by decode_device_id()
+        device_type_name: Device type name (optional)
+
+    Returns:
+        Formatted string with device information
+
+    """
+    bus_type = decode_info["bus_type_value"]
+    bus_type_name = decode_info["bus_type_name"]
+    bus = decode_info["bus"]
+    address = decode_info["address"]
+    devtype = decode_info["devtype"]
+    is_dronecan = decode_info["is_dronecan"]
+
+    if is_dronecan:
+        # For DRONECAN, devtype represents sensor_id (0-indexed)
+        return (
+            f"bus_type:{bus_type_name}({bus_type})  bus:{bus} "
+            f"address:{address}(0x{address:x}) sensor_id:{devtype - 1}(0x{devtype - 1:x}) "
+            f"{device_type_name}"
+        )
+    return (
+        f"bus_type:{bus_type_name}({bus_type})  bus:{bus} "
+        f"address:{address}(0x{address:x}) devtype:{devtype}(0x{devtype:x}) "
+        f"{device_type_name}"
+    )
+
+
+def main() -> None:
+    """Command-line interface."""
+    parser = optparse.OptionParser("decode_devid.py")
+    parser.add_option("-C", "--compass", action="store_true", help="decode compass IDs")
+    parser.add_option("-I", "--imu", action="store_true", help="decode IMU IDs")
+    parser.add_option("-B", "--baro", action="store_true", help="decode barometer IDs")
+    parser.add_option("-A", "--airspeed", action="store_true", help="decode airspeed IDs")
+    parser.add_option("-M", "--mavlink", action="store_true", help="decode MAVLink channel IDs")
+
+    opts, args = parser.parse_args()
+
+    if len(args) == 0:
+        print("Please supply a device ID")
+        sys.exit(1)
+
+    device_id = parse_device_id(args[0])
+    decoded = decode_device_id(device_id)
+
+    device_type_name = ""
+    if opts.compass:
+        device_type_name = get_device_type_name(int(decoded["devtype"]), "compass")
+    if opts.imu:
+        device_type_name = get_device_type_name(int(decoded["devtype"]), "imu")
+    if opts.baro:
+        device_type_name = get_device_type_name(int(decoded["devtype"]), "baro")
+    if opts.airspeed:
+        device_type_name = get_device_type_name(int(decoded["devtype"]), "airspeed")
+    if opts.mavlink:
+        device_type_name = get_device_type_name(int(decoded["devtype"]), "mavlink")
+
+    print(format_device_info(decoded, device_type_name))
+
+
+if __name__ == "__main__":
+    main()

--- a/Tools/scripts/decode_devid.py
+++ b/Tools/scripts/decode_devid.py
@@ -8,19 +8,23 @@ the sensor library, such as libraries/AP_Compass/AP_Compass_Backend.h
 
 AP_FLAKE8_CLEAN
 
-SPDX-FileCopyrightText: 2024-2026 ArduPilot developers
+SPDX-FileCopyrightText: 2017-2026 ArduPilot developers
 
 SPDX-License-Identifier: GPL-3.0-or-later
 
 """
 
-import optparse
+import argparse
 import sys
 
-from typing import Union
+from typing import Dict
+from typing import Literal
+from typing import Optional
+from typing import Tuple
+from typing import TypedDict
 
 # Device type lookup tables
-BUSTYPES = {
+BUSTYPES: Dict[int, str] = {
     1: "I2C",
     2: "SPI",
     3: "DRONECAN",
@@ -30,7 +34,7 @@ BUSTYPES = {
     7: "WSPI",
 }
 
-COMPASS_TYPES = {
+COMPASS_TYPES: Dict[int, str] = {
     0x01: "DEVTYPE_HMC5883_OLD",
     0x07: "DEVTYPE_HMC5883",
     0x02: "DEVTYPE_LSM303D",
@@ -58,7 +62,7 @@ COMPASS_TYPES = {
     0x1A: "DEVTYPE_AF9838",
 }
 
-IMU_TYPES = {
+IMU_TYPES: Dict[int, str] = {
     0x09: "DEVTYPE_BMI160",
     0x10: "DEVTYPE_L3G4200D",
     0x11: "DEVTYPE_ACC_LSM303D",
@@ -101,7 +105,7 @@ IMU_TYPES = {
     0x43: "DEVTYPE_INS_LSM6DSK320X",
 }
 
-BARO_TYPES = {
+BARO_TYPES: Dict[int, str] = {
     0x01: "DEVTYPE_BARO_SITL",
     0x02: "DEVTYPE_BARO_BMP085",
     0x03: "DEVTYPE_BARO_BMP280",
@@ -128,7 +132,7 @@ BARO_TYPES = {
     0x18: "DEVTYPE_BARO_MS5837_02BA",
 }
 
-AIRSPEED_TYPES = {
+AIRSPEED_TYPES: Dict[int, str] = {
     0x01: "DEVTYPE_AIRSPEED_SITL",
     0x02: "DEVTYPE_AIRSPEED_MS4525",
     0x03: "DEVTYPE_AIRSPEED_MS5525",
@@ -143,30 +147,63 @@ AIRSPEED_TYPES = {
     0x0C: "DEVTYPE_AIRSPEED_SCRIPTING",
 }
 
-MAVLINK_TYPES = {
+MAVLINK_TYPES: Dict[int, str] = {
     0x01: "DEVTYPE_MAVLINK_UART",
     0x02: "DEVTYPE_MAVLINK_NETWORKING",
     0x03: "DEVTYPE_MAVLINK_CAN",
     0x04: "DEVTYPE_MAVLINK_SCRIPTING",
 }
 
-def parse_device_id(device_id_str: str) -> int:
-    """Parse device ID from string (decimal or hex)."""
+
+class DeviceInfo(TypedDict):
+    bus_type_value: int
+    bus_type_name: str
+    bus: int
+    address: int
+    devtype: int
+    is_dronecan: bool
+
+
+DeviceCategory = Literal["compass", "imu", "baro", "airspeed", "mavlink"]
+
+
+def parse_device_id(device_id_str: str) -> Tuple[Optional[int], Optional[str]]:
+    """Parse a device ID and return a diagnostic message, if applicable."""
+    # backwards compatibility:
+    #  - assume all digit strings are decimal,
+    #  - assume strings without "0x" prefix but with characters A-F are hexadecimal
     try:
-        return int(device_id_str)
+        device_id = int(device_id_str)
     except ValueError:
-        return int(device_id_str, 16)
+        try:
+            device_id = int(device_id_str, 16)
+        except ValueError:
+            return None, f"Invalid device ID '{device_id_str}'"
+
+    if device_id < 0:
+        return None, "device ID must not be negative"
+
+    # Warn that ambiguous digits-only input is interpreted as decimal.
+    if device_id_str.isdigit():
+        return (
+            device_id,
+            f"Warning: device ID '{device_id_str}' is interpreted as decimal; prefix hexadecimal IDs with 0x.",
+        )
+
+    return device_id, None
 
 
-def decode_device_id(device_id: int) -> dict[str, Union[int, str, bool]]:
+def decode_device_id(device_id: int) -> Tuple[Optional[DeviceInfo], Optional[str]]:
     """
     Decode an ArduPilot device ID into its components.
 
     Args:
-        device_id: Device ID as integer (can be decimal or hex)
+        device_id: Device ID as integer
 
     Returns:
-        Dictionary with keys:
+        A tuple containing the decoded dictionary and an error message. If
+        device_id does not fit in the 24-bit device ID format, the decoded
+        dictionary is None. Otherwise, it contains these keys:
             - bus_type_value: Bus type numeric value
             - bus_type_name: Bus type name (I2C, SPI, etc.)
             - bus: Bus number
@@ -175,12 +212,15 @@ def decode_device_id(device_id: int) -> dict[str, Union[int, str, bool]]:
             - is_dronecan: Whether this is DRONECAN bus type
 
     """
+    if device_id < 0 or device_id > 0x00FFFFFF:
+        return None, f"Error: device ID 0x{device_id:x} is outside the 24-bit range."
+
     bus_type = device_id & 0x07
     bus = (device_id >> 3) & 0x1F
     address = (device_id >> 8) & 0xFF
-    devtype = device_id >> 16
+    devtype = (device_id >> 16) & 0xFF
 
-    return {
+    decoded: DeviceInfo = {
         "bus_type_value": bus_type,
         "bus_type_name": BUSTYPES.get(bus_type, "UNKNOWN"),
         "bus": bus,
@@ -188,15 +228,16 @@ def decode_device_id(device_id: int) -> dict[str, Union[int, str, bool]]:
         "devtype": devtype,
         "is_dronecan": bus_type == 3,
     }
+    return decoded, None
 
 
-def get_device_type_name(devtype: int, device_category: str) -> str:
+def get_device_type_name(devtype: int, device_category: DeviceCategory) -> str:
     """
     Look up device type name based on device category.
 
     Args:
         devtype: Device type numeric value
-        device_category: One of 'compass', 'imu', 'baro', 'airspeed'
+        device_category: One of 'compass', 'imu', 'baro', 'airspeed', 'mavlink'
 
     Returns:
         Device type name string, or 'UNKNOWN' if not found
@@ -210,20 +251,21 @@ def get_device_type_name(devtype: int, device_category: str) -> str:
         "mavlink": MAVLINK_TYPES,
     }
 
-    type_dict = category_map.get(device_category.lower())
-    if type_dict is None:
-        return "UNKNOWN"
+    try:
+        type_dict = category_map[device_category.lower()]
+    except KeyError:
+        raise ValueError(f"Unknown device category: {device_category}") from None
 
     return type_dict.get(devtype, "UNKNOWN")
 
 
-def format_device_info(decode_info: dict, device_type_name: str = "") -> str:
+def format_device_info(decode_info: DeviceInfo, device_type_name: str = "") -> str:
     """
     Format decoded device info as a readable string.
 
     Args:
         decode_info: Dictionary returned by decode_device_id()
-        device_type_name: Device type name (optional)
+        device_type_name: Device type name (optional; not applicable to DroneCAN IDs)
 
     Returns:
         Formatted string with device information
@@ -237,48 +279,64 @@ def format_device_info(decode_info: dict, device_type_name: str = "") -> str:
     is_dronecan = decode_info["is_dronecan"]
 
     if is_dronecan:
-        # For DRONECAN, devtype represents sensor_id (0-indexed)
+        # Compass DroneCAN IDs store sensor_id + 1; other DroneCAN IDs use 0.
+        sensor_id = devtype - 1 if devtype > 0 else None
+        sensor_id_info = (
+            f"sensor_id:{sensor_id}(0x{sensor_id:x})"
+            if sensor_id is not None
+            else "sensor_id:not encoded"
+        )
         return (
             f"bus_type:{bus_type_name}({bus_type})  bus:{bus} "
-            f"address:{address}(0x{address:x}) sensor_id:{devtype - 1}(0x{devtype - 1:x}) "
-            f"{device_type_name}"
+            f"address:{address}(0x{address:x}) {sensor_id_info}"
         )
+    device_type_suffix = f" {device_type_name}" if device_type_name else ""
     return (
         f"bus_type:{bus_type_name}({bus_type})  bus:{bus} "
-        f"address:{address}(0x{address:x}) devtype:{devtype}(0x{devtype:x}) "
-        f"{device_type_name}"
+        f"address:{address}(0x{address:x}) devtype:{devtype}(0x{devtype:x})"
+        f"{device_type_suffix}"
     )
 
 
 def main() -> None:
     """Command-line interface."""
-    parser = optparse.OptionParser("decode_devid.py")
-    parser.add_option("-C", "--compass", action="store_true", help="decode compass IDs")
-    parser.add_option("-I", "--imu", action="store_true", help="decode IMU IDs")
-    parser.add_option("-B", "--baro", action="store_true", help="decode barometer IDs")
-    parser.add_option("-A", "--airspeed", action="store_true", help="decode airspeed IDs")
-    parser.add_option("-M", "--mavlink", action="store_true", help="decode MAVLink channel IDs")
+    parser = argparse.ArgumentParser(description="DEVICE_ID must be decimal or hexadecimal with a 0x prefix")
+    category_group = parser.add_mutually_exclusive_group()
+    category_group.add_argument("-C", "--compass", action="store_true", help="decode compass IDs")
+    category_group.add_argument("-I", "--imu", action="store_true", help="decode IMU IDs")
+    category_group.add_argument("-B", "--baro", action="store_true", help="decode barometer IDs")
+    category_group.add_argument("-A", "--airspeed", action="store_true", help="decode airspeed IDs")
+    category_group.add_argument("-M", "--mavlink", action="store_true", help="decode MAVLink channel IDs")
+    parser.add_argument("device_id", help="decimal or hexadecimal device ID")
 
-    opts, args = parser.parse_args()
+    opts = parser.parse_args()
 
-    if len(args) == 0:
-        print("Please supply a device ID")
+    device_id, err_msg = parse_device_id(opts.device_id)
+    if err_msg is not None:
+        print(err_msg, file=sys.stderr)
+    if device_id is None:
         sys.exit(1)
 
-    device_id = parse_device_id(args[0])
-    decoded = decode_device_id(device_id)
+    decoded, err_msg = decode_device_id(device_id)
+    if err_msg is not None:
+        print(err_msg, file=sys.stderr)
+        sys.exit(1)
+
+    if decoded is None:
+        sys.exit(1)
 
     device_type_name = ""
-    if opts.compass:
-        device_type_name = get_device_type_name(int(decoded["devtype"]), "compass")
-    if opts.imu:
-        device_type_name = get_device_type_name(int(decoded["devtype"]), "imu")
-    if opts.baro:
-        device_type_name = get_device_type_name(int(decoded["devtype"]), "baro")
-    if opts.airspeed:
-        device_type_name = get_device_type_name(int(decoded["devtype"]), "airspeed")
-    if opts.mavlink:
-        device_type_name = get_device_type_name(int(decoded["devtype"]), "mavlink")
+    if not decoded["is_dronecan"]:
+        if opts.compass:
+            device_type_name = get_device_type_name(decoded["devtype"], "compass")
+        elif opts.imu:
+            device_type_name = get_device_type_name(decoded["devtype"], "imu")
+        elif opts.baro:
+            device_type_name = get_device_type_name(decoded["devtype"], "baro")
+        elif opts.airspeed:
+            device_type_name = get_device_type_name(decoded["devtype"], "airspeed")
+        elif opts.mavlink:
+            device_type_name = get_device_type_name(decoded["devtype"], "mavlink")
 
     print(format_device_info(decoded, device_type_name))
 


### PR DESCRIPTION
### Summary

Refactor the decode_devid script to be callable by other python scripts

Also fix the lining issues and provide tests and examples

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [x] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

Here is the output of the `python .\example_usage_decode_devid.py`

```
======================================================================
EXAMPLE 1: Decoding a specific device ID
======================================================================

Input device ID (hex): 0x00051001
Input device ID (dec): 331777

Decoded components:
  Bus type: I2C (1)
  Bus: 0
  Address: 0x10 (16)
  Device type: 0x05 (5)
  Device name: DEVTYPE_BMM150 
  Is DRONECAN: False

Formatted output:
  bus_type:I2C(1)  bus:0 address:16(0x10) devtype:5(0x5) DEVTYPE_BMM150 

======================================================================
EXAMPLE 2: Processing multiple device IDs
======================================================================

IMU device with I2C bus
  Device ID: 0x00031801
  Result: bus_type:I2C(1)  bus:0 address:24(0x18) devtype:3(0x3) UNKNOWN

Compass with SPI bus
  Device ID: 0x0006b001
  Result: bus_type:I2C(1)  bus:0 address:176(0xb0) devtype:6(0x6) DEVTYPE_LSM9DS1

Barometer with I2C bus
  Device ID: 0x00000c02
  Result: bus_type:SPI(2)  bus:0 address:12(0xc) devtype:0(0x0) UNKNOWN

======================================================================
EXAMPLE 3: Browsing available sensor types
======================================================================

Available Compass Types:
  0x01: DEVTYPE_HMC5883_OLD
  0x02: DEVTYPE_LSM303D
  0x04: DEVTYPE_AK8963 
  0x05: DEVTYPE_BMM150 
  0x06: DEVTYPE_LSM9DS1
  ... and 19 more

Available IMU Types: 35 types
Available Barometer Types: 24 types
Available Airspeed Types: 11 types

======================================================================
EXAMPLE 4: Using with string input (hex or decimal)
======================================================================

Parsing from hex string '0x00031801': 202753
Parsing from decimal string '3227137': 3227137
Are they equal? False
```

Here is the output of the `python .\test_decode_devid.py` test:

```
================================================================================
Testing individual library functions
================================================================================

Testing parse_device_id():
  parse_device_id('0x00051001') = 331777
  parse_device_id('331777') = 331777
  parse_device_id('0x0006b001') = 438273

Testing decode_device_id():
  Input: 0x00051001
  Bus type: I2C (1)
  Bus: 0
  Address: 0x10
  Device type: 5
  Is DRONECAN: False

Testing get_device_type_name():
  Compass 0x05: DEVTYPE_BMM150 
  IMU 0x09: DEVTYPE_BMI160

Testing format_device_info():
  bus_type:I2C(1)  bus:0 address:16(0x10) devtype:5(0x5) DEVTYPE_BMM150 
================================================================================
Testing decode_devid.py vs decode_devid_lib.py
================================================================================

✓ Compass - I2C bus, BMM150
  Device ID: 0x00051001, Flag: -C

✓ Compass - I2C bus, HMC5883
  Device ID: 0x00071E05, Flag: -C

✓ Compass - I2C bus, AK8963
  Device ID: 0x0001E004, Flag: -C

✓ IMU - I2C bus, ACC_MPU6000
  Device ID: 0x00091301, Flag: -I

✓ IMU - SPI bus, BMI160
  Device ID: 0x00000902, Flag: -I

✓ Barometer - SPI bus, BMP280
  Device ID: 0x00000302, Flag: -B

✓ Barometer - SPI bus, MS5611
  Device ID: 0x00040B02, Flag: -B

✓ Airspeed - SPI bus, MS4525
  Device ID: 0x00000102, Flag: -A

✓ Airspeed - SPI bus, MS5525
  Device ID: 0x00020302, Flag: -A

✓ DRONECAN compass
  Device ID: 0x00010083, Flag: -C

✓ DRONECAN IMU
  Device ID: 0x00010183, Flag: -I

✓ Minimal device ID
  Device ID: 0x00000001, Flag: -C

✓ Maximum device ID
  Device ID: 0xFFFFFFFF, Flag: -I

================================================================================
Test Results: 13 passed, 0 failed
================================================================================

✓ All tests passed! Both scripts produce identical output.
```

I did break the _lib script on purpose and the test code found the issues.

Should it be merged like this or should I just change the original script?