### PR TITLE
Add more sanity checks to CanForward and CanFilterModify / remove bus ID aliasing issue

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -19115,6 +19115,8 @@ return update, 1000
             self.UTMGlobalPosition,
             self.UTMGlobalPositionWaypoint,
             self.HomeAltResetTest,
+            self.CANForward,
+            self.CANFilterModify,
         ])
         return ret
 
@@ -19281,6 +19283,93 @@ return update, 1000
             # reset SITL home back to the default location so the framework's
             # post-test reboot_sitl() location check passes
             self.customise_SITL_commandline([])
+
+    def CANForward(self):
+        '''test MAV_CMD_CAN_FORWARD CAN-over-MAVLink forwarding'''
+        # for now this exercises bus validation: MAV_CMD_CAN_FORWARD must
+        # reject malformed bus values without indexing hal.can[] out of
+        # bounds
+        # MAV_CMD_CAN_FORWARD maps the requested bus to hal.can[bus-1].  A
+        # value that wraps to a negative int8_t previously read hal.can[]
+        # below the start of the array before the bounds check was applied,
+        # which could result in the request being accepted against a bogus
+        # interface.
+        self.set_parameters({
+            "CAN_P1_DRIVER": 1,
+        })
+        self.reboot_sitl()
+
+        # MAV_CMD_CAN_FORWARD is handled as a COMMAND_INT.  param1 is a
+        # float, so as well as negative and out-of-range buses the handler
+        # must reject values whose float-to-integer narrowing is undefined:
+        # 256 previously aliased the "disable forwarding" sentinel and 257
+        # aliased bus 1 where the conversion wrapped.  255 is the narrowing
+        # boundary; it maps to hal.can[254], which does not exist:
+        for bus in [-5, -50, 50, 255, 256, 257]:
+            self.run_cmd_int(
+                mavutil.mavlink.MAV_CMD_CAN_FORWARD,
+                p1=bus,
+                want_result=mavutil.mavlink.MAV_RESULT_FAILED,
+            )
+            self.wait_heartbeat()
+
+        # bus 1 maps to hal.can[0], which exists, so forwarding is accepted:
+        self.run_cmd_int(
+            mavutil.mavlink.MAV_CMD_CAN_FORWARD,
+            p1=1,
+            want_result=mavutil.mavlink.MAV_RESULT_ACCEPTED,
+        )
+        # bus 0 is the documented "disable forwarding" sentinel:
+        self.run_cmd_int(
+            mavutil.mavlink.MAV_CMD_CAN_FORWARD,
+            p1=0,
+            want_result=mavutil.mavlink.MAV_RESULT_ACCEPTED,
+        )
+
+    def CANFilterModify(self):
+        '''test CAN_FILTER_MODIFY CAN-over-MAVLink filtering'''
+        # for now this exercises bus validation: CAN_FILTER_MODIFY must
+        # reject malformed bus values without indexing hal.can[] out of
+        # bounds
+        # CAN_FILTER_MODIFY maps the requested bus to hal.can[bus-1].  A bus
+        # of 0 maps to hal.can[-1], and 200/255 wrap to negative int8_t
+        # values; all previously read hal.can[] below the start of the array
+        # before the bounds check.  The message is not acknowledged, so send
+        # the malformed values and confirm the vehicle keeps running and
+        # still processes commands.
+        self.set_parameters({
+            "CAN_P1_DRIVER": 1,
+        })
+        self.reboot_sitl()
+
+        ids = [0] * 16
+        for bus in [0, 200, 255]:
+            self.mav.mav.can_filter_modify_send(
+                self.sysid_thismav(),
+                1,  # target component
+                bus,
+                mavutil.mavlink.CAN_FILTER_REPLACE,
+                0,  # num_ids
+                ids,
+            )
+        self.wait_heartbeat()
+        # send a valid CAN_FILTER_MODIFY on bus 1.  The message has no
+        # acknowledgement, so this is a liveness check only; the command
+        # below being acked shows messages on the same channel are still
+        # being processed after the malformed ones:
+        self.mav.mav.can_filter_modify_send(
+            self.sysid_thismav(),
+            1,
+            1,
+            mavutil.mavlink.CAN_FILTER_REPLACE,
+            0,
+            ids,
+        )
+        self.run_cmd_int(
+            mavutil.mavlink.MAV_CMD_CAN_FORWARD,
+            p1=0,
+            want_result=mavutil.mavlink.MAV_RESULT_ACCEPTED,
+        )
 
     def testcan(self):
         ret = ([

--- a/libraries/AP_CANManager/AP_MAVLinkCAN.cpp
+++ b/libraries/AP_CANManager/AP_MAVLinkCAN.cpp
@@ -74,6 +74,20 @@ int16_t AP_MAVLinkCAN::packet_bus_num_to_bus(uint8_t bus_num)
 }
 
 /*
+  return the CAN interface addressed by the 1-indexed bus number used in
+  MAV_CMD_CAN_FORWARD and CAN_FILTER_MODIFY, or nullptr if the bus number
+  does not map to a present interface.
+ */
+AP_HAL::CANIface *AP_MAVLinkCAN::get_can_iface(uint8_t packet_bus_num)
+{
+    const int16_t bus = packet_bus_num_to_bus(packet_bus_num);
+    if (bus < 0 || bus >= HAL_NUM_CAN_IFACES) {
+        return nullptr;
+    }
+    return hal.can[bus];
+}
+
+/*
   handle MAV_CMD_CAN_FORWARD mavlink long command
  */
 bool AP_MAVLinkCAN::_handle_can_forward(mavlink_channel_t chan, const mavlink_command_int_t &packet, const mavlink_message_t &msg)
@@ -87,9 +101,9 @@ bool AP_MAVLinkCAN::_handle_can_forward(mavlink_channel_t chan, const mavlink_co
     if (packet.param1 < 0 || packet.param1 > UINT8_MAX) {
         return false;
     }
-    const int16_t bus = packet_bus_num_to_bus(uint8_t(packet.param1));
+    const uint8_t bus_num = uint8_t(packet.param1);
 
-    if (bus == -1) {
+    if (bus_num == 0) {
         /*
           a request to stop forwarding
          */
@@ -100,9 +114,13 @@ bool AP_MAVLinkCAN::_handle_can_forward(mavlink_channel_t chan, const mavlink_co
         return true;
     }
 
-    if (bus >= HAL_NUM_CAN_IFACES || hal.can[bus] == nullptr) {
+    auto *iface = get_can_iface(bus_num);
+    if (iface == nullptr) {
         return false;
     }
+    // the zero-indexed bus is also recorded in callback_bus and matched
+    // against forwarded frames, so it is needed beyond fetching the iface
+    const int16_t bus = packet_bus_num_to_bus(bus_num);
 
     if (can_forward.callback_id != 0 && can_forward.callback_bus != bus && can_forward.callback_bus < HAL_NUM_CAN_IFACES) {
         /*
@@ -113,7 +131,7 @@ bool AP_MAVLinkCAN::_handle_can_forward(mavlink_channel_t chan, const mavlink_co
     }
 
     if (can_forward.callback_id == 0 &&
-        !hal.can[bus]->register_frame_callback(
+        !iface->register_frame_callback(
             FUNCTOR_BIND_MEMBER(&AP_MAVLinkCAN::can_frame_callback, void, uint8_t, const AP_HAL::CANFrame &, AP_HAL::CANIface::CanIOFlags), can_forward.callback_id)) {
         // failed to register the callback
         return false;
@@ -228,8 +246,7 @@ void AP_MAVLinkCAN::_handle_can_filter_modify(const mavlink_message_t &msg)
 {
     mavlink_can_filter_modify_t p;
     mavlink_msg_can_filter_modify_decode(&msg, &p);
-    const int16_t bus = packet_bus_num_to_bus(p.bus);
-    if (bus < 0 || bus >= HAL_NUM_CAN_IFACES || hal.can[bus] == nullptr) {
+    if (get_can_iface(p.bus) == nullptr) {
         return;
     }
     if (p.num_ids > ARRAY_SIZE(p.ids)) {

--- a/libraries/AP_CANManager/AP_MAVLinkCAN.cpp
+++ b/libraries/AP_CANManager/AP_MAVLinkCAN.cpp
@@ -65,7 +65,15 @@ void AP_MAVLinkCAN::handle_can_filter_modify(const mavlink_message_t &msg)
 bool AP_MAVLinkCAN::_handle_can_forward(mavlink_channel_t chan, const mavlink_command_int_t &packet, const mavlink_message_t &msg)
 {
     WITH_SEMAPHORE(can_forward.sem);
-    const int8_t bus = int8_t(packet.param1)-1;
+
+    // param1 carries a 1-indexed bus number (0 disables forwarding). Reject
+    // values outside [0, 255] before narrowing; the float-to-integer
+    // conversion is undefined for values which do not fit. Fractional values
+    // truncate, as elsewhere in command handling.
+    if (packet.param1 < 0 || packet.param1 > UINT8_MAX) {
+        return false;
+    }
+    const int8_t bus = int8_t(uint8_t(packet.param1))-1;
 
     if (bus == -1) {
         /*

--- a/libraries/AP_CANManager/AP_MAVLinkCAN.cpp
+++ b/libraries/AP_CANManager/AP_MAVLinkCAN.cpp
@@ -60,6 +60,20 @@ void AP_MAVLinkCAN::handle_can_filter_modify(const mavlink_message_t &msg)
 
 
 /*
+  convert the 1-indexed bus number carried by MAV_CMD_CAN_FORWARD and
+  CAN_FILTER_MODIFY into a zero-indexed hal.can[] index. Unlike
+  CAN_FRAME/CANFD_FRAME, which carry a zero-indexed bus, these messages use
+  a 1-indexed bus number (bus 1 is the first interface, 0 means "no bus").
+  The bus number is unsigned, so the result is -1 for "no bus" and is
+  otherwise non-negative; the caller must still range-check it against
+  HAL_NUM_CAN_IFACES before indexing hal.can[].
+ */
+int16_t AP_MAVLinkCAN::packet_bus_num_to_bus(uint8_t bus_num)
+{
+    return int16_t(bus_num) - 1;
+}
+
+/*
   handle MAV_CMD_CAN_FORWARD mavlink long command
  */
 bool AP_MAVLinkCAN::_handle_can_forward(mavlink_channel_t chan, const mavlink_command_int_t &packet, const mavlink_message_t &msg)
@@ -73,7 +87,7 @@ bool AP_MAVLinkCAN::_handle_can_forward(mavlink_channel_t chan, const mavlink_co
     if (packet.param1 < 0 || packet.param1 > UINT8_MAX) {
         return false;
     }
-    const int8_t bus = int8_t(uint8_t(packet.param1))-1;
+    const int16_t bus = packet_bus_num_to_bus(uint8_t(packet.param1));
 
     if (bus == -1) {
         /*
@@ -86,7 +100,7 @@ bool AP_MAVLinkCAN::_handle_can_forward(mavlink_channel_t chan, const mavlink_co
         return true;
     }
 
-    if (bus < 0 || bus >= HAL_NUM_CAN_IFACES || hal.can[bus] == nullptr) {
+    if (bus >= HAL_NUM_CAN_IFACES || hal.can[bus] == nullptr) {
         return false;
     }
 
@@ -214,7 +228,7 @@ void AP_MAVLinkCAN::_handle_can_filter_modify(const mavlink_message_t &msg)
 {
     mavlink_can_filter_modify_t p;
     mavlink_msg_can_filter_modify_decode(&msg, &p);
-    const int8_t bus = int8_t(p.bus)-1;
+    const int16_t bus = packet_bus_num_to_bus(p.bus);
     if (bus < 0 || bus >= HAL_NUM_CAN_IFACES || hal.can[bus] == nullptr) {
         return;
     }

--- a/libraries/AP_CANManager/AP_MAVLinkCAN.h
+++ b/libraries/AP_CANManager/AP_MAVLinkCAN.h
@@ -77,6 +77,11 @@ private:
     // before indexing hal.can[].
     static int16_t packet_bus_num_to_bus(uint8_t bus_num);
 
+    // return the CAN interface addressed by the 1-indexed bus number used in
+    // MAV_CMD_CAN_FORWARD and CAN_FILTER_MODIFY, or nullptr if it does not
+    // map to a present interface.
+    static AP_HAL::CANIface *get_can_iface(uint8_t packet_bus_num);
+
     // Process CAN frame forwarding
     void process_frame_buffer();
 

--- a/libraries/AP_CANManager/AP_MAVLinkCAN.h
+++ b/libraries/AP_CANManager/AP_MAVLinkCAN.h
@@ -71,6 +71,12 @@ private:
 
     static AP_MAVLinkCAN *ensure_singleton();
 
+    // convert the 1-indexed bus number carried by MAV_CMD_CAN_FORWARD and
+    // CAN_FILTER_MODIFY into a zero-indexed hal.can[] index. The result is
+    // -1 for "no bus" and non-negative otherwise; it must be range-checked
+    // before indexing hal.can[].
+    static int16_t packet_bus_num_to_bus(uint8_t bus_num);
+
     // Process CAN frame forwarding
     void process_frame_buffer();
 


### PR DESCRIPTION
### Summary

Adds sanity checks on bus numbers passed into the code, adds autotests for the packets.  Also fixes an aliasing problem on bus ID.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Adds autotests and better constraining of values uses in the code.

MAV_CMD_CAN_FORWARD carries its target CAN bus as a float in param1 (1-indexed; 0 means "stop forwarding"). The handler narrowed it with int8_t(packet.param1), and that float-to-integer
  conversion is undefined behavior for any value that doesn't fit in int8_t. Where the conversion wrapped in practice, out-of-range bus numbers aliased valid requests:

  - 256 was accepted as the "disable forwarding" sentinel (wrapped to 0),
  - 257 enabled forwarding on bus 1 (wrapped to 1),
  - -0.5 was accepted as a disable request (truncated to 0),

  so a GCS sending a garbage bus number could have the command acknowledged as ACCEPTED and acting on a bus it never asked for, instead of being rejected. The fix validates that param1 is in
  [0, 255] before narrowing, so every such value now returns MAV_RESULT_FAILED. The CANForward autotest proves it by asserting 255/256/257 (and plain negatives) are all rejected while 0 and
  1 are still accepted.


Tail-end of changes made, the first bits of which fixed OOB/UB behaviour issues.
