### PR TITLE
RC_Channel/AP_Camera: add Camera Stream Video support

### DIFF
--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -190,6 +190,18 @@ bool AP_Camera::record_video(bool start_recording)
     return primary->record_video(start_recording);
 }
 
+// start/stop recording video for a specific instance
+// start_recording should be true to start recording, false to stop recording
+bool AP_Camera::stream_video(bool start_streaming)
+{
+    WITH_SEMAPHORE(_rsem);
+
+    if (primary == nullptr) {
+        return false;
+    }
+    return primary->stream_video(start_streaming);
+}
+
 // detect and initialise backends
 void AP_Camera::init()
 {
@@ -534,6 +546,25 @@ MAV_RESULT AP_Camera::handle_command(const mavlink_command_int_t &packet)
             return MAV_RESULT_FAILED;
         }
     }
+    case MAV_CMD_VIDEO_START_STREAMING:
+    case MAV_CMD_VIDEO_STOP_STREAMING:
+    {
+        bool success = false;
+        const bool start_streaming = (packet.command == MAV_CMD_VIDEO_START_STREAMING);
+        const uint8_t stream_id = packet.param1;  // Stream ID
+        if (stream_id == 0) {
+            // stream id of 0 interpreted as primary camera
+            success = stream_video(start_streaming);
+        } else {
+            // convert stream id to instance id
+            success = stream_video(stream_id - 1, start_streaming);
+        }
+        if (success) {
+            return MAV_RESULT_ACCEPTED;
+        } else {
+            return MAV_RESULT_FAILED;
+        }
+    }
     default:
         return MAV_RESULT_UNSUPPORTED;
     }
@@ -810,6 +841,21 @@ bool AP_Camera::record_video(uint8_t instance, bool start_recording)
 
     // call backend
     return backend->record_video(start_recording);
+}
+
+// start/stop streaming video
+// start_streaming should be true to start streaming, false to stop streaming
+bool AP_Camera::stream_video(uint8_t instance, bool start_streaming)
+{
+    WITH_SEMAPHORE(_rsem);
+
+    auto *backend = get_instance(instance);
+    if (backend == nullptr) {
+        return false;
+    }
+
+    // call backend
+    return backend->stream_video(start_streaming);
 }
 
 // zoom specified as a rate or percentage

--- a/libraries/AP_Camera/AP_Camera.h
+++ b/libraries/AP_Camera/AP_Camera.h
@@ -148,6 +148,11 @@ public:
     bool record_video(bool start_recording);
     bool record_video(uint8_t instance, bool start_recording);
 
+    // start/stop streaming video
+    // start_streaming should be true to start streaming, false to stop streaming
+    bool stream_video(bool start_streaming);
+    bool stream_video(uint8_t instance, bool start_streaming);
+
     // set zoom specified as a rate or percentage
     bool set_zoom(ZoomType zoom_type, float zoom_value);
     bool set_zoom(uint8_t instance, ZoomType zoom_type, float zoom_value);

--- a/libraries/AP_Camera/AP_Camera_Backend.h
+++ b/libraries/AP_Camera/AP_Camera_Backend.h
@@ -73,6 +73,10 @@ public:
     // set start_recording = true to start record, false to stop recording
     virtual bool record_video(bool start_recording) { return false; }
 
+    // start/stop streaming video.  returns true on success
+    // set start_streaming = true to start streaming, false to stop streaming
+    virtual bool stream_video(bool start_streaming) { return false; }
+
     // set zoom specified as a rate or percentage
     virtual bool set_zoom(ZoomType zoom_type, float zoom_value) { return false; }
 

--- a/libraries/AP_Camera/AP_Camera_MAVLinkCamV2.cpp
+++ b/libraries/AP_Camera/AP_Camera_MAVLinkCamV2.cpp
@@ -68,6 +68,33 @@ bool AP_Camera_MAVLinkCamV2::record_video(bool start_recording)
     return true;
 }
 
+// start/stop streaming video.  returns true on success
+// set start_streaming = true to start streaming, false to stop streaming
+bool AP_Camera_MAVLinkCamV2::stream_video(bool start_streaming)
+{
+    // exit immediately if have not found camera or does not support streaming video
+    if (_link == nullptr || !(_cam_info.flags & CAMERA_CAP_FLAGS_HAS_VIDEO_STREAM)) {
+        return false;
+    }
+
+    // prepare and send message
+    mavlink_command_long_t pkt {};
+    pkt.target_system = _sysid;
+    pkt.target_component = _compid;
+
+    if (start_streaming) {
+        pkt.command = MAV_CMD_VIDEO_START_STREAMING;
+        // param1 = 0, video stream id. 0 for all streams
+        // param2 = 0, status frequency.  frequency that CAMERA_CAPTURE_STATUS messages should be sent while recording. 0 for no messages
+    } else {
+        pkt.command = MAV_CMD_VIDEO_STOP_STREAMING;
+        // param1 = 0, video stream id. 0 for all streams
+    }
+
+    _link->send_message(MAVLINK_MSG_ID_COMMAND_LONG, (const char*)&pkt);
+    return true;
+}
+
 // set zoom specified as a rate or percentage
 bool AP_Camera_MAVLinkCamV2::set_zoom(ZoomType zoom_type, float zoom_value)
 {

--- a/libraries/AP_Camera/AP_Camera_MAVLinkCamV2.h
+++ b/libraries/AP_Camera/AP_Camera_MAVLinkCamV2.h
@@ -43,6 +43,10 @@ public:
     // set start_recording = true to start record, false to stop recording
     bool record_video(bool start_recording) override;
 
+    // start/stop streaming video.  returns true on success
+    // set start_streaming = true to start streaming, false to stop streaming
+    bool stream_video(bool start_streaming) override;
+
     // set zoom specified as a rate or percentage
     bool set_zoom(ZoomType zoom_type, float zoom_value) override;
 

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -253,6 +253,7 @@ const AP_Param::GroupInfo RC_Channel::var_info[] = {
     // @Values{Copter, Rover, Plane, Blimp, Sub}: 185:Mount Roll/Pitch Lock
     // @Values{Copter, Rover, Plane, Blimp, Sub}: 186:Mount POI Lock
     // @Values{Copter, Rover, Plane, Blimp, Sub}: 187:EKF Reset
+    // @Values{Copter, Rover, Plane, Blimp, Sub}: 188:Camera Stream Video
     // @Values{Rover}: 201:Roll
     // @Values{Rover}: 202:Pitch
     // @Values{Rover}: 207:MainSail
@@ -834,6 +835,7 @@ void RC_Channel::init_aux_function(const AUX_FUNC ch_option, const AuxSwitchPos 
     case AUX_FUNC::ARM_EMERGENCY_STOP:
 #if AP_CAMERA_ENABLED
     case AUX_FUNC::CAMERA_REC_VIDEO:
+    case AUX_FUNC::CAMERA_STREAM_VIDEO:
     case AUX_FUNC::CAMERA_ZOOM:
     case AUX_FUNC::CAMERA_MANUAL_FOCUS:
     case AUX_FUNC::CAMERA_AUTO_FOCUS:
@@ -955,6 +957,7 @@ const RC_Channel::LookupTable RC_Channel::lookuptable[] = {
 #endif
 #if AP_CAMERA_ENABLED
     { AUX_FUNC::CAMERA_REC_VIDEO, "Camera Record Video"},
+    { AUX_FUNC::CAMERA_STREAM_VIDEO, "Camera Stream Video"},
     { AUX_FUNC::CAMERA_ZOOM, "Camera Zoom"},
     { AUX_FUNC::CAMERA_MANUAL_FOCUS, "Camera Manual Focus"},
     { AUX_FUNC::CAMERA_AUTO_FOCUS, "Camera Auto Focus"},
@@ -1156,6 +1159,15 @@ bool RC_Channel::do_aux_function_record_video(const AuxSwitchPos ch_flag)
         return false;
     }
     return camera->record_video(ch_flag == AuxSwitchPos::HIGH);
+}
+
+bool RC_Channel::do_aux_function_camera_stream_video(const AuxSwitchPos ch_flag)
+{
+    AP_Camera *camera = AP::camera();
+    if (camera == nullptr) {
+        return false;
+    }
+    return camera->stream_video(ch_flag == AuxSwitchPos::HIGH);
 }
 
 bool RC_Channel::do_aux_function_camera_zoom(const AuxSwitchPos ch_flag)
@@ -1782,6 +1794,9 @@ bool RC_Channel::do_aux_function(const AuxFuncTrigger &trigger)
     }
     case AUX_FUNC::CAMERA_REC_VIDEO:
         return do_aux_function_record_video(ch_flag);
+
+    case AUX_FUNC::CAMERA_STREAM_VIDEO:
+        return do_aux_function_camera_stream_video(ch_flag);
 
     case AUX_FUNC::CAMERA_ZOOM:
         return do_aux_function_camera_zoom(ch_flag);

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -375,6 +375,9 @@ public:
 #if AP_AHRS_EKF_RESET_ENABLED
         EKF_RESET =          187, // trigger full EKF bootstrap reset
 #endif  // AP_AHRS_EKF_RESET_ENABLED
+#if AP_CAMERA_ENABLED
+        CAMERA_STREAM_VIDEO = 188, // start/stop video streaming
+#endif  // AP_CAMERA_ENABLED
         // inputs from 200 will eventually used to replace RCMAP
         ROLL =               201, // roll input
         PITCH =              202, // pitch input
@@ -504,6 +507,7 @@ protected:
     void do_aux_function_avoid_proximity(const AuxSwitchPos ch_flag);
     void do_aux_function_camera_trigger(const AuxSwitchPos ch_flag);
     bool do_aux_function_record_video(const AuxSwitchPos ch_flag);
+    bool do_aux_function_camera_stream_video(const AuxSwitchPos ch_flag);
     bool do_aux_function_camera_zoom(const AuxSwitchPos ch_flag);
     bool do_aux_function_camera_manual_focus(const AuxSwitchPos ch_flag);
     bool do_aux_function_camera_auto_focus(const AuxSwitchPos ch_flag);


### PR DESCRIPTION
### Summary

This adds a new RC auxiliary function and AP_Camera support for starting/stopping the video streaming.  This new function is only supported on the MAVLinkCamV2 backend.

I looked around to see if another existing auxiliary function might be used instead but I don't think any are quite right.  Still, I've listed the other possibilities below:

- CAM_MODE_TOGGLE <-- used by solo and RunCam to cycle through the camera modes.  We could toggle through camera, record video and streaming
- CAMERA_LENS <-- switches between lenses on multi-lens cameras so not the same
- CAMERA_REC_VIDEO <-- starts/stop recording video to the SD card
- RUNCAM_CONTROL <-- high: start recording, middle: osd options low:stop recording <-- maybe this could be combined with CAMERA_REC_VIDEO but this is out-of-scope
- VTX_POWER <-- switches between power levels on VTX Video transmitters.  Could be generalised perhaps

This has been [tested using RPanion](https://github.com/stephendade/Rpanion-server/pull/417) with a Sony IMX camera connected using CSI/MIPI

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request