### PR TITLE
AP_Follow: Fix parameter ranges to include their defaults

### DIFF
--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -165,7 +165,7 @@ const AP_Param::GroupInfo AP_Follow::var_info[] = {
     // @Param: _ACCEL_NE
     // @DisplayName: Acceleration limit for the horizontal kinematic input shaping
     // @Description: Acceleration limit of the horizontal kinematic path generation used to determine how quickly the estimate varies in velocity
-    // @Range: 0 5
+    // @Range: 0 10
     // @Units: m/s/s
     // @User: Advanced
     AP_GROUPINFO("_ACCEL_NE", 12, AP_Follow, _accel_max_ne_mss, 5.0),
@@ -181,7 +181,7 @@ const AP_Param::GroupInfo AP_Follow::var_info[] = {
     // @Param: _ACCEL_D
     // @DisplayName: Acceleration limit for the vertical kinematic input shaping
     // @Description: Acceleration limit of the vertical kinematic path generation used to determine how quickly the estimate varies in velocity
-    // @Range: 0 2.5
+    // @Range: 0 10
     // @Units: m/s/s
     // @User: Advanced
     AP_GROUPINFO("_ACCEL_D", 14, AP_Follow, _accel_max_d_mss, 5.0),
@@ -189,7 +189,7 @@ const AP_Param::GroupInfo AP_Follow::var_info[] = {
     // @Param: _JERK_D
     // @DisplayName: Jerk limit for the vertical kinematic input shaping
     // @Description: Jerk limit of the vertical kinematic path generation used to determine how quickly the estimate varies in acceleration
-    // @Range: 0 5
+    // @Range: 0 20
     // @Units: m/s/s/s
     // @User: Advanced
     AP_GROUPINFO("_JERK_D", 15, AP_Follow, _jerk_max_d_msss, 10.0),
@@ -197,7 +197,7 @@ const AP_Param::GroupInfo AP_Follow::var_info[] = {
     // @Param: _ACCEL_H
     // @DisplayName: Angular acceleration limit for the heading kinematic input shaping
     // @Description: Angular acceleration limit of the heading kinematic path generation used to determine how quickly the estimate varies in angular velocity
-    // @Range: 0 90
+    // @Range: 0 720
     // @Units: deg/s/s
     // @User: Advanced
     AP_GROUPINFO("_ACCEL_H", 16, AP_Follow, _accel_max_h_degss, 360.0),
@@ -205,7 +205,7 @@ const AP_Param::GroupInfo AP_Follow::var_info[] = {
     // @Param: _JERK_H
     // @DisplayName: Angular jerk limit for the heading kinematic input shaping
     // @Description: Angular jerk limit of the heading kinematic path generation used to determine how quickly the estimate varies in angular acceleration
-    // @Range: 0 360
+    // @Range: 0 1440
     // @Units: deg/s/s/s
     // @User: Advanced
     AP_GROUPINFO("_JERK_H", 17, AP_Follow, _jerk_max_h_degsss, 720.0),


### PR DESCRIPTION
### Summary

Fixes #33859

```
Board,antennatracker,blimp,bootloader,copter,heli,plane,rover,sub
CubeOrange,*,*,*,*,*,*,*,*
```

Widens the `@Range` metadata on five `FOLL_*` kinematic shaping parameters so each advertised range contains that parameter's own default value. Documentation metadata only, with no code or behaviour change.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change

Only the `@Range` comment lines change, so the compiled binary is byte identical and no flight testing applies. The effect is confined to the generated parameter metadata that ground stations consume.

### Description

Four of the AP_Follow kinematic shaping parameters shipped with a default value that sat outside the range advertised to ground stations, and a fifth sat exactly on its upper limit with no headroom to raise it. A ground station that honours the metadata will show these parameters as out of range at their factory values, and will clamp or warn when the user tries to set anything sensible.

| Parameter | Default | Old range | New range |
| --- | --- | --- | --- |
| `FOLL_ACCEL_NE` | 5 m/s/s | 0 to 5 | 0 to 10 |
| `FOLL_ACCEL_D` | 5 m/s/s | 0 to 2.5 | 0 to 10 |
| `FOLL_JERK_D` | 10 m/s/s/s | 0 to 5 | 0 to 20 |
| `FOLL_ACCEL_H` | 360 deg/s/s | 0 to 90 | 0 to 720 |
| `FOLL_JERK_H` | 720 deg/s/s/s | 0 to 360 | 0 to 1440 |

The new upper limits are set at roughly twice each default, which restores the intent that a default should sit mid range and leaves room to tune upward. `FOLL_JERK_NE` already had a consistent range of 0 to 20 against its default of 10, so it is left alone.

The parameter metadata tooling in `Tools/autotest/param_metadata/param_parse.py` validates only that `@Range` is a pair of numbers, and does not check the default against that pair, which is why CI never flagged this.

These parameters are exposed as `FOLL_*` on Copter, Plane and Rover through the shared `AP_Follow` subgroup, so all three vehicles pick up the corrected metadata.
