### PR TITLE
Correct dead-reckoning on Microstrain7 ExternalAHRS

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -23,6 +23,7 @@ from pysim import vehicleinfo
 from vehicle_test_suite import MAV_POS_TARGET_TYPE_MASK
 from vehicle_test_suite import AltFrame
 from vehicle_test_suite import AutoTestTimeoutException
+from vehicle_test_suite import Location
 from vehicle_test_suite import NotAchievedException
 from vehicle_test_suite import OldpymavlinkException
 from vehicle_test_suite import PreconditionFailedException
@@ -3216,7 +3217,8 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
                                    dist_to_final_wp_threshold_m=dist_to_final_wp_threshold_m)
 
     def fly_external_AHRS(self, sim, eahrs_type,
-                          dist_to_final_wp_threshold_m: float | None = None):
+                          dist_to_final_wp_threshold_m: float | None = None,
+                          max_position_lag_m=0.4):
         """Fly with external AHRS"""
         # The external AHRS drivers parse their serial stream on a
         # real-time thread.  At the default plane speedup (100x) that
@@ -3247,6 +3249,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.wait_ready_to_arm()
         self.arm_vehicle()
         self.fly_generic_mission("externalahrs.txt", dist_to_final_wp_threshold_m=dist_to_final_wp_threshold_m)
+        self.check_EAHRS_position_lag(max_position_lag_m)
 
     def wait_and_maintain_wind_estimate(
             self,
@@ -3563,6 +3566,63 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
     def MicroStrainEAHRS5(self):
         '''Test MicroStrain EAHRS series 5 support'''
         self.fly_external_AHRS("MicroStrain5", 2)
+
+    def check_EAHRS_position_lag(self, max_mean_error_m):
+        '''check logged AHRS position against simulator truth.  POS and
+        SIM are written back-to-back by AP_AHRS logging, so each pair
+        compares the estimate and the truth at effectively the same
+        instant.  ExternalAHRS extrapolates its position forward by
+        velocity from the last solution timestamp; a backend which
+        fails to stamp that timestamp reports a position stale by up
+        to one solution interval, an error proportional to speed.'''
+        dfreader = self.dfreader_for_current_onboard_log()
+        prev_sim = None
+        pos = None
+        count = 0
+        error_sum = 0.0
+        error_max = 0.0
+        while True:
+            m = dfreader.recv_match(type=['POS', 'SIM'])
+            if m is None:
+                break
+            if m.get_type() == 'POS':
+                pos = m
+                continue
+            sim = m
+            last_sim = prev_sim
+            prev_sim = sim
+            if pos is None or last_sim is None:
+                continue
+            if sim.TimeUS - pos.TimeUS > 20000:
+                # not the POS from this logging cycle; logging dropout?
+                continue
+            # only consider samples where the vehicle is moving
+            # quickly; staleness shows up as an error proportional
+            # to speed:
+            dt = (sim.TimeUS - last_sim.TimeUS)*1e-6
+            if dt <= 0:
+                continue
+            speed = self.get_distance(
+                Location.latlon_only(last_sim.Lat, last_sim.Lng),
+                Location.latlon_only(sim.Lat, sim.Lng)) / dt
+            if speed < 15:
+                continue
+            error = self.get_distance(
+                Location.latlon_only(pos.Lat, pos.Lng),
+                Location.latlon_only(sim.Lat, sim.Lng))
+            count += 1
+            error_sum += error
+            error_max = max(error_max, error)
+        if count < 100:
+            raise NotAchievedException(
+                "Insufficient fast-flight POS/SIM samples (%u)" % count)
+        mean_error = error_sum / count
+        self.progress("AHRS-vs-truth position error: mean=%.3fm max=%.3fm n=%u" %
+                      (mean_error, error_max, count))
+        if mean_error > max_mean_error_m:
+            raise NotAchievedException(
+                "AHRS position lags simulator truth (mean error %.3fm > %.3fm)" %
+                (mean_error, max_mean_error_m))
 
     def MicroStrainEAHRS7(self):
         '''Test MicroStrain EAHRS series 7 support'''

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_MicroStrain7.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_MicroStrain7.cpp
@@ -200,6 +200,7 @@ void AP_ExternalAHRS_MicroStrain7::post_filter() const
         // Use GNSS 0 even though it may be bad.
         state.location = Location{filter_data.lat, filter_data.lon, gnss_data[0].msl_altitude, Location::AltFrame::ABSOLUTE};
         state.have_location = true;
+        state.last_location_update_us = AP_HAL::micros();
 
         state.quat = filter_data.attitude_quat;
         state.have_quaternion = true;


### PR DESCRIPTION
### Summary

Fixes missing timestamp on location data which precludes it from doing dead reckoning.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Fixes the timestamp and adds a deadreckoning test for the backends.
