### PR TITLE
Reserve board ID for Pilotix

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -610,7 +610,7 @@ AP_HW_PixSurveyA2-IND                6104
 # IDs 6110 - 6119 for S-vehicle
 AP_HW_SVehicle-E2                    6110
 
-# IDs 6120-6129 reserved for Partizan Security sro
+# IDs 6120-6129 reserved for Partizan Security s.r.o
 AP_HW_PILOTIX                          6120
 
 # IDs 6600-6699 reserved for Eagle Eye Drones

--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -610,6 +610,9 @@ AP_HW_PixSurveyA2-IND                6104
 # IDs 6110 - 6119 for S-vehicle
 AP_HW_SVehicle-E2                    6110
 
+# IDs 6120-6129 reserved for Partizan Security sro
+AP_HW_PILOTIX                          6120
+
 # IDs 6600-6699 reserved for Eagle Eye Drones
 
 # IDs 6900-6909 reserved for Easy Aerial


### PR DESCRIPTION
Reserving board ID range 6120-6129 for Partizan Security sro / Pilotix hardware.

### Summary
Reserving a unique board ID for the Pilotix FPV flight controller board ahead of submitting the hwdef port.

### Classification & Testing (check all that apply and add your own)
- [ ] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description
This PR adds a new entry to Tools/AP_Bootloader/board_types.txt, reserving board ID range 6120-6129 for Partizan Security s.r.o.'s Pilotix hardware. This is the first step before submitting the full hwdef.dat/hwdef-bl.dat port for the board.