### PR TITLE
AP_Follow: discard target state when FOLL_SYSID changes

### DIFF
--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -494,12 +494,12 @@ bool AP_Follow::get_target_heading_rate_degs(float &heading_rate_degs)
 // Handles incoming MAVLink messages to update the target's position, velocity, and heading.
 void AP_Follow::handle_msg(const mavlink_message_t &msg)
 {
-    // FOLL_SYSID no longer matches the system that supplied the data we hold. Forget which
-    // message type the old target used so the new one is re-learned. This must run before
-    // the switch below, which consults _using_follow_target to decide whether
-    // GLOBAL_POSITION_INT is still wanted.
+    // FOLL_SYSID no longer matches the system that supplied the data we hold. Forget the old
+    // target's message type and update time. This must run before the switch below, which
+    // consults _using_follow_target to decide whether GLOBAL_POSITION_INT is still wanted.
     if (_sysid != _sysid_used) {
         _using_follow_target = false;
+        _last_location_update_ms = 0;   // 0 = nothing heard from this target
     }
 
     // Invalidate the estimate if no position update has been received within the timeout period.

--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -241,7 +241,14 @@ void AP_Follow::update_estimates()
     // if we do not hold fresh data from the configured target, invalidate the estimate.
     // this cannot gate on have_target() because that tests _estimate_valid, which is
     // cleared below, and the estimate could then never be rebuilt
-    if (!target_data_current()) {
+    if (!have_target_data()) {
+        clear_dist_and_bearing_to_target();
+        _estimate_valid = false;
+        return;
+    }
+
+    // check for timeout
+    if ((_last_location_update_ms == 0) || ((AP_HAL::millis() - _last_location_update_ms) > (uint32_t)(_timeout * 1000.0f))) {
         clear_dist_and_bearing_to_target();
         _estimate_valid = false;
         return;
@@ -955,7 +962,7 @@ void AP_Follow::Log_Write_FOLL()
 // Returns true if the target data we hold is fresh and was supplied by the configured system.
 // This is the gate for update_estimates().  It deliberately excludes _estimate_valid so that
 // update_estimates() can rebuild the estimate after that flag has been cleared.
-bool AP_Follow::target_data_current(void) const
+bool AP_Follow::have_target_data(void) const
 {
     if (!_enabled) {
         return false;
@@ -971,10 +978,6 @@ bool AP_Follow::target_data_current(void) const
         return false;
     }
 
-    // check for timeout
-    if ((_last_location_update_ms == 0) || ((AP_HAL::millis() - _last_location_update_ms) > (uint32_t)(_timeout * 1000.0f))) {
-        return false;
-    }
     return true;
 }
 
@@ -984,7 +987,7 @@ bool AP_Follow::target_data_current(void) const
 // getters return without checking them.
 bool AP_Follow::have_target(void) const
 {
-    return _estimate_valid && target_data_current();
+    return _estimate_valid && have_target_data();
 }
 
 //==============================================================================

--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -238,17 +238,13 @@ void AP_Follow::update_estimates()
 {
     WITH_SEMAPHORE(_follow_sem);
 
-    // check for target: if no valid target, invalidate estimate
-    if (!have_target()) {
+    // if we do not hold fresh data from the configured target, invalidate the estimate.
+    // this cannot gate on have_target() because that tests _estimate_valid, which is
+    // cleared below, and the estimate could then never be rebuilt
+    if (!target_data_current()) {
         clear_dist_and_bearing_to_target();
         _estimate_valid = false;
         return;
-    }
-
-    // if sysid changed, reset the estimation state
-    if (_sysid != _sysid_used) {
-        _sysid_used = _sysid;
-        _estimate_valid = false;
     }
 
     const uint32_t now = AP_HAL::millis();
@@ -366,7 +362,7 @@ void AP_Follow::update_estimates()
 // Retrieves the estimated target position, velocity, and acceleration in the NED frame (relative to origin).
 bool AP_Follow::get_target_pos_vel_accel_NED_m(Vector3p &pos_ned_m, Vector3f &vel_ned_ms, Vector3f &accel_ned_mss) const
 {
-    if (!_estimate_valid) {
+    if (!have_target()) {
         return false;
     }
 
@@ -380,7 +376,7 @@ bool AP_Follow::get_target_pos_vel_accel_NED_m(Vector3p &pos_ned_m, Vector3f &ve
 // Retrieves the estimated target position, velocity, and acceleration in the NED frame, including configured offsets.
 bool AP_Follow::get_ofs_pos_vel_accel_NED_m(Vector3p &pos_ofs_ned_m, Vector3f &vel_ofs_ned_ms, Vector3f &accel_ofs_ned_mss) const
 {
-    if (!_estimate_valid) {
+    if (!have_target()) {
         return false;
     }
 
@@ -396,7 +392,7 @@ bool AP_Follow::get_target_dist_and_vel_NED_m(Vector3f &dist_ned, Vector3f &dist
 {
     WITH_SEMAPHORE(_follow_sem);
     
-    if (!_estimate_valid) {
+    if (!have_target()) {
         return false;
     }
 
@@ -417,7 +413,7 @@ bool AP_Follow::get_target_dist_and_vel_NED_m(Vector3f &dist_ned, Vector3f &dist
 // Retrieves the estimated target heading and heading rate in radians.
 bool AP_Follow::get_heading_heading_rate_rad(float &heading_rad, float &heading_rate_rads) const
 {
-    if (!_estimate_valid) {
+    if (!have_target()) {
         return false;
     }
 
@@ -432,7 +428,7 @@ bool AP_Follow::get_target_location_and_velocity(Location &loc, Vector3f &vel_ne
 {
     WITH_SEMAPHORE(_follow_sem);
 
-    if (!_estimate_valid) {
+    if (!have_target()) {
         return false;
     }
 
@@ -451,7 +447,7 @@ bool AP_Follow::get_target_location_and_velocity_ofs(Location &loc, Vector3f &ve
 {
     WITH_SEMAPHORE(_follow_sem);
 
-    if (!_estimate_valid) {
+    if (!have_target()) {
         return false;
     }
     if (!AP::ahrs().get_location_from_origin_offset_NED(loc, _ofs_estimate_pos_ned_m)) {
@@ -467,7 +463,7 @@ bool AP_Follow::get_target_heading_deg(float &heading_deg)
 {
     WITH_SEMAPHORE(_follow_sem);
     
-    if (!_estimate_valid) {
+    if (!have_target()) {
         return false;
     }
 
@@ -481,7 +477,7 @@ bool AP_Follow::get_target_heading_rate_degs(float &heading_rate_degs)
 {
     WITH_SEMAPHORE(_follow_sem);
     
-    if (!_estimate_valid) {
+    if (!have_target()) {
         return false;
     }
 
@@ -498,6 +494,14 @@ bool AP_Follow::get_target_heading_rate_degs(float &heading_rate_degs)
 // Handles incoming MAVLink messages to update the target's position, velocity, and heading.
 void AP_Follow::handle_msg(const mavlink_message_t &msg)
 {
+    // FOLL_SYSID no longer matches the system that supplied the data we hold. Forget which
+    // message type the old target used so the new one is re-learned. This must run before
+    // the switch below, which consults _using_follow_target to decide whether
+    // GLOBAL_POSITION_INT is still wanted.
+    if (_sysid != _sysid_used) {
+        _using_follow_target = false;
+    }
+
     // Invalidate the estimate if no position update has been received within the timeout period.
     if ((_last_location_update_ms == 0) ||
         (AP_HAL::millis() - _last_location_update_ms > AP_FOLLOW_ESTIMATE_TIMEOUT_MS)) {
@@ -515,6 +519,10 @@ void AP_Follow::handle_msg(const mavlink_message_t &msg)
 
     switch (msg.msgid) {
     case MAVLINK_MSG_ID_GLOBAL_POSITION_INT: {
+        // if we are using follow_target, ignore global_position_int messages
+        if (_using_follow_target) {
+            return;
+        }
         // handle standard global position messages
         updated = handle_global_position_int_message(msg);
         break;
@@ -527,10 +535,13 @@ void AP_Follow::handle_msg(const mavlink_message_t &msg)
     }
 
     if (updated) {
-        // Check if estimate needs reset based on position and velocity errors
-        if (estimate_error_too_large()) {
+        // reset the estimate on a large error or a change of source system
+        if (estimate_error_too_large() || (_sysid_used != _sysid)) {
             _estimate_valid = false;
         }
+
+        // record the system that supplied this update
+        _sysid_used = _sysid;
 
 #if HAL_LOGGING_ENABLED
         // log current follow diagnostic data
@@ -544,6 +555,12 @@ bool AP_Follow::should_handle_message(const mavlink_message_t &msg) const
 {
     // exit immediately if not enabled
     if (!_enabled) {
+        return false;
+    }
+
+    // sysid 0 is the broadcast system and is never a valid target.  without this
+    // a sender broadcasting as sysid 0 would compare equal to an unset _sysid
+    if (msg.sysid == 0) {
         return false;
     }
 
@@ -626,11 +643,6 @@ bool AP_Follow::handle_global_position_int_message(const mavlink_message_t &msg)
 
     // ignore message if latitude and longitude are exactly zero (invalid GPS fix)
     if ((packet.lat == 0 && packet.lon == 0)) {
-        return false;
-    }
-
-    if (_using_follow_target) {
-        // if we are using follow_target, ignore global_position_int messages
         return false;
     }
 
@@ -781,7 +793,7 @@ bool AP_Follow::handle_follow_target_message(const mavlink_message_t &msg)
     // apply jitter-corrected timestamp to this update
     _last_location_update_ms = _jitter.correct_offboard_timestamp_msec(packet.timestamp, AP_HAL::millis());
 
-    // we are using follow_target: set sysid to sender's sysid
+    // prefer FOLLOW_TARGET over GLOBAL_POSITION_INT from now on
     _using_follow_target = true;
 
     return true;
@@ -801,7 +813,7 @@ void AP_Follow::init_offsets_if_required()
     }
     _offsets_were_zero = true;
 
-    if (!_estimate_valid) {
+    if (!have_target()) {
         return;
     }
 
@@ -935,10 +947,22 @@ void AP_Follow::Log_Write_FOLL()
 // Accessors and Helpers
 //==============================================================================
 
-// Returns true if following is enabled and a recent target update has been received.
-bool AP_Follow::have_target(void) const
+// Returns true if the target data we hold is fresh and was supplied by the configured system.
+// This is the gate for update_estimates().  It deliberately excludes _estimate_valid so that
+// update_estimates() can rebuild the estimate after that flag has been cleared.
+bool AP_Follow::target_data_current(void) const
 {
     if (!_enabled) {
+        return false;
+    }
+
+    // no target system has been configured
+    if (_sysid == 0) {
+        return false;
+    }
+
+    // we have not yet accepted an update from the configured system
+    if (_sysid_used != _sysid) {
         return false;
     }
 
@@ -947,6 +971,15 @@ bool AP_Follow::have_target(void) const
         return false;
     }
     return true;
+}
+
+// Returns true if a usable estimate of the configured target is available.
+// Every accessor is gated on this, so a true return guarantees that each of them succeeds.
+// Lua scripts depend on that: they test follow:have_target() and then use the values the
+// getters return without checking them.
+bool AP_Follow::have_target(void) const
+{
+    return _estimate_valid && target_data_current();
 }
 
 //==============================================================================

--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -494,12 +494,12 @@ bool AP_Follow::get_target_heading_rate_degs(float &heading_rate_degs)
 // Handles incoming MAVLink messages to update the target's position, velocity, and heading.
 void AP_Follow::handle_msg(const mavlink_message_t &msg)
 {
-    // FOLL_SYSID no longer matches the system that supplied the data we hold. Forget which
-    // message type the old target used so the new one is re-learned. This must run before
-    // the switch below, which consults _using_follow_target to decide whether
-    // GLOBAL_POSITION_INT is still wanted.
+    // FOLL_SYSID no longer matches the system that supplied the data we hold. Forget the old
+    // target's message type and update time. This must run before the switch below, which
+    // consults _using_follow_target to decide whether GLOBAL_POSITION_INT is still wanted.
     if (_sysid != _sysid_of_data) {
         _using_follow_target = false;
+        _last_location_update_ms = 0;   // 0 = nothing heard from this target
     }
 
     // Invalidate the estimate if no position update has been received within the timeout period.

--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -515,6 +515,10 @@ void AP_Follow::handle_msg(const mavlink_message_t &msg)
 
     switch (msg.msgid) {
     case MAVLINK_MSG_ID_GLOBAL_POSITION_INT: {
+        // if we are using follow_target, ignore global_position_int messages
+        if (_using_follow_target) {
+            return;
+        }
         // handle standard global position messages
         updated = handle_global_position_int_message(msg);
         break;
@@ -626,11 +630,6 @@ bool AP_Follow::handle_global_position_int_message(const mavlink_message_t &msg)
 
     // ignore message if latitude and longitude are exactly zero (invalid GPS fix)
     if ((packet.lat == 0 && packet.lon == 0)) {
-        return false;
-    }
-
-    if (_using_follow_target) {
-        // if we are using follow_target, ignore global_position_int messages
         return false;
     }
 

--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -455,7 +455,9 @@ bool AP_Follow::get_target_location_and_velocity_ofs(Location &loc, Vector3f &ve
     }
 
     vel_ned = _ofs_estimate_vel_ned_ms;
-    return true;
+
+    // give the caller the frame FOLL_ALT_TYPE asks for
+    return loc.change_alt_frame(_alt_type);
 }
 
 // Retrieves the estimated target heading in degrees (0° = North, 90° = East) for LUA bindings.

--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -238,17 +238,13 @@ void AP_Follow::update_estimates()
 {
     WITH_SEMAPHORE(_follow_sem);
 
-    // check for target: if no valid target, invalidate estimate
-    if (!have_target()) {
+    // if we do not hold fresh data from the configured target, invalidate the estimate.
+    // this cannot gate on have_target() because that tests _estimate_valid, which is
+    // cleared below, and the estimate could then never be rebuilt
+    if (!target_data_current()) {
         clear_dist_and_bearing_to_target();
         _estimate_valid = false;
         return;
-    }
-
-    // if sysid changed, reset the estimation state
-    if (_sysid != _sysid_used) {
-        _sysid_used = _sysid;
-        _estimate_valid = false;
     }
 
     const uint32_t now = AP_HAL::millis();
@@ -366,7 +362,7 @@ void AP_Follow::update_estimates()
 // Retrieves the estimated target position, velocity, and acceleration in the NED frame (relative to origin).
 bool AP_Follow::get_target_pos_vel_accel_NED_m(Vector3p &pos_ned_m, Vector3f &vel_ned_ms, Vector3f &accel_ned_mss) const
 {
-    if (!_estimate_valid) {
+    if (!have_target()) {
         return false;
     }
 
@@ -380,7 +376,7 @@ bool AP_Follow::get_target_pos_vel_accel_NED_m(Vector3p &pos_ned_m, Vector3f &ve
 // Retrieves the estimated target position, velocity, and acceleration in the NED frame, including configured offsets.
 bool AP_Follow::get_ofs_pos_vel_accel_NED_m(Vector3p &pos_ofs_ned_m, Vector3f &vel_ofs_ned_ms, Vector3f &accel_ofs_ned_mss) const
 {
-    if (!_estimate_valid) {
+    if (!have_target()) {
         return false;
     }
 
@@ -396,7 +392,7 @@ bool AP_Follow::get_target_dist_and_vel_NED_m(Vector3f &dist_ned, Vector3f &dist
 {
     WITH_SEMAPHORE(_follow_sem);
     
-    if (!_estimate_valid) {
+    if (!have_target()) {
         return false;
     }
 
@@ -417,7 +413,7 @@ bool AP_Follow::get_target_dist_and_vel_NED_m(Vector3f &dist_ned, Vector3f &dist
 // Retrieves the estimated target heading and heading rate in radians.
 bool AP_Follow::get_heading_heading_rate_rad(float &heading_rad, float &heading_rate_rads) const
 {
-    if (!_estimate_valid) {
+    if (!have_target()) {
         return false;
     }
 
@@ -432,7 +428,7 @@ bool AP_Follow::get_target_location_and_velocity(Location &loc, Vector3f &vel_ne
 {
     WITH_SEMAPHORE(_follow_sem);
 
-    if (!_estimate_valid) {
+    if (!have_target()) {
         return false;
     }
 
@@ -451,7 +447,7 @@ bool AP_Follow::get_target_location_and_velocity_ofs(Location &loc, Vector3f &ve
 {
     WITH_SEMAPHORE(_follow_sem);
 
-    if (!_estimate_valid) {
+    if (!have_target()) {
         return false;
     }
     if (!AP::ahrs().get_location_from_origin_offset_NED(loc, _ofs_estimate_pos_ned_m)) {
@@ -467,7 +463,7 @@ bool AP_Follow::get_target_heading_deg(float &heading_deg)
 {
     WITH_SEMAPHORE(_follow_sem);
     
-    if (!_estimate_valid) {
+    if (!have_target()) {
         return false;
     }
 
@@ -481,7 +477,7 @@ bool AP_Follow::get_target_heading_rate_degs(float &heading_rate_degs)
 {
     WITH_SEMAPHORE(_follow_sem);
     
-    if (!_estimate_valid) {
+    if (!have_target()) {
         return false;
     }
 
@@ -498,6 +494,14 @@ bool AP_Follow::get_target_heading_rate_degs(float &heading_rate_degs)
 // Handles incoming MAVLink messages to update the target's position, velocity, and heading.
 void AP_Follow::handle_msg(const mavlink_message_t &msg)
 {
+    // FOLL_SYSID no longer matches the system that supplied the data we hold. Forget which
+    // message type the old target used so the new one is re-learned. This must run before
+    // the switch below, which consults _using_follow_target to decide whether
+    // GLOBAL_POSITION_INT is still wanted.
+    if (_sysid != _sysid_of_data) {
+        _using_follow_target = false;
+    }
+
     // Invalidate the estimate if no position update has been received within the timeout period.
     if ((_last_location_update_ms == 0) ||
         (AP_HAL::millis() - _last_location_update_ms > AP_FOLLOW_ESTIMATE_TIMEOUT_MS)) {
@@ -531,10 +535,13 @@ void AP_Follow::handle_msg(const mavlink_message_t &msg)
     }
 
     if (updated) {
-        // Check if estimate needs reset based on position and velocity errors
-        if (estimate_error_too_large()) {
+        // reset the estimate on a large error or a change of source system
+        if (estimate_error_too_large() || (_sysid_of_data != _sysid)) {
             _estimate_valid = false;
         }
+
+        // record the system that supplied this update
+        _sysid_of_data = _sysid;
 
 #if HAL_LOGGING_ENABLED
         // log current follow diagnostic data
@@ -548,6 +555,12 @@ bool AP_Follow::should_handle_message(const mavlink_message_t &msg) const
 {
     // exit immediately if not enabled
     if (!_enabled) {
+        return false;
+    }
+
+    // sysid 0 is the broadcast system and is never a valid target.  without this
+    // a sender broadcasting as sysid 0 would compare equal to an unset _sysid
+    if (msg.sysid == 0) {
         return false;
     }
 
@@ -780,7 +793,7 @@ bool AP_Follow::handle_follow_target_message(const mavlink_message_t &msg)
     // apply jitter-corrected timestamp to this update
     _last_location_update_ms = _jitter.correct_offboard_timestamp_msec(packet.timestamp, AP_HAL::millis());
 
-    // we are using follow_target: set sysid to sender's sysid
+    // prefer FOLLOW_TARGET over GLOBAL_POSITION_INT from now on
     _using_follow_target = true;
 
     return true;
@@ -800,7 +813,7 @@ void AP_Follow::init_offsets_if_required()
     }
     _offsets_were_zero = true;
 
-    if (!_estimate_valid) {
+    if (!have_target()) {
         return;
     }
 
@@ -934,10 +947,22 @@ void AP_Follow::Log_Write_FOLL()
 // Accessors and Helpers
 //==============================================================================
 
-// Returns true if following is enabled and a recent target update has been received.
-bool AP_Follow::have_target(void) const
+// Returns true if the target data we hold is fresh and was supplied by the configured system.
+// This is the gate for update_estimates().  It deliberately excludes _estimate_valid so that
+// update_estimates() can rebuild the estimate after that flag has been cleared.
+bool AP_Follow::target_data_current(void) const
 {
     if (!_enabled) {
+        return false;
+    }
+
+    // no target system has been configured
+    if (_sysid == 0) {
+        return false;
+    }
+
+    // we have not yet accepted an update from the configured system
+    if (_sysid_of_data != _sysid) {
         return false;
     }
 
@@ -946,6 +971,15 @@ bool AP_Follow::have_target(void) const
         return false;
     }
     return true;
+}
+
+// Returns true if a usable estimate of the configured target is available.
+// Every accessor is gated on this, so a true return guarantees that each of them succeeds.
+// Lua scripts depend on that: they test follow:have_target() and then use the values the
+// getters return without checking them.
+bool AP_Follow::have_target(void) const
+{
+    return _estimate_valid && target_data_current();
 }
 
 //==============================================================================

--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -984,9 +984,10 @@ bool AP_Follow::have_target_data(void) const
 }
 
 // Returns true if a usable estimate of the configured target is available.
-// Every accessor is gated on this, so a true return guarantees that each of them succeeds.
-// Lua scripts depend on that: they test follow:have_target() and then use the values the
-// getters return without checking them.
+// Every accessor is gated on this, but a true return does not guarantee that they succeed.
+// The location getters can still fail on the AHRS origin lookup or on the FOLL_ALT_TYPE frame
+// conversion, and the target state can change between this call and the accessor call, so
+// callers must check the value every accessor returns.
 bool AP_Follow::have_target(void) const
 {
     return _estimate_valid && have_target_data();

--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -494,6 +494,9 @@ bool AP_Follow::get_target_heading_rate_degs(float &heading_rate_degs)
 // Handles incoming MAVLink messages to update the target's position, velocity, and heading.
 void AP_Follow::handle_msg(const mavlink_message_t &msg)
 {
+    // the LUA accessors read this state from the scripting thread
+    WITH_SEMAPHORE(_follow_sem);
+
     // FOLL_SYSID no longer matches the system that supplied the data we hold. Forget the old
     // target's message type and update time. This must run before the switch below, which
     // consults _using_follow_target to decide whether GLOBAL_POSITION_INT is still wanted.

--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -46,7 +46,7 @@ extern const AP_HAL::HAL& hal;
 //==============================================================================
 
 #define AP_FOLLOW_TIMEOUT          3     // position estimate timeout in seconds
-#define AP_FOLLOW_SYSID_TIMEOUT_MS 10000 // forget sysid we are following if we have not heard from them in 10 seconds
+#define AP_FOLLOW_ESTIMATE_TIMEOUT_MS 10000 // discard the target estimate if we have not heard from the target in 10 seconds
 
 #define AP_FOLLOW_OFFSET_TYPE_NED       0   // offsets are in north-east-down frame
 #define AP_FOLLOW_OFFSET_TYPE_RELATIVE  1   // offsets are relative to lead vehicle's heading
@@ -500,7 +500,7 @@ void AP_Follow::handle_msg(const mavlink_message_t &msg)
 {
     // Invalidate the estimate if no position update has been received within the timeout period.
     if ((_last_location_update_ms == 0) ||
-        (AP_HAL::millis() - _last_location_update_ms > AP_FOLLOW_SYSID_TIMEOUT_MS)) {
+        (AP_HAL::millis() - _last_location_update_ms > AP_FOLLOW_ESTIMATE_TIMEOUT_MS)) {
         _estimate_valid = false;   // mark estimate as invalid
         _using_follow_target = false; // reset follow-target usage flag
     }

--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -346,6 +346,16 @@ void AP_Follow::update_estimates()
         _estimate_valid = false;
         return;
     }
+
+    // the location getters must succeed whenever have_target() is true, so confirm the
+    // estimate can be expressed as a location in the frame FOLL_ALT_TYPE asks for
+    Location loc;
+    if (!AP::ahrs().get_location_from_origin_offset_NED(loc, _ofs_estimate_pos_ned_m) ||
+        !loc.change_alt_frame(_alt_type)) {
+        _estimate_valid = false;
+        return;
+    }
+
     const Vector3p dist_vec_ned_m = _target_pos_ned_m - current_position_ned_m;
     // If _dist_max_m is not positive, we don't check the distance
     if (is_positive(_dist_max_m.get()) && (dist_vec_ned_m.length() > _dist_max_m)) {

--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -82,7 +82,7 @@ const AP_Param::GroupInfo AP_Follow::var_info[] = {
 
     // @Param: _SYSID
     // @DisplayName: Follow target's mavlink system id
-    // @Description: Follow target's mavlink system id
+    // @Description: Follow target's mavlink system id. Zero means no target has been selected and following is inactive.
     // @Range: 0 255
     // @User: Standard
     AP_GROUPINFO("_SYSID", 3, AP_Follow, _sysid, 0),
@@ -499,13 +499,8 @@ bool AP_Follow::get_target_heading_rate_degs(float &heading_rate_degs)
 void AP_Follow::handle_msg(const mavlink_message_t &msg)
 {
     // Invalidate the estimate if no position update has been received within the timeout period.
-    // If using automatic sysid tracking, clear the sysid and reset tracking state.
     if ((_last_location_update_ms == 0) ||
         (AP_HAL::millis() - _last_location_update_ms > AP_FOLLOW_SYSID_TIMEOUT_MS)) {
-        if (_automatic_sysid) {
-            _sysid.set(0);         // clear target system ID
-            _sysid_used = 0;       // reset used sysid tracking
-        }
         _estimate_valid = false;   // mark estimate as invalid
         _using_follow_target = false; // reset follow-target usage flag
     }
@@ -557,8 +552,9 @@ bool AP_Follow::should_handle_message(const mavlink_message_t &msg) const
         return false;
     }
 
-    // skip message if not from our target
-    if (_sysid != 0 && msg.sysid != _sysid) {
+    // skip message if not from our target.  a _sysid of zero means no target
+    // has been selected, so no message is ever accepted
+    if (msg.sysid != _sysid) {
         return false;
     }
 
@@ -695,14 +691,6 @@ bool AP_Follow::handle_global_position_int_message(const mavlink_message_t &msg)
     // apply jitter-corrected timestamp to this update
     _last_location_update_ms = _jitter.correct_offboard_timestamp_msec(packet.time_boot_ms, AP_HAL::millis());
 
-    // if sysid not yet set, adopt sender’s sysid and enable automatic sysid tracking
-    if (_sysid == 0) {
-        _sysid.set(msg.sysid);
-        _sysid_used = 0;
-        _estimate_valid = false;
-        _automatic_sysid = true;
-    }
-
     return true;
 }
 
@@ -792,12 +780,6 @@ bool AP_Follow::handle_follow_target_message(const mavlink_message_t &msg)
 
     // apply jitter-corrected timestamp to this update
     _last_location_update_ms = _jitter.correct_offboard_timestamp_msec(packet.timestamp, AP_HAL::millis());
-
-    // if sysid not yet assigned, adopt sender's sysid and enable automatic sysid tracking
-    if (_sysid == 0) {
-        _sysid.set(msg.sysid);
-        _automatic_sysid = true;
-    }
 
     // we are using follow_target: set sysid to sender's sysid
     _using_follow_target = true;

--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -548,12 +548,14 @@ void AP_Follow::handle_msg(const mavlink_message_t &msg)
 
     if (updated) {
         // reset the estimate on a large error or a change of source system
-        if (estimate_error_too_large() || (_sysid_of_data != _sysid)) {
+        if (estimate_error_too_large() || (_sysid_of_data != msg.sysid)) {
             _estimate_valid = false;
         }
 
-        // record the system that supplied this update
-        _sysid_of_data = _sysid;
+        // record the system that supplied this update.  this is msg.sysid rather than
+        // _sysid because msg.sysid is the value should_handle_message() validated, and
+        // _sysid can be written by the scripting thread part way through this function
+        _sysid_of_data = msg.sysid;
 
 #if HAL_LOGGING_ENABLED
         // log current follow diagnostic data

--- a/libraries/AP_Follow/AP_Follow.h
+++ b/libraries/AP_Follow/AP_Follow.h
@@ -77,7 +77,8 @@ public:
     // Target Estimation and Tracking Methods
     //==========================================================================
 
-    // Returns true if following is enabled and a recent target location update has been received.
+    // Returns true if a usable estimate of the configured target is available.  Every accessor
+    // below is gated on this, so a true return guarantees each of them succeeds.
     bool have_target() const;
 
     // Projects the target’s position, velocity, and heading forward using the latest updates, smoothing with input shaping if necessary 
@@ -169,6 +170,9 @@ private:
     // returns true if we should extract information from msg
     bool should_handle_message(const mavlink_message_t &msg) const;
 
+    // Returns true if the target data we hold is fresh and was supplied by the configured system.
+    bool target_data_current() const;
+
     // Checks whether the current estimate should be reset based on position and velocity errors.
     bool estimate_error_too_large() const;
     
@@ -236,7 +240,7 @@ private:
     Vector3f    _ofs_estimate_vel_ned_ms;       // Estimated velocity with offsets applied (NED frame)
     Vector3f    _ofs_estimate_accel_ned_mss;    // Estimated acceleration with offsets applied (NED frame)
 
-    int16_t     _sysid_used;                    // Currently active sysid used for updates
+    int16_t     _sysid_used;                    // sysid that supplied the target data we currently hold
     float       _dist_to_target_m;              // Horizontal distance to target, for reporting (meters)
     float       _bearing_to_target_deg;         // Bearing to target from vehicle (degrees, 0 = North)
     bool        _offsets_were_zero;             // True if initial offset was zero before being initialized

--- a/libraries/AP_Follow/AP_Follow.h
+++ b/libraries/AP_Follow/AP_Follow.h
@@ -171,7 +171,7 @@ private:
     bool should_handle_message(const mavlink_message_t &msg) const;
 
     // Returns true if the target data we hold is fresh and was supplied by the configured system.
-    bool target_data_current() const;
+    bool have_target_data() const;
 
     // Checks whether the current estimate should be reset based on position and velocity errors.
     bool estimate_error_too_large() const;

--- a/libraries/AP_Follow/AP_Follow.h
+++ b/libraries/AP_Follow/AP_Follow.h
@@ -78,7 +78,8 @@ public:
     //==========================================================================
 
     // Returns true if a usable estimate of the configured target is available.  Every accessor
-    // below is gated on this, so a true return guarantees each of them succeeds.
+    // below is gated on this, but a true return does not guarantee they will succeed, so callers
+    // must still check what each accessor returns.
     bool have_target() const;
 
     // Projects the target’s position, velocity, and heading forward using the latest updates, smoothing with input shaping if necessary 

--- a/libraries/AP_Follow/AP_Follow.h
+++ b/libraries/AP_Follow/AP_Follow.h
@@ -77,7 +77,8 @@ public:
     // Target Estimation and Tracking Methods
     //==========================================================================
 
-    // Returns true if following is enabled and a recent target location update has been received.
+    // Returns true if a usable estimate of the configured target is available.  Every accessor
+    // below is gated on this, so a true return guarantees each of them succeeds.
     bool have_target() const;
 
     // Projects the target’s position, velocity, and heading forward using the latest updates, smoothing with input shaping if necessary 
@@ -169,6 +170,9 @@ private:
     // returns true if we should extract information from msg
     bool should_handle_message(const mavlink_message_t &msg) const;
 
+    // Returns true if the target data we hold is fresh and was supplied by the configured system.
+    bool target_data_current() const;
+
     // Checks whether the current estimate should be reset based on position and velocity errors.
     bool estimate_error_too_large() const;
     
@@ -236,7 +240,7 @@ private:
     Vector3f    _ofs_estimate_vel_ned_ms;       // Estimated velocity with offsets applied (NED frame)
     Vector3f    _ofs_estimate_accel_ned_mss;    // Estimated acceleration with offsets applied (NED frame)
 
-    int16_t     _sysid_used;                    // Currently active sysid used for updates
+    int16_t     _sysid_of_data;                    // sysid that supplied the target data we currently hold
     float       _dist_to_target_m;              // Horizontal distance to target, for reporting (meters)
     float       _bearing_to_target_deg;         // Bearing to target from vehicle (degrees, 0 = North)
     bool        _offsets_were_zero;             // True if initial offset was zero before being initialized

--- a/libraries/AP_Follow/AP_Follow.h
+++ b/libraries/AP_Follow/AP_Follow.h
@@ -194,7 +194,7 @@ private:
     //==========================================================================
 
     AP_Int8     _enabled;           // 1 = Follow mode is enabled; 0 = disabled
-    AP_Int16    _sysid;             // MAVLink system ID of the target (0 = auto-select first sender)
+    AP_Int16    _sysid;             // MAVLink system ID of the target (0 = no target selected)
     AP_Float    _dist_max_m;        // Maximum allowed distance to target in meters; if exceeded, estimation is rejected
     AP_Int8     _offset_type;       // Offset frame type: 0 = NED, 1 = relative to lead vehicle heading
     AP_Vector3f _offset_m;          // Offset from lead vehicle (meters), in NED or FRD frame depending on _offset_type
@@ -236,7 +236,6 @@ private:
     Vector3f    _ofs_estimate_vel_ned_ms;       // Estimated velocity with offsets applied (NED frame)
     Vector3f    _ofs_estimate_accel_ned_mss;    // Estimated acceleration with offsets applied (NED frame)
 
-    bool        _automatic_sysid;               // True if target sysid was automatically selected
     int16_t     _sysid_used;                    // Currently active sysid used for updates
     float       _dist_to_target_m;              // Horizontal distance to target, for reporting (meters)
     float       _bearing_to_target_deg;         // Bearing to target from vehicle (degrees, 0 = North)


### PR DESCRIPTION
### Summary

FOLL_SYSID only filters incoming messages; it does not invalidate the target data already held, so after a change the library keeps reporting the previous vehicle's position, velocity and heading as valid. This makes the held target state belong to the system named by FOLL_SYSID.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Tested manually, description below (e.g. SITL)

Found in a Copter flight log where a Lua script switched FOLL_SYSID between two beacons roughly 5 m apart. The vehicle continued to be positioned relative to the previous beacon, and the mode consuming the follow estimate advanced its state machine against the old beacon's geometry. SITL Copter ModeFollow_with_FOLLOW_TARGET and three ship-landing tests exercising GLOBAL_POSITION_INT follow pass with this change on a downstream branch. No existing autotest changes FOLL_SYSID in flight, so the retarget path itself is not covered by automated testing.

### Description

_sysid is used only as an inbound filter in should_handle_message(). The cached target state carries no record of which system supplied it, and have_target() checks only the age of _last_location_update_ms. So for up to FOLL_TIMEOUT after FOLL_SYSID changes, get_target_sysid() reports the new vehicle while every getter returns the previous one. update_estimates() noticed the change but only cleared _estimate_valid, and the re-init branch immediately re-seeded the estimate from the previous target's last position and marked it valid again.

Two other pieces of state also survived a retarget. _using_follow_target latches when a FOLLOW_TARGET message arrives and causes every GLOBAL_POSITION_INT to be rejected, so retargeting from a FOLLOW_TARGET vehicle to one that only sends GLOBAL_POSITION_INT stalled until the 10 second sysid timeout. _automatic_sysid was set on adoption and never cleared, so a later explicit FOLL_SYSID write could be discarded by that same timeout and the parameter reset to 0.

The change gives _sysid_used a single meaning, the system that supplied the data currently held, updated wherever an update is accepted. have_target() rejects a mismatch, so the estimate and every getter report no target until the new system transmits. On a mismatch the FOLLOW_TARGET preference is dropped and _automatic_sysid is cleared, since a parameter write has superseded an adoption. The estimate is reset when an accepted update comes from a different system, so it snaps to the new target rather than shaping across the gap.

Sysid adoption for FOLL_SYSID = 0 was duplicated in both message decoders and is now done once in handle_msg(), along with the _using_follow_target gate on GLOBAL_POSITION_INT. No parameter changes, and no behaviour change while FOLL_SYSID is fixed.
