### PR TITLE
AP_SurfaceDistance: Log Write: only write if there has been data

### DIFF
--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -11580,14 +11580,14 @@ Also, ignores heartbeats not from our target system'''
         self.wait_disarmed()
         self.delay_sim_time(15, reason="Allow log persistence to finish")
         self.assert_current_log_filesizes({
-            1: (1980*1024, 2020*1024),
+            1: (1950*1024, 1980*1024),
         })
         self.progress("Creating a second log")
         self.arm_vehicle()
         self.wait_disarmed()
         self.delay_sim_time(15, reason="Allow log persistence to finish")
         self.assert_current_log_filesizes({
-            1: (1980*1024, 2020*1024),
+            1: (1950*1024, 1980*1024),
             2: (1000*1024, 1100*1024),
         })
 

--- a/libraries/AP_SurfaceDistance/AP_SurfaceDistance.cpp
+++ b/libraries/AP_SurfaceDistance/AP_SurfaceDistance.cpp
@@ -151,6 +151,11 @@ bool AP_SurfaceDistance::get_rangefinder_height_interpolated_m(float& height_m) 
 #if HAL_LOGGING_ENABLED
 void AP_SurfaceDistance::Log_Write(void) const
 {
+    // Don't log if there has never been data
+    if (last_healthy_ms == 0) {
+        return;
+    }
+
     // @LoggerMessage: SURF
     // @Vehicles: Copter
     // @Description: Surface distance measurement


### PR DESCRIPTION
### Summary

Currently the log always happens even if no rangefinder is fitted.

<!-- Put a one or two line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
