### PR TITLE
hwdef: ARK_RTK_GPS: do not save u-blox config to receiver flash

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/ARK_RTK_GPS/defaults.parm
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ARK_RTK_GPS/defaults.parm
@@ -1,0 +1,5 @@
+# Default Parameters for the ARK RTK GPS
+
+# The node configures its own ZED-F9P at every boot, so persisting that config to the
+# receiver's flash gains nothing and risks a torn write if power is cut mid-save.
+GPS_SAVE_CFG 0


### PR DESCRIPTION
## Summary

AP_Periph configures the ZED-F9P from its own parameters at every boot, so the copy saved into the receiver's flash is never the source of truth. Each save is a `UBX-CFG-CFG` sent with no `deviceMask`, which the ZED-F9P interface description defines as defaulting the operation to BBR **and flash** — an erase and program of the whole flash configuration layer.

That write lands 5 s or more after startup (`_save_cfg()`'s own 5 s gate, plus the config sequence ahead of it) and only while disarmed, which is exactly when a unit is likely to be unplugged. The receiver shares the board supply with the node, so there is no orderly shutdown, and a power cut mid-save can leave the configuration layer corrupt.

Defaulting `GPS_SAVE_CFG` to 0 on this board keeps the receiver configured from RAM on every boot — which the node does regardless — and removes the write entirely. It is the same choice the driver's own GNSS/M10/L5 config lists already make by passing `UBX_VALSET_LAYER_RAM | UBX_VALSET_LAYER_BBR` rather than the `UBX_VALSET_LAYER_ALL` default.

Motivated by a returned unit whose receiver had to be recovered through safeboot; the corruption mechanism is consistent with a torn write, though this change is worth making on its own terms since the saved config serves no purpose on a self-configuring node.

## Testing

`./waf configure --board ARK_RTK_GPS && ./waf AP_Periph` builds clean. The hwdef picks the file up (`Default parameters path from hwdef: libraries/AP_HAL_ChibiOS/hwdef/ARK_RTK_GPS/defaults.parm`) and it is embedded in ROMFS as a 225-byte `defaults.parm`. 257 KB flash free on the board.