### PR TITLE
autotest: fix flaky Copter CameraLogMessages by opening log after RTL

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -16815,8 +16815,9 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.set_rc(1, 1500)
         self.set_rc(2, 1500)
 
-        dfreader = self.dfreader_for_current_onboard_log()
         self.do_RTL()
+
+        dfreader = self.dfreader_for_current_onboard_log()
 
         for i in range(len(gpis)):
             gpi = gpis[i]


### PR DESCRIPTION
### Summary

Fix race condition in log file content in Camera test

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

CameraLogMessages triggers the camera three times, then reads the three resulting CAM messages back from the onboard log to compare their logged position/attitude against what was observed live.  The log was opened before do_RTL(), i.e. while the vehicle was still flying and the most recent CAM records may not yet have been flushed to disk.  DFReader maps the file at construction, so a short (not-yet-flushed) snapshot leaves recv_match(type="CAM") returning None and the comparison crashes with AttributeError ("'NoneType' object has no attribute 'Alt'"), seen intermittently under CI load.

Open the log after do_RTL() instead: the vehicle disarms at the end of RTL, which flushes the log and guarantees all three CAM records are present.  This is strictly safer than the previous ordering, as the log is opened later once more data has been flushed.


        # Open the log only after do_RTL(): the vehicle disarms at the end of
        # RTL, which flushes the log and ensures all the CAM messages written
        # when the camera was triggered are present.  Opening it beforehand
        # snapshots the file (DFReader maps it at construction) while CAM
        # records may still be unflushed, so recv_match() returns None and the
        # test crashes with AttributeError on the missing message.
