### PR TITLE
AP_Bootloader: reserve board IDs for Skyronin

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -363,6 +363,11 @@ AP_HW_PRINCIPIOT_H7PI                1248
 
 AP_HW_KT_FMU_F1                      1250
 
+# IDs 1251-1260 reserved for Skyronin
+AP_HW_SkyroninL431                   1251
+AP_HW_Skyronin-Mag                   1252
+AP_HW_Skyronin-PowerMon              1253
+
 AP_HW_GPILOT_P1						 1275
 
 AP_HW_SKYDROID-S3                    1300

--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -365,8 +365,8 @@ AP_HW_KT_FMU_F1                      1250
 
 # IDs 1251-1260 reserved for Skyronin
 AP_HW_SkyroninL431                   1251
-AP_HW_Skyronin-Mag                   1252
-AP_HW_Skyronin-PowerMon              1253
+AP_HW_SkyroninMag                    1252
+
 
 AP_HW_GPILOT_P1						 1275
 


### PR DESCRIPTION
### Summary

Reserve board IDs 1251-1260 for Skyronin and allocate two entries for
upcoming boards.

### Classification & Testing

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change

### Description
We are in the process of developing Ardupilot-compatible boards and we would to reserve board IDs in `board_types.txt` to prevent conflicts in the future.