### PR TITLE
AP_OSD: use Betaflight SYM_TOTAL_DISTANCE for DisplayPort distance icon

### DIFF
--- a/libraries/AP_OSD/AP_OSD_MSP_DisplayPort.h
+++ b/libraries/AP_OSD/AP_OSD_MSP_DisplayPort.h
@@ -150,7 +150,7 @@ private:
     static const uint8_t SYM_FENCE_ENABLED = 0xF5;
     static const uint8_t SYM_FENCE_DISABLED = 0xF6;
     static const uint8_t SYM_RNGFD = 0x7F;
-    static const uint8_t SYM_LQ = 0xF8;
+    static const uint8_t SYM_LQ = 0x7B;
 
     static const uint8_t SYM_SIDEBAR_L_ARROW = 0x02;
     static const uint8_t SYM_SIDEBAR_R_ARROW = 0x03;

--- a/libraries/AP_OSD/AP_OSD_MSP_DisplayPort.h
+++ b/libraries/AP_OSD/AP_OSD_MSP_DisplayPort.h
@@ -139,7 +139,7 @@ private:
     static const uint8_t SYM_XERR = 0x21;
     static const uint8_t SYM_KN = 0xF0;
     static const uint8_t SYM_NM = 0xF1;
-    static const uint8_t SYM_DIST = 0x04;
+    static const uint8_t SYM_DIST = 0x71;
     static const uint8_t SYM_FLY = 0x9C;
     static const uint8_t SYM_EFF = 0xF2;
     static const uint8_t SYM_AH = 0xF3;


### PR DESCRIPTION
### Summary

Fixes the DJI O4 OSD showing a throttle icon next to the distance-flown panel by remapping SYM_DIST from 0x04 to 0x71 in the MSP DisplayPort BTFL font table.

Also remaps SYM_LQ from 0xF8, which rendered no icon, to 0x7B (SYM_LINK_QUALITY).

Fixes #33895

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Hardware testing by @boa-pe: MicoairH743v2 + DJI O4 and O4 Pro + Goggles 3 and both icons confirmed displaying correctly (see PR comments)

Compiled successfully for SITL copter.
Glyph correctness verified against the OSD glyph [reference](https://betaflight.com/docs/development/OSD-Glyps)
The reporter's parameter file (shared in the forum thread) confirms MSP_OPTIONS=4 (Betaflight fonts) and OSD_TYPE=5 (MSP DisplayPort)



### Description

The OSDn_DIST (distance flown) panel prefixes its values with SYM_DIST.
On MSP DisplayPort with Betaflight fonts enabled, SYM_DIST was mapped to font index 0x04 which in the Betaflight font is SYM_THR. This resulted in the DJI goggles drawing a throttle symbol next to the distance value. This remap to 0x71 is the proper total distance glyph Betaflight uses - SYM_TOTAL_DISTANCE.

SYM_LQ (link quality) was similar, mapped to 0xF8 which has no glyph defined in the Betaflight font, so no icon rendered. 0x7B is defined as SYM_LINK_QUALITY in osd_symbols.h