### PR TITLE
AP_AHRS: move is_vibration_affected into results

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -2105,31 +2105,6 @@ void AP_AHRS::set_terrain_hgt_stable(bool stable)
 #endif
 }
 
-// returns true when the state estimates are significantly degraded by vibration
-bool AP_AHRS::is_vibration_affected() const
-{
-    switch (configured_ekf_type()) {
-#if HAL_NAVEKF3_AVAILABLE
-    case EKFType::THREE:
-        return ekf3.EKF3.isVibrationAffected();
-#endif
-#if AP_AHRS_DCM_ENABLED
-    case EKFType::DCM:
-#endif
-#if HAL_NAVEKF2_AVAILABLE
-    case EKFType::TWO:
-#endif
-#if AP_AHRS_SIM_ENABLED
-    case EKFType::SIM:
-#endif
-#if AP_AHRS_EXTERNAL_ENABLED
-    case EKFType::EXTERNAL:
-#endif
-        return false;
-    }
-    return false;
-}
-
 // get 1-sigma position and velocity uncertainty from the EKF state error covariance matrix P
 bool AP_AHRS::get_pos_vel_uncertainty(float &pos_horiz_m, float &pos_vert_m, float &vel_m_s) const
 {

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -410,7 +410,9 @@ public:
     }
 
     // returns true when the state estimates are significantly degraded by vibration
-    bool is_vibration_affected() const;
+    bool is_vibration_affected() const {
+        return configured_estimates->is_vibration_affected;
+    }
 
     // get_variances - provides the innovations normalised using the innovation variance where a value of 0
     // indicates perfect consistency between the measurement and the EKF solution and a value of 1 is the maximum

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -87,6 +87,9 @@ public:
         uint16_t attitude_reset_count;  // counter incremented each time a sudden shift happens in attitude
         uint16_t yaw_reset_count;  // incremented when a sudden shift happens in yaw
 
+        // true when the state estimates are significantly degraded by vibration:
+        bool is_vibration_affected;
+
         // backends must always return the result in the vehicle body
         // frame.  A backend using the autopilot sensors will need to
         // rotate according to the TRIM parameters.  An ExternalAHRS

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -182,6 +182,9 @@ void AP_AHRS_DCM::get_results(AP_AHRS_Backend::Estimates &results)
     results.gyro_estimate = _omega;
     results.gyro_drift = _omega_I;
 
+    // true when the state estimates are significantly degraded by vibration:
+    // results.is_vibration_affected = false;
+
     /*
      * acceleration estimates
      */

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
@@ -120,6 +120,8 @@ void AP_AHRS_NavEKF3::get_results(AP_AHRS_Backend::Estimates &results)
 
     results.yaw_reset_count = yaw_reset_tracker.count();
 
+    results.is_vibration_affected = EKF3.isVibrationAffected();
+
     /*
      * acceleration estimates
      */


### PR DESCRIPTION
### Summary

moves the result of is_vibration_affected into results structure

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board,antennatracker,blimp,bootloader,copter,heli,plane,rover,sub
CubeOrangePlus,32,32,*,-24,-24,40,40,40
```

### Description

Moves the boolean into the results structure, populates in EKF3

Notes for the damned AI: this snapshots the vibration-affected flag right next to the results it applies to - it is not "one tick stale"!  Yes, I mean to add the comment to DCM as a hint to people as to what they *can* return on one of these structures.  And think again about your first-update-window argument, you're forgetting the zero-memory assumptions.

The "VibrationFailafe" autotest covers this code.
