### PR TITLE
Merge Mission and Camera handling of multiple cameras image capture

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -8388,22 +8388,22 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                     f"Camera still has an interval set: {got}")
         img_idx_at_stop = self.camera_feedback_img_idx(1)
 
-        self.progress("Multiple images with a zero interval must not work")
+        self.progress("Multiple images with a zero interval must be denied")
         self.run_cmd_int(
             mavutil.mavlink.MAV_CMD_IMAGE_START_CAPTURE,
             p1=1,  # camera instance 1
             p2=0,  # interval
             p3=2,  # total images
-            want_result=mavutil.mavlink.MAV_RESULT_FAILED,
+            want_result=mavutil.mavlink.MAV_RESULT_DENIED,
         )
 
-        self.progress("Negative camera id must not work")
+        self.progress("Negative camera id must be denied")
         self.run_cmd_int(
             mavutil.mavlink.MAV_CMD_IMAGE_START_CAPTURE,
             p1=-1,  # invalid camera instance
             p2=0,   # interval
             p3=1,   # total images
-            want_result=mavutil.mavlink.MAV_RESULT_UNSUPPORTED,
+            want_result=mavutil.mavlink.MAV_RESULT_DENIED,
         )
 
         self.progress("Capture on an absent camera instance must fail")

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -8084,6 +8084,15 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         })
         self.customise_SITL_commandline(["--serial5=sim:avt_cm62_gimbal:"])
 
+        self.progress("Capture on an unconfigured camera instance must fail")
+        self.run_cmd_int(
+            mavutil.mavlink.MAV_CMD_IMAGE_START_CAPTURE,
+            p1=2,  # camera instance 2 is not configured
+            p2=0,  # interval
+            p3=1,  # total images
+            want_result=mavutil.mavlink.MAV_RESULT_FAILED,
+        )
+
     def _setup_avt_cm62_dual(self):
         '''configure two SIM_AVT_CM62 simulators on serial5 and serial6'''
         self.set_parameters({
@@ -8204,6 +8213,13 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             (mavutil.mavlink.MAV_CMD_NAV_TAKEOFF, 0, 0, 20),
             self.create_MISSION_ITEM_INT(
                 mavutil.mavlink.MAV_CMD_IMAGE_START_CAPTURE,
+                p1=0,    # 0 means all cameras
+                p2=0,    # interval (0 = single shot)
+                p3=1,    # total images = 1
+                autocontinue=1,
+            ),
+            self.create_MISSION_ITEM_INT(
+                mavutil.mavlink.MAV_CMD_IMAGE_START_CAPTURE,
                 p1=1,    # camera instance 1
                 p2=0,    # interval (0 = single shot)
                 p3=1,    # total images = 1
@@ -8266,10 +8282,11 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.start_flying_simple_relhome_mission(mission_items)
 
         self.progress("Verify CAMERA_CAPTURE_STATUS reports the interval capture")
-        # wait for camera 2 to finish the images it was asked for, leaving
-        # camera 1 as the only one with an interval set for the rest of the
-        # climb
-        self.wait_camera_img_idx([(1, 2)])
+        # wait for camera 2 to finish the images it was asked for (one
+        # from the all-cameras item, two from its own item), leaving
+        # camera 1 as the only one with an interval set for the rest of
+        # the climb
+        self.wait_camera_img_idx([(1, 3)])
         got = sorted(self.camera_capture_statuses(2))
         if got != [CAMERA_IMAGE_STATUS_IDLE, CAMERA_IMAGE_STATUS_INTERVAL_IDLE]:
             raise NotAchievedException(
@@ -8289,7 +8306,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.wait_disarmed()
 
         self.progress("Verify per-camera shot counts from mission items")
-        self.wait_camera_img_idx([(0, img_idx_at_stop), (1, 2)])
+        self.wait_camera_img_idx([(0, img_idx_at_stop), (1, 3)])
 
         self.progress("Verify CAMERA_CAPTURE_STATUS reports no interval capture")
         got = self.camera_capture_statuses(2)
@@ -8301,6 +8318,115 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             (cam1_compid, 25, 40),
             (cam2_compid, 75, 80),
         ])
+
+    def MountAVTCM62DualImageStartCapture(self):
+        '''test MAV_CMD_IMAGE_START_CAPTURE mavlink command against two
+        SIM_AVT_CM62 cameras'''
+        self._setup_avt_cm62_dual()
+
+        # note that CAMERA_FEEDBACK uses cam_idx numbers starting from 0
+        want_img_idx = [1, 1]
+        self.progress("Single image on all cameras (interval and total both zero)")
+        self.run_cmd_int(
+            mavutil.mavlink.MAV_CMD_IMAGE_START_CAPTURE,
+            p1=0,  # 0 means all cameras
+            p2=0,  # interval
+            p3=0,  # total images; zero with a zero interval means one image
+        )
+        self.wait_camera_img_idx(list(enumerate(want_img_idx)))
+
+        for cam in 0, 1:
+            self.progress(f"Single image on just cam{cam} (total images is 1)")
+            self.run_cmd_int(
+                mavutil.mavlink.MAV_CMD_IMAGE_START_CAPTURE,
+                p1=cam+1,  # camera instance
+                p2=0,      # interval
+                p3=1,      # total images
+            )
+            # the count for the other camera must not move
+            want_img_idx[cam] += 1
+            self.wait_camera_img_idx(list(enumerate(want_img_idx)))
+
+        self.progress("Fixed number of images on just cam0, via COMMAND_LONG")
+        self.run_cmd(
+            mavutil.mavlink.MAV_CMD_IMAGE_START_CAPTURE,
+            p1=1,  # camera instance 1
+            p2=1,  # interval (s)
+            p3=3,  # total images
+        )
+        want_img_idx[0] += 3
+        self.wait_camera_img_idx(list(enumerate(want_img_idx)))
+
+        self.progress("Capture-until-stopped on cam1 (total images is 0)")
+        self.run_cmd_int(
+            mavutil.mavlink.MAV_CMD_IMAGE_START_CAPTURE,
+            p1=2,  # camera instance 2
+            p2=1,  # interval (s)
+            p3=0,  # total images; zero with an interval means until stopped
+        )
+        # wait for several images so we know it does not stop by itself
+        want_img_idx[1] += 3
+        self.wait_camera_img_idx(list(enumerate(want_img_idx)))
+        got = sorted(self.camera_capture_statuses(2))
+        if got != [CAMERA_IMAGE_STATUS_IDLE, CAMERA_IMAGE_STATUS_INTERVAL_IDLE]:
+            raise NotAchievedException(
+                f"Wanted exactly one camera capturing on an interval: {got}")
+
+        self.progress("Stop the capture on cam1")
+        self.run_cmd_int(
+            mavutil.mavlink.MAV_CMD_IMAGE_STOP_CAPTURE,
+            p1=2,  # camera instance 2
+        )
+        self.progress("Wait for CAMERA_CAPTURE_STATUS to report no interval capture")
+        tstart = self.get_sim_time()
+        while True:
+            got = self.camera_capture_statuses(2)
+            if got == [CAMERA_IMAGE_STATUS_IDLE, CAMERA_IMAGE_STATUS_IDLE]:
+                break
+            if self.get_sim_time_cached() - tstart > 10:
+                raise NotAchievedException(
+                    f"Camera still has an interval set: {got}")
+        img_idx_at_stop = self.camera_feedback_img_idx(1)
+
+        self.progress("Multiple images with a zero interval must not work")
+        self.run_cmd_int(
+            mavutil.mavlink.MAV_CMD_IMAGE_START_CAPTURE,
+            p1=1,  # camera instance 1
+            p2=0,  # interval
+            p3=2,  # total images
+            want_result=mavutil.mavlink.MAV_RESULT_FAILED,
+        )
+
+        self.progress("Negative camera id must not work")
+        self.run_cmd_int(
+            mavutil.mavlink.MAV_CMD_IMAGE_START_CAPTURE,
+            p1=-1,  # invalid camera instance
+            p2=0,   # interval
+            p3=1,   # total images
+            want_result=mavutil.mavlink.MAV_RESULT_UNSUPPORTED,
+        )
+
+        self.progress("Capture on an absent camera instance must fail")
+        self.run_cmd_int(
+            mavutil.mavlink.MAV_CMD_IMAGE_START_CAPTURE,
+            p1=3,  # camera instance 3 does not exist
+            p2=0,  # interval
+            p3=1,  # total images
+            want_result=mavutil.mavlink.MAV_RESULT_FAILED,
+        )
+
+        self.progress("Two-image capture on cam0; cam1 must remain stopped")
+        self.run_cmd_int(
+            mavutil.mavlink.MAV_CMD_IMAGE_START_CAPTURE,
+            p1=1,  # camera instance 1
+            p2=1,  # interval (s)
+            p3=2,  # total images
+        )
+        # waiting for these images to arrive also spans two of cam1's
+        # old capture intervals, so this checks cam1 really stopped and
+        # that the denied/failed commands above took no images
+        want_img_idx[0] += 2
+        self.wait_camera_img_idx([(0, want_img_idx[0]), (1, img_idx_at_stop)])
 
     def assert_mount_rpy(self, r, p, y, tolerance=1):
         '''assert mount atttiude in degrees'''
@@ -19015,6 +19141,7 @@ return update, 1000
             self.MountAVTCM62,
             self.MountAVTCM62Dual,
             self.MountAVTCM62DualMission,
+            self.MountAVTCM62DualImageStartCapture,
             self.MountRCFailAngle,
             self.MountRCFailRate,
             self.FlyMissionTwice,

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -8628,6 +8628,15 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         })
         self.customise_SITL_commandline(["--serial5=sim:avt_cm62_gimbal:"])
 
+        self.progress("Capture on an unconfigured camera instance must fail")
+        self.run_cmd_int(
+            mavutil.mavlink.MAV_CMD_IMAGE_START_CAPTURE,
+            p1=2,  # camera instance 2 is not configured
+            p2=0,  # interval
+            p3=1,  # total images
+            want_result=mavutil.mavlink.MAV_RESULT_FAILED,
+        )
+
     def _setup_avt_cm62_dual(self):
         '''configure two SIM_AVT_CM62 simulators on serial5 and serial6'''
         self.set_parameters({
@@ -8748,6 +8757,13 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             (mavutil.mavlink.MAV_CMD_NAV_TAKEOFF, 0, 0, 20),
             self.create_MISSION_ITEM_INT(
                 mavutil.mavlink.MAV_CMD_IMAGE_START_CAPTURE,
+                p1=0,    # 0 means all cameras
+                p2=0,    # interval (0 = single shot)
+                p3=1,    # total images = 1
+                autocontinue=1,
+            ),
+            self.create_MISSION_ITEM_INT(
+                mavutil.mavlink.MAV_CMD_IMAGE_START_CAPTURE,
                 p1=1,    # camera instance 1
                 p2=0,    # interval (0 = single shot)
                 p3=1,    # total images = 1
@@ -8810,10 +8826,11 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.start_flying_simple_relhome_mission(mission_items)
 
         self.progress("Verify CAMERA_CAPTURE_STATUS reports the interval capture")
-        # wait for camera 2 to finish the images it was asked for, leaving
-        # camera 1 as the only one with an interval set for the rest of the
-        # climb
-        self.wait_camera_img_idx([(1, 2)])
+        # wait for camera 2 to finish the images it was asked for (one
+        # from the all-cameras item, two from its own item), leaving
+        # camera 1 as the only one with an interval set for the rest of
+        # the climb
+        self.wait_camera_img_idx([(1, 3)])
         got = sorted(self.camera_capture_statuses(2))
         if got != [CAMERA_IMAGE_STATUS_IDLE, CAMERA_IMAGE_STATUS_INTERVAL_IDLE]:
             raise NotAchievedException(
@@ -8833,7 +8850,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.wait_disarmed()
 
         self.progress("Verify per-camera shot counts from mission items")
-        self.wait_camera_img_idx([(0, img_idx_at_stop), (1, 2)])
+        self.wait_camera_img_idx([(0, img_idx_at_stop), (1, 3)])
 
         self.progress("Verify CAMERA_CAPTURE_STATUS reports no interval capture")
         got = self.camera_capture_statuses(2)
@@ -8845,6 +8862,115 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             (cam1_compid, 25, 40),
             (cam2_compid, 75, 80),
         ])
+
+    def MountAVTCM62DualImageStartCapture(self):
+        '''test MAV_CMD_IMAGE_START_CAPTURE mavlink command against two
+        SIM_AVT_CM62 cameras'''
+        self._setup_avt_cm62_dual()
+
+        # note that CAMERA_FEEDBACK uses cam_idx numbers starting from 0
+        want_img_idx = [1, 1]
+        self.progress("Single image on all cameras (interval and total both zero)")
+        self.run_cmd_int(
+            mavutil.mavlink.MAV_CMD_IMAGE_START_CAPTURE,
+            p1=0,  # 0 means all cameras
+            p2=0,  # interval
+            p3=0,  # total images; zero with a zero interval means one image
+        )
+        self.wait_camera_img_idx(list(enumerate(want_img_idx)))
+
+        for cam in 0, 1:
+            self.progress(f"Single image on just cam{cam} (total images is 1)")
+            self.run_cmd_int(
+                mavutil.mavlink.MAV_CMD_IMAGE_START_CAPTURE,
+                p1=cam+1,  # camera instance
+                p2=0,      # interval
+                p3=1,      # total images
+            )
+            # the count for the other camera must not move
+            want_img_idx[cam] += 1
+            self.wait_camera_img_idx(list(enumerate(want_img_idx)))
+
+        self.progress("Fixed number of images on just cam0, via COMMAND_LONG")
+        self.run_cmd(
+            mavutil.mavlink.MAV_CMD_IMAGE_START_CAPTURE,
+            p1=1,  # camera instance 1
+            p2=1,  # interval (s)
+            p3=3,  # total images
+        )
+        want_img_idx[0] += 3
+        self.wait_camera_img_idx(list(enumerate(want_img_idx)))
+
+        self.progress("Capture-until-stopped on cam1 (total images is 0)")
+        self.run_cmd_int(
+            mavutil.mavlink.MAV_CMD_IMAGE_START_CAPTURE,
+            p1=2,  # camera instance 2
+            p2=1,  # interval (s)
+            p3=0,  # total images; zero with an interval means until stopped
+        )
+        # wait for several images so we know it does not stop by itself
+        want_img_idx[1] += 3
+        self.wait_camera_img_idx(list(enumerate(want_img_idx)))
+        got = sorted(self.camera_capture_statuses(2))
+        if got != [CAMERA_IMAGE_STATUS_IDLE, CAMERA_IMAGE_STATUS_INTERVAL_IDLE]:
+            raise NotAchievedException(
+                f"Wanted exactly one camera capturing on an interval: {got}")
+
+        self.progress("Stop the capture on cam1")
+        self.run_cmd_int(
+            mavutil.mavlink.MAV_CMD_IMAGE_STOP_CAPTURE,
+            p1=2,  # camera instance 2
+        )
+        self.progress("Wait for CAMERA_CAPTURE_STATUS to report no interval capture")
+        tstart = self.get_sim_time()
+        while True:
+            got = self.camera_capture_statuses(2)
+            if got == [CAMERA_IMAGE_STATUS_IDLE, CAMERA_IMAGE_STATUS_IDLE]:
+                break
+            if self.get_sim_time_cached() - tstart > 10:
+                raise NotAchievedException(
+                    f"Camera still has an interval set: {got}")
+        img_idx_at_stop = self.camera_feedback_img_idx(1)
+
+        self.progress("Multiple images with a zero interval must not work")
+        self.run_cmd_int(
+            mavutil.mavlink.MAV_CMD_IMAGE_START_CAPTURE,
+            p1=1,  # camera instance 1
+            p2=0,  # interval
+            p3=2,  # total images
+            want_result=mavutil.mavlink.MAV_RESULT_FAILED,
+        )
+
+        self.progress("Negative camera id must not work")
+        self.run_cmd_int(
+            mavutil.mavlink.MAV_CMD_IMAGE_START_CAPTURE,
+            p1=-1,  # invalid camera instance
+            p2=0,   # interval
+            p3=1,   # total images
+            want_result=mavutil.mavlink.MAV_RESULT_UNSUPPORTED,
+        )
+
+        self.progress("Capture on an absent camera instance must fail")
+        self.run_cmd_int(
+            mavutil.mavlink.MAV_CMD_IMAGE_START_CAPTURE,
+            p1=3,  # camera instance 3 does not exist
+            p2=0,  # interval
+            p3=1,  # total images
+            want_result=mavutil.mavlink.MAV_RESULT_FAILED,
+        )
+
+        self.progress("Two-image capture on cam0; cam1 must remain stopped")
+        self.run_cmd_int(
+            mavutil.mavlink.MAV_CMD_IMAGE_START_CAPTURE,
+            p1=1,  # camera instance 1
+            p2=1,  # interval (s)
+            p3=2,  # total images
+        )
+        # waiting for these images to arrive also spans two of cam1's
+        # old capture intervals, so this checks cam1 really stopped and
+        # that the denied/failed commands above took no images
+        want_img_idx[0] += 2
+        self.wait_camera_img_idx([(0, want_img_idx[0]), (1, img_idx_at_stop)])
 
     def assert_mount_rpy(self, r, p, y, tolerance=1):
         '''assert mount atttiude in degrees'''
@@ -20630,6 +20756,7 @@ return update, 1000
             self.MountAVTCM62,
             self.MountAVTCM62Dual,
             self.MountAVTCM62DualMission,
+            self.MountAVTCM62DualImageStartCapture,
             self.MountRCFailAngle,
             self.MountRCFailRate,
             self.FlyMissionTwice,

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -8932,22 +8932,22 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                     f"Camera still has an interval set: {got}")
         img_idx_at_stop = self.camera_feedback_img_idx(1)
 
-        self.progress("Multiple images with a zero interval must not work")
+        self.progress("Multiple images with a zero interval must be denied")
         self.run_cmd_int(
             mavutil.mavlink.MAV_CMD_IMAGE_START_CAPTURE,
             p1=1,  # camera instance 1
             p2=0,  # interval
             p3=2,  # total images
-            want_result=mavutil.mavlink.MAV_RESULT_FAILED,
+            want_result=mavutil.mavlink.MAV_RESULT_DENIED,
         )
 
-        self.progress("Negative camera id must not work")
+        self.progress("Negative camera id must be denied")
         self.run_cmd_int(
             mavutil.mavlink.MAV_CMD_IMAGE_START_CAPTURE,
             p1=-1,  # invalid camera instance
             p2=0,   # interval
             p3=1,   # total images
-            want_result=mavutil.mavlink.MAV_RESULT_UNSUPPORTED,
+            want_result=mavutil.mavlink.MAV_RESULT_DENIED,
         )
 
         self.progress("Capture on an absent camera instance must fail")

--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -460,7 +460,7 @@ MAV_RESULT AP_Camera::handle_command(const mavlink_command_int_t &packet)
         // param3 : total num images
         // sanity check instance
         if (is_negative(packet.param1)) {
-            return MAV_RESULT_UNSUPPORTED;
+            return MAV_RESULT_DENIED;
         }
         // check if this is a single picture request (e.g. total images is 1 or interval and total images are zero)
         if (is_equal(packet.param3, 1.0f) ||
@@ -479,6 +479,10 @@ MAV_RESULT AP_Camera::handle_command(const mavlink_command_int_t &packet)
             }
             return take_multiple_pictures(packet.param1-1, packet.param2*1000, -1) ? MAV_RESULT_ACCEPTED : MAV_RESULT_FAILED;
         } else {
+            if (is_zero(packet.param2)) {
+                // multiple pictures with zero interval is not permitted
+                return MAV_RESULT_DENIED;
+            }
             // take multiple pictures equal to the number specified in param3
             if (is_zero(packet.param1)) {
                 // take pictures for every backend

--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -109,50 +109,6 @@ bool AP_Camera::take_picture(uint8_t instance)
     return backend->take_picture();
 }
 
-// take multiple pictures, time_interval between two consecutive pictures is in miliseconds
-// if instance is not provided, all available cameras affected
-// time_interval_ms must be positive
-// total_num is number of pictures to be taken, -1 means capture forever
-// returns true if at least one camera is successful
-bool AP_Camera::take_multiple_pictures(uint32_t time_interval_ms, int16_t total_num)
-{
-    WITH_SEMAPHORE(_rsem);
-
-    // sanity check time interval
-    if (time_interval_ms == 0) {
-        return false;
-    }
-
-    // call for all instances
-    bool success = false;
-    for (uint8_t i = 0; i < AP_CAMERA_MAX_INSTANCES; i++) {
-        if (_backends[i] != nullptr) {
-            _backends[i]->take_multiple_pictures(time_interval_ms, total_num);
-            success = true;
-        }
-    }
-
-    // return true if at least once backend was successful
-    return success;
-}
-
-bool AP_Camera::take_multiple_pictures(uint8_t instance, uint32_t time_interval_ms, int16_t total_num)
-{
-    WITH_SEMAPHORE(_rsem);
-
-    // sanity check time interval
-    if (time_interval_ms == 0) {
-        return false;
-    }
-
-    auto *backend = get_instance(instance);
-    if (backend == nullptr) {
-        return false;
-    }
-    backend->take_multiple_pictures(time_interval_ms, total_num);
-    return true;
-}
-
 // stop capturing multiple image sequence
 void AP_Camera::stop_capture()
 {
@@ -401,6 +357,57 @@ MAV_RESULT AP_Camera::handle_mav_SET_CAMERA_FOCUS(uint8_t instance_id, SET_FOCUS
 
     return result;
 }
+
+MAV_RESULT AP_Camera::handle_mav_IMG_START_CAPTURE(const float instance, float interval, uint32_t total_num_images)
+{
+    WITH_SEMAPHORE(_rsem);
+
+    // sanity check instance
+    if (is_negative(instance)) {
+        return MAV_RESULT_DENIED;
+    }
+    const uint8_t instance_id = instance;
+
+    const uint32_t interval_ms = interval*1000;
+
+    // check if this is a single picture request (e.g. total images is 1 or interval and total images are zero)
+    const bool single_picture = (total_num_images == 1 ||
+                                 (interval_ms == 0 && total_num_images == 0));
+
+    if (!single_picture && total_num_images != 0 && interval_ms == 0) {
+        // multiple pictures with zero interval is not permitted
+        return MAV_RESULT_DENIED;
+    }
+
+    // total_num_images of zero means capture forever, which
+    // take_multiple_pictures expresses as -1
+    const int16_t total_num = total_num_images == 0 ? -1 : total_num_images;
+
+    bool success = false;
+    for (uint8_t i=0; i<AP_CAMERA_MAX_INSTANCES; i++) {
+        if (_backends[i] == nullptr) {
+            continue;
+        }
+        // honour packet instance number:
+        if (instance_id != 0 && i+1 != instance_id) {
+            continue;
+        }
+        if (single_picture) {
+            if (_backends[i]->take_picture()) {
+                success = true;
+            }
+            continue;
+        }
+        _backends[i]->take_multiple_pictures(interval_ms, total_num);
+        success = true;
+    }
+
+    if (!success) {
+        return MAV_RESULT_FAILED;
+    }
+    return MAV_RESULT_ACCEPTED;
+}
+
 #endif  // HAL_MAVLINK_BINDINGS_ENABLED
 
 // handle command_long mavlink messages
@@ -455,41 +462,11 @@ MAV_RESULT AP_Camera::handle_command(const mavlink_command_int_t &packet)
 #endif
 
     case MAV_CMD_IMAGE_START_CAPTURE:
-        // param1 : camera id
-        // param2 : interval (in seconds)
-        // param3 : total num images
-        // sanity check instance
-        if (is_negative(packet.param1)) {
-            return MAV_RESULT_DENIED;
-        }
-        // check if this is a single picture request (e.g. total images is 1 or interval and total images are zero)
-        if (is_equal(packet.param3, 1.0f) ||
-            (is_zero(packet.param2) && is_zero(packet.param3))) {
-            if (is_zero(packet.param1)) {
-                // take pictures for every backend
-                return take_picture() ? MAV_RESULT_ACCEPTED : MAV_RESULT_FAILED;
-            }
-            // take picture for specified instance
-            return take_picture(packet.param1-1) ? MAV_RESULT_ACCEPTED : MAV_RESULT_FAILED;
-        } else if (is_zero(packet.param3)) {
-            // multiple picture request, take pictures forever
-            if (is_zero(packet.param1)) {
-                // take pictures for every backend
-                return take_multiple_pictures(packet.param2*1000, -1) ? MAV_RESULT_ACCEPTED : MAV_RESULT_FAILED;
-            }
-            return take_multiple_pictures(packet.param1-1, packet.param2*1000, -1) ? MAV_RESULT_ACCEPTED : MAV_RESULT_FAILED;
-        } else {
-            if (is_zero(packet.param2)) {
-                // multiple pictures with zero interval is not permitted
-                return MAV_RESULT_DENIED;
-            }
-            // take multiple pictures equal to the number specified in param3
-            if (is_zero(packet.param1)) {
-                // take pictures for every backend
-                return take_multiple_pictures(packet.param2*1000, packet.param3) ? MAV_RESULT_ACCEPTED : MAV_RESULT_FAILED;
-            }
-            return take_multiple_pictures(packet.param1-1, packet.param2*1000, packet.param3) ? MAV_RESULT_ACCEPTED : MAV_RESULT_FAILED;
-        }
+        return handle_mav_IMG_START_CAPTURE(
+            packet.param1,  // param1 : camera id
+            packet.param2,  // param2 : interval (in seconds)
+            packet.param3   // param3 : total num images
+        );
     case MAV_CMD_IMAGE_STOP_CAPTURE:
         // param1 : camera id
         if (is_negative(packet.param1)) {

--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -109,50 +109,6 @@ bool AP_Camera::take_picture(uint8_t instance)
     return backend->take_picture();
 }
 
-// take multiple pictures, time_interval between two consecutive pictures is in miliseconds
-// if instance is not provided, all available cameras affected
-// time_interval_ms must be positive
-// total_num is number of pictures to be taken, -1 means capture forever
-// returns true if at least one camera is successful
-bool AP_Camera::take_multiple_pictures(uint32_t time_interval_ms, int16_t total_num)
-{
-    WITH_SEMAPHORE(_rsem);
-
-    // sanity check time interval
-    if (time_interval_ms == 0) {
-        return false;
-    }
-
-    // call for all instances
-    bool success = false;
-    for (uint8_t i = 0; i < AP_CAMERA_MAX_INSTANCES; i++) {
-        if (_backends[i] != nullptr) {
-            _backends[i]->take_multiple_pictures(time_interval_ms, total_num);
-            success = true;
-        }
-    }
-
-    // return true if at least once backend was successful
-    return success;
-}
-
-bool AP_Camera::take_multiple_pictures(uint8_t instance, uint32_t time_interval_ms, int16_t total_num)
-{
-    WITH_SEMAPHORE(_rsem);
-
-    // sanity check time interval
-    if (time_interval_ms == 0) {
-        return false;
-    }
-
-    auto *backend = get_instance(instance);
-    if (backend == nullptr) {
-        return false;
-    }
-    backend->take_multiple_pictures(time_interval_ms, total_num);
-    return true;
-}
-
 // stop capturing multiple image sequence
 void AP_Camera::stop_capture()
 {
@@ -401,6 +357,59 @@ MAV_RESULT AP_Camera::handle_mav_SET_CAMERA_FOCUS(uint8_t instance_id, SET_FOCUS
 
     return result;
 }
+
+MAV_RESULT AP_Camera::handle_mav_IMG_START_CAPTURE(const float instance, float interval, uint32_t total_num_images)
+{
+    WITH_SEMAPHORE(_rsem);
+
+    // sanity check instance
+    if (is_negative(instance) || instance > 255) {
+        return MAV_RESULT_DENIED;
+    }
+    const uint8_t instance_id = instance;
+
+    // commanding sub-millisecond intervals is not supported; we treat
+    // them as "take a single image:
+    const uint32_t interval_ms = interval*1000;
+
+    // check if this is a single picture request (e.g. total images is 1 or interval and total images are zero)
+    const bool single_picture = (total_num_images == 1 ||
+                                 (interval_ms == 0 && total_num_images == 0));
+
+    if (!single_picture && total_num_images != 0 && interval_ms == 0) {
+        // multiple pictures with zero interval is not permitted
+        return MAV_RESULT_DENIED;
+    }
+
+    // total_num_images of zero means capture forever, which
+    // take_multiple_pictures expresses as -1
+    const int16_t total_num = total_num_images == 0 ? -1 : total_num_images;
+
+    bool success = false;
+    for (uint8_t i=0; i<AP_CAMERA_MAX_INSTANCES; i++) {
+        if (_backends[i] == nullptr) {
+            continue;
+        }
+        // honour packet instance number:
+        if (instance_id != 0 && i+1 != instance_id) {
+            continue;
+        }
+        if (single_picture) {
+            if (_backends[i]->take_picture()) {
+                success = true;
+            }
+            continue;
+        }
+        _backends[i]->take_multiple_pictures(interval_ms, total_num);
+        success = true;
+    }
+
+    if (!success) {
+        return MAV_RESULT_FAILED;
+    }
+    return MAV_RESULT_ACCEPTED;
+}
+
 #endif  // HAL_MAVLINK_BINDINGS_ENABLED
 
 // handle command_long mavlink messages
@@ -455,41 +464,11 @@ MAV_RESULT AP_Camera::handle_command(const mavlink_command_int_t &packet)
 #endif
 
     case MAV_CMD_IMAGE_START_CAPTURE:
-        // param1 : camera id
-        // param2 : interval (in seconds)
-        // param3 : total num images
-        // sanity check instance
-        if (is_negative(packet.param1)) {
-            return MAV_RESULT_DENIED;
-        }
-        // check if this is a single picture request (e.g. total images is 1 or interval and total images are zero)
-        if (is_equal(packet.param3, 1.0f) ||
-            (is_zero(packet.param2) && is_zero(packet.param3))) {
-            if (is_zero(packet.param1)) {
-                // take pictures for every backend
-                return take_picture() ? MAV_RESULT_ACCEPTED : MAV_RESULT_FAILED;
-            }
-            // take picture for specified instance
-            return take_picture(packet.param1-1) ? MAV_RESULT_ACCEPTED : MAV_RESULT_FAILED;
-        } else if (is_zero(packet.param3)) {
-            // multiple picture request, take pictures forever
-            if (is_zero(packet.param1)) {
-                // take pictures for every backend
-                return take_multiple_pictures(packet.param2*1000, -1) ? MAV_RESULT_ACCEPTED : MAV_RESULT_FAILED;
-            }
-            return take_multiple_pictures(packet.param1-1, packet.param2*1000, -1) ? MAV_RESULT_ACCEPTED : MAV_RESULT_FAILED;
-        } else {
-            if (is_zero(packet.param2)) {
-                // multiple pictures with zero interval is not permitted
-                return MAV_RESULT_DENIED;
-            }
-            // take multiple pictures equal to the number specified in param3
-            if (is_zero(packet.param1)) {
-                // take pictures for every backend
-                return take_multiple_pictures(packet.param2*1000, packet.param3) ? MAV_RESULT_ACCEPTED : MAV_RESULT_FAILED;
-            }
-            return take_multiple_pictures(packet.param1-1, packet.param2*1000, packet.param3) ? MAV_RESULT_ACCEPTED : MAV_RESULT_FAILED;
-        }
+        return handle_mav_IMG_START_CAPTURE(
+            packet.param1,  // param1 : camera id
+            packet.param2,  // param2 : interval (in seconds)
+            packet.param3   // param3 : total num images
+        );
     case MAV_CMD_IMAGE_STOP_CAPTURE:
         // param1 : camera id
         if (is_negative(packet.param1)) {

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -106,6 +106,7 @@ public:
     MAV_RESULT handle_mav_DO_SET_CAM_TRIGG_DISTANCE(uint8_t instance_id, bool trigger, float dist_m);
     MAV_RESULT handle_mav_SET_CAMERA_ZOOM(uint8_t instance_id, CAMERA_ZOOM_TYPE mav_zoom_type, float zoom_value);
     MAV_RESULT handle_mav_SET_CAMERA_FOCUS(uint8_t instance_id, SET_FOCUS_TYPE mav_focus_type, float focus_value);
+    MAV_RESULT handle_mav_IMG_START_CAPTURE(float instance, float interval, uint32_t total_num_images);
 #endif  // HAL_MAVLINK_BINDINGS_ENABLED
 
     // select which instance to send on the next deferred MSG_CAMERA_INFORMATION send
@@ -130,14 +131,6 @@ public:
     // returns true if at least one camera took a picture
     bool take_picture();
     bool take_picture(uint8_t instance);
-
-    // take multiple pictures, time_interval between two consecutive pictures is in miliseconds
-    // if instance is not provided, all available cameras affected
-    // time_interval_ms must be positive
-    // total_num is number of pictures to be taken, -1 means capture forever
-    // returns true if at least one camera is successful
-    bool take_multiple_pictures(uint32_t time_interval_ms, int16_t total_num);
-    bool take_multiple_pictures(uint8_t instance, uint32_t time_interval_ms, int16_t total_num);
 
     // stop capturing multiple image sequence
     void stop_capture();

--- a/libraries/AP_Mission/AP_Mission_Commands.cpp
+++ b/libraries/AP_Mission/AP_Mission_Commands.cpp
@@ -169,28 +169,12 @@ bool AP_Mission::start_command_camera(const AP_Mission::Mission_Command& cmd)
 #endif
 
     case MAV_CMD_IMAGE_START_CAPTURE:
-        // check if this is a single picture request (e.g. total images is 1 or interval and total images are zero)
-        if ((cmd.content.image_start_capture.total_num_images == 1) ||
-            (cmd.content.image_start_capture.total_num_images == 0 && is_zero(cmd.content.image_start_capture.interval_s))) {
-            if (cmd.content.image_start_capture.instance == 0) {
-                // take pictures for every backend
-                return camera->take_picture();
-            }
-            return camera->take_picture(cmd.content.image_start_capture.instance-1);
-        } else if (cmd.content.image_start_capture.total_num_images == 0) {
-            // multiple picture request, take pictures forever
-            if (cmd.content.image_start_capture.instance == 0) {
-                // take pictures for every backend
-                return camera->take_multiple_pictures(cmd.content.image_start_capture.interval_s*1000, -1);
-            }
-            return camera->take_multiple_pictures(cmd.content.image_start_capture.instance-1, cmd.content.image_start_capture.interval_s*1000, -1);
-        } else {
-            if (cmd.content.image_start_capture.instance == 0) {
-                // take pictures for every backend
-                return camera->take_multiple_pictures(cmd.content.image_start_capture.interval_s*1000, cmd.content.image_start_capture.total_num_images);
-            }
-            return camera->take_multiple_pictures(cmd.content.image_start_capture.instance-1, cmd.content.image_start_capture.interval_s*1000, cmd.content.image_start_capture.total_num_images);
-        }
+        return camera->handle_mav_IMG_START_CAPTURE(
+            cmd.content.image_start_capture.instance,
+            cmd.content.image_start_capture.interval_s,
+            cmd.content.image_start_capture.total_num_images
+        ) == MAV_RESULT_ACCEPTED;
+
     case MAV_CMD_IMAGE_STOP_CAPTURE:
         if (cmd.p1 == 0) {
             // stop capture for each backend

--- a/libraries/SITL/SIM_AVT_CM62.h
+++ b/libraries/SITL/SIM_AVT_CM62.h
@@ -49,9 +49,13 @@ private:
     const char *get_camera_model_name()       const override { return "SIM_AVTA_CAM"; }
     uint32_t    get_camera_firmware_version() const override { return (3U << 16) | (2U << 8) | 1U; }
     uint32_t    get_camera_cap_flags()        const override {
+        // we lie a little about the CM62 capabilities here to allow
+        // for more comprehensive testing.  If we find a camera that
+        // supports a wider range of capabilities we should switch
+        // testing to that camera.
         return CAMERA_CAP_FLAGS_CAPTURE_IMAGE |
-               CAMERA_CAP_FLAGS_HAS_BASIC_ZOOM |   // speculative: unverified on real hardware
-               CAMERA_CAP_FLAGS_HAS_BASIC_FOCUS;   // speculative: unverified on real hardware
+               CAMERA_CAP_FLAGS_HAS_BASIC_ZOOM |   // We support MAV_CMD_SET_CAMERA_ZOOM (all zoom types except ZOOM_TYPE_FOCAL_LENGTH)
+               CAMERA_CAP_FLAGS_HAS_BASIC_FOCUS;   // We do not support MAV_CMD_SET_CAMERA_FOCUS
     }
 
     void camera_send_mavlink_message(const mavlink_message_t &msg) override {


### PR DESCRIPTION
### Summary

De-duplicates logic where multiple cameras are involved.  Adds many tests for same.  Corrects some error codes.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Removes duplicate handling of multiple-cameras commands between Mission/direct-GCS-command - before they start to diverge!

Also add some tweaks/apologies into the AVT simulation - based on feedback from the vendor.

```
Board,AP_Periph,antennatracker,blimp,bootloader,copter,heli,iofirmware,plane,rover,sub
CubeOrange-periph-heavy,*,,,*,,,,,,
Durandal,,-328,-328,*,-328,-328,,-328,-328,-328
Hitec-Airspeed,*,,,*,,,,,,
KakuteH7-bdshot,,-328,-328,*,-328,-328,,-328,-328,-328
MatekF405,,-384,-384,*,-392,-392,,-392,-384,-392
Pixhawk1-1M-bdshot,,-392,-392,,-392,-384,,-392,-384,-392
f103-QiotekPeriph,*,,,*,,,,,,
f303-Universal,*,,,*,,,,,,
iomcu,,,,,,,*,,,
revo-mini,,-392,-392,*,-392,-384,,-384,-384,-392
skyviper-v2450,,,,,-384,,,,,
```

<img width="1321" height="330" alt="image" src="https://github.com/user-attachments/assets/1756ea7c-a1f3-46e1-9953-e43883af2f43" />
<img width="3242" height="288" alt="image" src="https://github.com/user-attachments/assets/e226d244-4554-4817-a899-c7b305bd5ed5" />
<img width="3242" height="288" alt="image" src="https://github.com/user-attachments/assets/80a71fa6-2eb0-4903-b417-b02d241cae78" />
