### PR TITLE
AP_HAL_ChibiOS: fix STM32L4+ bootloader build with no I2C configured

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/common/stm32l4+_mcuconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/stm32l4+_mcuconf.h
@@ -239,6 +239,18 @@
 /*
  * I2C driver system settings.
  */
+#ifndef STM32_I2C_USE_I2C1
+#define STM32_I2C_USE_I2C1                  FALSE
+#endif
+#ifndef STM32_I2C_USE_I2C2
+#define STM32_I2C_USE_I2C2                  FALSE
+#endif
+#ifndef STM32_I2C_USE_I2C3
+#define STM32_I2C_USE_I2C3                  FALSE
+#endif
+#ifndef STM32_I2C_USE_I2C4
+#define STM32_I2C_USE_I2C4                  FALSE
+#endif
 #define STM32_I2C_BUSY_TIMEOUT              50
 #define STM32_IRQ_I2C1_PRIORITY             5
 #define STM32_IRQ_I2C2_PRIORITY             5


### PR DESCRIPTION
### Summary

Correct compilation of PixFlamingo bootloader

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Compilation fails before / passed afterwards

```
git submodule update --init --recursive  && rm -rf build && ./waf configure --board=PixFlamingo --bootloader &&  ./waf bootloader
```

### Description

The STM32L4+ port's stm32_isr.c unconditionally includes the stm32_i2c1..4.inc ISR files, which require STM32_I2C_USE_I2Cx to be defined. In bootloader builds HAL_USE_I2C is FALSE so hal_i2c_lld.h (which supplies FALSE defaults) is never included, breaking the PixFlamingo bootloader build.

Add ifndef-guarded FALSE defaults, matching the STM32G4 fix in abffee1520.
