### PR TITLE
AP_Scripting: nest parameter names one level below Parameters headings

### DIFF
--- a/libraries/AP_Scripting/applets/BattEstimate.md
+++ b/libraries/AP_Scripting/applets/BattEstimate.md
@@ -15,27 +15,27 @@ for).
 Then you should restart scripting or reboot and set the following
 parameters per SoC estimator.
 
-## BATT_SOCn_IDX
+### BATT_SOCn_IDX
 
 The IDX is the battery index, starting at 1.
 
-## BATT_SOCn_NCELL
+### BATT_SOCn_NCELL
 
 Set the number of cells in your battery in the NCELL parameter
 
-## BATT_SOCn_C1
+### BATT_SOCn_C1
 
 C1 is the first coefficient from your fit of your battery
 
-## BATT_SOCn_C2
+### BATT_SOCn_C2
 
 C2 is the second coefficient from your fit of your battery
 
-## BATT_SOCn_C3
+### BATT_SOCn_C3
 
 C3 is the third coefficient from your fit of your battery
 
-## BATT_SOCn_C4
+### BATT_SOCn_C4
 
 C4 is the fourth coefficient from your fit of your battery
 

--- a/libraries/AP_Scripting/applets/BatteryTag.md
+++ b/libraries/AP_Scripting/applets/BatteryTag.md
@@ -9,15 +9,15 @@ The data for each battery is logged in the BTAG log message
 
 ## Parameters
 
-## BTAG_ENABLE
+### BTAG_ENABLE
 
 Allow for enable/disable of the script
 
-## BTAG_MAX_CYCLES
+### BTAG_MAX_CYCLES
 
 Maximum number of battery cycles to allow arming
 
-## BTAG_CUR_CYCLES
+### BTAG_CUR_CYCLES
 
 Current maximum of number of cycles from all active BatteryTag
 nodes. This can be used by other scripts to adjust battery percentage

--- a/libraries/AP_Scripting/applets/RockBlock-9704.md
+++ b/libraries/AP_Scripting/applets/RockBlock-9704.md
@@ -27,7 +27,7 @@ Caveats:
 
 The script has the following parameters:
 
-## RK9_FORCEHL
+### RK9_FORCEHL
 
 Mode of operation:
 
@@ -35,38 +35,38 @@ Mode of operation:
 - 1 = start enabled, can be disabled via MAV_CMD_CONTROL_HIGH_LATENCY
 - 2 = enabled on loss of telemetry (GCS) link for RK9_TIMEOUT seconds
 
-## RK9_PERIOD
+### RK9_PERIOD
 
 When in High Latency mode, send Rockblock updates every RK9_PERIOD seconds. Defaults to 30 seconds.
 
-## RK9_DEBUG
+### RK9_DEBUG
 
 Sends Rockblock debug text to GCS via statustexts. Defaults to 0 (disabled).
 
-## RK9_ENABLE
+### RK9_ENABLE
 
 Enables the modem transmission. Defaults to 1 (enabled).
 
-## RK9_TIMEOUT
+### RK9_TIMEOUT
 
 If RK9_FORCEHL=2, this is the number of seconds of no-messages from the GCS until High Latency mode is auto-enabled.
 Defaults to 5 seconds.
 
-## RK9_SERPORT
+### RK9_SERPORT
 
 Serial port number to which the Rockblock is connected.
 This is the index of the SERIALn_ ports that are set to 28 for "scripting". Defaults to 0.
 
-## RK9_SCRPORT
+### RK9_SCRPORT
 
 Scripting Serial port number to which the Rockblock is connected for HL2 messages.
 This is the index of the SCR_SDEV ports that are set to 2 for "MavlinkHL". Defaults to 0.
 
-## RK9_RELAY
+### RK9_RELAY
 
 RELAYn output to control Rockblock power. This connects to I_EN on the Rockblock header. Defaults to RELAY1.
 
-## RK9_BOOTED
+### RK9_BOOTED
 
 SERVOn GPIO pin number (usually 50 or greater) that reads the Rockblock booted state.
 This connects to I_BTD on the Rockblock header. Requires SERVOn_FUNCTION=-1. Defaults to 52 (SERVO3).

--- a/libraries/AP_Scripting/applets/RockBlock.md
+++ b/libraries/AP_Scripting/applets/RockBlock.md
@@ -28,7 +28,7 @@ Caveats:
 
 The script adds the following parameters:
 
-## RCK_FORCEHL
+### RCK_FORCEHL
 
 Mode of operation:
 
@@ -36,19 +36,19 @@ Mode of operation:
 - 1 = start enabled, can be disabled via MAV_CMD_CONTROL_HIGH_LATENCY
 - 2 = enabled on loss of telemetry (GCS) link for RCK_TIMEOUT seconds
 
-## RCK_PERIOD
+### RCK_PERIOD
 
 When in High Latency mode, send Rockblock updates every RCK_PERIOD seconds
 
-## RCK_DEBUG
+### RCK_DEBUG
 
 Sends Rockblock debug text to GCS via statustexts
 
-## RCK_ENABLE
+### RCK_ENABLE
 
 Enables the modem transmission
 
-## RCK_TIMEOUT
+### RCK_TIMEOUT
 
 If RCK_FORCEHL=2, this is the number of seconds of no-messages from the GCS until High Latency mode is auto-enabled
 

--- a/libraries/AP_Scripting/applets/VTOL-quicktune.md
+++ b/libraries/AP_Scripting/applets/VTOL-quicktune.md
@@ -13,34 +13,34 @@ VTOL modes.
 The script adds 7 parameters to control it's behaviour. The parameters
 are:
 
-## QUIK_ENABLE
+### QUIK_ENABLE
 
 this must be set to 1 to enable the script
 
-## QUIK_RC_FUNC
+### QUIK_RC_FUNC
 
 The RCz_OPTIONS scripting function binding to be used for this script.
 Default RCz_OPTIONS binding is 300 (scripting1).
 
-## QUIK_AXES
+### QUIK_AXES
 
 This is the set of axes that the tune will run on. The default is 7,
 which means roll, pitch and yaw. It is a bitmask, so if you want just
 roll and pitch then set this to 3. For just yaw you would set it to 4.
 
-## QUIK_DOUBLE_TIME
+### QUIK_DOUBLE_TIME
 
 This controls how quickly a gain is raised while tuning. It is a time
 in seconds for the gain to double. Most users will want to leave this
 at the default of 10 seconds.
 
-## QUIK_GAIN_MARGIN
+### QUIK_GAIN_MARGIN
 
 This is the percentage gain margin to use. Once the oscillation point
 for a gain is found the gain is reduced by this percentage. The
 default of 60% is good for most users.
 
-## QUIK_OSC_SMAX
+### QUIK_OSC_SMAX
 
 This is the oscillation threshold in Hertz for detecting oscillation
 when a gain is raised. The default of 5Hz is good for most vehicles,
@@ -52,7 +52,7 @@ You can tell you have this set too high if you still have visible
 oscillations after a parameter has completed tuning. In that case
 halve this parameter and try again.
 
-## QUIK_YAW_P_MAX
+### QUIK_YAW_P_MAX
 
 This sets a limit on the YAW_P rate gain. The yaw axis on most
 multirotor style vehicles needs to have a much lower limit on the P
@@ -60,7 +60,7 @@ gain than the oscillation limit to ensure that enough control remains
 for roll, pitch and thrust. A maximum of 0.5 is good for most VTOL
 vehicles.
 
-## QUIK_YAW_D_MAX
+### QUIK_YAW_D_MAX
 
 This sets a limit on the YAW_D rate gain. The yaw axis on most
 multirotor style vehicles needs to have a much lower limit on the D
@@ -68,7 +68,7 @@ gain than the oscillation limit to ensure that enough control remains
 for roll, pitch and thrust. A maximum of 0.01 is good for most VTOL
 vehicles.
 
-## QUIK_RP_PI_RATIO
+### QUIK_RP_PI_RATIO
 
 This is the ratio for P to I for roll and pitch axes. This should
 normally be 1, but on some large vehicles a value of up to 3 can be
@@ -77,7 +77,7 @@ used if the I term in the PID is causing too much phase lag.
 If QUIK_RP_PI_RATIO is less than 1 then the I value will not be
 changed at all when P is changed.
 
-## QUIK_Y_PI_RATIO
+### QUIK_Y_PI_RATIO
 
 This is the ratio for P to I for the yax axis. This should
 normally be 10, but a different value may be needed on some vehicle
@@ -86,12 +86,12 @@ types.
 If QUIK_Y_PI_RATIO is less than 1 then the I value will not be
 changed at all when P is changed.
 
-## QUIK_AUTO_FILTER
+### QUIK_AUTO_FILTER
 
 This enables automatic setting of the PID filters based on the
 INS_GYRO_FILTER value. Set to zero to disable this feature.
 
-## QUIK_AUTO_SAVE
+### QUIK_AUTO_SAVE
 
 This enables automatic saving of the tune if this number of seconds
 pass after the end of the tune without reverting the tune. Setting
@@ -99,7 +99,7 @@ this to a non-zero value allows you to use quicktune with a 2-position
 switch, with the switch settings as low and mid positions. A zero
 value disables auto-save and you need to have a 3 position switch.
 
-## QUIK_MAX_REDUCE
+### QUIK_MAX_REDUCE
 
 This controls how much quicktune is allowed to lower gains from the
 original gains. If the vehicle already has a reasonable tune and is

--- a/libraries/AP_Scripting/applets/actuator_chirp.md
+++ b/libraries/AP_Scripting/applets/actuator_chirp.md
@@ -24,48 +24,48 @@ disconnected as appropriate.
 
 The script adds the following parameters to control its behaviour.
 
-## ACHRP_CHAN
+### ACHRP_CHAN
 
 The 1-based servo/ESC output channel to drive with the chirp. Setting
 this to a channel number starts the chirp, and setting it to zero
 stops it. It is reset to zero on boot, and automatically set back to
 zero when the chirp completes.
 
-## ACHRP_PWM_MIN
+### ACHRP_PWM_MIN
 
 The lower PWM bound of the chirp waveform. Together with
 ACHRP_PWM_MAX this sets the center point and amplitude of the sweep.
 
-## ACHRP_PWM_MAX
+### ACHRP_PWM_MAX
 
 The upper PWM bound of the chirp waveform.
 
-## ACHRP_F_START
+### ACHRP_F_START
 
 The chirp start frequency in Hz. The script dwells at this frequency
 for a short time before the sweep begins.
 
-## ACHRP_F_STOP
+### ACHRP_F_STOP
 
 The chirp stop frequency in Hz. Must be greater than or equal to the
 start frequency.
 
-## ACHRP_F_FADE_IN
+### ACHRP_F_FADE_IN
 
 The time in seconds to ramp the chirp amplitude from zero to full at
 the start of the sweep.
 
-## ACHRP_F_FADE_OUT
+### ACHRP_F_FADE_OUT
 
 The time in seconds to ramp the chirp amplitude back to zero at the
 end of the sweep.
 
-## ACHRP_TIME
+### ACHRP_TIME
 
 The total sweep time in seconds, including the initial dwell and the
 fade-in and fade-out periods.
 
-## ACHRP_TYPE
+### ACHRP_TYPE
 
 The type of actuator being tested. Set to 0 for an ESC (feedback is
 RPM from ESC telemetry) or 1 for a servo (feedback is measured

--- a/libraries/AP_Scripting/applets/arming-checks.md
+++ b/libraries/AP_Scripting/applets/arming-checks.md
@@ -12,80 +12,80 @@ There is a single parameter defined for each arming check. The error or warning 
 
 All arming check parameters are prefixed with ARM_. Copter specific checks are prefexed with ARM_C_, Plane specific checks are prefixed with ARM_P_, Rover specific checks are prefixed with ARM_R_, Blimp specific checks are prefixed with ARM_B_, Antenna Tracker specific checks are prefixe with ARM_A_, TradHeli specific checks are prefixed with ARM_H_.
 
-## Generic checks
+### Generic checks
 
 These checks apply to all firmware types
 
-## ARM_SYSID
+#### ARM_SYSID
 
 If the SYSID_THISMAV parameter has not been changed from it's default value of 1, this arming check will prevent arming. This is intended to be used in large fleets, were SYSID_THISMAV should always be set.
 
-## ARM_FOLL_SYSID_X
+#### ARM_FOLL_SYSID_X
 
 If the FOLL_SYSID parameter has not been changed from it's default value of 0, this arming check will prevent arming. This is intended to be used in large fleets flying in swarms, were FOLL_SYSID should almost always be set.
 
-## ARM_FOLL_OFS_DEF
+#### ARM_FOLL_OFS_DEF
 
 Follow offsets should not be left as the default (0). If using the Follow library, leaving the follow offsets at zero will
 mean the follow vehicle will attempt to fly to where the target is, which would likely cause a crash.
 
-## ARM_MNTX_SYSID
+#### ARM_MNTX_SYSID
 
 If the MNTX_SYSID parameter does not match the FOLL_SYSID, this arming check will prevent arming. This is intended to be used in large fleets flying in swarms, were the camera mount should always be pointing to the vehicle being followed.
 
-## ARM_RTL_CLIMB
+#### ARM_RTL_CLIMB
 
 This check is to by default warn if the vehicle RTL_CLIMB has not been set. This is intended to be an example of how specific configuration checks could be added for specific requirements without having to change the firmware.
 
-## ARM_ESTOP
+#### ARM_ESTOP
 
 This check will fail if the motors are emergency stopped. The standard pre-arm will not prevent arming if the emergency stop
 has been set by a switch (set using RCx_OPTION = 165). This check will prevent arming regardless of the reason for the EStop.
 
-## ARM_FENCE
+#### ARM_FENCE
 
 If fences are loaded but no fence is enabled this will prevent arming.
 
-## ARM_RALLY
+#### ARM_RALLY
 
 If there is a rally point more than RALLY_LIMIT_KM kilometers from the home location, this will prevent arming..T
 
-## Copter specific checks
+### Copter specific checks
 
 The following checks only apply if the firmware is ArduCopter
 
-## ARM_C_RTL_ALT_M
+#### ARM_C_RTL_ALT_M
 
 This check is to by default warn if the vehicle RTL_ALT_M has been set to a value > ARM_V_ALT_LEGAL.
 
-## Plane specific checks
+### Plane specific checks
 
 The following checks only apply if the firmware is ArduPlane
 
-## ARM_P_RTL_ALT
+#### ARM_P_RTL_ALT
 
 This check is to by default warn if RTL_ALTITUDE > ARM_V_ALT_LEGAL which defaults to 120m (400ft) which is the legal limit in many jurisdictions. This is intended to be an example of how specific configuration checks could be added for specific requirements without having to change the firmware.
 
-## ARM_P_QRTL_ALT
+#### ARM_P_QRTL_ALT
 
 This check is to by default warn if Q_RTL_ALT > ARM_V_ALT_LEGAL which defaults to 120m (400ft) which is the legal limit in many jurisdictions. This is intended to be an example of how specific configuration checks could be added for specific requirements without having to change the firmware.
 
-## ARM_P_Q_FS_LAND and ARM_P_Q_FS_RTL
+#### ARM_P_Q_FS_LAND and ARM_P_Q_FS_RTL
 
 These two checks are to display important configuration information for a vehicle at boot time. One of these checks should be displayed. Neither is an error. This is to demonstrate how to notify the pilot of important configuration information at boot time without preventing flying.
 
-## ARM_P_AIRSPEED
+#### ARM_P_AIRSPEED
 
 The values of AIRSPEED_STALL (optional) should be less than AIRSPEED_MIN which should be less than AIRSPEED_CRUISE
 which should be less than AIRSPEED_MAX. This validates that this rule has not been broken.
 
-## ARM_P_STALL
+#### ARM_P_STALL
 
 AIRSPEED_STALL is a newly added and optional value, but if set, AIRSPEED_MIN should not be more than 25% higher
 than AIRSPEED_STALL. When looked at the other way round, AIRSPEED_STALL should not be more than 20% lower than
 AIRSPEED_MIN.
 
-## ARM_P_SCALING
+#### ARM_P_SCALING
 
 The SCALING_SPEED should be close to AIRSPEED_CRUISE. Its quite easy to remember to set AIRSPEED_CRUISE correctly
 when setting up an aircraft, but not to reset SCALING_SPEED. The aircraft should be retuned if SCALING_SPEED is changed. The airThis gives a warning if the values are very different.

--- a/libraries/AP_Scripting/applets/camera-change-settings.md
+++ b/libraries/AP_Scripting/applets/camera-change-settings.md
@@ -4,7 +4,7 @@ Allows changing some camera settings that are not normallly used by the autopilo
 
 ## Parameters
 
-## CAM1_THERM_PAL
+### CAM1_THERM_PAL
 
 Set the camera's thermal palette
 
@@ -22,7 +22,7 @@ Supported values are
 10: BlackHot
 11: GloryHot
 
-## CAM1_THERM_GAIN
+### CAM1_THERM_GAIN
 
 Set the camera's thermal gain
 
@@ -31,7 +31,7 @@ Supported values are
 0: LowGain (50C to 550C)
 1: HighGain (-20C to 150C)
 
-## CAM1_THERM_RAW
+### CAM1_THERM_RAW
 
 Enable/Disable the saving of raw thermal images.  Enabling raw iamges slightly slows the live video feed
 

--- a/libraries/AP_Scripting/applets/copter_terrain_brake.md
+++ b/libraries/AP_Scripting/applets/copter_terrain_brake.md
@@ -8,11 +8,11 @@ is useful when flying in LOITER mode in steep terrain.
 
 The script adds the following parameters to control it's behaviour.
 
-## TERR_BRK_ENABLE
+### TERR_BRK_ENABLE
 
 This must be set to 1 to enable the script.
 
-## TERR_BRK_ALT
+### TERR_BRK_ALT
 
 This is the terrain altitude threshold for engaging BRAKE mode. The
 onboard terrain system must be enabled with TERRAIN_ENABLE=1 and
@@ -23,14 +23,14 @@ station over MAVLink.
 Make sure you set sufficient margin to cope with obstacles such as
 trees or any local towers or other obstacles.
 
-## TERR_BRK_HDIST
+### TERR_BRK_HDIST
 
 This is the distance from home for the BRAKE checking to be
 enabled. The default of 100 meters is good for most operations. This
 threshold allows you to take over in LOITER mode for low altitude
 operations and takeoff/landing when close to home.
 
-## TERR_BRK_SPD
+### TERR_BRK_SPD
 
 This is a speed threshold BRAKE checking to be enabled. If both the
 horizontal speed and the descent rate are below this threshold then

--- a/libraries/AP_Scripting/applets/net_webserver.md
+++ b/libraries/AP_Scripting/applets/net_webserver.md
@@ -6,25 +6,25 @@ This implements a web server for boards that have networking support.
 
 The web server has a small number of parameters
 
-## WEB_ENABLE
+### WEB_ENABLE
 
 This must be set to 1 to enable the web server
 
-## WEB_BIND_PORT
+### WEB_BIND_PORT
 
 This sets the network port to use for the server. It defaults to 8080
 
-## WEB_DEBUG
+### WEB_DEBUG
 
 This enables verbose debugging
 
-## WEB_BLOCK_SIZE
+### WEB_BLOCK_SIZE
 
 This sets the block size for network and file read/write
 operations. Setting a larger value can increase performance at the
 cost of more memory
 
-## WEB_TIMEOUT
+### WEB_TIMEOUT
 
 This sets the timeout in seconds for inactive client connections.
 

--- a/libraries/AP_Scripting/applets/plane_follow.md
+++ b/libraries/AP_Scripting/applets/plane_follow.md
@@ -19,83 +19,83 @@ The script adds the following parameters to control it's behaviour. It uses
 the existing FOLL parameters that are used for the Copter FOLLOW mode. In addition
 the following "FOLLP" parameters are added.
 
-## FOLLP_FAIL_MODE
+### FOLLP_FAIL_MODE
 
 This is the mode the plane will change to if following fails. Failure happens
 if the following plane loses telemetry from the target, or the distance exceeds
 FOLL_DIST_MAX.
 
-## FOLLP_EXIT_MODE
+### FOLLP_EXIT_MODE
 
 The flight mode the plane will switch to if it exits following.
 
-## FOLLP_ACT_FN
+### FOLLP_ACT_FN
 
 The scripting action that will trigger the plane to start following. When this
 happens the plane will switch to GUIDED mode and the script will use guided mode
 commands to steer the plane towards the target.
 
-## FOLLP_TIMEOUT
+### FOLLP_TIMEOUT
 
 If the target is lost, this is the timeout to wait to re-aquire the target before
 triggering FOLLP_FAIL_MODE
 
-## FOLLP_OVRSHT_DEG
+### FOLLP_OVRSHT_DEG
 
 This is for the heuristic that uses the difference between the target vehicle heading
 and the follow vehicle heading to determine if the vehicle has overshot and should slow
 down and turn around. 75 degrees is a good start but tune for your circumstances.
 
-## FOLLP_TURN_DEG
+### FOLLP_TURN_DEG
 
 This is for the heuristic that uses the difference between the target vehicle heading
 and the follow vehicle heading to determine if the target vehicle is executing a turn.
 15 degrees is a good start but tune for your circumstances.
 
-## FOLLP_DIST_CLOSE
+### FOLLP_DIST_CLOSE
 
 One of the most important heuristics the follow logic uses to match the heading and speed
 of the target plane is to trigger different behavior when the target location is "close".
 How close is determined by this value, likely a larger number makes more sense for larger
 and faster vehicles and lower values for smaller and slower vehicles. Tune for your circumstances.
 
-## FOLLP_ALT_OVR
+### FOLLP_ALT_OVR
 
 The follow logic can have the follow vehicle track the altitude of the target, but setting a value
 in FOLLP_ALT_OVR allows the follow vehicle to follow at a fixed altitude regardless of the altitude
 of the target. The FOLLP_ALT_OVR is in meters in FOLL_ALT_TYPE frame.
 
-## FOLLP_D_P
+### FOLLP_D_P
 
 The follow logic uses two PID controllers for controlling speed, the first uses distance (D)
 as the error. This is the P gain for the "D" PID controller.
 
-## FOLLP_D_I
+### FOLLP_D_I
 
 The follow logic uses two PID controllers for controlling speed, the first uses distance (D)
 as the error. This is the I gain for the "D" PID controller.
 
-## FOLLP_D_D
+### FOLLP_D_D
 
 The follow logic uses two PID controllers for controlling speed, the first uses distance (D)
 as the error. This is the D gain for the "D" PID controller.
 
-## FOLLP_V_P
+### FOLLP_V_P
 
 The follow logic uses two PID controllers for controlling speed, the first uses velocity (V)
 as the error. This is the P gain for the "V" PID controller.
 
-## FOLLP_V_I
+### FOLLP_V_I
 
 The follow logic uses two PID controllers for controlling speed, the first uses distance (V)
 as the error. This is the I gain for the "V" PID controller.
 
-## FOLLP_V_D
+### FOLLP_V_D
 
 The follow logic uses two PID controllers for controlling speed, the first uses distance (V)
 as the error. This is the D gain for the "V" PID controller.
 
-## FOLLP_LKAHD
+### FOLLP_LKAHD
 
 Time to "lookahead" when calculating distance errors.
 

--- a/libraries/AP_Scripting/applets/plane_package_place.md
+++ b/libraries/AP_Scripting/applets/plane_package_place.md
@@ -10,24 +10,24 @@ enable scripting with SCR_ENABLE=1 and reboot.
 
 The script adds the following parameters:
 
-## PKG_ENABLE
+### PKG_ENABLE
 
 You need to set PKG_ENABLE=1 to enable this script
 
-## PKG_RELEASE_FUNC
+### PKG_RELEASE_FUNC
 
 This needs to be set to the SERVOn_FUNCTION of the release servo. It
 is recommended that you leave it at the default of 94 and set
 SERVOn_FUNCTION to 94 for the servo you want to use for package
 release.
 
-## PKG_RELEASE_HGT
+### PKG_RELEASE_HGT
 
 The parameter PKG_RELEASE_HGT controls the rangefinder height at which
 the package will be released. This can be zero if you want to release
 the package after you land.
 
-## PKG_RELEASE_HOLD
+### PKG_RELEASE_HOLD
 
 This controls the time that the vehicle will stop the descent before
 it releases the package. This defaults to 1 second and is used to let

--- a/libraries/AP_Scripting/applets/plane_precland.md
+++ b/libraries/AP_Scripting/applets/plane_precland.md
@@ -11,7 +11,7 @@ QLAND, QRTL and AUTO landing.
 Beyond the normal PLND parameters the script adds 2 additional parameters to
 control it's behaviour. The parameters are:
 
-## PLND_ALT_CUTOFF
+### PLND_ALT_CUTOFF
 
 This is an optional altitude in meters below which the precision
 landing system will stop correcting the landing position. Many
@@ -19,7 +19,7 @@ precision landing sensors have poor performance at low altitudes, so
 setting this to around 5 meters is advisable. A value of zero disables
 this cutoff.
 
-## PLND_DIST_CUTOFF
+### PLND_DIST_CUTOFF
 
 This is a maximum horizontal distance in meters that will be accepted
 for a landing corrections. If this parameter is greater than zero and

--- a/libraries/AP_Scripting/applets/quadplane_terrain_avoid.md
+++ b/libraries/AP_Scripting/applets/quadplane_terrain_avoid.md
@@ -35,71 +35,71 @@ Note:
 Beyond the normal Q_ASSIST parameters the script adds several additional parameters to
 control it's behaviour. The parameters are prefixed with ZTA and ZTB. The parameters are:
 
-## TA_ACT_FN
+### TA_ACT_FN
 
 An RC scripting function to disable terrain avoidance. It defaults to on.
 
-## TA_HOME_DIST
+### TA_HOME_DIST
 
 A circle around home (in meters), where terrain avoidance will not run.
 Allows for safe takeoff and landing at the home location.
 
-## TA_ALT_MAX
+### TA_ALT_MAX
 
 Maximum altitude above terrain that the plane can go to if avoiding terrain.
 Set this to avoid "flyways" usually caused by malfunctioning rangefinders.
 
-## TA_PTCH_DWN_MIN
+### TA_PTCH_DWN_MIN
 
 The minimum distance to the ground directly when pitching will start.
 
-## TA_PTCH_FWD_MIN
+### TA_PTCH_FWD_MIN
 
 The minimum distance forward where pitching will start. This requires
 a forward facing range finder best installed pointing at a 45 degree
 angle.
 
-## TA_PTCH_GSP_MIN
+### TA_PTCH_GSP_MIN
 
 The minimum groundspeed to use pitching. If groundspeed is below this then
 pitching will not be attempted.
 
-## TA_QUAD_DWN_MIN
+### TA_QUAD_DWN_MIN
 
 The minimum distance to the ground directly when quading will start.
 Should be lower than TA_PTCH_DWN_MIN by at least 5m.
 
-## TA_QUAD_FWD_MIN
+### TA_QUAD_FWD_MIN
 
 The minimum distance forward where quadinging will start. This requires
 a forward facing range finder best installed pointing at a 45 degree
 angle. (the same one used by TA_PTCH_FWD_MIN)
 
-## TA_GSP_MAX
+### TA_GSP_MAX
 
 The maximum groundspeed to attempt to fly. For best results when doing
 magnetometry surveys ideally a steady groundspeed is required even
 in windy conditions. This attempts to achieve that.
 
-## TA_GSP_AIRBRAKE
+### TA_GSP_AIRBRAKE
 
 If the vehicle exceeds ZTB_GSP_MAX and slowing the motors (desired airspeed)
 isn't working then if this is set to 1, the script will attempt to use QHOVER
 to reduce airspeed. This doesn't work very well, so test it for your use case.
 It defaults to off.
 
-## TA_CMTC_ENABLE
+### TA_CMTC_ENABLE
 
 Enable the Can't Make That Climb (CMTC) feature, which will circle to gain altitude if
 the required pitch up to the next waypoint exceeds PTCH_LIM_MAX_DEG / 2.
 
-## TA_CMTC_HGT
+### TA_CMTC_HGT
 
 If CMTC is enabled, uses this height as the clearance required above terrain altitude to
 use for CMTC calculation. If the plane can't make this number of meters clearance above the
 terrain between the current location and the next waypoint then CMTC will be engaged.
 
-## TA_CMTC_RAD
+### TA_CMTC_RAD
 
 When loitering to gain altitude if CMTC is triggered, use this as the loiter radius. If not set
 or is <= 0 then use WP_LOITER_RAD. Should normally be set lower than WP_LOITER_RAD.

--- a/libraries/AP_Scripting/applets/revert_param.md
+++ b/libraries/AP_Scripting/applets/revert_param.md
@@ -11,11 +11,11 @@ changes to the values from startup.
 The script adds 2 parameters to control it's behaviour. The parameters
 are:
 
-## PREV_ENABLE
+### PREV_ENABLE
 
 this must be set to 1 to enable the script
 
-## PREV_RC_FUNC
+### PREV_RC_FUNC
 
 The RCz_OPTIONS scripting function binding to be used for this script.
 Default RCz_OPTIONS binding is 300 (scripting1).

--- a/libraries/AP_Scripting/applets/rover-quicktune.md
+++ b/libraries/AP_Scripting/applets/rover-quicktune.md
@@ -67,56 +67,56 @@ If the vehicle is not able to turn correctly to enter or track the circle, the `
 
 The script has the following parameters to configure its behaviour
 
-## RTUN_ENABLE
+### RTUN_ENABLE
 
 Set to 1 to enable the script
 
-## RTUN_RC_FUNC
+### RTUN_RC_FUNC
 
 The RCx_OPTIONS function number to be used to start/stop tuning
 By default RCx_OPTIONS of 300 (scripting1) is used
 
-## RTUN_AXES
+### RTUN_AXES
 
 The axes that will be tuned. The default is 3 meaning steering and speed
 This parameter is a bitmask, so set 1 to tune just steering.  2 for just speed
 
-## RTUN_STR_FFRATIO
+### RTUN_STR_FFRATIO
 
 Ratio between measured response and FF gain. Raise this to get a higher FF gain
 The default of 0.9 is good for most users.
 
-## RTUN_STR_P_RATIO
+### RTUN_STR_P_RATIO
 
 Ratio between steering FF and P gains. Raise this to get a higher P gain, 0 to leave P unchanged
 The default of 0.2 is good for most users.
 
-## RTUN_STR_I_RATIO
+### RTUN_STR_I_RATIO
 
 Ratio between steering FF and I gains. Raise this to get a higher I gain, 0 to leave I unchanged
 The default of 0.2 is good for most users.
 
-## RTUN_SPD_FFRATIO
+### RTUN_SPD_FFRATIO
 
 Ratio between measured response and CRUISE_THROTTLE value. Raise this to get a higher CRUISE_THROTTLE value
 The default of 1.0 is good for most users.
 
-## RTUN_SPD_P_RATIO
+### RTUN_SPD_P_RATIO
 
 Ratio between speed FF and P gain. Raise this to get a higher P gain, 0 to leave P unchanged
 The default of 1.0 is good for most users.
 
-## RTUN_SPD_I_RATIO
+### RTUN_SPD_I_RATIO
 
 Ratio between speed FF and I gain. Raise this to get a higher I gain, 0 to leave I unchanged
 The default of 1.0 is good for most users.
 
-## RTUN_AUTO_FILTER
+### RTUN_AUTO_FILTER
 
 This enables automatic setting of the PID filters based on the
 INS_GYRO_FILTER value. Set to zero to disable this feature.
 
-## RTUN_AUTO_SAVE
+### RTUN_AUTO_SAVE
 
 Enables automatic saving of the gains this many seconds after the tuning
 completes unless the pilot move the RC switch low to revert the tune.
@@ -124,7 +124,7 @@ Setting this to a non-zero value allows you to use quicktune with a 2-position
 switch, with the switch settings as low and mid positions. A zero
 value disables auto-save and you need to have a 3 position switch.
 
-## RTUN_SPEED_MIN
+### RTUN_SPEED_MIN
 
 The minimum speed at which tuning will occur. The vehicle must be able to
 run in Circle mode at this speed or greater.

--- a/libraries/AP_Scripting/applets/throttle_kill.md
+++ b/libraries/AP_Scripting/applets/throttle_kill.md
@@ -12,24 +12,24 @@ using a low throttle input.
 
 The script creates a set of parameters with names starting withg THR_KILL
 
-## THR_KILL_FUNC
+### THR_KILL_FUNC
 
 This is the auxillary function to use for activating the throttle
 kill. This should be set to a scripting auxillary function such as 300
 
-## THR_KILL_CHAN
+### THR_KILL_CHAN
 
 This is the output channel to apply the throttle kill to. This is
 normally 3 for SERVO3
 
-## THR_KILL_VAL
+### THR_KILL_VAL
 
 This is the auxiliary function value to activate the kill
 switch. This is normally 2 meaning to activate on a high value of the
 auxillary function. If you want it to activate on low values then set
 this to 0.
 
-## THR_KILL_DEF
+### THR_KILL_DEF
 
 This is the default auxiliary function value at startup. If you want
 the engine to be killed by default on startup then set this to the

--- a/libraries/AP_Scripting/applets/x-quad-cg-allocation.md
+++ b/libraries/AP_Scripting/applets/x-quad-cg-allocation.md
@@ -19,7 +19,7 @@ not use in any other frame configuration!
 
 The script adds 1 parameter to control its behaviour.
 
-## CGA_RATIO
+### CGA_RATIO
 
 This is the desired ratio between the front and back thrust. To have the front
 motors produce more lift that the rear, increase higher than 1.

--- a/libraries/AP_Scripting/drivers/BattMon_ANX.md
+++ b/libraries/AP_Scripting/drivers/BattMon_ANX.md
@@ -6,15 +6,15 @@ This driver implements support for the ANX CAN battery protocol
 
 The script used the following parameters:
 
-## BATT_ANX_ENABLE
+### BATT_ANX_ENABLE
 
 this must be set to 1 to enable the driver
 
-## BATT_ANX_CANDRV
+### BATT_ANX_CANDRV
 
 This sets the scripting CAN driver to use, this should be 1 or 2.
 
-## BATT_ANX_INDEX
+### BATT_ANX_INDEX
 
 This sets the battery monitor index to use. Set to 1 for BATT1, 2 for
 BATT2 etc

--- a/libraries/AP_Scripting/drivers/EFI_DLA.md
+++ b/libraries/AP_Scripting/drivers/EFI_DLA.md
@@ -9,11 +9,11 @@ this system:
 
 The script used the following parameters:
 
-## EFI_DLA_ENABLE
+### EFI_DLA_ENABLE
 
 this must be set to 1 to enable the driver
 
-## EFI_DLA_LPS
+### EFI_DLA_LPS
 
 This sets the fuel consumption rate in litres per second of injector
 time. This will need to be tuned per engine to give the right value

--- a/libraries/AP_Scripting/drivers/EFI_DLA64.md
+++ b/libraries/AP_Scripting/drivers/EFI_DLA64.md
@@ -6,7 +6,7 @@ This driver implements support for the DLA64 EFI serial protocol
 
 The script used the following parameters:
 
-## EFI_DFA64_ENABLE
+### EFI_DFA64_ENABLE
 
 this must be set to 1 to enable the driver
 

--- a/libraries/AP_Scripting/drivers/EFI_HFE.md
+++ b/libraries/AP_Scripting/drivers/EFI_HFE.md
@@ -9,32 +9,32 @@ ICE subsystem in fixed wing aircraft for engine control.
 
 The script used the following parameters:
 
-## EFI_HFE_ENABLE
+### EFI_HFE_ENABLE
 
 this must be set to 1 to enable the driver
 
-## EFI_HFE_CANDRV
+### EFI_HFE_CANDRV
 
 This sets the CAN scripting driver number to attach to. This is
 normally set to 1 to use a CAN driver with CAN_Dx_PROTOCOL=10. To use
 the 2nd scripting CAN driver set this to 2 and set CAN_Dx_PROTOCOL=12.
 
-## EFI_HFE_ECU_IDX
+### EFI_HFE_ECU_IDX
 
 This sets the ECU number on the CAN bus. A value of zero means that
 the ECU number is auto-detected based on the first ECU seen on the
 bus.
 
-## EFI_HFE_RATE_HZ
+### EFI_HFE_RATE_HZ
 
 This sets the update rate of the driver. A value of 200 is reasonable
 
-## EFI_HFE_FUEL_DTY
+### EFI_HFE_FUEL_DTY
 
 This sets the fuel density in grams per litre, for fuel consumption
 calculations
 
-## EFI_HFE_REL_IDX
+### EFI_HFE_REL_IDX
 
 This sets a relay number to use for the ECU enable function. if the
 ECU requires a high voltage GPIO to enable then you should set a

--- a/libraries/AP_Scripting/drivers/EFI_Halo6000.md
+++ b/libraries/AP_Scripting/drivers/EFI_Halo6000.md
@@ -7,17 +7,17 @@ multicopters, using CAN protocol.
 
 The script used the following parameters:
 
-## EFI_H6K_ENABLE
+### EFI_H6K_ENABLE
 
 this must be set to 1 to enable the driver
 
-## EFI_H6K_CANDRV
+### EFI_H6K_CANDRV
 
 This sets the CAN scripting driver number to attach to. This is
 normally set to 1 to use a CAN driver with CAN_Dx_PROTOCOL=10. To use
 the 2nd scripting CAN driver set this to 2 and set CAN_Dx_PROTOCOL=12.
 
-## EFI_H6K_START_FN
+### EFI_H6K_START_FN
 
 This is the RC option to use to monitor start control. This should be
 set to one of the scripting RC options (from 300 to 307). Then an
@@ -26,16 +26,16 @@ the generator start function will be sent to the ECU. When this switch
 goes low a generator stop will be sent. A value of 0 disables the starter
 control.
 
-## EFI_H6K_TELEM_RT
+### EFI_H6K_TELEM_RT
 
 This is the rate in Hz at which NAMED_VALUE_FLOAT messages are used to
 send additional telemetry data to the GCS for display to the operator.
 
-## EFI_H6K_FUELTOT
+### EFI_H6K_FUELTOT
 
 This is the total fuel tank capacity in litres
 
-## EFI_H6K_OPTIONS
+### EFI_H6K_OPTIONS
 
 This provides additional options. Currently just one option is
 available. If you set EFI_H6K_OPTIONS to 1 then all CAN frames will be

--- a/libraries/AP_Scripting/drivers/EFI_NMEA2k.md
+++ b/libraries/AP_Scripting/drivers/EFI_NMEA2k.md
@@ -7,11 +7,11 @@ CAN messages.
 
 The script used the following parameters:
 
-## EFI_2K_ENABLE
+### EFI_2K_ENABLE
 
 this must be set to 1 to enable the driver
 
-## EFI_2K_OPTIONS
+### EFI_2K_OPTIONS
 
 This sets options for the driver. Currently the only option is to set
 EFI_2K_OPTIONS to 1 to enable logging of the raw CAN frames for

--- a/libraries/AP_Scripting/drivers/EFI_SkyPower.md
+++ b/libraries/AP_Scripting/drivers/EFI_SkyPower.md
@@ -7,34 +7,34 @@ control units. It supports monitoring and control of SkyPower engines.
 
 The script used the following parameters:
 
-## EFI_SP_ENABLE
+### EFI_SP_ENABLE
 
 this must be set to 1 to enable the driver
 
-## EFI_SP_CANDRV
+### EFI_SP_CANDRV
 
 This sets the CAN scripting driver number to attach to. This is
 normally set to 1 to use a CAN driver with CAN_Dx_PROTOCOL=10. To use
 the 2nd scripting CAN driver set this to 2 and set CAN_Dx_PROTOCOL=12.
 
-## EFI_SP_UPDATE_HZ
+### EFI_SP_UPDATE_HZ
 
 This sets the update rate of the script in Hz (how often it checks for
 new data from the ECU). A value of 200 is reasonable.
 
-## EFI_SP_THR_FN
+### EFI_SP_THR_FN
 
 This sets the SERVOn_FUNCTION number to monitor for throttle
 command. For fixed wing forward throttle this should be set to 70. For
 heli RSC control this should be set to 31. If set to zero then no
 throttle control will be done by the driver.
 
-## EFI_SPI_THR_RATE
+### EFI_SPI_THR_RATE
 
 This is the throttle output rate in Hz. A value of zero will disable
 throttle control. A typical rate would be 50Hz.
 
-## EFI_SP_START_FN
+### EFI_SP_START_FN
 
 This is the RC option to use to monitor start control. This should be
 set to one of the scripting RC options (from 300 to 307). Then an
@@ -43,7 +43,7 @@ the engine start function will be sent to the ECU. When this switch
 goes low a engine stop will be sent. A value of 0 disables the starter
 control.
 
-## EFI_SP_GEN_FN
+### EFI_SP_GEN_FN
 
 This is the RC option (auxiliary function) to use for generator
 control. This should be set to one of the scripting RC options (from
@@ -53,7 +53,7 @@ start function will be sent to the ECU. When this switch goes low a
 generator stop will be sent. A value of 0 disables the generator
 control.
 
-## EFI_SP_MIN_RPM
+### EFI_SP_MIN_RPM
 
 This is the minimum running RPM. When set to a positive value then the
 driver will monitor engine RPM when the engine is started and if it

--- a/libraries/AP_Scripting/drivers/Generator_SVFFI.md
+++ b/libraries/AP_Scripting/drivers/Generator_SVFFI.md
@@ -7,7 +7,7 @@ this system [SVFFI](http://www.svffi.com/en/)
 
 The script used the following parameters:
 
-## EFI_SVF_ENABLE
+### EFI_SVF_ENABLE
 
 this must be set to 1 to enable the driver
 

--- a/libraries/AP_Scripting/drivers/Hobbywing_DataLink.md
+++ b/libraries/AP_Scripting/drivers/Hobbywing_DataLink.md
@@ -10,16 +10,16 @@ to 8 ESCs.
 
 The script used the following parameters:
 
-## ESC_HW_ENABLE
+### ESC_HW_ENABLE
 
 this must be set to 1 to enable the driver
 
-## ESC_HW_POLES
+### ESC_HW_POLES
 
 this should be set to the number of motor poles for eRPM to RPM
 scaling. Please confirm the correct RPM using a tachometer
 
-## ESC_HW_OFS
+### ESC_HW_OFS
 
 this parameter sets an offset for the first ESC number. It is useful
 on vehicles where the first ESC is not the first SERVOn output, for

--- a/libraries/AP_Scripting/drivers/INF_Inject.md
+++ b/libraries/AP_Scripting/drivers/INF_Inject.md
@@ -9,11 +9,11 @@ control units.
 
 The script used the following parameters:
 
-## EFI_INF_ENABLE
+### EFI_INF_ENABLE
 
 this must be set to 1 to enable the driver
 
-## EFI_INF_OPTIONS
+### EFI_INF_OPTIONS
 
 This sets options for the driver. Currently the only option is to set
 EFI_INF_OPTIONS to 1 to enable logging of the raw serial bytes to a

--- a/libraries/AP_Scripting/drivers/LTE_modem.md
+++ b/libraries/AP_Scripting/drivers/LTE_modem.md
@@ -31,12 +31,12 @@ There are some limitations:
 
 The script uses the following parameters:
 
-## LTE_ENABLE
+### LTE_ENABLE
 
 This must be set to 1 to enable the driver. Set to 0 to disable the
 LTE modem driver.
 
-## LTE_PROTOCOL
+### LTE_PROTOCOL
 
 This controls if a PPP connection will be used or a raw TCP connection
 with MAVLink2.
@@ -50,12 +50,12 @@ parameters for the TCP server you want to connect to.
 Note that the LTE_PROTOCOL parameter must match the value of the
 SCR_SDEVn_PROTO parameter.
 
-## LTE_SERPORT
+### LTE_SERPORT
 
 This sets the serial port to use for the LTE modem. This is the index
 of the SERIALn_ ports that are set to 28 for "scripting".
 
-## LTE_SCRPORT
+### LTE_SCRPORT
 
 This sets the scripting serial port to use for the LTE modem. This is
 the index of the SCR_SDEVn ports that are set to 2 for "MAVLink2". This
@@ -63,51 +63,51 @@ port handles the MAVLink data that will be transmitted over the LTE
 connection. You must first set SCR_SDEV_EN to 1 to enable scripting
 serial devices.
 
-## LTE_SERVER_IP0
+### LTE_SERVER_IP0
 
 This is the first octet of the server IP address to connect to. The
 full IP address is constructed from LTE_SERVER_IP0 through
 LTE_SERVER_IP3. Range: 0-255. This is not used with PPP.
 
-## LTE_SERVER_IP1
+### LTE_SERVER_IP1
 
 This is the second octet of the server IP address to connect to.
 Range: 0-255. This is not used with PPP.
 
-## LTE_SERVER_IP2
+### LTE_SERVER_IP2
 
 This is the third octet of the server IP address to connect to.
 Range: 0-255. This is not used with PPP.
 
-## LTE_SERVER_IP3
+### LTE_SERVER_IP3
 
 This is the fourth octet of the server IP address to connect to.
 Range: 0-255. This is not used with PPP.
 
-## LTE_SERVER_PORT
+### LTE_SERVER_PORT
 
 This sets the IPv4 port of the server to connect to. This should match
 the port that your ground control station or server is listening on.
 Range: 1-65525. This is not used with PPP.
 
-## LTE_BAUD
+### LTE_BAUD
 
 This sets the baud rate for the serial port to the LTE modem to use
 for data transfer. Common values are 115200 or 921600. Default:
 115200.
 
-## LTE_IBAUD
+### LTE_IBAUD
 
 The initial baud rate when the modem is powered on. This is normally
 115200 but can be changed in the modem using the AT+IREX terminal command.
 
-## LTE_TIMEOUT
+### LTE_TIMEOUT
 
 This sets the timeout in seconds for the LTE connection. If no data is
 received for this time, the connection will be reset and the driver
 will attempt to reconnect. Range: 1-60 seconds. Default: 10 seconds.
 
-## LTE_OPTIONS
+### LTE_OPTIONS
 
 This sets options for debugging and data display
 

--- a/libraries/AP_Scripting/drivers/UltraMotion.md
+++ b/libraries/AP_Scripting/drivers/UltraMotion.md
@@ -6,23 +6,23 @@ This driver implements support for the UltraMotion CAN servos
 
 The script used the following parameters:
 
-## UM_SERVO_MASK
+### UM_SERVO_MASK
 
 Mask of servo channels to transmit using UltraMotion CAN messages
 
-## UM_CANDRV
+### UM_CANDRV
 
 This sets the CAN scripting driver number to attach to. This is
 normally set to 1 to use a CAN driver with CAN_Dx_PROTOCOL=10. To use
 the 2nd scripting CAN driver set this to 2 and set CAN_Dx_PROTOCOL=12.
 
-## UM_RATE_HZ
+### UM_RATE_HZ
 
 This sets the update rate of the script in Hz (how often it sends
 commands and checks for new data from the actuator). A value of 200 is
 reasonable.
 
-## UM_OPTIONS
+### UM_OPTIONS
 
 This sets optional features. Set bit 1 for enabling CAN logging. Bit 2
 enables telemetry parsing. Bit 3 for sending the position of all

--- a/libraries/AP_Scripting/drivers/VSPeak_flow_meter.md
+++ b/libraries/AP_Scripting/drivers/VSPeak_flow_meter.md
@@ -102,27 +102,27 @@ PWM pulse.
 
 The script used the following parameters:
 
-## VSPF_ENABLE
+### VSPF_ENABLE
 
 Setting this to 1 enables the driver.
 
-## VSPF_BAT_IDX
+### VSPF_BAT_IDX
 
 Selects which battery monitor instance will be fed the fuel consumption
 information. 1-indexed.
 
-## VSPF_CFACT
+### VSPF_CFACT
 
 This is multiplicative factor to correct the measured flow. Set to <1 if your
 sensor measures too high and vice versa.
 
-## VSPF_MODE
+### VSPF_MODE
 
 Tells the script which mode it is operating in.
 0: Mode A, save consumption.
 1: Mode B, reset consumption.
 
-## VSPF_PORT
+### VSPF_PORT
 
 Which Scripting serial port the sensor is connected at.
 Set to 0 to select the first serial port, 1 to select the 2nd serial port, etc...


### PR DESCRIPTION
### Summary

Correct nesting depth of parameters in applets and drivers

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Before: 
<img width="2316" height="1018" alt="image" src="https://github.com/user-attachments/assets/32058308-acc1-4c1b-a527-b1931fb6357b" />

After:
<img width="2316" height="1018" alt="image" src="https://github.com/user-attachments/assets/e8592390-eb38-40fe-be6f-66bc90755608" />


### Description

Parameter-name headings in the driver and applet markdown docs were at the same level as the "Parameters" heading they sit under, so they rendered as siblings rather than being nested within that section. Demote them one level throughout.
