### PR TITLE
AP_Camera: take _rsem in the handle_mav methods

### DIFF
--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -302,6 +302,8 @@ void AP_Camera::handle_message(mavlink_channel_t chan, const mavlink_message_t &
 // instance_id is zero or matches backend instance ID code is run
 MAV_RESULT AP_Camera::handle_mav_DO_SET_CAM_TRIGG_DISTANCE(uint8_t instance_id, bool trigger, float dist_m)
 {
+    WITH_SEMAPHORE(_rsem);
+
     for (uint8_t i=0; i<AP_CAMERA_MAX_INSTANCES; i++) {
         if (_backends[i] == nullptr) {
             continue;
@@ -321,6 +323,8 @@ MAV_RESULT AP_Camera::handle_mav_DO_SET_CAM_TRIGG_DISTANCE(uint8_t instance_id, 
 
 MAV_RESULT AP_Camera::handle_mav_SET_CAMERA_ZOOM(uint8_t instance_id, CAMERA_ZOOM_TYPE mav_zoom_type, float zoom_value)
 {
+    WITH_SEMAPHORE(_rsem);
+
     ZoomType zoom_type;
     switch (mav_zoom_type) {
     case ZOOM_TYPE_CONTINUOUS:
@@ -354,6 +358,8 @@ MAV_RESULT AP_Camera::handle_mav_SET_CAMERA_ZOOM(uint8_t instance_id, CAMERA_ZOO
 
 MAV_RESULT AP_Camera::handle_mav_SET_CAMERA_FOCUS(uint8_t instance_id, SET_FOCUS_TYPE mav_focus_type, float focus_value)
 {
+    WITH_SEMAPHORE(_rsem);
+
     // note: focus_value can be modified before it is used
 
     FocusType focus_type;


### PR DESCRIPTION
### Summary

Locks main thread against parallel mutation of state from other threads (notably scripting)

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Discovered as part of https://github.com/ArduPilot/ardupilot/pull/33900 - we need to lock the state.

These methods mutate backend state which the Lua scripting thread also accesses while holding _rsem; the camera bindings for take_picture, set_trigger_distance and get_state can race with the unlocked command path, losing counter updates or observing torn zoom/focus state.

These commands held the semaphore via the frontend methods until ef02dec9d2 ("AP_Camera: add ability to zoom and trigger multiple different cameras") replaced the frontend calls with direct backend iteration.

These were lost in the refactoring of mission/camera code relatively recently, e.g. ef02dec9d2
