### PR TITLE
Fix CAMERA_CAPTURE_STATUS.image_status when in "until stopped" mode

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -8265,6 +8265,16 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.start_flying_simple_relhome_mission(mission_items)
 
+        self.progress("Verify CAMERA_CAPTURE_STATUS reports the interval capture")
+        # wait for camera 2 to finish the images it was asked for, leaving
+        # camera 1 as the only one with an interval set for the rest of the
+        # climb
+        self.wait_camera_img_idx([(1, 2)])
+        got = sorted(self.camera_capture_statuses(2))
+        if got != [CAMERA_IMAGE_STATUS_IDLE, CAMERA_IMAGE_STATUS_INTERVAL_IDLE]:
+            raise NotAchievedException(
+                f"Wanted exactly one camera capturing on an interval: {got}")
+
         # the return-to-launch is the last item, so home is its sequence
         # number; by the time it is current camera 1 has been stopped
         self.wait_current_waypoint(len(mission_items))

--- a/libraries/AP_Camera/AP_Camera_Backend.cpp
+++ b/libraries/AP_Camera/AP_Camera_Backend.cpp
@@ -346,7 +346,8 @@ void AP_Camera_Backend::send_camera_fov_status(mavlink_channel_t chan) const
 void AP_Camera_Backend::send_camera_capture_status(mavlink_channel_t chan) const
 {
     // Current status of image capturing (0: idle, 1: capture in progress, 2: interval set but idle, 3: interval set and capture in progress)
-    const uint8_t image_status = (time_interval_settings.num_remaining > 0) ? 2 : 0;
+    // num_remaining is -1 when capturing until stopped, so test the same way update() does
+    const uint8_t image_status = (time_interval_settings.num_remaining != 0) ? 2 : 0;
 
     // send CAMERA_CAPTURE_STATUS message
     mavlink_msg_camera_capture_status_send(


### PR DESCRIPTION
### Summary

Fix `CAMERA_CAPTURE_STATUS.image_status` so a camera capturing on an interval "until stopped" no longer reports itself as idle.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Verified in SITL with `Tools/autotest/autotest.py test.Copter.MountAVTCM62DualMission` (dual AVT CM62 cameras). The new assertion passes with the fix and fails without it: reverting `AP_Camera_Backend.cpp` to the old `num_remaining > 0` predicate makes the captured statuses `[0, 0]` instead of the expected `[0, 2]`, so the test correctly catches the regression. The full `MountAVTCM62`, `MountAVTCM62Dual` and `MountAVTCM62DualMission` set also passes.

### Description

`AP_Camera_Backend::send_camera_capture_status()` computed `image_status` from `time_interval_settings.num_remaining > 0`. But `take_multiple_pictures()` sets `num_remaining` to `-1` when asked to capture until stopped (`MAV_CMD_IMAGE_START_CAPTURE` with Total Images = 0), so such a camera reported `image_status = 0` (idle) to the GCS while it was actively capturing on an interval.

The fix tests `num_remaining != 0` instead — the same condition `AP_Camera_Backend::update()` already uses when deciding whether to take the next interval image — so the reported status matches the driver's actual state.

The status value stays `2` ("interval set but idle") rather than `3` ("interval set and capture in progress"): the backend only knows an interval is configured, not whether a shutter/exposure is momentarily in progress, and it already reports finite interval sequences as `2`, so `2` is the accurate and consistent value.

This PR was prepared with AI assistance (Claude Code, with a second-opinion review from OpenAI Codex). The human author has reviewed and is responsible for every line.
