### PR TITLE
Tools: fix Windows path normalization and SPECIAL_SUBSYSTEMS ordering

### DIFF
--- a/Tools/scripts/allowed_subsystems.py
+++ b/Tools/scripts/allowed_subsystems.py
@@ -190,6 +190,7 @@ class AllowedSubsystems(object):
         matches; callers should treat that as "needs a mapping rule".
         '''
         # normalise a leading "./"
+        path = path.replace('\\', '/')
         if path.startswith('./'):
             path = path[2:]
 
@@ -218,7 +219,7 @@ class AllowedSubsystems(object):
             filename = parts[-1]
             for sub_prefix in self.SPECIAL_SUBSYSTEMS.get(lib, []):
                 if filename.startswith(sub_prefix):
-                    return [lib, sub_prefix]
+                    return [sub_prefix, lib]
             return [lib]
 
         # most-specific-first special directory rules


### PR DESCRIPTION
### Summary

Normalizes backslashes to forward slashes in `allowed_subsystems.py` to support Windows paths, and reorders returned candidate subsystems so specific `SPECIAL_SUBSYSTEMS` take priority over generic library names.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

This PR addresses two minor edge cases in `Tools/scripts/allowed_subsystems.py`:

1. **Windows Path Handling:** Added backslash (`\`) normalization to forward slashes (`/`) in `subsystems_for_path()` so that file paths passed on Windows environments do not fall through as root files.
2. **Subsystem Priority Order:** Reordered candidate subsystems returned for `SPECIAL_SUBSYSTEMS` from `[lib, sub_prefix]` to `[sub_prefix, lib]` to ensure that specific subsystem prefixes take priority over generic library directory names, matching the "most conventional first" convention documented in the script.