### PR TITLE
Tools: Kill SITL pane on sim end when sim_vehicle.sh runs in tmux

### DIFF
--- a/Tools/autotest/run_in_terminal_window.sh
+++ b/Tools/autotest/run_in_terminal_window.sh
@@ -29,7 +29,10 @@ if [ -n "$SITL_RITW_TERMINAL" ]; then
   chmod +x "$FILEPATH"
   $SITL_RITW_TERMINAL "$FILEPATH" &
 elif [ -n "$TMUX" ]; then
-  tmux new-window -dn "$name" "$TMUX_PREFIX $*"
+  # tmux starts the pane's command from the *server's* environment, and parents
+  # it to the server, so sim_vehicle.py's cleanup paths do not reach it. Poll 
+  # whether sim_vehicle.py has died and if so close yourself too.
+  tmux new-window -dn "$name" "$TMUX_PREFIX $* & c=\$!; while kill -0 $PPID 2>/dev/null && kill -0 \$c 2>/dev/null; do sleep 1; done; kill \$c 2>/dev/null"
 elif [ -n "$DISPLAY" -a -n "$(which osascript)" ]; then
   osascript -e 'tell application "Terminal" to do script "'"cd $(pwd) && clear && $* "'"'
 elif [ -n "$DISPLAY" -a -n "$(which xterm)" ]; then


### PR DESCRIPTION
## Summary

Previously upon exit, sim_vehicle.py could not find the PID of the SITL and it would fail to close it. Now the SITL pane checks if sim_vehicle.py has died and closes itself.

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [ ] Non-functional change
- [X] No-binary change
- [X] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [X] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

When one launches `sim_vehicle.py` from tmux, the SITL binary does not launch on a new window, but on a new pane:
<img width="437" height="40" alt="Screenshot from 2026-07-30 22-47-22" src="https://github.com/user-attachments/assets/19a0cfa2-06a7-43ec-ad5e-1614c5b737ce" />

When you `Ctrl+C` `sim_vehicle.py` the SITL binary would not close, it would linger, hogging a subsequent launch. Also the tmux pane of the SITL binary would not close. One would have to manually `Ctrl+C` the SITL binary as well to close the pane.

This change fixes the behaviour and the SITL binary and pane close along with `sim_vehicle.py`.

The fix was LLM-driven, and frankly is at the limit of my understanding. The way I understand it is that the new pane is tasked to poll for the `sim_vehicle.py` PID and if it sees that it has died, it kills itself as well.

Here's what the machine has to say about it:
[tmux_pane.md](https://github.com/user-attachments/files/30598618/tmux_pane.md)

