### PR TITLE
AP_Follow: remove auto sysid

### DIFF
--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -46,7 +46,7 @@ extern const AP_HAL::HAL& hal;
 //==============================================================================
 
 #define AP_FOLLOW_TIMEOUT          3     // position estimate timeout in seconds
-#define AP_FOLLOW_SYSID_TIMEOUT_MS 10000 // forget sysid we are following if we have not heard from them in 10 seconds
+#define AP_FOLLOW_ESTIMATE_TIMEOUT_MS 10000 // discard the target estimate if we have not heard from the target in 10 seconds
 
 #define AP_FOLLOW_OFFSET_TYPE_NED       0   // offsets are in north-east-down frame
 #define AP_FOLLOW_OFFSET_TYPE_RELATIVE  1   // offsets are relative to lead vehicle's heading
@@ -500,7 +500,7 @@ void AP_Follow::handle_msg(const mavlink_message_t &msg)
 {
     // Invalidate the estimate if no position update has been received within the timeout period.
     if ((_last_location_update_ms == 0) ||
-        (AP_HAL::millis() - _last_location_update_ms > AP_FOLLOW_SYSID_TIMEOUT_MS)) {
+        (AP_HAL::millis() - _last_location_update_ms > AP_FOLLOW_ESTIMATE_TIMEOUT_MS)) {
         _estimate_valid = false;   // mark estimate as invalid
         _using_follow_target = false; // reset follow-target usage flag
     }

--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -82,7 +82,7 @@ const AP_Param::GroupInfo AP_Follow::var_info[] = {
 
     // @Param: _SYSID
     // @DisplayName: Follow target's mavlink system id
-    // @Description: Follow target's mavlink system id
+    // @Description: Follow target's mavlink system id. Zero means no target has been selected and following is inactive.
     // @Range: 0 255
     // @User: Standard
     AP_GROUPINFO("_SYSID", 3, AP_Follow, _sysid, 0),
@@ -499,13 +499,8 @@ bool AP_Follow::get_target_heading_rate_degs(float &heading_rate_degs)
 void AP_Follow::handle_msg(const mavlink_message_t &msg)
 {
     // Invalidate the estimate if no position update has been received within the timeout period.
-    // If using automatic sysid tracking, clear the sysid and reset tracking state.
     if ((_last_location_update_ms == 0) ||
         (AP_HAL::millis() - _last_location_update_ms > AP_FOLLOW_SYSID_TIMEOUT_MS)) {
-        if (_automatic_sysid) {
-            _sysid.set(0);         // clear target system ID
-            _sysid_used = 0;       // reset used sysid tracking
-        }
         _estimate_valid = false;   // mark estimate as invalid
         _using_follow_target = false; // reset follow-target usage flag
     }
@@ -557,8 +552,9 @@ bool AP_Follow::should_handle_message(const mavlink_message_t &msg) const
         return false;
     }
 
-    // skip message if not from our target
-    if (_sysid != 0 && msg.sysid != _sysid) {
+    // skip message if not from our target.  a _sysid of zero means no target
+    // has been selected, so no message is ever accepted
+    if (msg.sysid != _sysid) {
         return false;
     }
 
@@ -695,14 +691,6 @@ bool AP_Follow::handle_global_position_int_message(const mavlink_message_t &msg)
     // apply jitter-corrected timestamp to this update
     _last_location_update_ms = _jitter.correct_offboard_timestamp_msec(packet.time_boot_ms, AP_HAL::millis());
 
-    // if sysid not yet set, adopt sender’s sysid and enable automatic sysid tracking
-    if (_sysid == 0) {
-        _sysid.set(msg.sysid);
-        _sysid_used = 0;
-        _estimate_valid = false;
-        _automatic_sysid = true;
-    }
-
     return true;
 }
 
@@ -792,12 +780,6 @@ bool AP_Follow::handle_follow_target_message(const mavlink_message_t &msg)
 
     // apply jitter-corrected timestamp to this update
     _last_location_update_ms = _jitter.correct_offboard_timestamp_msec(packet.timestamp, AP_HAL::millis());
-
-    // if sysid not yet assigned, adopt sender's sysid and enable automatic sysid tracking
-    if (_sysid == 0) {
-        _sysid.set(msg.sysid);
-        _automatic_sysid = true;
-    }
 
     // we are using follow_target: set sysid to sender's sysid
     _using_follow_target = true;

--- a/libraries/AP_Follow/AP_Follow.h
+++ b/libraries/AP_Follow/AP_Follow.h
@@ -194,7 +194,7 @@ private:
     //==========================================================================
 
     AP_Int8     _enabled;           // 1 = Follow mode is enabled; 0 = disabled
-    AP_Int16    _sysid;             // MAVLink system ID of the target (0 = auto-select first sender)
+    AP_Int16    _sysid;             // MAVLink system ID of the target (0 = no target selected)
     AP_Float    _dist_max_m;        // Maximum allowed distance to target in meters; if exceeded, estimation is rejected
     AP_Int8     _offset_type;       // Offset frame type: 0 = NED, 1 = relative to lead vehicle heading
     AP_Vector3f _offset_m;          // Offset from lead vehicle (meters), in NED or FRD frame depending on _offset_type
@@ -236,7 +236,6 @@ private:
     Vector3f    _ofs_estimate_vel_ned_ms;       // Estimated velocity with offsets applied (NED frame)
     Vector3f    _ofs_estimate_accel_ned_mss;    // Estimated acceleration with offsets applied (NED frame)
 
-    bool        _automatic_sysid;               // True if target sysid was automatically selected
     int16_t     _sysid_used;                    // Currently active sysid used for updates
     float       _dist_to_target_m;              // Horizontal distance to target, for reporting (meters)
     float       _bearing_to_target_deg;         // Bearing to target from vehicle (degrees, 0 = North)


### PR DESCRIPTION
### Summary

Removes the behaviour where `FOLL_SYSID = 0` causes AP_Follow to latch onto the
first vehicle it hears from. Zero now means no target has been selected.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Tested manually, description below (e.g. SITL)

SITL Copter and Plane. `ModeFollow_with_FOLLOW_TARGET` and `ModeFollow` both pass;
the latter is flaky on my machine for unrelated reasons (harness timeout waiting to
receive `GLOBAL_POSITION_INT` from the vehicle). Both commits build standalone. Not
flown on hardware.

### Description

`FOLL_SYSID = 0` meant "follow the first vehicle we hear from": AP_Follow wrote the
first sender's system id into the parameter, and cleared it back to zero if that
vehicle went quiet for ten seconds. So the library mutated a user facing parameter
on its own, and the target was chosen by message arrival order rather than by
configuration. `MAV_CMD_DO_FOLLOW` already rejects a target id of zero, so this
makes the parameter agree with the command interface.

Zero now means no target is selected: no target message is accepted and the library
never writes `FOLL_SYSID`. The second commit is a rename only, since
`AP_FOLLOW_SYSID_TIMEOUT_MS` no longer has anything to do with the system id.

**Behaviour change.** Anyone relying on the default of zero to follow a single lead
vehicle must now set `FOLL_SYSID`. In Copter, FOLLOW mode holds position instead.
Worth a release note.
