### PR TITLE
AR_WPNav: remove dead store in OA update

### DIFF
--- a/libraries/AR_WPNav/AR_WPNav_OA.cpp
+++ b/libraries/AR_WPNav/AR_WPNav_OA.cpp
@@ -93,7 +93,6 @@ void AR_WPNav_OA::update(float dt)
                 // this should never happen.  this means the path planner has returned success but has returned an invalid planner
                 INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
                 _oa_active = false;
-                stop_vehicle = true;
                 return;
 
             case AP_OAPathPlanner::OAPathPlannerUsed::Dijkstras:


### PR DESCRIPTION
### Summary

Remove a dead-store of a local in an early return path - expand up to find it declared on the stack at line 41

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

In the OA_SUCCESS/None path, stop_vehicle was set to true immediately before a return, after an INTERNAL_ERROR, so the value was never read (the stop_vehicle handling is past the return).  Remove the dead store.

Part of getting clang-scan-build into CI
