### PR TITLE
Tools: ros2: tear down rclpy cleanly in the AP_DDS tests

### DIFF
--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/ros_helpers.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/ros_helpers.py
@@ -1,0 +1,70 @@
+# Copyright 2026 ArduPilot.org.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+"""Helpers for managing the rclpy lifecycle in the AP_DDS tests."""
+
+import threading
+
+from contextlib import contextmanager
+
+import rclpy
+
+from rclpy.executors import SingleThreadedExecutor
+
+# How long to wait for a spin thread to notice its executor was shut down.
+SPIN_JOIN_TIMEOUT = 10.0
+
+
+@contextmanager
+def ros_node(node_class, *args, **kwargs):
+    """
+    Initialise rclpy, construct and spin a node, then tear it all down again.
+
+    Spinning on a private executor, rather than via rclpy.spin(), is what lets
+    the spin thread be stopped and joined and the node destroyed while the
+    context is still valid.
+
+    Keep the executor in a local: assigning it to ``node.executor`` would not
+    hold it, as that property's setter keeps only a weak reference.
+    """
+    rclpy.init()
+    node = None
+    executor = None
+    spin_thread = None
+    body_succeeded = False
+    try:
+        node = node_class(*args, **kwargs)
+        executor = SingleThreadedExecutor()
+        executor.add_node(node)
+        spin_thread = threading.Thread(target=executor.spin)
+        spin_thread.start()
+        yield node
+        body_succeeded = True
+    finally:
+        # Stop the executor first: that is what makes spin() return, so the
+        # thread must be joined before the node may be destroyed.  Bound the
+        # wait for in-flight callbacks so a stuck one fails the test rather
+        # than hanging it.
+        if executor is not None:
+            executor.shutdown(timeout_sec=SPIN_JOIN_TIMEOUT)
+        if spin_thread is not None:
+            spin_thread.join(timeout=SPIN_JOIN_TIMEOUT)
+            # Only complain about a stuck spin thread when the test itself
+            # passed, so this cannot mask the real failure.
+            if body_succeeded:
+                assert not spin_thread.is_alive(), "Spin thread did not stop."
+        if node is not None:
+            node.destroy_node()
+        rclpy.shutdown()

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_battery_msg_received.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_battery_msg_received.py
@@ -32,6 +32,7 @@ import rclpy.node
 import threading
 
 from launch_pytest.tools import process as process_tools
+from ros_helpers import ros_node
 
 from rclpy.qos import QoSProfile
 from rclpy.qos import QoSReliabilityPolicy
@@ -72,10 +73,6 @@ class BatteryListener(rclpy.node.Node):
 
         self.subscription = self.create_subscription(BatteryState, self.topic, self.subscriber_callback, qos_profile)
 
-        # Add a spin thread.
-        self.ros_spin_thread = threading.Thread(target=lambda node: rclpy.spin(node), args=(self,))
-        self.ros_spin_thread.start()
-
     def subscriber_callback(self, msg):
         """Process a BatteryState message."""
         if self.msg_event_object.set():
@@ -108,9 +105,7 @@ def test_dds_serial_battery_msg_recv(launch_context, launch_sitl_copter_dds_seri
     process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=WAIT_FOR_START_TIMEOUT)
     process_tools.wait_for_start_sync(launch_context, sitl, timeout=WAIT_FOR_START_TIMEOUT)
 
-    rclpy.init()
-    try:
-        node = BatteryListener()
+    with ros_node(BatteryListener) as node:
         node.start_subscriber()
         msgs_received_flag = node.msg_event_object.wait(timeout=10.0)
         assert msgs_received_flag, f"Did not receive '{TOPIC}' msgs."
@@ -118,8 +113,6 @@ def test_dds_serial_battery_msg_recv(launch_context, launch_sitl_copter_dds_seri
         assert battery_correct_flag, f"Did not receive correct battery ID."
         battery_incorrect_flag = not node.frame_id_incorrect_object.wait(timeout=10.0)
         assert battery_correct_flag, f"Did received incorrect battery ID."
-    finally:
-        rclpy.shutdown()
     yield
 
 
@@ -136,9 +129,7 @@ def test_dds_udp_battery_msg_recv(launch_context, launch_sitl_copter_dds_udp):
     process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=WAIT_FOR_START_TIMEOUT)
     process_tools.wait_for_start_sync(launch_context, sitl, timeout=WAIT_FOR_START_TIMEOUT)
 
-    rclpy.init()
-    try:
-        node = BatteryListener()
+    with ros_node(BatteryListener) as node:
         node.start_subscriber()
         msgs_received_flag = node.msg_event_object.wait(timeout=10.0)
         assert msgs_received_flag, f"Did not receive '{TOPIC}' msgs."
@@ -146,7 +137,4 @@ def test_dds_udp_battery_msg_recv(launch_context, launch_sitl_copter_dds_udp):
         assert battery_correct_flag, f"Did not receive correct battery ID."
         battery_incorrect_flag = not node.frame_id_incorrect_object.wait(timeout=10.0)
         assert battery_correct_flag, f"Did received incorrect battery ID."
-
-    finally:
-        rclpy.shutdown()
     yield

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_dds_namespace_enabled.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_dds_namespace_enabled.py
@@ -27,6 +27,7 @@ import rclpy.node
 from builtin_interfaces.msg import Time
 from launch_fixtures import launch_sitl_copter_dds_udp_use_ns
 from launch_pytest.tools import process as process_tools
+from ros_helpers import ros_node
 from std_srvs.srv import Trigger
 
 TOPIC = "ap/v1/time"
@@ -49,10 +50,6 @@ class TimeListener(rclpy.node.Node):
     def start_subscriber(self):
         """Start the subscriber."""
         self.subscription = self.create_subscription(Time, self.topic, self.subscriber_callback, 1)
-
-        # Add a spin thread.
-        self.ros_spin_thread = threading.Thread(target=lambda node: rclpy.spin(node), args=(self,))
-        self.ros_spin_thread.start()
 
     def subscriber_callback(self, msg):
         """Process a Time message."""
@@ -81,14 +78,10 @@ def test_dds_udp_time_msg_recv(launch_context, launch_sitl_copter_dds_udp_use_ns
     process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=WAIT_FOR_START_TIMEOUT)
     process_tools.wait_for_start_sync(launch_context, sitl, timeout=WAIT_FOR_START_TIMEOUT)
 
-    rclpy.init()
-    try:
-        node = TimeListener()
+    with ros_node(TimeListener) as node:
         node.start_subscriber()
         msgs_received_flag = node.msg_event_object.wait(timeout=10.0)
         assert msgs_received_flag, f"Did not receive '{TOPIC}' msgs."
-    finally:
-        rclpy.shutdown()
     yield
 
 
@@ -99,11 +92,6 @@ class PreamService(rclpy.node.Node):
         self.service_available_object = threading.Event()
         self.is_armable_object = threading.Event()
         self._client_prearm = self.create_client(Trigger, SERVICE)
-
-    def start_node(self):
-        # Add a spin thread.
-        self.ros_spin_thread = threading.Thread(target=lambda node: rclpy.spin(node), args=(self,))
-        self.ros_spin_thread.start()
 
     def prearm_check(self):
         req = Trigger.Request()
@@ -149,13 +137,8 @@ def test_dds_udp_prearm_service_call(launch_context, launch_sitl_copter_dds_udp_
     process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=WAIT_FOR_START_TIMEOUT)
     process_tools.wait_for_start_sync(launch_context, sitl, timeout=WAIT_FOR_START_TIMEOUT)
 
-    rclpy.init()
-    try:
-        node = PreamService()
-        node.start_node()
+    with ros_node(PreamService) as node:
         node.start_prearm()
         is_armable_flag = node.is_armable_object.wait(timeout=25.0)
         assert is_armable_flag, f"Vehicle not armable."
-    finally:
-        rclpy.shutdown()
     yield

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_geopose_msg_received.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_geopose_msg_received.py
@@ -31,6 +31,7 @@ from scipy.spatial.transform import Rotation as R
 import threading
 
 from launch_pytest.tools import process as process_tools
+from ros_helpers import ros_node
 
 from rclpy.qos import QoSProfile
 from rclpy.qos import QoSReliabilityPolicy
@@ -118,10 +119,6 @@ class GeoPoseListener(rclpy.node.Node):
 
         self.subscription = self.create_subscription(GeoPoseStamped, self.topic, self.subscriber_callback, qos_profile)
 
-        # Add a spin thread.
-        self.ros_spin_thread = threading.Thread(target=lambda node: rclpy.spin(node), args=(self,))
-        self.ros_spin_thread.start()
-
     def subscriber_callback(self, msg):
         """Process a GeoPoseStamped message."""
         if self.msg_event_object.set():
@@ -156,9 +153,7 @@ def test_dds_serial_geopose_msg_recv(launch_context, launch_sitl_copter_dds_seri
     process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=WAIT_FOR_START_TIMEOUT)
     process_tools.wait_for_start_sync(launch_context, sitl, timeout=WAIT_FOR_START_TIMEOUT)
 
-    rclpy.init()
-    try:
-        node = GeoPoseListener()
+    with ros_node(GeoPoseListener) as node:
         node.start_subscriber()
         msgs_received_flag = node.msg_event_object.wait(timeout=10.0)
         assert msgs_received_flag, f"Did not receive '{TOPIC}' msgs."
@@ -166,8 +161,6 @@ def test_dds_serial_geopose_msg_recv(launch_context, launch_sitl_copter_dds_seri
         assert pose_correct_flag, f"Did not receive correct position."
         orientation_correct_flag = node.orientation_event_object.wait(timeout=10.0)
         assert orientation_correct_flag, f"Did not receive correct orientation."
-    finally:
-        rclpy.shutdown()
     yield
 
 
@@ -184,14 +177,10 @@ def test_dds_udp_geopose_msg_recv(launch_context, launch_sitl_copter_dds_udp):
     process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=WAIT_FOR_START_TIMEOUT)
     process_tools.wait_for_start_sync(launch_context, sitl, timeout=WAIT_FOR_START_TIMEOUT)
 
-    rclpy.init()
-    try:
-        node = GeoPoseListener()
+    with ros_node(GeoPoseListener) as node:
         node.start_subscriber()
         msgs_received_flag = node.msg_event_object.wait(timeout=10.0)
         assert msgs_received_flag, f"Did not receive '{TOPIC}' msgs."
         pose_correct_flag = node.position_correct_event_object.wait(timeout=10.0)
         assert pose_correct_flag, f"Did not receive correct position."
-    finally:
-        rclpy.shutdown()
     yield

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_joy_msg_received.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_joy_msg_received.py
@@ -38,6 +38,7 @@ from sensor_msgs.msg import Joy
 from scipy.spatial.transform import Rotation as R
 import pytest
 from launch_pytest.tools import process as process_tools
+from ros_helpers import ros_node
 import threading
 
 from launch_fixtures import launch_sitl_copter_dds_udp
@@ -83,10 +84,6 @@ class PlaneFbwbJoyControl(Node):
 
         self._subscription_twist = self.create_subscription(TwistStamped, "/ap/twist/filtered", self.twist_cb, qos)
         self._climb_rate = 0.0
-
-        # Add a spin thread.
-        self.ros_spin_thread = threading.Thread(target=lambda node: rclpy.spin(node), args=(self,))
-        self.ros_spin_thread.start()
 
     def geopose_cb(self, msg: GeoPoseStamped):
         """Process a GeoPose message."""
@@ -197,12 +194,8 @@ def test_dds_udp_joy_msg_recv(launch_context, launch_sitl_copter_dds_udp):
     process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=WAIT_FOR_START_TIMEOUT)
     process_tools.wait_for_start_sync(launch_context, sitl, timeout=WAIT_FOR_START_TIMEOUT)
 
-    rclpy.init()
-    try:
-        node = PlaneFbwbJoyControl()
+    with ros_node(PlaneFbwbJoyControl) as node:
         node.arm_and_takeoff()
         climb_flag = node.climbing_event_object.wait(10)
         assert climb_flag, "Could not climb"
-    finally:
-        rclpy.shutdown()
     yield

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_navsat_msg_received.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_navsat_msg_received.py
@@ -22,6 +22,7 @@ import rclpy.node
 import threading
 
 from launch_pytest.tools import process as process_tools
+from ros_helpers import ros_node
 
 from rclpy.qos import QoSProfile
 from rclpy.qos import QoSReliabilityPolicy
@@ -60,10 +61,6 @@ class NavSatFixListener(rclpy.node.Node):
 
         self.subscription = self.create_subscription(NavSatFix, self.topic, self.subscriber_callback, qos_profile)
 
-        # Add a spin thread.
-        self.ros_spin_thread = threading.Thread(target=lambda node: rclpy.spin(node), args=(self,))
-        self.ros_spin_thread.start()
-
     def subscriber_callback(self, msg):
         """Process a NavSatFix message."""
         if self.msg_event_object.set():
@@ -93,14 +90,10 @@ def test_dds_serial_navsat_msg_recv(launch_context, launch_sitl_copter_dds_seria
     process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=WAIT_FOR_START_TIMEOUT)
     process_tools.wait_for_start_sync(launch_context, sitl, timeout=WAIT_FOR_START_TIMEOUT)
 
-    rclpy.init()
-    try:
-        node = NavSatFixListener()
+    with ros_node(NavSatFixListener) as node:
         node.start_subscriber()
         msgs_received_flag = node.msg_event_object.wait(timeout=10.0)
         assert msgs_received_flag, f"Did not receive '{TOPIC}' msgs."
-    finally:
-        rclpy.shutdown()
     yield
 
 
@@ -117,12 +110,8 @@ def test_dds_udp_navsat_msg_recv(launch_context, launch_sitl_copter_dds_udp):
     process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=WAIT_FOR_START_TIMEOUT)
     process_tools.wait_for_start_sync(launch_context, sitl, timeout=WAIT_FOR_START_TIMEOUT)
 
-    rclpy.init()
-    try:
-        node = NavSatFixListener()
+    with ros_node(NavSatFixListener) as node:
         node.start_subscriber()
         msgs_received_flag = node.msg_event_object.wait(timeout=10.0)
         assert msgs_received_flag, f"Did not receive '{TOPIC}' msgs."
-    finally:
-        rclpy.shutdown()
     yield

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_parameter_service.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_parameter_service.py
@@ -35,6 +35,7 @@ import time
 from launch import LaunchDescription
 
 from launch_pytest.tools import process as process_tools
+from ros_helpers import ros_node
 
 from rclpy.qos import QoSProfile
 from rclpy.qos import QoSReliabilityPolicy
@@ -78,10 +79,6 @@ class ParameterClient(rclpy.node.Node):
         self.set_cli = self.create_client(SetParameters, 'ap/set_parameters')
         while not self.set_cli.wait_for_service(timeout_sec=1.0):
             self.get_logger().info('SetParameters service not available, waiting again...')
-
-        # Add a spin thread
-        self.ros_spin_thread = threading.Thread(target=lambda node: rclpy.spin(node), args=(self,))
-        self.ros_spin_thread.start()
 
     def send_get_param_req(self, param_name):
         self.get_req = GetParameters.Request()
@@ -179,9 +176,7 @@ def test_dds_udp_parameter_services(launch_context, launch_sitl_copter_dds_udp):
     process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=WAIT_FOR_START_TIMEOUT)
     process_tools.wait_for_start_sync(launch_context, sitl, timeout=WAIT_FOR_START_TIMEOUT)
 
-    rclpy.init()
-    try:
-        node = ParameterClient()
+    with ros_node(ParameterClient) as node:
         node.start_client()
         parameter_name = "LOIT_SPEED_MS"
         param_change_value = 12.50
@@ -195,7 +190,4 @@ def test_dds_udp_parameter_services(launch_context, launch_sitl_copter_dds_udp):
         node.check_param_change()
         set_param_changed_flag = node.set_correct_object.wait(timeout=10.0)
         assert set_param_changed_flag, f"Did not confirm '{parameter_name}' value change"
-
-    finally:
-        rclpy.shutdown()
     yield

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_plane_airspeed.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_plane_airspeed.py
@@ -35,6 +35,7 @@ from launch_pytest.tools import process as process_tools
 from rclpy.qos import QoSHistoryPolicy
 from rclpy.qos import QoSProfile
 from rclpy.qos import QoSReliabilityPolicy
+from ros_helpers import ros_node
 
 TOPIC = "/ap/airspeed"
 WAIT_FOR_START_TIMEOUT = 5.0
@@ -58,10 +59,6 @@ class AirspeedTester(rclpy.node.Node):
         )
 
         self.subscription = self.create_subscription(Airspeed, TOPIC, self.airspeed_data_callback, qos_profile)
-
-        # Add a spin thread.
-        self.ros_spin_thread = threading.Thread(target=lambda node: rclpy.spin(node), args=(self,))
-        self.ros_spin_thread.start()
 
     def airspeed_data_callback(self, msg):
         """Process a airspeed message from the autopilot."""
@@ -149,14 +146,10 @@ def test_dds_serial_airspeed_msg_recv_copter(launch_context, launch_sitl_copter_
     process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=WAIT_FOR_START_TIMEOUT)
     process_tools.wait_for_start_sync(launch_context, sitl, timeout=WAIT_FOR_START_TIMEOUT)
 
-    rclpy.init()
-    try:
-        node = AirspeedTester()
+    with ros_node(AirspeedTester) as node:
         node.start_subscriber()
         msgs_received_flag = node.msg_event_object.wait(timeout=AIRSPEED_RECV_TIMEOUT)
         assert msgs_received_flag, f"Did not receive '{TOPIC}' msgs."
-    finally:
-        rclpy.shutdown()
     yield
 
 
@@ -173,15 +166,10 @@ def test_dds_udp_airspeed_msg_recv_copter(launch_context, launch_sitl_copter_dds
     process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=WAIT_FOR_START_TIMEOUT)
     process_tools.wait_for_start_sync(launch_context, sitl, timeout=WAIT_FOR_START_TIMEOUT)
 
-    rclpy.init()
-    try:
-        node = AirspeedTester()
+    with ros_node(AirspeedTester) as node:
         node.start_subscriber()
         msgs_received_flag = node.msg_event_object.wait(timeout=AIRSPEED_RECV_TIMEOUT)
         assert msgs_received_flag, f"Did not receive '{TOPIC}' msgs."
-
-    finally:
-        rclpy.shutdown()
     yield
 
 
@@ -200,14 +188,10 @@ def test_dds_serial_airspeed_msg_recv_plane(launch_context, launch_sitl_plane_dd
     process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=WAIT_FOR_START_TIMEOUT)
     process_tools.wait_for_start_sync(launch_context, sitl, timeout=WAIT_FOR_START_TIMEOUT)
 
-    rclpy.init()
-    try:
-        node = AirspeedTester()
+    with ros_node(AirspeedTester) as node:
         node.start_subscriber()
         msgs_received_flag = node.msg_event_object.wait(timeout=AIRSPEED_RECV_TIMEOUT)
         assert msgs_received_flag, f"Did not receive '{TOPIC}' msgs."
-    finally:
-        rclpy.shutdown()
     yield
 
 
@@ -224,13 +208,8 @@ def test_dds_udp_airspeed_msg_recv_plane(launch_context, launch_sitl_plane_dds_u
     process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=WAIT_FOR_START_TIMEOUT)
     process_tools.wait_for_start_sync(launch_context, sitl, timeout=WAIT_FOR_START_TIMEOUT)
 
-    rclpy.init()
-    try:
-        node = AirspeedTester()
+    with ros_node(AirspeedTester) as node:
         node.start_subscriber()
         msgs_received_flag = node.msg_event_object.wait(timeout=AIRSPEED_RECV_TIMEOUT)
         assert msgs_received_flag, f"Did not receive '{TOPIC}' msgs."
-
-    finally:
-        rclpy.shutdown()
     yield

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_prearm_service.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_prearm_service.py
@@ -31,6 +31,7 @@ import rclpy.node
 import threading
 
 from launch_pytest.tools import process as process_tools
+from ros_helpers import ros_node
 from std_srvs.srv import Trigger
 
 from launch_fixtures import (
@@ -49,11 +50,6 @@ class PreamService(rclpy.node.Node):
         self.service_available_object = threading.Event()
         self.is_armable_object = threading.Event()
         self._client_prearm = self.create_client(Trigger, "/ap/prearm_check")
-
-    def start_node(self):
-        # Add a spin thread.
-        self.ros_spin_thread = threading.Thread(target=lambda node: rclpy.spin(node), args=(self,))
-        self.ros_spin_thread.start()
 
     def prearm_check(self):
         req = Trigger.Request()
@@ -101,15 +97,10 @@ def test_dds_serial_prearm_service_call(launch_context, launch_sitl_copter_dds_s
     process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=WAIT_FOR_START_TIMEOUT)
     process_tools.wait_for_start_sync(launch_context, sitl, timeout=WAIT_FOR_START_TIMEOUT)
 
-    rclpy.init()
-    try:
-        node = PreamService()
-        node.start_node()
+    with ros_node(PreamService) as node:
         node.start_prearm()
         is_armable_flag = node.is_armable_object.wait(timeout=25.0)
         assert is_armable_flag, f"Vehicle not armable."
-    finally:
-        rclpy.shutdown()
     yield
 
 
@@ -126,13 +117,8 @@ def test_dds_udp_prearm_service_call(launch_context, launch_sitl_copter_dds_udp)
     process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=WAIT_FOR_START_TIMEOUT)
     process_tools.wait_for_start_sync(launch_context, sitl, timeout=WAIT_FOR_START_TIMEOUT)
 
-    rclpy.init()
-    try:
-        node = PreamService()
-        node.start_node()
+    with ros_node(PreamService) as node:
         node.start_prearm()
         is_armable_flag = node.is_armable_object.wait(timeout=25.0)
         assert is_armable_flag, f"Vehicle not armable."
-    finally:
-        rclpy.shutdown()
     yield

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_rc_msg_received.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_rc_msg_received.py
@@ -32,6 +32,7 @@ import rclpy.node
 import threading
 
 from launch_pytest.tools import process as process_tools
+from ros_helpers import ros_node
 
 from rclpy.qos import QoSProfile
 from rclpy.qos import QoSReliabilityPolicy
@@ -70,10 +71,6 @@ class RcListener(rclpy.node.Node):
 
         self.subscription = self.create_subscription(Rc, self.topic, self.subscriber_callback, qos_profile)
 
-        # Add a spin thread.
-        self.ros_spin_thread = threading.Thread(target=lambda node: rclpy.spin(node), args=(self,))
-        self.ros_spin_thread.start()
-
     def subscriber_callback(self, msg):
         """Process a Rc message."""
         if self.msg_event_object.set():
@@ -98,14 +95,10 @@ def test_dds_serial_rc_msg_recv(launch_context, launch_sitl_copter_dds_serial):
     process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=WAIT_FOR_START_TIMEOUT)
     process_tools.wait_for_start_sync(launch_context, sitl, timeout=WAIT_FOR_START_TIMEOUT)
 
-    rclpy.init()
-    try:
-        node = RcListener()
+    with ros_node(RcListener) as node:
         node.start_subscriber()
         msgs_received_flag = node.msg_event_object.wait(timeout=10.0)
         assert msgs_received_flag, f"Did not receive '{TOPIC}' msgs."
-    finally:
-        rclpy.shutdown()
     yield
 
 
@@ -122,13 +115,8 @@ def test_dds_udp_rc_msg_recv(launch_context, launch_sitl_copter_dds_udp):
     process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=WAIT_FOR_START_TIMEOUT)
     process_tools.wait_for_start_sync(launch_context, sitl, timeout=WAIT_FOR_START_TIMEOUT)
 
-    rclpy.init()
-    try:
-        node = RcListener()
+    with ros_node(RcListener) as node:
         node.start_subscriber()
         msgs_received_flag = node.msg_event_object.wait(timeout=10.0)
         assert msgs_received_flag, f"Did not receive '{TOPIC}' msgs."
-
-    finally:
-        rclpy.shutdown()
     yield

--- a/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_time_msg_received.py
+++ b/Tools/ros2/ardupilot_dds_tests/test/ardupilot_dds_tests/test_time_msg_received.py
@@ -24,6 +24,7 @@ from builtin_interfaces.msg import Time
 from launch_fixtures import launch_sitl_copter_dds_serial
 from launch_fixtures import launch_sitl_copter_dds_udp
 from launch_pytest.tools import process as process_tools
+from ros_helpers import ros_node
 
 TOPIC = "ap/time"
 WAIT_FOR_START_TIMEOUT = 5.0
@@ -44,10 +45,6 @@ class TimeListener(rclpy.node.Node):
     def start_subscriber(self):
         """Start the subscriber."""
         self.subscription = self.create_subscription(Time, self.topic, self.subscriber_callback, 1)
-
-        # Add a spin thread.
-        self.ros_spin_thread = threading.Thread(target=lambda node: rclpy.spin(node), args=(self,))
-        self.ros_spin_thread.start()
 
     def subscriber_callback(self, msg):
         """Process a Time message."""
@@ -78,14 +75,10 @@ def test_dds_serial_time_msg_recv(launch_context, launch_sitl_copter_dds_serial)
     process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=WAIT_FOR_START_TIMEOUT)
     process_tools.wait_for_start_sync(launch_context, sitl, timeout=WAIT_FOR_START_TIMEOUT)
 
-    rclpy.init()
-    try:
-        node = TimeListener()
+    with ros_node(TimeListener) as node:
         node.start_subscriber()
         msgs_received_flag = node.msg_event_object.wait(timeout=10.0)
         assert msgs_received_flag, f"Did not receive '{TOPIC}' msgs."
-    finally:
-        rclpy.shutdown()
     yield
 
 
@@ -102,12 +95,8 @@ def test_dds_udp_time_msg_recv(launch_context, launch_sitl_copter_dds_udp):
     process_tools.wait_for_start_sync(launch_context, mavproxy, timeout=WAIT_FOR_START_TIMEOUT)
     process_tools.wait_for_start_sync(launch_context, sitl, timeout=WAIT_FOR_START_TIMEOUT)
 
-    rclpy.init()
-    try:
-        node = TimeListener()
+    with ros_node(TimeListener) as node:
         node.start_subscriber()
         msgs_received_flag = node.msg_event_object.wait(timeout=10.0)
         assert msgs_received_flag, f"Did not receive '{TOPIC}' msgs."
-    finally:
-        rclpy.shutdown()
     yield


### PR DESCRIPTION
### Summary

Fixes segfault recently starting in colcon tests

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Every test in ardupilot_dds_tests tore down with nothing but rclpy.shutdown(), which shuts the context down while that context's node, subscriptions and DDS participant are all still alive, and left its rclpy.spin() thread unjoined.  colcon runs the whole package in one interpreter, so those zombie endpoints accumulated from test to test.

They race with Fast-DDS intra-process delivery, and the process intermittently died with SIGSEGV on an internal DDS thread:

  History::get_change_nts
  StatefulReader::NotifyChanges
  StatefulReader::change_received
  StatefulReader::processDataMsg
  StatefulWriter::deliver_sample_to_intraprocesses
  FlowControllerImpl<...>::run

Both CI occurrences were in the 22nd of the 23 tests, i.e. at maximum accumulation, and killed the whole pytest run with exit code -11.

rclpy.spin() cannot be torn down cleanly: it uses a process-wide global executor bound to whichever context was current when the first test span, and the only way to make it return is to shut the context down.  So spin on a private SingleThreadedExecutor via a ros_node() context manager, which shuts the executor down, joins the spin thread and destroys the node while the context is still valid.

Reproduced by repeating the time tests in one pytest process (pytest --count=40).  Over 6 shards x 4 loops, with identical harness and only this change differing: 4 of 24 loops segfaulted before, 0 of 24 after, with all 80 tests passing in every loop.
