### PR TITLE
AP_HAL_ChibiOS: don't fake CAN send success in bootloader builds

### DIFF
--- a/libraries/AP_HAL_ChibiOS/CANFDIface.cpp
+++ b/libraries/AP_HAL_ChibiOS/CANFDIface.cpp
@@ -368,6 +368,7 @@ int16_t CANIface::send(const AP_HAL::CANFrame& frame, uint64_t tx_deadline,
 
         if ((can_->TXFQS & FDCAN_TXFQS_TFQF) != 0) {
             stats.tx_overflow++;
+#if !defined(HAL_BOOTLOADER_BUILD)
             if (stats.tx_success == 0) {
                 /*
                   if we have never successfully transmitted a frame
@@ -379,6 +380,7 @@ int16_t CANIface::send(const AP_HAL::CANFrame& frame, uint64_t tx_deadline,
                  */
                 return AP_HAL::CANIface::send(frame, tx_deadline, flags);
             }
+#endif
             return 0;    //we don't have free space
         }
         index = ((can_->TXFQS & FDCAN_TXFQS_TFQPI) >> FDCAN_TXFQS_TFQPI_Pos);


### PR DESCRIPTION
### Summary

Guard the FDCAN "consider it sent" fallback with HAL_BOOTLOADER_BUILD, so a bootloader no longer reports success for frames it silently discards. Without this, a peripheral with two CAN interfaces and only one bus connected loses every multi-frame transfer from its bootloader.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Tested on hardware

Tested on an STM32G474 AP_Periph node with two CAN interfaces, CAN1 connected to a Mission Planner SLCAN adapter and CAN2 unconnected.

Before the change, the node appears in the DroneCAN node list in MAINTENANCE mode with a counting uptime, but its Name, HW Version and SW Version columns stay blank and firmware update over CAN cannot start. The bootloader is confirmed alive and receiving throughout, since the receive loop toggles LED_BOOTLOADER on every frame taken off the bus and the LED visibly changes when the CAN cable is plugged in.

After the change, the same board enumerates fully with its node name, hardware version and software version, and firmware update over CAN proceeds.

Also confirmed that application builds are unaffected. The compiled CANFDIface object retains both calls to AP_HAL::CANIface::send in an AP_Periph build and has only the post-queue MAVCAN forward in a bootloader build.

### Description

Commit 05d43fd00b ("HAL_ChibiOS: allow for MCAST UDP with no CAN link") added a fallback to ChibiOS::CANIface::send in CANFDIface.cpp. When the hardware TX FIFO is full and the interface has never successfully transmitted a frame, the frame is handed to AP_HAL::CANIface::send and the send is reported as successful. The intent is to let MAVCAN forwarding and UDP MCAST bridging work on a board with no CAN cable plugged in.

That parent function walks the registered frame callbacks and then returns 1 unconditionally. Frame callbacks are only ever registered by CAN logging, MAVLink CAN forwarding and AP_Networking_CAN, none of which exist in a bootloader build. So in a bootloader the parent call does nothing at all and the frame is discarded while being reported as sent.

This becomes a real fault on a peripheral with more than one CAN interface where not every bus is connected. An unconnected interface never receives an acknowledgement, so stats.tx_success stays at zero and, after a few NodeStatus broadcasts, its TX FIFO is permanently full. From then on it answers "sent" to every frame.

The bootloader's transmit loop in Tools/AP_Bootloader/can.cpp offers each frame to every interface and ORs the results, retiring the frame from the canard queue if any interface claims success. Once one interface is a sink, every frame that the genuinely connected interface refuses for lack of space is destroyed rather than retried. Single-frame broadcasts such as NodeStatus always fit in the FIFO and are unaffected, which is why the node still appears in the node list. Multi-frame service replies such as the roughly eleven-frame GetNodeInfo response overrun the FIFO and lose frames, so the transfer fails reassembly at the far end. Firmware update over CAN fails for the same reason.

The application side is not affected, because CanardInterface::processTx in AP_Canard_iface.cpp tracks each interface separately, treats an interface with no recent successful transmit as down, and clears only that interface's mask bit rather than ORing a single success across all of them.

The fix mirrors what the bxCAN driver already does. CanIface.cpp has carried this same fallback wrapped in #if !defined(HAL_BOOTLOADER_BUILD) since it was introduced; the FDCAN copy simply never received the same guard. Application and flight-controller builds are byte-identical after this change, and bootloader builds return to the pre-05d43fd00b behaviour of reporting a full FIFO honestly so the caller retries.
