### PR TITLE
Plane: reject a NaN airspeed in GUIDED_CHANGE_SPEED

### DIFF
--- a/ArduPlane/mode_guided.cpp
+++ b/ArduPlane/mode_guided.cpp
@@ -122,6 +122,12 @@ bool ModeGuided::handle_guided_request(Location target_loc)
 #if AP_PLANE_OFFBOARD_GUIDED_SLEW_ENABLED
 bool ModeGuided::handle_change_airspeed(const float airspeed, const float acceleration)
 {
+    // a NaN compares false against both limits below, so it would pass the
+    // envelope check and be stored as the guided airspeed target
+    if (isnan(airspeed)) {
+        return false;
+    }
+
     // reject airspeeds that are outside of the tuning envelope
     if (airspeed > plane.aparm.airspeed_max || airspeed < plane.aparm.airspeed_min) {
         return false;

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -941,6 +941,33 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
         self.reboot_sitl(force=True)
 
+    def GuidedChangeSpeedNaN(self):
+        '''ensure GUIDED_CHANGE_SPEED rejects a NaN airspeed'''
+        # a NaN compares false against both envelope limits, so before the fix
+        # it passed the range check and was stored as the guided airspeed
+        # target, where the next is_positive() on it tripped the SITL floating
+        # point trap and aborted the vehicle
+        self.takeoff(alt=100, mode="TAKEOFF", timeout=120)
+        self.set_rc(3, 1500)
+        self.change_mode("GUIDED")
+        self.send_do_reposition(self.get_location(frame=AltFrame.ABOVE_HOME))
+        self.delay_sim_time(5, reason="vehicle to establish GUIDED position")
+
+        self.run_cmd(
+            mavutil.mavlink.MAV_CMD_GUIDED_CHANGE_SPEED,
+            p1=0,              # SPEED_TYPE_AIRSPEED
+            p2=float("nan"),   # target airspeed m/s
+            p3=5,              # acceleration m/s/s
+            want_result=mavutil.mavlink.MAV_RESULT_FAILED,
+        )
+
+        # keep flying; an accepted NaN would abort the vehicle here rather
+        # than merely leaving a bad target behind
+        self.delay_sim_time(10, reason="vehicle to keep flying on a sane airspeed")
+        self.assert_mode("GUIDED")
+
+        self.reboot_sitl(force=True)
+
     def DO_CHANGE_SPEED_mavlink_int(self):
         self.DO_CHANGE_SPEED_mavlink(self.run_cmd_int)
 
@@ -8710,6 +8737,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.TestFlaps,
             self.DO_CHANGE_SPEED,
             self.GuidedThrottleNudge,
+            self.GuidedChangeSpeedNaN,
             self.DO_REPOSITION,
             self.GuidedRequest,
             self.MainFlight,


### PR DESCRIPTION
### Summary

`ModeGuided::handle_change_airspeed()` screens airspeeds against the tuning envelope with two comparisons, both of which are false for a NaN. A NaN passed the check, was stored in `guided_state.target_airspeed_cm`, and aborted the vehicle on the next `is_positive()` evaluation of it.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

`ArduPlane/mode_guided.cpp`:

```cpp
if (airspeed > plane.aparm.airspeed_max || airspeed < plane.aparm.airspeed_min) {
    return false;
}
```

A NaN compares false against both limits, so it is neither "too high" nor "too low" and falls through as if valid. It is then multiplied by 100 and written to `guided_state.target_airspeed_cm`. The next scheduler pass through `Plane::calc_airspeed_errors()` evaluates `is_positive(guided_state.target_airspeed_cm)` and raises SIGFPE:

```
Floating point exception - aborting
#6 is_positive<float> (fVal1=-nan(0x400000)) at libraries/AP_Math/AP_Math.h:68
#7 Plane::calc_airspeed_errors () at ArduPlane/navigation.cpp:191
```

This is reachable from any source of the command, not just one script: `MAV_CMD_GUIDED_CHANGE_SPEED` from a GCS or companion computer, and `AP_ExternalControl_Plane::set_airspeed()` (DDS/ROS 2), all call `handle_change_airspeed()`.

The check added here mirrors the existing NaN screening in the same subsystem (`GCS_MAVLink_Plane.cpp` already rejects a NaN `param4` in `MAV_CMD_DO_REPOSITION`), and the neighbouring `GUIDED_CHANGE_ALTITUDE` handler likewise rejects known-dangerous values before storing them.

Rejecting rather than clamping is deliberate: the command is refused with `MAV_RESULT_FAILED`, so whatever produced the NaN still learns that its command did not take effect instead of silently flying a substituted value.

### Testing

`Plane.GuidedChangeSpeedNaN` sends `MAV_CMD_GUIDED_CHANGE_SPEED` with a NaN airspeed while in GUIDED, asserts it is refused, and keeps flying for 10s afterwards. Verified against freshly built binaries in both directions: with
the fix reverted the vehicle aborts and the test fails with a lost connection; with the fix applied it passes.

### AI assistance

This contribution was AI-assisted (Claude Code). AI was used for the investigation, the fix, and the autotest. I directed the work, reviewed the changes, and the SITL testing.
