### PR TITLE
.github: add VOXL3 to qurt-binaries.zip artifact

### DIFF
--- a/.github/workflows/qurt_build.yml
+++ b/.github/workflows/qurt_build.yml
@@ -175,5 +175,10 @@ jobs:
             build/ModalAI-VOXL2/ArduPilot_Plane.so
             build/ModalAI-VOXL2/ArduPilot_Rover.so
             build/ModalAI-VOXL2/ArduPilot.so
+            build/ModalAI-VOXL3/ardupilot
+            build/ModalAI-VOXL3/ArduPilot_Copter.so
+            build/ModalAI-VOXL3/ArduPilot_Plane.so
+            build/ModalAI-VOXL3/ArduPilot_Rover.so
+            build/ModalAI-VOXL3/ArduPilot.so
             libraries/AP_HAL_QURT/packaging/*.deb
           retention-days: 7


### PR DESCRIPTION
### Summary

Adds VOXL3 to qurt-binaries.zip

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

More missing steps in getting a new ModalAI board properly infrastructurified.  Maybe we should have written stuff down for next time...
