### PR TITLE
Copter: fix CONDITION_YAW with absolute angle when WP_YAW_BEHAVIOR = 0

### DIFF
--- a/ArduCopter/autoyaw.cpp
+++ b/ArduCopter/autoyaw.cpp
@@ -70,6 +70,7 @@ void Mode::AutoYaw::set_mode(Mode yaw_mode)
     switch (_mode) {
 
     case Mode::HOLD:
+        _yaw_angle_rad = copter.attitude_control->get_att_target_euler_rad().z;
         break;
 
     case Mode::LOOK_AT_NEXT_WP:
@@ -277,6 +278,7 @@ float Mode::AutoYaw::yaw_rad()
         break;
     }
 
+    case Mode::HOLD:
     case Mode::RATE:
     case Mode::WEATHERVANE:
     case Mode::PILOT_RATE:

--- a/ArduCopter/autoyaw.cpp
+++ b/ArduCopter/autoyaw.cpp
@@ -124,6 +124,11 @@ void Mode::AutoYaw::set_fixed_yaw_rad(float yaw_rad, float yaw_rate_rads, int8_t
         _fixed_yaw_offset_rad = angle_rad * (direction >= 0 ? 1.0 : -1.0);
     } else {
         // absolute angle
+        if (_mode == Mode::HOLD) {
+            // _yaw_angle_rad is not maintained while in HOLD so re-anchor it to
+            // the attitude controller's yaw target before taking the offset
+            _yaw_angle_rad = copter.attitude_control->get_att_target_euler_rad().z;
+        }
         _fixed_yaw_offset_rad = wrap_PI(angle_rad - _yaw_angle_rad);
         if (direction < 0 && is_positive(_fixed_yaw_offset_rad)) {
             _fixed_yaw_offset_rad -= M_2PI;


### PR DESCRIPTION
### Summary

Absolute-angle counterpart of #27318: with `WP_YAW_BEHAVIOR = 0`, an absolute `MAV_CMD_CONDITION_YAW` received while the vehicle is translating anchors the fixed-yaw target on the vehicle's *travel bearing* instead of the heading it is holding, so it turns the wrong way at the yaw slew limit, ignoring both the commanded turn rate and direction. This keeps `AutoYaw::_yaw_angle_rad` aligned with the attitude controller's yaw target while in `HOLD`, so later absolute `CONDITION_YAW` commands start from the heading being held rather than the vehicle's travel bearing.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

**SITL** (quad, master `e57b8a4` vs same commit + this patch; `WP_YAW_BEHAVIOR=0`, `WP_SPD=6`): take off in GUIDED, yaw to 90 deg, send a position-only target 600 m north, and while cruising at 6 m/s (nose still on 90 deg, auto yaw in HOLD) send an absolute `CONDITION_YAW` 3 deg away:

- `CONDITION_YAW 93 18 1 0` (+3 deg CW) — master: **-72.9 deg excursion** toward the travel bearing, opposite param3, peak 70.7 deg/s. Patched: +3.5 deg as commanded.
- `CONDITION_YAW 87 18 -1 0` (-3 deg CCW) — master: **-365.7 deg, a full wrap-around**. Patched: -3.6 deg.
- Controls: the same commands sent while stationary behave identically on master and on this branch (deltas <= 0.02 deg).

**Hardware evidence:** first seen on a 12.4 kg quad on 4.6.3 in GUIDED with position-only targets: of 21 absolute `CONDITION_YAW` commands, the 19 processed while stationary executed correctly; the 2 processed mid-leg at 6 m/s both slewed the long way at 60 deg/s, and the `ATT.DesYaw` steps match the desired-velocity bearing reconstructed from `PSCN`/`PSCE` to within 2.5 deg. `.bin` logs available on request.

### Description

`set_fixed_yaw_rad()` takes the absolute-angle offset from `_yaw_angle_rad`:

https://github.com/ArduPilot/ardupilot/blob/master/ArduCopter/autoyaw.cpp#L125-L127

While auto yaw is in `HOLD` that member does not hold the heading: `HOLD` has no case of its own in `yaw_rad()` and falls through to `default:`, which overwrites it every loop with `pos_control->get_yaw_rad()`:

https://github.com/ArduPilot/ardupilot/blob/master/ArduCopter/autoyaw.cpp#L286-L291

and `AC_PosControl::calculate_yaw_and_rate_yaw()` sets that to the bearing of the desired velocity whenever the vehicle moves faster than 5% of its speed limit:

https://github.com/ArduPilot/ardupilot/blob/master/libraries/AC_AttitudeControl/AC_PosControl.cpp#L1658-L1666

So an absolute `CONDITION_YAW` arriving mid-leg starts the `FIXED` slew from the travel bearing, stepping the yaw target by up to 180 deg; the attitude controller closes that step the geometrically shortest way at the `ATC_SLEW_YAW`/`ATC_RATE_WPY_MAX` limit, so `param2` and `param3` are both ignored during the excursion.

This PR gives `HOLD` its own path in `yaw_rad()`, alongside the other rate-only modes, so `_yaw_angle_rad` remains aligned with the attitude controller's yaw target. It also initializes the cached yaw when entering `HOLD`, preventing an absolute `CONDITION_YAW` received before the next `yaw_rad()` update from using a stale value.

I can add an autotest for this as a second commit if the maintainers find it useful — the existing `GuidedSubModeChange` "yaw through absolute angles" subtest only runs while stationary, which is likely why this went unnoticed.

Partly AI-assisted: the flight-log forensics and this diagnosis were joint work between me and an AI assistant; I have reviewed and verified the mechanism, the patch and the SITL results myself and take responsibility for the change.

This addresses the same underlying `HOLD` yaw-cache problem as #27318 but fixes it at the source. If the maintainers agree, I would like it considered for the 4.7 (and, if still being patched, 4.6) backport list once merged to master.
