### PR TITLE
SITL: make the plane moment of inertia an explicit term

### DIFF
--- a/libraries/SITL/SIM_Plane.h
+++ b/libraries/SITL/SIM_Plane.h
@@ -94,22 +94,25 @@ protected:
 
     struct Coefficients coefficient;
 
+    // the constructor only ever sets these to true, from tokens in the frame
+    // string, so they must default to false rather than to whatever the
+    // allocation happened to contain
     float thrust_scale;
-    bool reverse_thrust;
-    bool elevons;
-    bool vtail;
-    bool dspoilers;
-    bool redundant;
-    bool reverse_elevator_rudder;
-    bool ice_engine;
-    bool tailsitter;
-    bool aerobatic;
-    bool copter_tailsitter;
-    bool have_launcher;
-    bool have_steering;
-    float launch_accel;
-    float launch_time;
-    uint64_t launch_start_ms;
+    bool reverse_thrust = false;
+    bool elevons = false;
+    bool vtail = false;
+    bool dspoilers = false;
+    bool redundant = false;
+    bool reverse_elevator_rudder = false;
+    bool ice_engine = false;
+    bool tailsitter = false;
+    bool aerobatic = false;
+    bool copter_tailsitter = false;
+    bool have_launcher = false;
+    bool have_steering = false;
+    float launch_accel = 0;
+    float launch_time = 0;
+    uint64_t launch_start_ms = 0;
 
     const uint8_t throttle_servo = 2;
     const int8_t choke_servo = 14;


### PR DESCRIPTION
SITL::Plane::calculate_forces() assigned the aerodynamic moments from getTorque()
straight to rot_accel, which mixes up N.m with rad/s^2. This divides them by an
explicit moment of inertia instead. The default is unity, so existing behaviour is
reproduced bit for bit.

Classification & Testing (check all that apply and add your own)
 Checked by a human programmer
 Non-functional change
 No-binary change
 Infrastructure change (e.g. unit tests, helper scripts)
 Automated test(s) verify changes (e.g. unit test, autotest)
 Tested manually, description below (e.g. SITL)
 Tested on hardware
 Logs attached
 Logs available on request
New gtest in libraries/SITL/tests/test_sim_plane_inertia.cpp, run with
./waf configure --board sitl && ./waf tests. Two cases:

unit_inertia_preserves_legacy_behaviour compares plane (2kg) against
plane-heavy (8kg), which differ only in mass. It asserts rot_accel is
bit-identical to the raw getTorque() output on both, and identical between
them. accel_body is the control: it is divided by mass explicitly, so it
shows the expected 4x ratio, which proves the measurement is sensitive to
mass at all.
explicit_inertia_scales_angular_acceleration sets the inertia to
{2, 4, 8} and asserts each axis of rot_accel is that axis' moment
divided by that axis' inertia. Distinct powers of two, so the division is
exact in binary and a swapped axis cannot pass.
SITL suites were also run locally, on top of master 06a33a1:

Tools/autotest/autotest.py build.Plane test.Plane test.QuadPlane
test.QuadPlane passes in full, which is the case that motivates the separate
json key. test.Plane reports one failure, LoggedNamedValueString, a Lua
scripting test unrelated to this change. It fails identically on a clean
rebuild of master 06a33a1 with the same message ("Did not get
NAMED_VALUE_STRING after 1.0 seconds"), so it is pre-existing rather than
caused by this PR.

Description
getTorque() returns aerodynamic moments in N.m. calculate_forces() assigned
them directly to rot_accel, and update_dynamics() integrates that as an
angular acceleration, so the moment of inertia was implicitly 1 kg.m^2 on every
axis. This makes the term explicit and divides by it.

The default stays {1, 1, 1}, which is not a physical value for any airframe.
It is deliberate: the aerodynamic coefficients in the shipped model files and the
default autopilot gains are all tuned around the current response. Realistic
values are of order 0.1 to 0.3 kg.m^2, so using them would make the angular
response several times sharper and would mean retuning both. That is separate
work, and this PR does not attempt it.

The inertia is also not derived from mass and geometry. The form is
I = m*(R*L)^2, but R depends on how the mass is distributed rather than on
the airframe's dimensions: a fuselage model carrying its battery near the centre
and a flying wing of the same span and weight do not share one. It is a measured
per-airframe property, not something the simulator can infer from what it
already has, so it is exposed as a model file key instead.

That key is spelled aero_moment_inertia, not moment_inertia which SIM_Frame
already reads. For a quadplane the same json file is handed to both models, and a
copter inertia is one to two orders of magnitude smaller than the value the
aerodynamic side is tuned around, so sharing the key would divide the aerodynamic
moments by a copter inertia and multiply them by twenty to fifty. The key is
documented and left commented out in Tools/autotest/models/skywalker_2013.json.
Values are validated as positive on all three axes at load time.

Partially addresses #26972.