### PR TITLE
Log per-core source set in XKFS

### DIFF
--- a/libraries/AP_NavEKF/AP_NavEKF_Source.h
+++ b/libraries/AP_NavEKF/AP_NavEKF_Source.h
@@ -82,7 +82,6 @@ public:
 
     // set position, velocity and yaw sources to either 0=primary, 1=secondary, 2=tertiary
     void setPosVelYawSourceSet(SourceSetSelection source_set_idx);
-    uint8_t getPosVelYawSourceSet() const { return active_source_set; }
 
     // get/set velocity source
     SourceXY getVelXYSource(uint8_t core_index) const { return _source_set[getActiveSourceSet(core_index)].velxy; }

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp
@@ -100,7 +100,7 @@ void NavEKF3_core::Log_Write_XKFS(uint64_t time_us) const
         baro_index     : selected_baro,
         gps_index      : selected_gps,
         airspeed_index : getActiveAirspeed(),
-        source_set     : frontend->sources.getPosVelYawSourceSet(),
+        source_set     : frontend->sources.getActiveSourceSet(core_index),
         gps_good_to_align : gpsGoodToAlign,
         wait_for_gps_checks : waitingForGpsChecks,
         mag_fusion: (uint8_t) magFusionSel


### PR DESCRIPTION
Use getActiveSourceSet(core_index) instead of getPosVelYawSourceSet() so each EKF core logs its actual active source set.

### Summary

<!-- Put a one or two line summary of what your PR does here -->
Log correct core source

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [x] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description
AP_NavEKF3: log per-core source set in XKFS

Use getActiveSourceSet(core_index) instead of getPosVelYawSourceSet()
so each EKF core logs its actual active source set.

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->

**Testing**

I have two EKF cores configured.
Before the change, in MavProxyExplorer: graph XKFS[0].SS XKFS[1].SS
<img width="1854" height="1089" alt="graph0" src="https://github.com/user-attachments/assets/fc6d2db6-529e-4909-a0fb-d772c9815b3c" />
After the change, the same command gives
<img width="1854" height="1089" alt="graph1" src="https://github.com/user-attachments/assets/209c1bef-65ce-4b01-ba1a-bf4057c0812c" />
