### PR TITLE
AP_Bootloader: reserve TARGET_HW_ARK_X20_GPS board ID 89

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -50,6 +50,7 @@ TARGET_HW_ARK_CAN_RTK_GPS              82
 TARGET_HW_ARK_CANNODE                  83
 TARGET_HW_FF_RTK_CAN_GPS               85
 TARGET_HW_PDW_MAS_MAIN-V1              86
+TARGET_HW_ARK_X20_GPS                  89
 TARGET_HW_ATL_MANTIS_EDU               97
 TARGET_HW_THE_PEACH_K1                212
 TARGET_HW_THE_PEACH_R1                213


### PR DESCRIPTION
### Summary

Reserve board ID 89 for the ARK X20 RTK GPS AP_Periph target in `board_types.txt`.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Allocate `TARGET_HW_ARK_X20_GPS` as board ID **89**, matching the PX4 `ark/x20-gps` board_id.

Split out from #33941 per review so the ID can land independently of the full hwdef.

This contribution was AI-assisted; the human author is responsible for the change.