### PR TITLE
Tools: show a prominent error banner if env setup script fails

### DIFF
--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -3,6 +3,29 @@ echo "---------- $0 start ----------"
 set -e
 set -x
 
+# Display a very visible error banner if any step of this script fails so that
+# users do not miss the failure (see https://github.com/ArduPilot/ardupilot/issues/13415)
+function install_failure() {
+    local _status=$?
+    set +e
+    printf "\n\033[1;31m"
+    echo "############################################################"
+    echo "#                                                          #"
+    echo "#                  SOMETHING WENT WRONG !                  #"
+    echo "#                                                          #"
+    echo "#  Task failed:  $BASH_COMMAND"
+    echo "#                                                          #"
+    echo "#  The ArduPilot environment setup did not complete.       #"
+    echo "#  Please fix the reported error and re-run this script.   #"
+    echo "#  If the problem persists, ask for help on:               #"
+    echo "#      https://discuss.ardupilot.org/                      #"
+    echo "#                                                          #"
+    echo "############################################################"
+    printf "\033[0m\n"
+    exit $_status
+}
+trap install_failure ERR
+
 if [ $EUID == 0 ]; then
     echo "Please do not run this script as root; don't sudo it!"
     exit 1


### PR DESCRIPTION
## Summary

Fixes #13415

The Ubuntu environment setup script (`Tools/environment_install/install-prereqs-ubuntu.sh`) runs with `set -e`, so any failing command causes the script to exit immediately. Previously, this often resulted in the script terminating without a clear explanation, leaving users unsure why the environment setup had failed and why subsequent SITL builds were not working.

This PR adds an `ERR` trap that displays a clear, user-friendly error banner whenever a command fails.

Example output:

```text
############################################################
#                  SOMETHING WENT WRONG !                  #
#  Task failed: <failing command>                          #
#  The ArduPilot environment setup did not complete.       #
#  Please fix the reported error and re-run this script.   #
#  If the problem persists, ask for help on:               #
#      https://discuss.ardupilot.org/                      #
############################################################