### PR TITLE
AP_Bootloader: reserve NewBeeDrone Hummingbird board IDs

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -586,8 +586,11 @@ AP_HW_VIMDRONES_BMS                  5820
 #IDs 5830 ~ 5839 reserved for CyberX
 AP_HW_CyberX-v10                     5830
 
-# IDs 5900-5909 reserved for NewBeeDrone PixNova
+# IDs 5900-5904 reserved for NewBeeDrone PixNova
 AP_HW_NewBeeDrone_PixNova            5900
+
+# IDs 5905-5909 reserved for NewBeeDrone HUMMINGBIRD
+AP_HW_NewBeeDrone_HUMMINGBIRD_FC305_H7    5905
 
 # IDs 6000-6099 reserved for SpektreWorks
 AP_HW_sw-spar-f407                   6000


### PR DESCRIPTION
### Summary

This PR reserves the board ID for the upcoming NewBeeDrone Hummingbird FC305 H7 board in board_types.txt.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

We are planning to add support for the NewBeeDrone Hummingbird series FC305 H7 hardware (`HUMMINGBIRD_FC305_H7`) and need to reserve its board ID in `board_types.txt` to prevent ID conflicts with other vendors.