### PR TITLE
AP_Bootloader: reserve board IDs for Skyronin

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -373,6 +373,9 @@ AP_HW_CBU_H753-SOM                   1302
 AP_HW_KHA_ETH                        1315
 AP_HW_SAAMPIXV1_1                    1316
 
+# IDs 1320-1329 reserved for Skyronin
+AP_HW_SkyroninL431                   1320
+
 # IDs 1330-1339 reserved for Nyxtronics
 AP_HW_NYXTRONICS_NYX405V1            1330
 


### PR DESCRIPTION
### Summary

Reserve board IDs 1320-1329 for Skyronin and allocate one entrie for
upcoming board.

### Classification & Testing

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change

### Description

We are in the process of developing Ardupilot-compatible boards and we would to reserve board IDs in board_types.txt to prevent conflicts in the future.