### PR TITLE
AP_Scripting: pid.lua: don't divide by a zero dt

### DIFF
--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -5013,6 +5013,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         })
         self.install_test_modules_context()
         self.install_mavlink_module_context()
+        self.install_script_module_context(self.script_modules_source_path("pid.lua"), "pid.lua")
 
         self.install_test_scripts_context([
             "scripting_test.lua",
@@ -5020,6 +5021,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             "math.lua",
             "strings.lua",
             "mavlink_test.lua",
+            "pid_test.lua",
         ])
 
         self.context_collect('STATUSTEXT')
@@ -5032,6 +5034,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
                 "Require test 2 passed",
                 "Math tests passed",
                 "String tests passed",
+                "PID tests passed",
                 "Received heartbeat from"
         ]:
             self.wait_statustext(success_text, check_context=True)

--- a/libraries/AP_Scripting/applets/plane_follow.lua
+++ b/libraries/AP_Scripting/applets/plane_follow.lua
@@ -304,8 +304,23 @@ local windspeed_max = WINDSPEED_MAX:get()
 --- Utility Functions
 -------------------------------------------------------------------------------
 
+local last_constrain_nan_warning_ms = 0
+
 ---@diagnostic disable-next-line:lowercase-global
 function constrain(v, vmin, vmax)
+   -- a NaN fails every comparison below, so without this check it would be
+   -- returned unclamped and could propagate into a MAVLink command. Follow
+   -- AP_Math::constrain_value()'s lead: return the mid-range value, and make
+   -- noise about it rather than silently papering over the caller's bug.
+   -- Rate limited so a persistent NaN can't flood the link.
+   if v ~= v then
+      local nan_now_ms = millis():tofloat()
+      if nan_now_ms - last_constrain_nan_warning_ms > 2000 then
+         gcs:send_text(MAV_SEVERITY.ERROR, SCRIPT_NAME_SHORT .. ": constrain() got NaN, using mid-range")
+         last_constrain_nan_warning_ms = nan_now_ms
+      end
+      return (vmin + vmax) * 0.5
+   end
    if v < vmin then
       v = vmin
    end

--- a/libraries/AP_Scripting/modules/pid.lua
+++ b/libraries/AP_Scripting/modules/pid.lua
@@ -37,8 +37,24 @@ PIDcontroller.SCRIPT_NAME_SHORT = "PID"
 
 PIDcontroller.MAV_SEVERITY = {EMERGENCY=0, ALERT=1, CRITICAL=2, ERROR=3, WARNING=4, NOTICE=5, INFO=6, DEBUG=7}
 
+local last_constrain_nan_warning_ms = 0
+
 -- constrain a value between limits
 function PIDcontroller.constrain(v, vmin, vmax)
+    -- a NaN fails every comparison below, so without this check it would be
+    -- returned unclamped and could propagate into a MAVLink command. Follow
+    -- AP_Math::constrain_value()'s lead: return the mid-range value, and make
+    -- noise about it rather than silently papering over the caller's bug.
+    -- Rate limited so a persistent NaN can't flood the link.
+    if v ~= v then
+       local nan_now_ms = millis():tofloat()
+       if nan_now_ms - last_constrain_nan_warning_ms > 2000 then
+          gcs:send_text(PIDcontroller.MAV_SEVERITY.ERROR,
+                        PIDcontroller.SCRIPT_NAME_SHORT .. ": constrain() got NaN, using mid-range")
+          last_constrain_nan_warning_ms = nan_now_ms
+       end
+       return (vmin + vmax) * 0.5
+    end
     if v < vmin then
        v = vmin
     end
@@ -122,7 +138,11 @@ function PIDcontroller.PID_controller(kP,kI,kD,iMax,min,max)
             _error = _error + self.get_filt_E_alpha(dt) * ((_target - current) - _error);
 
             -- calculate and filter derivative
-            if (dt >= 0) then
+            -- dt must be strictly positive: at dt == 0 this divide is 0/0 when
+            -- the error is unchanged (NaN) and +/-Inf otherwise, and either
+            -- poisons _derivative and every later output of this controller.
+            -- AC_PID guards the same divide with is_positive(dt).
+            if (dt > 0) then
                 local derivative = (_error - error_last) / dt;
                 _derivative = _derivative + self.get_filt_D_alpha(dt) * (derivative - _derivative);
             end

--- a/libraries/AP_Scripting/tests/pid_test.lua
+++ b/libraries/AP_Scripting/tests/pid_test.lua
@@ -1,0 +1,82 @@
+--[[
+   tests for the shared pid.lua module
+
+   The regression this mainly guards is a NaN escaping the controller: a NaN
+   propagates silently through every later output, and for a controller driving
+   an airspeed demand it ends up in a MAVLink command and traps in SITL.
+--]]
+
+local pid = require("pid")
+
+-- true only for a real, usable number
+local function is_finite(v)
+   return v == v and v ~= math.huge and v ~= -math.huge
+end
+
+gcs:send_text(6, "testing pid module")
+
+-------------------------------------------------------------------------------
+-- constrain()
+-------------------------------------------------------------------------------
+
+-- ordinary clamping still behaves
+assert(pid.constrain(5, 0, 10) == 5)
+assert(pid.constrain(-1, 0, 10) == 0)
+assert(pid.constrain(11, 0, 10) == 10)
+
+-- a NaN fails every comparison, so an unguarded constrain() would hand it
+-- straight back. It must be clamped to something usable instead.
+local nan = 0.0/0.0
+assert(nan ~= nan) -- sanity: this really is a NaN
+local constrained_nan = pid.constrain(nan, 10, 20)
+assert(is_finite(constrained_nan))
+assert(constrained_nan >= 10 and constrained_nan <= 20)
+
+-- infinities must be clamped by the normal comparisons
+assert(pid.constrain(math.huge, 10, 20) == 20)
+assert(pid.constrain(-math.huge, 10, 20) == 10)
+
+-------------------------------------------------------------------------------
+-- PID_controller update() must never emit a non-finite value
+-------------------------------------------------------------------------------
+
+--[[
+   Two updates within the same microsecond give dt == 0. The derivative term
+   divides by dt, which is 0/0 (NaN) when the error is unchanged and +/-Inf
+   otherwise; either poisons the controller for the rest of the flight. Freeze
+   micros() to reproduce that deterministically rather than relying on timing.
+--]]
+local real_micros = micros
+local frozen_us = real_micros()
+micros = function() return frozen_us end -- luacheck: ignore
+
+local controller = pid.PID_controller(0.1, 0.1, 0.1, 1.0, 0, 100)
+
+-- first call initialises the filter, the rest run with dt == 0
+for _ = 1, 5 do
+   assert(is_finite(controller.update(0, 0)))
+end
+for i = 1, 5 do
+   assert(is_finite(controller.update(i * 2, i)))
+end
+
+micros = real_micros -- luacheck: ignore
+
+--[[
+   The damage from dividing by dt == 0 is not just the one bad output: it is
+   latched into the derivative state and every later update inherits it. A
+   clamp on the way out hides that, so check the controller still *responds*
+   to its input rather than just that the number looks reasonable - a poisoned
+   controller returns the same clamped value no matter what it is asked for.
+--]]
+local low = controller.update(10, 0)
+local high = controller.update(90, 0)
+assert(is_finite(low) and is_finite(high))
+assert(low ~= high, "controller stopped responding to its input")
+
+function update() -- luacheck: ignore
+   gcs:send_text(6, 'PID tests passed')
+   return update, 1000
+end
+
+return update()


### PR DESCRIPTION
### Summary

`PIDcontroller.update()` in `modules/pid.lua` divided by `dt` without requiring `dt` to be positive, producing a `NaN`/`Inf` derivative that was latched into the controller. For `plane_follow.lua`, whose output becomes a
`GUIDED_CHANGE_SPEED` airspeed demand, that reached `guided_state.target_airspeed_cm` and tripped the SITL floating point trap.

This fixes the divide, and hardens both `constrain()` implementations to follow the C++ convention rather than silently swallowing a NaN.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Concretely, three things change:

- constrain(NaN, ...) returns a different value — previously the NaN itself, now the mid-range value.
- The PID output differs whenever dt == 0 — previously a poisoned derivative, now the derivative term is simply skipped.
- New GCS ERROR messages appear that never existed before. That's user-visible on the ground station.

I questioned whether this is a non-functional change. Here's the response:
Your instinct isn't wrong about the part that matters most in practice: in nominal operation the outputs are bit-identical. When dt > 0 and nothing is NaN — which is essentially always — dt >= 0 and dt > 0 take the same branch and produce the same numbers. So if the convention you're working to is "no change to normal flight behaviour," it'd qualify as a non-functional change.

`update()` guarded the derivative divide with `dt >= 0`, which admits `dt == 0`.
Two updates landing in the same microsecond then evaluate

```lua
(_error - error_last) / dt
```

as `0/0` when the error is unchanged, and `±Inf` when it is not. Either result is
stored in `_derivative`, so the controller is poisoned for every subsequent
update rather than just the one that hit the bad `dt`. `AC_PID` guards the same
divide with `is_positive(dt)`; `pid.lua` now uses `dt > 0` to match.

This was reachable in flight. `plane_follow.lua` feeds the controller's output to `GUIDED_CHANGE_SPEED`, so the NaN reached `guided_state.target_airspeed_cm` and was trapped by SITL in `Plane::calc_airspeed_errors()`:

```
Floating point exception - aborting
#6 is_positive<float> (fVal1=-nan(0x400000)) at libraries/AP_Math/AP_Math.h:68
#7 Plane::calc_airspeed_errors () at ArduPlane/navigation.cpp:191
        airspeed_lower_bound = nan(0x200000)
```

`constrain()` in both `pid.lua` and `plane_follow.lua` returned a NaN unchanged,
since a NaN compares false against both limits. Simply clamping it would have
hidden the defect above instead of fixing it, so these now follow
`AP_Math::constrain_value()`: return the mid-range value and report it on the
GCS, rate limited so a persistent NaN cannot flood the link.

Note that an earlier revision of this PR attributed the NaN to the turn-radius
`tan()` singularity in `plane_follow.lua`. That was incorrect — that value is
gated by `if my_airspeed > 0 ...`, which a NaN fails, so it never reaches the
vehicle. The `dt` divide above is the actual source.

There are 14 other hand-rolled `constrain()` implementations in
`libraries/AP_Scripting` with the same NaN behaviour. They are deliberately left
alone here: `constrain_float` is not exposed in `bindings.desc`, and a single
shared implementation is a better fix than clamping each copy. Proposed as
separate work.

### Testing

`libraries/AP_Scripting/tests/pid_test.lua` is added and run from the Rover scripting internal test. It freezes `micros()` to force `dt == 0` deterministically, then checks the controller still responds to its input — a clamp alone does not restore that, so the test fails on a clamp-only fix. Verified it fails on both the original code and on a clamp-without-`dt`-fix build, and passes with this change.

This was added to the rover tests ecause that's where the vehicle-agnostic Lua module tests already live. test_scripting_internal_test in rover.py is the existing home for math.lua, strings.lua, mavlink_test.lua and scripting_test.lua — none of which are Rover-specific either. Adding to it cost 3 lines; putting it under Plane would have meant new scaffolding for a test that isn't about Plane.

Also run: `Plane.PlaneFollowAppletSanity`, `Rover.Scripting`, `luacheck` clean on
all changed scripts.

More extensive end-to-end coverage of `plane_follow.lua` — flying a real second SITL instance as the follow target — is in #33432 (`Plane.PlaneFollowApplet`). That test is what surfaced this crash in CI.

### AI assistance

This contribution was AI-assisted (Claude Code). AI was used for the investigation, the code changes, and `tests/pid_test.lua`. I directed the work, reviewed every change, and ran the SITL testing described above.

Worth noting for reviewers: the AI's first diagnosis of this bug was wrong — it attributed the NaN to the turn-radius `tan()` singularity. I pushed back on it, based on feedback from @tpwrules  and @peterbarker , which led to retrieving the actual CI stack trace and finding the `dt == 0` divide. The retracted explanation is called out in the Description above so the earlier revision of this PR isn't taken at face value.