### PR TITLE
Correct default parameter values being out of range specified in the metadata

### DIFF
--- a/AntennaTracker/Parameters.cpp
+++ b/AntennaTracker/Parameters.cpp
@@ -19,7 +19,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: SYSID_TARGET
     // @DisplayName: Target vehicle's MAVLink system ID
     // @Description: The identifier of the vehicle being tracked. This should be zero (to auto detect) or be the same as the MAV_SYSID parameter of the vehicle being tracked.
-    // @Range: 1 255
+    // @Range: 0 255
     // @User: Advanced
     GSCALAR(sysid_target,           "SYSID_TARGET",    0),
 
@@ -455,7 +455,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: CMD_TOTAL
     // @DisplayName: Number of loaded mission items
     // @Description: Set to 1 if HOME location has been loaded by the ground station. Do not change this manually.
-    // @Range: 1 255
+    // @Range: 0 255
     // @User: Advanced
     GSCALAR(command_total,          "CMD_TOTAL",      0),
 

--- a/AntennaTracker/Parameters.cpp
+++ b/AntennaTracker/Parameters.cpp
@@ -299,7 +299,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: PITCH2SRV_FLTT
     // @DisplayName: Pitch axis controller target frequency in Hz
     // @Description: Pitch axis controller target frequency in Hz
-    // @Range: 1 50
+    // @Range: 0 50
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -307,7 +307,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: PITCH2SRV_FLTE
     // @DisplayName: Pitch axis controller error frequency in Hz
     // @Description: Pitch axis controller error frequency in Hz
-    // @Range: 1 100
+    // @Range: 0 100
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -315,7 +315,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: PITCH2SRV_FLTD
     // @DisplayName: Pitch axis controller derivative frequency in Hz
     // @Description: Pitch axis controller derivative frequency in Hz
-    // @Range: 1 100
+    // @Range: 0 100
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -345,13 +345,13 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: PITCH2SRV_NTF
     // @DisplayName: Pitch Target notch filter index
     // @Description: Pitch Target notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     // @Param: PITCH2SRV_NEF
     // @DisplayName: Pitch Error notch filter index
     // @Description: Pitch Error notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     GGROUP(pidPitch2Srv,       "PITCH2SRV_", AC_PID),
@@ -395,7 +395,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: YAW2SRV_FLTT
     // @DisplayName: Yaw axis controller target frequency in Hz
     // @Description: Yaw axis controller target frequency in Hz
-    // @Range: 1 50
+    // @Range: 0 50
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -403,7 +403,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: YAW2SRV_FLTE
     // @DisplayName: Yaw axis controller error frequency in Hz
     // @Description: Yaw axis controller error frequency in Hz
-    // @Range: 1 100
+    // @Range: 0 100
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -411,7 +411,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: YAW2SRV_FLTD
     // @DisplayName: Yaw axis controller derivative frequency in Hz
     // @Description: Yaw axis controller derivative frequency in Hz
-    // @Range: 1 100
+    // @Range: 0 100
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -441,13 +441,13 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: YAW2SRV_NTF
     // @DisplayName: Yaw Target notch filter index
     // @Description: Yaw Target notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     // @Param: YAW2SRV_NEF
     // @DisplayName: Yaw Error notch filter index
     // @Description: Yaw Error notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     GGROUP(pidYaw2Srv,         "YAW2SRV_", AC_PID),

--- a/AntennaTracker/Parameters.cpp
+++ b/AntennaTracker/Parameters.cpp
@@ -299,7 +299,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: PITCH2SRV_FLTT
     // @DisplayName: Pitch axis controller target frequency in Hz
     // @Description: Pitch axis controller target frequency in Hz
-    // @Range: 1 50
+    // @Range: 0 50
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -307,7 +307,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: PITCH2SRV_FLTE
     // @DisplayName: Pitch axis controller error frequency in Hz
     // @Description: Pitch axis controller error frequency in Hz
-    // @Range: 1 100
+    // @Range: 0 100
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -315,7 +315,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: PITCH2SRV_FLTD
     // @DisplayName: Pitch axis controller derivative frequency in Hz
     // @Description: Pitch axis controller derivative frequency in Hz
-    // @Range: 1 100
+    // @Range: 0 100
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -395,7 +395,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: YAW2SRV_FLTT
     // @DisplayName: Yaw axis controller target frequency in Hz
     // @Description: Yaw axis controller target frequency in Hz
-    // @Range: 1 50
+    // @Range: 0 50
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -403,7 +403,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: YAW2SRV_FLTE
     // @DisplayName: Yaw axis controller error frequency in Hz
     // @Description: Yaw axis controller error frequency in Hz
-    // @Range: 1 100
+    // @Range: 0 100
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -411,7 +411,7 @@ const AP_Param::Info Tracker::var_info[] = {
     // @Param: YAW2SRV_FLTD
     // @DisplayName: Yaw axis controller derivative frequency in Hz
     // @Description: Yaw axis controller derivative frequency in Hz
-    // @Range: 1 100
+    // @Range: 0 100
     // @Increment: 1
     // @Units: Hz
     // @User: Standard

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -307,7 +307,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @DisplayName: Stall airspeed
     // @Description: If stall prevention is enabled this speed is used to calculate the minimum airspeed while banking. It is also used during landing final as the minimum airspeed that can be demanded by the TECS, which allows using TECS_LAND_ARSPD or LAND_PF_ARSPD to achieve landings slower than AIRSPEED_MIN. If this is set to 0 then the stall speed is assumed to be the minimum airspeed speed. Typically set slightly higher then true stall speed.
     // @Units: m/s
-    // @Range: 5 75
+    // @Range: 0 75
     // @User: Standard
     ASCALAR(airspeed_stall, "AIRSPEED_STALL", 0),
 
@@ -1141,7 +1141,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Param: FWD_BAT_VOLT_MAX
     // @DisplayName: Forward throttle battery voltage compensation maximum voltage
     // @Description: Forward throttle battery voltage compensation maximum voltage (voltage above this will have no additional scaling effect on thrust). Recommend 4.2 * cell count, 0 = Disabled. Recommend THR_MAX is set to no more than 100 x FWD_BAT_VOLT_MIN / FWD_BAT_VOLT_MAX, THR_MIN is set to no less than -100 x FWD_BAT_VOLT_MIN / FWD_BAT_VOLT_MAX and climb descent rate limits are set accordingly.
-    // @Range: 6 35
+    // @Range: 0 35
     // @Units: V
     // @Increment: 0.1
     // @User: Advanced
@@ -1150,7 +1150,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Param: FWD_BAT_VOLT_MIN
     // @DisplayName: Forward throttle battery voltage compensation minimum voltage
     // @Description: Forward throttle battery voltage compensation minimum voltage (voltage below this will have no additional scaling effect on thrust).  Recommend 3.5 * cell count, 0 = Disabled. Recommend THR_MAX is set to no more than 100 x FWD_BAT_VOLT_MIN / FWD_BAT_VOLT_MAX, THR_MIN is set to no less than -100 x FWD_BAT_VOLT_MIN / FWD_BAT_VOLT_MAX and climb descent rate limits are set accordingly.
-    // @Range: 6 35
+    // @Range: 0 35
     // @Units: V
     // @Increment: 0.1
     // @User: Advanced

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -308,7 +308,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @DisplayName: Stall airspeed
     // @Description: If stall prevention is enabled this speed is used to calculate the minimum airspeed while banking. It is also used during landing final as the minimum airspeed that can be demanded by the TECS, which allows using TECS_LAND_ARSPD or LAND_PF_ARSPD to achieve landings slower than AIRSPEED_MIN. If this is set to 0 then the stall speed is assumed to be the minimum airspeed speed. Typically set slightly higher then true stall speed.
     // @Units: m/s
-    // @Range: 5 75
+    // @Range: 0 75
     // @User: Standard
     ASCALAR(airspeed_stall, "AIRSPEED_STALL", 0),
 
@@ -1143,7 +1143,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Param: FWD_BAT_VOLT_MAX
     // @DisplayName: Forward throttle battery voltage compensation maximum voltage
     // @Description: Forward throttle battery voltage compensation maximum voltage (voltage above this will have no additional scaling effect on thrust). Recommend 4.2 * cell count, 0 = Disabled. Recommend THR_MAX is set to no more than 100 x FWD_BAT_VOLT_MIN / FWD_BAT_VOLT_MAX, THR_MIN is set to no less than -100 x FWD_BAT_VOLT_MIN / FWD_BAT_VOLT_MAX and climb descent rate limits are set accordingly.
-    // @Range: 6 35
+    // @Range: 0 35
     // @Units: V
     // @Increment: 0.1
     // @User: Advanced
@@ -1152,7 +1152,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Param: FWD_BAT_VOLT_MIN
     // @DisplayName: Forward throttle battery voltage compensation minimum voltage
     // @Description: Forward throttle battery voltage compensation minimum voltage (voltage below this will have no additional scaling effect on thrust).  Recommend 3.5 * cell count, 0 = Disabled. Recommend THR_MAX is set to no more than 100 x FWD_BAT_VOLT_MIN / FWD_BAT_VOLT_MAX, THR_MIN is set to no less than -100 x FWD_BAT_VOLT_MIN / FWD_BAT_VOLT_MAX and climb descent rate limits are set accordingly.
-    // @Range: 6 35
+    // @Range: 0 35
     // @Units: V
     // @Increment: 0.1
     // @User: Advanced

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -49,7 +49,7 @@ const AP_Param::GroupInfo QuadPlane::var_info[] = {
     // @DisplayName: Pilot maximum vertical speed down
     // @Description: The maximum vertical velocity the pilot may request in m/s going down. If 0, uses Q_PILOT_SPD_UP value.
     // @Units: m/s
-    // @Range: 0.5 5
+    // @Range: 0 5
     // @Increment: 0.1
     // @User: Standard
     AP_GROUPINFO("PILOT_SPD_DN", 60, QuadPlane, pilot_speed_z_max_dn_ms, 0),
@@ -385,7 +385,7 @@ const AP_Param::GroupInfo QuadPlane::var_info2[] = {
     // @Param: TKOFF_FAIL_SCL
     // @DisplayName: Takeoff time failure scalar
     // @Description: Scalar for how long past the expected takeoff time a takeoff should be considered as failed and the vehicle will switch to QLAND. If set to 0 there is no limit on takeoff time.
-    // @Range: 1.1 5.0
+    // @Range: 0 5.0
     // @Increment: 5.1
     // @User: Advanced
     AP_GROUPINFO("TKOFF_FAIL_SCL", 14, QuadPlane, takeoff_failure_scalar, 0),

--- a/ArduPlane/tailsitter.cpp
+++ b/ArduPlane/tailsitter.cpp
@@ -43,7 +43,7 @@ const AP_Param::GroupInfo Tailsitter::var_info[] = {
     // @DisplayName: Tailsitter VTOL transition angle
     // @Description: This is the pitch angle at which tailsitter aircraft will change from fixed wing control to VTOL control, if zero Q_TAILSIT_ANGLE will be used
     // @Units: deg
-    // @Range: 5 80
+    // @Range: 0 80
     AP_GROUPINFO("ANG_VT", 3, Tailsitter, transition_angle_vtol, 0),
 
     // @Param: INPUT

--- a/ArduPlane/tiltrotor.cpp
+++ b/ArduPlane/tiltrotor.cpp
@@ -48,7 +48,7 @@ const AP_Param::GroupInfo Tiltrotor::var_info[] = {
     // @Description: This is the maximum speed at which the motor angle will change for a tiltrotor when moving from hover to forward flight. When this is zero the Q_TILT_RATE_UP value is used.
     // @Units: deg/s
     // @Increment: 1
-    // @Range: 10 300
+    // @Range: 0 300
     // @User: Standard
     AP_GROUPINFO("RATE_DN", 6, Tiltrotor, max_rate_down_dps, 0),
 

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -235,7 +235,7 @@ const AP_Param::Info Sub::var_info[] = {
     // @DisplayName: Pilot maximum vertical descending speed
     // @Description: The maximum vertical descending velocity the pilot may request in cm/s
     // @Units: cm/s
-    // @Range: 20 500
+    // @Range: 0 500
     // @Increment: 10
     // @User: Standard
     GSCALAR(pilot_speed_dn,     "PILOT_SPEED_DN",   0),

--- a/Blimp/Loiter.cpp
+++ b/Blimp/Loiter.cpp
@@ -813,7 +813,7 @@ const AP_Param::GroupInfo Loiter::var_info[] = {
     // @DisplayName: Deadzone for the position PIDs
     // @Description: Output 0 thrust signal when blimp is within this distance (in meters) of the target position. Warning: If this param is greater than LOIT_MAX_POS_X multiplied by LOIT_LAG then the blimp won't move at all in the X axis in Loiter mode. Same for the other axes.
     // @Units: m
-    // @Range: 0.1 1
+    // @Range: 0 1
     // @User: Standard
     AP_GROUPINFO("PID_DZ", 17, Loiter, pid_dz, 0),
 
@@ -828,7 +828,7 @@ const AP_Param::GroupInfo Loiter::var_info[] = {
     // @DisplayName: Loiter position lag
     // @Description: Number of seconds' worth of travel that the actual position can be behind the target position.
     // @Units: s
-    // @Range: 0 0.999
+    // @Range: 0 1
     // @User: Standard
     AP_GROUPINFO("POS_LAG", 19, Loiter, pos_lag, 1),
 

--- a/Blimp/Loiter.cpp
+++ b/Blimp/Loiter.cpp
@@ -85,13 +85,13 @@ const AP_Param::GroupInfo Loiter::var_info[] = {
     // @Param: VELX_NTF
     // @DisplayName: X axis velocity target notch filter index
     // @Description: X axis velocity target notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     // @Param: VELX_NEF
     // @DisplayName: X axis velocity error notch filter index
     // @Description: X axis velocity error notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
     AP_SUBGROUPINFO(pid_vel_x, "VELX_", 0, Loiter, AC_PID),
 
@@ -178,13 +178,13 @@ const AP_Param::GroupInfo Loiter::var_info[] = {
     // @Param: VELY_NTF
     // @DisplayName: Y axis velocity target notch filter index
     // @Description: Y axis velocity target notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     // @Param: VELY_NEF
     // @DisplayName: Y axis velocity error notch filter index
     // @Description: Y axis velocity error notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
     AP_SUBGROUPINFO(pid_vel_y, "VELY_", 1, Loiter, AC_PID),
 
@@ -271,13 +271,13 @@ const AP_Param::GroupInfo Loiter::var_info[] = {
     // @Param: VELZ_NTF
     // @DisplayName: Z axis velocity target notch filter index
     // @Description: Z axis velocity target notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     // @Param: VELZ_NEF
     // @DisplayName: Z axis velocity error notch filter index
     // @Description: Z axis velocity error notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
     AP_SUBGROUPINFO(pid_vel_z, "VELZ_", 2, Loiter, AC_PID),
 
@@ -364,13 +364,13 @@ const AP_Param::GroupInfo Loiter::var_info[] = {
     // @Param: VELYAW_NTF
     // @DisplayName: Yaw axis velocity target notch filter index
     // @Description: Yaw axis velocity target notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     // @Param: VELYAW_NEF
     // @DisplayName: Yaw axis velocity error notch filter index
     // @Description: Yaw axis velocity error notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
     AP_SUBGROUPINFO(pid_vel_yaw, "VELYAW_", 3, Loiter, AC_PID),
 
@@ -457,13 +457,13 @@ const AP_Param::GroupInfo Loiter::var_info[] = {
     // @Param: POSX_NTF
     // @DisplayName: X axis position target notch filter index
     // @Description: X axis position target notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     // @Param: POSX_NEF
     // @DisplayName: X axis position error notch filter index
     // @Description: X axis position error notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
     AP_SUBGROUPINFO(pid_pos_x, "POSX_", 4, Loiter, AC_PID),
 
@@ -550,13 +550,13 @@ const AP_Param::GroupInfo Loiter::var_info[] = {
     // @Param: POSY_NTF
     // @DisplayName: Y axis position target notch filter index
     // @Description: Y axis position target notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     // @Param: POSY_NEF
     // @DisplayName: Y axis position error notch filter index
     // @Description: Y axis position error notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
     AP_SUBGROUPINFO(pid_pos_y, "POSY_", 5, Loiter, AC_PID),
 
@@ -643,13 +643,13 @@ const AP_Param::GroupInfo Loiter::var_info[] = {
     // @Param: POSZ_NTF
     // @DisplayName: Z axis position target notch filter index
     // @Description: Z axis position target notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     // @Param: POSZ_NEF
     // @DisplayName: Z axis position error notch filter index
     // @Description: Z axis position error notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
     AP_SUBGROUPINFO(pid_pos_z, "POSZ_", 6, Loiter, AC_PID),
 
@@ -736,13 +736,13 @@ const AP_Param::GroupInfo Loiter::var_info[] = {
     // @Param: POSYAW_NTF
     // @DisplayName: Yaw axis position target notch filter index
     // @Description: Yaw axis position target notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     // @Param: POSYAW_NEF
     // @DisplayName: Yaw axis position error notch filter index
     // @Description: Yaw axis position error notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
     AP_SUBGROUPINFO(pid_pos_yaw, "POSYAW_", 7, Loiter, AC_PID),
 

--- a/Blimp/Parameters.cpp
+++ b/Blimp/Parameters.cpp
@@ -378,7 +378,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @DisplayName: Pilot maximum vertical speed descending
     // @Description: The maximum vertical descending velocity the pilot may request in cm/s
     // @Units: cm/s
-    // @Range: 50 500
+    // @Range: 0 500
     // @Increment: 10
     // @User: Standard
     AP_GROUPINFO("PILOT_SPEED_DN", 24, ParametersG2, pilot_speed_dn, 0),

--- a/Rover/mode_dock.cpp
+++ b/Rover/mode_dock.cpp
@@ -16,7 +16,7 @@ const AP_Param::GroupInfo ModeDock::var_info[] = {
     // @DisplayName: Dock mode direction of approach
     // @Description: Compass direction in which vehicle should approach towards dock. -1 value represents unset parameter
     // @Units: deg
-    // @Range: 0 360
+    // @Range: -1 360
     // @Increment: 1
     // @User: Advanced
     AP_GROUPINFO("_DIR", 2, ModeDock, desired_dir, -1.00f),

--- a/Tools/AP_Periph/Parameters.cpp
+++ b/Tools/AP_Periph/Parameters.cpp
@@ -329,7 +329,7 @@ const AP_Param::Info AP_Periph_FW::var_info[] = {
     // @Param: RNGFND2_PORT
     // @DisplayName: Rangefinder Serial Port
     // @Description: This is the serial port number where SERIALx_PROTOCOL will be set to Rangefinder.
-    // @Range: 0 10
+    // @Range: -1 10
     // @Increment: 1
     // @User: Advanced
     // @RebootRequired: True

--- a/Tools/autotest/param_metadata/param_parse.py
+++ b/Tools/autotest/param_metadata/param_parse.py
@@ -69,6 +69,35 @@ prog_param_tagged_fields = re.compile(r"[ \t]*// @(\w+){([^}]+)}: ([^\r\n]*)")
 
 prog_groups = re.compile(r"@Group: *(\w*).*((?:\n[ \t]*// @(Path): (\S+))+)", re.MULTILINE)
 
+# macros which define a parameter, mapped to the indices of the macro
+# arguments which hold the parameter's name and its default value.
+# Macros which do not supply a default value (e.g.
+# AP_GROUPINFO_FLAGS_DEFAULT_POINTER) are deliberately absent:
+prog_param_macros = {
+    #                          (name, default)
+    "AP_GROUPINFO": (0, 4),             # (name, idx, clazz, element, def)
+    "AP_GROUPINFO_FLAGS": (0, 4),       # (name, idx, clazz, element, def, flags)
+    "AP_GROUPINFO_FRAME": (0, 4),       # (name, idx, clazz, element, def, frame_flags)
+    "AP_GROUPINFO_FLAGS_FRAME": (0, 4), # (name, idx, clazz, element, def, flags, frame_flags)  # noqa
+    "GSCALAR": (1, 2),                  # (v, name, def)
+    "ASCALAR": (1, 2),                  # (v, name, def)
+    "GARRAY": (2, 3),                   # (v, index, name, def)
+}
+
+# match the start of a macro invocation at the start of a line
+prog_macro_start = re.compile(r"^[ \t]*(\w+)[ \t]*\(")
+
+# match a plain numeric literal, possibly with a C numeric suffix
+prog_number_literal = re.compile(r"^[-+]?(?:0[xX][0-9a-fA-F]+|(?:\d+\.?\d*|\.\d+)(?:[eE][-+]?\d+)?)[fFuUlL]*$")
+
+# match a cast of a numeric literal; e.g. "(float)5" or "uint8_t(5)".
+# Only casts to built-in types are recognised; a function call (e.g.
+# "radians(30)") must not be mistaken for a cast:
+prog_c_type = (r"(?:const\s+)?(?:unsigned\s+|signed\s+)?"
+               r"(?:u?int(?:8|16|32|64)_t|float|double|bool|char|short|long|int)")
+prog_cast_prefix = re.compile(r"^\(\s*" + prog_c_type + r"\s*\)\s*(.*)$")
+prog_cast_functional = re.compile(r"^" + prog_c_type + r"\s*\((.*)\)$")
+
 apm_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../../')
 
 
@@ -101,6 +130,150 @@ def debug(str_to_print):
     """Debug output if verbose is set."""
     if args.verbose:
         print(str_to_print)
+
+
+def split_macro_arguments(text, offset):
+    """Split the arguments of a macro invocation.
+
+    offset must be the index of the opening bracket of the macro
+    invocation in text.  Returns a list of the (unstripped) arguments,
+    or None if the closing bracket is not found.
+    """
+    args_found = []
+    depth = 0
+    current = ''
+    in_string = False
+    in_char = False
+    i = offset
+    while i < len(text):
+        c = text[i]
+        i += 1
+        if in_string or in_char:
+            current += c
+            if c == '\\':
+                # skip the escaped character
+                if i < len(text):
+                    current += text[i]
+                    i += 1
+            elif in_string and c == '"':
+                in_string = False
+            elif in_char and c == "'":
+                in_char = False
+            continue
+        if c == '"':
+            in_string = True
+        elif c == "'":
+            in_char = True
+        elif c in '([{':
+            depth += 1
+            if depth == 1:
+                # this is the opening bracket of the macro itself
+                continue
+        elif c in ')]}':
+            depth -= 1
+            if depth == 0:
+                args_found.append(current)
+                return args_found
+        elif c == ',' and depth == 1:
+            args_found.append(current)
+            current = ''
+            continue
+        current += c
+
+    return None
+
+
+def number_from_c_literal(value):
+    """Return the number a C expression evaluates to, or None.
+
+    Only simple numeric literals (and casts of those literals) are
+    understood; anything more complicated (e.g. a #define or an
+    arithmetic expression) returns None.
+    """
+    value = value.strip()
+
+    # strip comments (e.g. a trailing "// note") and newlines:
+    value = re.sub(r"/\*.*?\*/", " ", value, flags=re.DOTALL)
+    value = re.sub(r"//[^\n]*", " ", value)
+    value = " ".join(value.split())
+
+    # strip casts and redundant brackets; e.g. "(float)5", "int8_t(5)",
+    # "((0.5))":
+    while True:
+        stripped = prog_cast_prefix.match(value)
+        if stripped is not None:
+            value = stripped.group(1).strip()
+            continue
+        stripped = prog_cast_functional.match(value)
+        if stripped is not None:
+            value = stripped.group(1).strip()
+            continue
+        if value.startswith("(") and value.endswith(")"):
+            value = value[1:-1].strip()
+            continue
+        break
+
+    if not prog_number_literal.match(value):
+        return None
+
+    # remove any C numeric suffix:
+    value = value.rstrip("fFuUlL")
+
+    try:
+        if value[0:2].lower() == "0x" or value[0:3].lower() in ("+0x", "-0x"):
+            return float(int(value, 16))
+        return float(value)
+    except ValueError:
+        return None
+
+
+def find_default_value(text, param_match, param_name):
+    """Find the default value of the parameter documented by param_match.
+
+    The parameter's default value comes from the macro invocation
+    immediately following the documentation block.  Returns None if the
+    default value can not be determined - for example if the parameter
+    is not defined by a macro we understand (Lua parameters, for
+    example, are not), or if the default is not a simple number.
+    """
+    # the documentation block match ends part-way into the line
+    # following the documentation; step back to the start of that line:
+    offset = text.rfind("\n", 0, param_match.end()) + 1
+
+    while offset < len(text):
+        eol = text.find("\n", offset)
+        if eol == -1:
+            eol = len(text)
+        line = text[offset:eol]
+        stripped = line.strip()
+        # step over anything between the documentation and the macro:
+        if (stripped == "" or
+                stripped.startswith("//") or
+                stripped.startswith("#") or
+                stripped.startswith("--")):
+            offset = eol + 1
+            continue
+
+        macro = prog_macro_start.match(line)
+        if macro is None:
+            return None
+        offsets = prog_param_macros.get(macro.group(1), None)
+        if offsets is None:
+            # not a macro which supplies a default value
+            return None
+        (name_offset, default_offset) = offsets
+        macro_args = split_macro_arguments(text, offset + macro.end() - 1)
+        if macro_args is None or len(macro_args) <= default_offset:
+            return None
+
+        # only trust the macro if it is defining the parameter we have
+        # just seen documentation for:
+        if macro_args[name_offset].strip() != '"%s"' % param_name:
+            return None
+
+        return number_from_c_literal(macro_args[default_offset])
+
+    return None
 
 
 def lua_applets():
@@ -202,12 +375,12 @@ def process_vehicle(vehicle):
             libraries.append(lib)
 
     param_matches = []
-    param_matches = prog_param.findall(p_text)
+    param_matches = prog_param.finditer(p_text)
 
     for param_match in param_matches:
-        (only_vehicles, param_name, field_text) = (param_match[0].strip(),
-                                                   param_match[1].strip(),
-                                                   param_match[2].strip())
+        (only_vehicles, param_name, field_text) = ((param_match.group(1) or '').strip(),
+                                                   param_match.group(2).strip(),
+                                                   param_match.group(3).strip())
         if len(only_vehicles):
             only_vehicles_list = [x.strip() for x in only_vehicles.split(",")]
             for only_vehicle in only_vehicles_list:
@@ -221,6 +394,7 @@ def process_vehicle(vehicle):
         current_param = p.name
         fields = prog_param_fields.findall(field_text)
         p.__field_text = field_text
+        p.__default_value = find_default_value(p_text, param_match, param_name)
         field_list = []
         for field in fields:
             (field_name, field_value) = (field[0].strip(), field[1].strip())
@@ -291,12 +465,12 @@ def process_library(vehicle, library, pathprefix=None):
             error("Path %s not found for library %s (fname=%s)" % (path, library.name, libraryfname))
             continue
 
-        param_matches = prog_param.findall(p_text)
+        param_matches = list(prog_param.finditer(p_text))
         debug("Found %u documented parameters" % len(param_matches))
         for param_match in param_matches:
-            (only_vehicles, param_name, field_text) = (param_match[0].strip(),
-                                                       param_match[1].strip(),
-                                                       param_match[2].strip())
+            (only_vehicles, param_name, field_text) = ((param_match.group(1) or '').strip(),
+                                                       param_match.group(2).strip(),
+                                                       param_match.group(3).strip())
             if len(only_vehicles):
                 only_vehicles_list = [x.strip() for x in only_vehicles.split(",")]
                 for only_vehicle in only_vehicles_list:
@@ -310,6 +484,7 @@ def process_library(vehicle, library, pathprefix=None):
             current_param = p.name
             fields = prog_param_fields.findall(field_text)
             p.__field_text = field_text
+            p.__default_value = find_default_value(p_text, param_match, param_name)
             field_list = []
             for field in fields:
                 (field_name, field_value) = (field[0].strip(), field[1].strip())
@@ -584,6 +759,29 @@ def do_copy_fields(vehicle_params, libraries, param):
           (param.name, wanted_name))
 
 
+def validate_default_value(param):
+    """Check the parameter's default value against its documentation.
+
+    A default value which the documentation says is invalid is either a
+    bug in the code or (more usually) a bug in the documentation; a user
+    resetting a parameter to its default via a GCS must not end up with
+    a value the GCS is told is out-of-range.
+    """
+    default_value = getattr(param, "__default_value", None)
+    if default_value is None:
+        # we were unable to work out what the default value is
+        return
+
+    if hasattr(param, "Range"):
+        range_values = param.Range.split(" ")
+        # malformed ranges are complained about elsewhere:
+        if len(range_values) == 2 and is_number(range_values[0]) and is_number(range_values[1]):
+            (min_range, max_range) = (float(range_values[0]), float(range_values[1]))
+            if default_value < min_range or default_value > max_range:
+                error("Default value of %g is outside Range of %g to %g" %
+                      (default_value, min_range, max_range))
+
+
 def validate(param, is_library=False):
     """
     Validates the parameter meta data.
@@ -656,6 +854,10 @@ def validate(param, is_library=False):
         if maxValue > maxRange:
             error("Range of %f to %f and value of: %f" % (minRange, maxRange, maxValue))
 
+    # Check the parameter's default value is consistent with its
+    # documentation:
+    validate_default_value(param)
+
     # Validate increment
     if (hasattr(param, "Increment")):
         if not is_number(param.Increment):
@@ -706,6 +908,14 @@ for library in libraries:
 for library in libraries:
     for param in library.params:
         validate(param, is_library=True)
+
+# the default value is used for validation only; remove it so that it
+# does not appear in the emitted metadata:
+for param in vehicle.params:
+    param.__dict__.pop('__default_value', None)
+for library in libraries:
+    for param in library.params:
+        param.__dict__.pop('__default_value', None)
 
 if not args.emit_params:
     sys.exit(error_count)

--- a/Tools/autotest/param_metadata/param_parse.py
+++ b/Tools/autotest/param_metadata/param_parse.py
@@ -84,6 +84,35 @@ prog_param_tagged_fields = re.compile(r"[ \t]*// @(\w+){([^}]+)}: ([^\r\n]*)")
 
 prog_groups = re.compile(r"@Group: *(\w*).*((?:\n[ \t]*// @(Path): (\S+))+)", re.MULTILINE)
 
+# macros which define a parameter, mapped to the indices of the macro
+# arguments which hold the parameter's name and its default value.
+# Macros which do not supply a default value (e.g.
+# AP_GROUPINFO_FLAGS_DEFAULT_POINTER) are deliberately absent:
+prog_param_macros = {
+    #                          (name, default)
+    "AP_GROUPINFO": (0, 4),             # (name, idx, clazz, element, def)
+    "AP_GROUPINFO_FLAGS": (0, 4),       # (name, idx, clazz, element, def, flags)
+    "AP_GROUPINFO_FRAME": (0, 4),       # (name, idx, clazz, element, def, frame_flags)
+    "AP_GROUPINFO_FLAGS_FRAME": (0, 4), # (name, idx, clazz, element, def, flags, frame_flags)  # noqa
+    "GSCALAR": (1, 2),                  # (v, name, def)
+    "ASCALAR": (1, 2),                  # (v, name, def)
+    "GARRAY": (2, 3),                   # (v, index, name, def)
+}
+
+# match the start of a macro invocation at the start of a line
+prog_macro_start = re.compile(r"^[ \t]*(\w+)[ \t]*\(")
+
+# match a plain numeric literal, possibly with a C numeric suffix
+prog_number_literal = re.compile(r"^[-+]?(?:0[xX][0-9a-fA-F]+|(?:\d+\.?\d*|\.\d+)(?:[eE][-+]?\d+)?)[fFuUlL]*$")
+
+# match a cast of a numeric literal; e.g. "(float)5" or "uint8_t(5)".
+# Only casts to built-in types are recognised; a function call (e.g.
+# "radians(30)") must not be mistaken for a cast:
+prog_c_type = (r"(?:const\s+)?(?:unsigned\s+|signed\s+)?"
+               r"(?:u?int(?:8|16|32|64)_t|float|double|bool|char|short|long|int)")
+prog_cast_prefix = re.compile(r"^\(\s*" + prog_c_type + r"\s*\)\s*(.*)$")
+prog_cast_functional = re.compile(r"^" + prog_c_type + r"\s*\((.*)\)$")
+
 apm_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), '../../../')
 
 
@@ -116,6 +145,150 @@ def debug(str_to_print):
     """Debug output if verbose is set."""
     if args.verbose:
         print(str_to_print)
+
+
+def split_macro_arguments(text, offset):
+    """Split the arguments of a macro invocation.
+
+    offset must be the index of the opening bracket of the macro
+    invocation in text.  Returns a list of the (unstripped) arguments,
+    or None if the closing bracket is not found.
+    """
+    args_found = []
+    depth = 0
+    current = ''
+    in_string = False
+    in_char = False
+    i = offset
+    while i < len(text):
+        c = text[i]
+        i += 1
+        if in_string or in_char:
+            current += c
+            if c == '\\':
+                # skip the escaped character
+                if i < len(text):
+                    current += text[i]
+                    i += 1
+            elif in_string and c == '"':
+                in_string = False
+            elif in_char and c == "'":
+                in_char = False
+            continue
+        if c == '"':
+            in_string = True
+        elif c == "'":
+            in_char = True
+        elif c in '([{':
+            depth += 1
+            if depth == 1:
+                # this is the opening bracket of the macro itself
+                continue
+        elif c in ')]}':
+            depth -= 1
+            if depth == 0:
+                args_found.append(current)
+                return args_found
+        elif c == ',' and depth == 1:
+            args_found.append(current)
+            current = ''
+            continue
+        current += c
+
+    return None
+
+
+def number_from_c_literal(value):
+    """Return the number a C expression evaluates to, or None.
+
+    Only simple numeric literals (and casts of those literals) are
+    understood; anything more complicated (e.g. a #define or an
+    arithmetic expression) returns None.
+    """
+    value = value.strip()
+
+    # strip comments (e.g. a trailing "// note") and newlines:
+    value = re.sub(r"/\*.*?\*/", " ", value, flags=re.DOTALL)
+    value = re.sub(r"//[^\n]*", " ", value)
+    value = " ".join(value.split())
+
+    # strip casts and redundant brackets; e.g. "(float)5", "int8_t(5)",
+    # "((0.5))":
+    while True:
+        stripped = prog_cast_prefix.match(value)
+        if stripped is not None:
+            value = stripped.group(1).strip()
+            continue
+        stripped = prog_cast_functional.match(value)
+        if stripped is not None:
+            value = stripped.group(1).strip()
+            continue
+        if value.startswith("(") and value.endswith(")"):
+            value = value[1:-1].strip()
+            continue
+        break
+
+    if not prog_number_literal.match(value):
+        return None
+
+    # remove any C numeric suffix:
+    value = value.rstrip("fFuUlL")
+
+    try:
+        if value[0:2].lower() == "0x" or value[0:3].lower() in ("+0x", "-0x"):
+            return float(int(value, 16))
+        return float(value)
+    except ValueError:
+        return None
+
+
+def find_default_value(text, param_match, param_name):
+    """Find the default value of the parameter documented by param_match.
+
+    The parameter's default value comes from the macro invocation
+    immediately following the documentation block.  Returns None if the
+    default value can not be determined - for example if the parameter
+    is not defined by a macro we understand (Lua parameters, for
+    example, are not), or if the default is not a simple number.
+    """
+    # the documentation block match ends part-way into the line
+    # following the documentation; step back to the start of that line:
+    offset = text.rfind("\n", 0, param_match.end()) + 1
+
+    while offset < len(text):
+        eol = text.find("\n", offset)
+        if eol == -1:
+            eol = len(text)
+        line = text[offset:eol]
+        stripped = line.strip()
+        # step over anything between the documentation and the macro:
+        if (stripped == "" or
+                stripped.startswith("//") or
+                stripped.startswith("#") or
+                stripped.startswith("--")):
+            offset = eol + 1
+            continue
+
+        macro = prog_macro_start.match(line)
+        if macro is None:
+            return None
+        offsets = prog_param_macros.get(macro.group(1), None)
+        if offsets is None:
+            # not a macro which supplies a default value
+            return None
+        (name_offset, default_offset) = offsets
+        macro_args = split_macro_arguments(text, offset + macro.end() - 1)
+        if macro_args is None or len(macro_args) <= default_offset:
+            return None
+
+        # only trust the macro if it is defining the parameter we have
+        # just seen documentation for:
+        if macro_args[name_offset].strip() != '"%s"' % param_name:
+            return None
+
+        return number_from_c_literal(macro_args[default_offset])
+
+    return None
 
 
 def lua_applets():
@@ -217,12 +390,12 @@ def process_vehicle(vehicle):
             libraries.append(lib)
 
     param_matches = []
-    param_matches = prog_param.findall(p_text)
+    param_matches = prog_param.finditer(p_text)
 
     for param_match in param_matches:
-        (only_vehicles, param_name, field_text) = (param_match[0].strip(),
-                                                   param_match[1].strip(),
-                                                   param_match[2].strip())
+        (only_vehicles, param_name, field_text) = ((param_match.group(1) or '').strip(),
+                                                   param_match.group(2).strip(),
+                                                   param_match.group(3).strip())
         if len(only_vehicles):
             only_vehicles_list = [x.strip() for x in only_vehicles.split(",")]
             for only_vehicle in only_vehicles_list:
@@ -236,6 +409,7 @@ def process_vehicle(vehicle):
         current_param = p.name
         fields = prog_param_fields.findall(field_text)
         p.__field_text = field_text
+        p.__default_value = find_default_value(p_text, param_match, param_name)
         field_list = []
         for field in fields:
             (field_name, field_value) = (field[0].strip(), field[1].strip())
@@ -306,12 +480,12 @@ def process_library(vehicle, library, pathprefix=None):
             error("Path %s not found for library %s (fname=%s)" % (path, library.name, libraryfname))
             continue
 
-        param_matches = prog_param.findall(p_text)
+        param_matches = list(prog_param.finditer(p_text))
         debug("Found %u documented parameters" % len(param_matches))
         for param_match in param_matches:
-            (only_vehicles, param_name, field_text) = (param_match[0].strip(),
-                                                       param_match[1].strip(),
-                                                       param_match[2].strip())
+            (only_vehicles, param_name, field_text) = ((param_match.group(1) or '').strip(),
+                                                       param_match.group(2).strip(),
+                                                       param_match.group(3).strip())
             if len(only_vehicles):
                 only_vehicles_list = [x.strip() for x in only_vehicles.split(",")]
                 for only_vehicle in only_vehicles_list:
@@ -325,6 +499,7 @@ def process_library(vehicle, library, pathprefix=None):
             current_param = p.name
             fields = prog_param_fields.findall(field_text)
             p.__field_text = field_text
+            p.__default_value = find_default_value(p_text, param_match, param_name)
             field_list = []
             for field in fields:
                 (field_name, field_value) = (field[0].strip(), field[1].strip())
@@ -599,6 +774,29 @@ def do_copy_fields(vehicle_params, libraries, param):
           (param.name, wanted_name))
 
 
+def validate_default_value(param):
+    """Check the parameter's default value against its documentation.
+
+    A default value which the documentation says is invalid is either a
+    bug in the code or (more usually) a bug in the documentation; a user
+    resetting a parameter to its default via a GCS must not end up with
+    a value the GCS is told is out-of-range.
+    """
+    default_value = getattr(param, "__default_value", None)
+    if default_value is None:
+        # we were unable to work out what the default value is
+        return
+
+    if hasattr(param, "Range"):
+        range_values = param.Range.split(" ")
+        # malformed ranges are complained about elsewhere:
+        if len(range_values) == 2 and is_number(range_values[0]) and is_number(range_values[1]):
+            (min_range, max_range) = (float(range_values[0]), float(range_values[1]))
+            if default_value < min_range or default_value > max_range:
+                error("Default value of %g is outside Range of %g to %g" %
+                      (default_value, min_range, max_range))
+
+
 def validate(param, is_library=False):
     """
     Validates the parameter meta data.
@@ -671,6 +869,10 @@ def validate(param, is_library=False):
         if maxValue > maxRange:
             error("Range of %f to %f and value of: %f" % (minRange, maxRange, maxValue))
 
+    # Check the parameter's default value is consistent with its
+    # documentation:
+    validate_default_value(param)
+
     # Validate increment
     if (hasattr(param, "Increment")):
         if not is_number(param.Increment):
@@ -721,6 +923,14 @@ for library in libraries:
 for library in libraries:
     for param in library.params:
         validate(param, is_library=True)
+
+# the default value is used for validation only; remove it so that it
+# does not appear in the emitted metadata:
+for param in vehicle.params:
+    param.__dict__.pop('__default_value', None)
+for library in libraries:
+    for param in library.params:
+        param.__dict__.pop('__default_value', None)
 
 if not args.emit_params:
     sys.exit(error_count)

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -15,6 +15,7 @@ import fnmatch
 import glob
 import importlib.util
 import io
+import json
 import math
 import operator
 import os
@@ -2724,6 +2725,82 @@ class TestSuite(abc.ABC):
             "CC_TYPE": 2,         # AC_CustomControl: PID backend (ArduCopter)
         }
 
+    def parameters_with_known_out_of_range_values(self):
+        '''parameters whose value on a running vehicle is outside the range
+        their documentation gives, but where it is not clear whether the
+        documentation or the value is the thing which is wrong.  Each of
+        these wants a decision from someone who knows the controller in
+        question; until then they are not failures.'''
+        return {
+            # the vehicle's default gain sits outside the range documented
+            # in the shared library the parameter comes from:
+            "RLL2SRV_TCONST": "Plane ships 0.25, documented 0.4 to 1.0",
+            "PTCH2SRV_TCONST": "Plane ships 0.25, documented 0.4 to 1.0",
+            "YAW_RATE_P": "Plane ships 0.04, documented 0.08 to 0.35",
+            "PSC_POS_P": "Rover ships 0.2, documented 0.5 to 2.0",
+            "WRC_RATE_FF": "Rover ships 8, documented 0.1 to 2.0",
+            "WRC2_RATE_FF": "Rover ships 8, documented 0.1 to 2.0",
+            "ATC_ACC_Y_MAX": "Sub ships 1100, documented 0 to 720",
+            "ATC_THR_MIX_MAN": "Sub ships 0.1, documented 0.5 to 0.9",
+            "LOIT_BRK_JRK_M": "Heli ships 2.5, documented 5 to 50",
+            "Q_LOIT_BRK_JRK_M": "QuadPlane ships 2.5, documented 5 to 50",
+            "AROT_FWD_I": "Heli ships 2.0, documented 0.02 to 1.0",
+            "PHLD_BRK_ANGLE": "Heli ships 8, documented 20 to 45",
+
+            # Copter's @Group: ATC_ takes in both
+            # AC_AttitudeControl_Multi.cpp and AC_AttitudeControl_Heli.cpp,
+            # so where a parameter is documented in both files one set of
+            # documentation wins and a multirotor ends up advertising the
+            # helicopter's range.  Fixing this needs the documentation
+            # restructured, not a range widened:
+            "ATC_RAT_RLL_FF": "multirotor gets the AC_AttitudeControl_Heli range",
+            "ATC_RAT_PIT_FF": "multirotor gets the AC_AttitudeControl_Heli range",
+            "ATC_RAT_RLL_FLTE": "multirotor gets the AC_AttitudeControl_Heli range",
+            "ATC_RAT_PIT_FLTE": "multirotor gets the AC_AttitudeControl_Heli range",
+            "ATC_RAT_YAW_FLTE": "multirotor gets the AC_AttitudeControl_Heli range",
+        }
+
+    def test_parameter_values_within_documented_ranges(self, parameters):
+        '''check the value each parameter holds on the running vehicle is
+        within the @Range its documentation gives for it.  param_parse.py
+        checks the defaults it can extract from the source code, but many
+        defaults come from #defines, enumerations or are set at runtime;
+        those only show up on a live vehicle.'''
+
+        # the json metadata was emitted alongside the xml, above:
+        json_filepath = os.path.join(self.buildlogs_dirpath(), "apm.pdef.json")
+        metadata = {}
+        for (group, group_params) in json.load(open(json_filepath)).items():
+            if group == 'json':
+                # this group holds the metadata format version
+                continue
+            metadata.update(group_params)
+
+        fail = False
+        for (param, value) in parameters.items():
+            if param in self.parameters_with_known_out_of_range_values():
+                continue
+            if param not in metadata:
+                # missing documentation is complained about above
+                continue
+            param_range = metadata[param].get('Range', None)
+            if param_range is None:
+                continue
+            (low, high) = (float(param_range['low']), float(param_range['high']))
+            # parameters come off the wire as single-precision floats, so
+            # a value which is exactly on a limit can land just outside
+            # it; don't complain about that:
+            if math.isclose(value, low, rel_tol=1e-6, abs_tol=1e-9):
+                continue
+            if math.isclose(value, high, rel_tol=1e-6, abs_tol=1e-9):
+                continue
+            if value < low or value > high:
+                self.progress("%s value %f is outside documented range %f to %f" %
+                              (param, value, low, high))
+                fail = True
+        if fail:
+            raise NotAchievedException("Parameter values outside documented ranges")
+
     def test_parameter_documentation_get_all_parameters(self):
 
         xml_filepath = os.path.join(self.buildlogs_dirpath(), "apm.pdef.xml")
@@ -2770,6 +2847,8 @@ class TestSuite(abc.ABC):
                 fail = True
         if fail:
             raise NotAchievedException("Downloaded parameters missing in XML")
+
+        self.test_parameter_values_within_documented_ranges(parameters)
 
         # FIXME: this should be doable if we filter out e.g BRD_* and CAN_*?
 #        self.progress("Checking no extra parameters present in XML")

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -15,6 +15,7 @@ import fnmatch
 import glob
 import importlib.util
 import io
+import json
 import math
 import operator
 import os
@@ -2779,6 +2780,82 @@ class TestSuite(abc.ABC):
             "CC_TYPE": 2,         # AC_CustomControl: PID backend (ArduCopter)
         }
 
+    def parameters_with_known_out_of_range_values(self):
+        '''parameters whose value on a running vehicle is outside the range
+        their documentation gives, but where it is not clear whether the
+        documentation or the value is the thing which is wrong.  Each of
+        these wants a decision from someone who knows the controller in
+        question; until then they are not failures.'''
+        return {
+            # the vehicle's default gain sits outside the range documented
+            # in the shared library the parameter comes from:
+            "RLL2SRV_TCONST": "Plane ships 0.25, documented 0.4 to 1.0",
+            "PTCH2SRV_TCONST": "Plane ships 0.25, documented 0.4 to 1.0",
+            "YAW_RATE_P": "Plane ships 0.04, documented 0.08 to 0.35",
+            "PSC_POS_P": "Rover ships 0.2, documented 0.5 to 2.0",
+            "WRC_RATE_FF": "Rover ships 8, documented 0.1 to 2.0",
+            "WRC2_RATE_FF": "Rover ships 8, documented 0.1 to 2.0",
+            "ATC_ACC_Y_MAX": "Sub ships 1100, documented 0 to 720",
+            "ATC_THR_MIX_MAN": "Sub ships 0.1, documented 0.5 to 0.9",
+            "LOIT_BRK_JRK_M": "Heli ships 2.5, documented 5 to 50",
+            "Q_LOIT_BRK_JRK_M": "QuadPlane ships 2.5, documented 5 to 50",
+            "AROT_FWD_I": "Heli ships 2.0, documented 0.02 to 1.0",
+            "PHLD_BRK_ANGLE": "Heli ships 8, documented 20 to 45",
+
+            # Copter's @Group: ATC_ takes in both
+            # AC_AttitudeControl_Multi.cpp and AC_AttitudeControl_Heli.cpp,
+            # so where a parameter is documented in both files one set of
+            # documentation wins and a multirotor ends up advertising the
+            # helicopter's range.  Fixing this needs the documentation
+            # restructured, not a range widened:
+            "ATC_RAT_RLL_FF": "multirotor gets the AC_AttitudeControl_Heli range",
+            "ATC_RAT_PIT_FF": "multirotor gets the AC_AttitudeControl_Heli range",
+            "ATC_RAT_RLL_FLTE": "multirotor gets the AC_AttitudeControl_Heli range",
+            "ATC_RAT_PIT_FLTE": "multirotor gets the AC_AttitudeControl_Heli range",
+            "ATC_RAT_YAW_FLTE": "multirotor gets the AC_AttitudeControl_Heli range",
+        }
+
+    def test_parameter_values_within_documented_ranges(self, parameters):
+        '''check the value each parameter holds on the running vehicle is
+        within the @Range its documentation gives for it.  param_parse.py
+        checks the defaults it can extract from the source code, but many
+        defaults come from #defines, enumerations or are set at runtime;
+        those only show up on a live vehicle.'''
+
+        # the json metadata was emitted alongside the xml, above:
+        json_filepath = os.path.join(self.buildlogs_dirpath(), "apm.pdef.json")
+        metadata = {}
+        for (group, group_params) in json.load(open(json_filepath)).items():
+            if group == 'json':
+                # this group holds the metadata format version
+                continue
+            metadata.update(group_params)
+
+        fail = False
+        for (param, value) in parameters.items():
+            if param in self.parameters_with_known_out_of_range_values():
+                continue
+            if param not in metadata:
+                # missing documentation is complained about above
+                continue
+            param_range = metadata[param].get('Range', None)
+            if param_range is None:
+                continue
+            (low, high) = (float(param_range['low']), float(param_range['high']))
+            # parameters come off the wire as single-precision floats, so
+            # a value which is exactly on a limit can land just outside
+            # it; don't complain about that:
+            if math.isclose(value, low, rel_tol=1e-6, abs_tol=1e-9):
+                continue
+            if math.isclose(value, high, rel_tol=1e-6, abs_tol=1e-9):
+                continue
+            if value < low or value > high:
+                self.progress("%s value %f is outside documented range %f to %f" %
+                              (param, value, low, high))
+                fail = True
+        if fail:
+            raise NotAchievedException("Parameter values outside documented ranges")
+
     def test_parameter_documentation_get_all_parameters(self):
 
         xml_filepath = os.path.join(self.buildlogs_dirpath(), "apm.pdef.xml")
@@ -2825,6 +2902,8 @@ class TestSuite(abc.ABC):
                 fail = True
         if fail:
             raise NotAchievedException("Downloaded parameters missing in XML")
+
+        self.test_parameter_values_within_documented_ranges(parameters)
 
         # FIXME: this should be doable if we filter out e.g BRD_* and CAN_*?
 #        self.progress("Checking no extra parameters present in XML")

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.cpp
@@ -103,13 +103,13 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Param: RAT_RLL_NTF
     // @DisplayName: Roll Target notch filter index
     // @Description: Roll Target notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     // @Param: RAT_RLL_NEF
     // @DisplayName: Roll Error notch filter index
     // @Description: Roll Error notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(_pid_rate_roll, "RAT_RLL_", 2, AC_AttitudeControl_Heli, AC_HELI_PID),
@@ -201,13 +201,13 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Param: RAT_PIT_NTF
     // @DisplayName: Pitch Target notch filter index
     // @Description: Pitch Target notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     // @Param: RAT_PIT_NEF
     // @DisplayName: Pitch Error notch filter index
     // @Description: Pitch Error notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(_pid_rate_pitch, "RAT_PIT_", 3, AC_AttitudeControl_Heli, AC_HELI_PID),
@@ -268,7 +268,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Param: RAT_YAW_FLTE
     // @DisplayName: Yaw axis rate controller error frequency in Hz
     // @Description: Yaw axis rate controller error frequency in Hz
-    // @Range: 5 50
+    // @Range: 0 50
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -299,14 +299,14 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Param: RAT_YAW_NTF
     // @DisplayName: Yaw Target notch filter index
     // @Description: Yaw Target notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @Units: Hz
     // @User: Advanced
 
     // @Param: RAT_YAW_NEF
     // @DisplayName: Yaw Error notch filter index
     // @Description: Yaw Error notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(_pid_rate_yaw, "RAT_YAW_", 4, AC_AttitudeControl_Heli, AC_HELI_PID),

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.cpp
@@ -268,7 +268,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @Param: RAT_YAW_FLTE
     // @DisplayName: Yaw axis rate controller error frequency in Hz
     // @Description: Yaw axis rate controller error frequency in Hz
-    // @Range: 5 50
+    // @Range: 0 50
     // @Increment: 1
     // @Units: Hz
     // @User: Standard

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp
@@ -96,13 +96,13 @@ const AP_Param::GroupInfo AC_AttitudeControl_Multi::var_info[] = {
     // @Param: RAT_RLL_NTF
     // @DisplayName: Roll Target notch filter index
     // @Description: Roll Target notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     // @Param: RAT_RLL_NEF
     // @DisplayName: Roll Error notch filter index
     // @Description: Roll Error notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(_pid_rate_roll, "RAT_RLL_", 1, AC_AttitudeControl_Multi, AC_PID),
@@ -194,13 +194,13 @@ const AP_Param::GroupInfo AC_AttitudeControl_Multi::var_info[] = {
     // @Param: RAT_PIT_NTF
     // @DisplayName: Pitch Target notch filter index
     // @Description: Pitch Target notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     // @Param: RAT_PIT_NEF
     // @DisplayName: Pitch Error notch filter index
     // @Description: Pitch Error notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(_pid_rate_pitch, "RAT_PIT_", 2, AC_AttitudeControl_Multi, AC_PID),
@@ -292,14 +292,14 @@ const AP_Param::GroupInfo AC_AttitudeControl_Multi::var_info[] = {
     // @Param: RAT_YAW_NTF
     // @DisplayName: Yaw Target notch filter index
     // @Description: Yaw Target notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @Units: Hz
     // @User: Advanced
 
     // @Param: RAT_YAW_NEF
     // @DisplayName: Yaw Error notch filter index
     // @Description: Yaw Error notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(_pid_rate_yaw, "RAT_YAW_", 3, AC_AttitudeControl_Multi, AC_PID),

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Sub.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Sub.cpp
@@ -53,7 +53,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Sub::var_info[] = {
     // @Param: RAT_RLL_FLTE
     // @DisplayName: Roll axis rate controller input frequency in Hz
     // @Description: Roll axis rate controller input frequency in Hz
-    // @Range: 1 100
+    // @Range: 0 100
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -146,7 +146,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Sub::var_info[] = {
     // @Param: RAT_PIT_FLTE
     // @DisplayName: Pitch axis rate controller input frequency in Hz
     // @Description: Pitch axis rate controller input frequency in Hz
-    // @Range: 1 100
+    // @Range: 0 100
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -239,7 +239,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Sub::var_info[] = {
     // @Param: RAT_YAW_FLTE
     // @DisplayName: Yaw axis rate controller input frequency in Hz
     // @Description: Yaw axis rate controller input frequency in Hz
-    // @Range: 1 100
+    // @Range: 0 100
     // @Increment: 1
     // @Units: Hz
     // @User: Standard

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Sub.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Sub.cpp
@@ -53,7 +53,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Sub::var_info[] = {
     // @Param: RAT_RLL_FLTE
     // @DisplayName: Roll axis rate controller input frequency in Hz
     // @Description: Roll axis rate controller input frequency in Hz
-    // @Range: 1 100
+    // @Range: 0 100
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -89,13 +89,13 @@ const AP_Param::GroupInfo AC_AttitudeControl_Sub::var_info[] = {
     // @Param: RAT_RLL_NTF
     // @DisplayName: Roll Target notch filter index
     // @Description: Roll Target notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     // @Param: RAT_RLL_NEF
     // @DisplayName: Roll Error notch filter index
     // @Description: Roll Error notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(_pid_rate_roll, "RAT_RLL_", 1, AC_AttitudeControl_Sub, AC_PID),
@@ -146,7 +146,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Sub::var_info[] = {
     // @Param: RAT_PIT_FLTE
     // @DisplayName: Pitch axis rate controller input frequency in Hz
     // @Description: Pitch axis rate controller input frequency in Hz
-    // @Range: 1 100
+    // @Range: 0 100
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -182,13 +182,13 @@ const AP_Param::GroupInfo AC_AttitudeControl_Sub::var_info[] = {
     // @Param: RAT_PIT_NTF
     // @DisplayName: Pitch Target notch filter index
     // @Description: Pitch Target notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     // @Param: RAT_PIT_NEF
     // @DisplayName: Pitch Error notch filter index
     // @Description: Pitch Error notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(_pid_rate_pitch, "RAT_PIT_", 2, AC_AttitudeControl_Sub, AC_PID),
@@ -239,7 +239,7 @@ const AP_Param::GroupInfo AC_AttitudeControl_Sub::var_info[] = {
     // @Param: RAT_YAW_FLTE
     // @DisplayName: Yaw axis rate controller input frequency in Hz
     // @Description: Yaw axis rate controller input frequency in Hz
-    // @Range: 1 100
+    // @Range: 0 100
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -275,13 +275,13 @@ const AP_Param::GroupInfo AC_AttitudeControl_Sub::var_info[] = {
     // @Param: RAT_YAW_NTF
     // @DisplayName: Yaw Target notch filter index
     // @Description: Yaw Target notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     // @Param: RAT_YAW_NEF
     // @DisplayName: Yaw Error notch filter index
     // @Description: Yaw Error notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(_pid_rate_yaw, "RAT_YAW_", 3, AC_AttitudeControl_Sub, AC_PID),

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -235,7 +235,7 @@ const AP_Param::GroupInfo AC_PosControl::var_info[] = {
     // @Param: _D_ACC_FLTT
     // @DisplayName: Acceleration (vertical) controller target frequency in Hz
     // @Description: Acceleration (vertical) controller target frequency in Hz. Previously _ACCZ_FLTT.
-    // @Range: 1 50
+    // @Range: 0 50
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -251,7 +251,7 @@ const AP_Param::GroupInfo AC_PosControl::var_info[] = {
     // @Param: _D_ACC_FLTD
     // @DisplayName: Acceleration (vertical) controller derivative frequency in Hz
     // @Description: Acceleration (vertical) controller derivative frequency in Hz. Previously _ACCZ_FLTD.
-    // @Range: 1 100
+    // @Range: 0 100
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -338,7 +338,7 @@ const AP_Param::GroupInfo AC_PosControl::var_info[] = {
     // @Param: _NE_VEL_FF
     // @DisplayName: Velocity (horizontal) feed forward gain
     // @Description: Velocity (horizontal) feed forward gain. Converts the difference between desired velocity to a target acceleration. Previously _VELXY_FF.
-    // @Range: 0.10 10.00
+    // @Range: 0 10.00
     // @Increment: 0.01
     // @User: Advanced
     AP_SUBGROUPINFO(_pid_vel_ne_m, "_NE_VEL_", 14, AC_PosControl, AC_PID_2D),

--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -235,7 +235,7 @@ const AP_Param::GroupInfo AC_PosControl::var_info[] = {
     // @Param: _D_ACC_FLTT
     // @DisplayName: Acceleration (vertical) controller target frequency in Hz
     // @Description: Acceleration (vertical) controller target frequency in Hz. Previously _ACCZ_FLTT.
-    // @Range: 1 50
+    // @Range: 0 50
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -251,7 +251,7 @@ const AP_Param::GroupInfo AC_PosControl::var_info[] = {
     // @Param: _D_ACC_FLTD
     // @DisplayName: Acceleration (vertical) controller derivative frequency in Hz
     // @Description: Acceleration (vertical) controller derivative frequency in Hz. Previously _ACCZ_FLTD.
-    // @Range: 1 100
+    // @Range: 0 100
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -280,13 +280,13 @@ const AP_Param::GroupInfo AC_PosControl::var_info[] = {
     // @Param: _D_ACC_NTF
     // @DisplayName: Accel (vertical) Target notch filter index
     // @Description: Accel (vertical) Target notch filter index. If upgrading from 4.6 this is Previously _ACCZ_NTF.
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     // @Param: _D_ACC_NEF
     // @DisplayName: Accel (vertical) Error notch filter index
     // @Description: Accel (vertical) Error notch filter index. If upgrading from 4.6 this is Previously _ACCZ_NEF.
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
     AP_SUBGROUPINFO(_pid_accel_d_m, "_D_ACC_", 13, AC_PosControl, AC_PID),
 
@@ -338,7 +338,7 @@ const AP_Param::GroupInfo AC_PosControl::var_info[] = {
     // @Param: _NE_VEL_FF
     // @DisplayName: Velocity (horizontal) feed forward gain
     // @Description: Velocity (horizontal) feed forward gain. Converts the difference between desired velocity to a target acceleration. Previously _VELXY_FF.
-    // @Range: 0.10 10.00
+    // @Range: 0 10.00
     // @Increment: 0.01
     // @User: Advanced
     AP_SUBGROUPINFO(_pid_vel_ne_m, "_NE_VEL_", 14, AC_PosControl, AC_PID_2D),

--- a/libraries/AC_AttitudeControl/AC_WeatherVane.cpp
+++ b/libraries/AC_AttitudeControl/AC_WeatherVane.cpp
@@ -31,7 +31,7 @@ const AP_Param::GroupInfo AC_WeatherVane::var_info[] = {
     // @Param: GAIN
     // @DisplayName: Weathervaning gain
     // @Description: This converts the target roll/pitch angle of the aircraft into the correcting (into wind) yaw rate. e.g. Gain = 2, roll = 30 deg, pitch = 0 deg, yaw rate = 60 deg/s.
-    // @Range: 0.5 4
+    // @Range: 0 4
     // @Increment: 0.1
     // @User: Standard
     AP_GROUPINFO("GAIN", 2, AC_WeatherVane, _gain, WVANE_PARAM_GAIN_DEFAULT),

--- a/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
+++ b/libraries/AC_AutoTune/AC_AutoTune_Heli.cpp
@@ -115,7 +115,7 @@ const AP_Param::GroupInfo AC_AutoTune_Heli::var_info[] = {
     // @Param: ACC_MAX
     // @DisplayName: AutoTune maximum allowable angular acceleration
     // @Description: maximum angular acceleration in deg/s/s allowed during autotune maneuvers
-    // @Range: 1 4000
+    // @Range: 0 4000
     // @User: Standard
     // @Units: deg/s/s
     AP_GROUPINFO("ACC_MAX", 7, AC_AutoTune_Heli, accel_max_degss, 0.0f),

--- a/libraries/AC_Autorotation/AC_Autorotation.cpp
+++ b/libraries/AC_Autorotation/AC_Autorotation.cpp
@@ -48,7 +48,7 @@ const AP_Param::GroupInfo AC_Autorotation::var_info[] = {
     // @DisplayName: Entry Phase Collective Filter
     // @Description: Cut-off frequency for collective low pass filter. For the entry phase. Acts as a following trim.  Must be higher than AROT_COL_FILT_G.
     // @Units: Hz
-    // @Range: 0.2 0.5
+    // @Range: 0.2 1.0
     // @Increment: 0.01
     // @User: Standard
     AP_GROUPINFO("COL_FILT_E", 5, AC_Autorotation, _param_col_entry_cutoff_freq, 0.7),
@@ -74,9 +74,8 @@ const AP_Param::GroupInfo AC_Autorotation::var_info[] = {
     // @Param: HS_SENSOR
     // @DisplayName: Main Rotor RPM Sensor 
     // @Description: Allocate the RPM sensor instance to use for measuring head speed. RPM1 = 0.  RPM2 = 1.
-    // @Units: s
-    // @Range: 0.5 3
-    // @Increment: 0.1
+    // @Range: 0 1
+    // @Increment: 1
     // @User: Standard
     AP_GROUPINFO("HS_SENSOR", 8, AC_Autorotation, _param_rpm_instance, 0),
 

--- a/libraries/AC_Autorotation/AC_Autorotation.cpp
+++ b/libraries/AC_Autorotation/AC_Autorotation.cpp
@@ -73,8 +73,8 @@ const AP_Param::GroupInfo AC_Autorotation::var_info[] = {
 
     // @Param: HS_SENSOR
     // @DisplayName: Main Rotor RPM Sensor 
-    // @Description: Allocate the RPM sensor instance to use for measuring head speed. RPM1 = 0.  RPM2 = 1.
-    // @Range: 0 1
+    // @Description: Allocate the RPM sensor instance to use for measuring head speed. RPM1 = 0.  RPM2 = 1.  RPM3 = 2.  RPM4 = 3.
+    // @Range: 0 3
     // @Increment: 1
     // @User: Standard
     AP_GROUPINFO("HS_SENSOR", 8, AC_Autorotation, _param_rpm_instance, 0),

--- a/libraries/AC_CustomControl/AC_CustomControl_PID.cpp
+++ b/libraries/AC_CustomControl/AC_CustomControl_PID.cpp
@@ -275,7 +275,7 @@ const AP_Param::GroupInfo AC_CustomControl_PID::var_info[] = {
     // @Param: RAT_YAW_FLTD
     // @DisplayName: Yaw axis rate controller derivative frequency in Hz
     // @Description: Yaw axis rate controller derivative frequency in Hz
-    // @Range: 5 50
+    // @Range: 0 50
     // @Increment: 1
     // @Units: Hz
     // @User: Standard

--- a/libraries/AC_CustomControl/AC_CustomControl_PID.cpp
+++ b/libraries/AC_CustomControl/AC_CustomControl_PID.cpp
@@ -115,13 +115,13 @@ const AP_Param::GroupInfo AC_CustomControl_PID::var_info[] = {
     // @Param: RAT_RLL_NTF
     // @DisplayName: Roll Target notch filter index
     // @Description: Roll Target notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     // @Param: RAT_RLL_NEF
     // @DisplayName: Roll Error notch filter index
     // @Description: Roll Error notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(_pid_atti_rate_roll, "RAT_RLL_", 4, AC_CustomControl_PID, AC_PID),
@@ -209,13 +209,13 @@ const AP_Param::GroupInfo AC_CustomControl_PID::var_info[] = {
     // @Param: RAT_PIT_NTF
     // @DisplayName: Pitch Target notch filter index
     // @Description: Pitch Target notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     // @Param: RAT_PIT_NEF
     // @DisplayName: Pitch Error notch filter index
     // @Description: Pitch Error notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(_pid_atti_rate_pitch, "RAT_PIT_", 5, AC_CustomControl_PID, AC_PID),
@@ -275,7 +275,7 @@ const AP_Param::GroupInfo AC_CustomControl_PID::var_info[] = {
     // @Param: RAT_YAW_FLTD
     // @DisplayName: Yaw axis rate controller derivative frequency in Hz
     // @Description: Yaw axis rate controller derivative frequency in Hz
-    // @Range: 5 50
+    // @Range: 0 50
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -304,13 +304,13 @@ const AP_Param::GroupInfo AC_CustomControl_PID::var_info[] = {
     // @Param: RAT_YAW_NTF
     // @DisplayName: Yaw Target notch filter index
     // @Description: Yaw Target notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     // @Param: RAT_YAW_NEF
     // @DisplayName: Yaw Error notch filter index
     // @Description: Yaw Error notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(_pid_atti_rate_yaw, "RAT_YAW_", 6, AC_CustomControl_PID, AC_PID),

--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -102,7 +102,7 @@ const AP_Param::GroupInfo AC_Fence::var_info[] = {
     // @Param: TOTAL
     // @DisplayName: Fence polygon point total
     // @Description: Number of polygon points saved in eeprom (do not update manually)
-    // @Range: 1 20
+    // @Range: 0 20
     // @User: Standard
     AP_GROUPINFO("TOTAL", 6, AC_Fence, _total, 0),
 

--- a/libraries/AC_PID/AC_HELI_PID.cpp
+++ b/libraries/AC_PID/AC_HELI_PID.cpp
@@ -87,14 +87,14 @@ const AP_Param::GroupInfo AC_HELI_PID::var_info[] = {
     // @Param: NTF
     // @DisplayName: PID Target notch filter index
     // @Description: PID Target notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
     AP_GROUPINFO("NTF", 15, AC_HELI_PID, _notch_T_filter, 0),
 
     // @Param: NEF
     // @DisplayName: PID Error notch filter index
     // @Description: PID Error notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
     AP_GROUPINFO("NEF", 16, AC_HELI_PID, _notch_E_filter, 0),
 #endif

--- a/libraries/APM_Control/AP_PitchController.cpp
+++ b/libraries/APM_Control/AP_PitchController.cpp
@@ -88,7 +88,7 @@ const AP_Param::GroupInfo AP_PitchController::var_info[] = {
     // @Param: _RATE_D
     // @DisplayName: Pitch axis rate controller D gain
     // @Description: Pitch axis rate controller D gain.  Compensates for short-term change in desired pitch rate vs actual pitch rate
-    // @Range: 0.001 0.03
+    // @Range: 0 0.03
     // @Increment: 0.001
     // @User: Standard
 
@@ -110,7 +110,7 @@ const AP_Param::GroupInfo AP_PitchController::var_info[] = {
     // @Param: _RATE_FLTE
     // @DisplayName: Pitch axis rate controller error frequency in Hz
     // @Description: Pitch axis rate controller error frequency in Hz
-    // @Range: 2 50
+    // @Range: 0 50
     // @Increment: 1
     // @Units: Hz
     // @User: Standard

--- a/libraries/APM_Control/AP_PitchController.cpp
+++ b/libraries/APM_Control/AP_PitchController.cpp
@@ -88,7 +88,7 @@ const AP_Param::GroupInfo AP_PitchController::var_info[] = {
     // @Param: _RATE_D
     // @DisplayName: Pitch axis rate controller D gain
     // @Description: Pitch axis rate controller D gain.  Compensates for short-term change in desired pitch rate vs actual pitch rate
-    // @Range: 0.001 0.03
+    // @Range: 0 0.03
     // @Increment: 0.001
     // @User: Standard
 
@@ -110,7 +110,7 @@ const AP_Param::GroupInfo AP_PitchController::var_info[] = {
     // @Param: _RATE_FLTE
     // @DisplayName: Pitch axis rate controller error frequency in Hz
     // @Description: Pitch axis rate controller error frequency in Hz
-    // @Range: 2 50
+    // @Range: 0 50
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -146,13 +146,13 @@ const AP_Param::GroupInfo AP_PitchController::var_info[] = {
     // @Param: _RATE_NTF
     // @DisplayName: Pitch Target notch filter index
     // @Description: Pitch Target notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     // @Param: _RATE_NEF
     // @DisplayName: Pitch Error notch filter index
     // @Description: Pitch Error notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(rate_pid, "_RATE_", 11, AP_PitchController, AC_PID),

--- a/libraries/APM_Control/AP_RollController.cpp
+++ b/libraries/APM_Control/AP_RollController.cpp
@@ -71,7 +71,7 @@ const AP_Param::GroupInfo AP_RollController::var_info[] = {
     // @Param: _RATE_D
     // @DisplayName: Roll axis rate controller D gain
     // @Description: Roll axis rate controller D gain.  Compensates for short-term change in desired roll rate vs actual roll rate
-    // @Range: 0.001 0.03
+    // @Range: 0 0.03
     // @Increment: 0.001
     // @User: Standard
 
@@ -93,7 +93,7 @@ const AP_Param::GroupInfo AP_RollController::var_info[] = {
     // @Param: _RATE_FLTE
     // @DisplayName: Roll axis rate controller error frequency in Hz
     // @Description: Roll axis rate controller error frequency in Hz
-    // @Range: 2 50
+    // @Range: 0 50
     // @Increment: 1
     // @Units: Hz
     // @User: Standard

--- a/libraries/APM_Control/AP_RollController.cpp
+++ b/libraries/APM_Control/AP_RollController.cpp
@@ -71,7 +71,7 @@ const AP_Param::GroupInfo AP_RollController::var_info[] = {
     // @Param: _RATE_D
     // @DisplayName: Roll axis rate controller D gain
     // @Description: Roll axis rate controller D gain.  Compensates for short-term change in desired roll rate vs actual roll rate
-    // @Range: 0.001 0.03
+    // @Range: 0 0.03
     // @Increment: 0.001
     // @User: Standard
 
@@ -93,7 +93,7 @@ const AP_Param::GroupInfo AP_RollController::var_info[] = {
     // @Param: _RATE_FLTE
     // @DisplayName: Roll axis rate controller error frequency in Hz
     // @Description: Roll axis rate controller error frequency in Hz
-    // @Range: 2 50
+    // @Range: 0 50
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -129,13 +129,13 @@ const AP_Param::GroupInfo AP_RollController::var_info[] = {
     // @Param: _RATE_NTF
     // @DisplayName: Roll Target notch filter index
     // @Description: Roll Target notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     // @Param: _RATE_NEF
     // @DisplayName: Roll Error notch filter index
     // @Description: Roll Error notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(rate_pid, "_RATE_", 9, AP_RollController, AC_PID),

--- a/libraries/APM_Control/AP_YawController.cpp
+++ b/libraries/APM_Control/AP_YawController.cpp
@@ -103,7 +103,7 @@ const AP_Param::GroupInfo AP_YawController::var_info[] = {
     // @Param: _RATE_D
     // @DisplayName: Yaw axis rate controller D gain
     // @Description: Yaw axis rate controller D gain.  Compensates for short-term change in desired yaw rate vs actual yaw rate
-    // @Range: 0.001 0.03
+    // @Range: 0 0.03
     // @Increment: 0.001
     // @User: Standard
 
@@ -125,7 +125,7 @@ const AP_Param::GroupInfo AP_YawController::var_info[] = {
     // @Param: _RATE_FLTE
     // @DisplayName: Yaw axis rate controller error frequency in Hz
     // @Description: Yaw axis rate controller error frequency in Hz
-    // @Range: 2 50
+    // @Range: 0 50
     // @Increment: 1
     // @Units: Hz
     // @User: Standard

--- a/libraries/APM_Control/AP_YawController.cpp
+++ b/libraries/APM_Control/AP_YawController.cpp
@@ -103,7 +103,7 @@ const AP_Param::GroupInfo AP_YawController::var_info[] = {
     // @Param: _RATE_D
     // @DisplayName: Yaw axis rate controller D gain
     // @Description: Yaw axis rate controller D gain.  Compensates for short-term change in desired yaw rate vs actual yaw rate
-    // @Range: 0.001 0.03
+    // @Range: 0 0.03
     // @Increment: 0.001
     // @User: Standard
 
@@ -125,7 +125,7 @@ const AP_Param::GroupInfo AP_YawController::var_info[] = {
     // @Param: _RATE_FLTE
     // @DisplayName: Yaw axis rate controller error frequency in Hz
     // @Description: Yaw axis rate controller error frequency in Hz
-    // @Range: 2 50
+    // @Range: 0 50
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -161,13 +161,13 @@ const AP_Param::GroupInfo AP_YawController::var_info[] = {
     // @Param: _RATE_NTF
     // @DisplayName: Yaw Target notch filter index
     // @Description: Yaw Target notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     // @Param: _RATE_NEF
     // @DisplayName: Yaw Error notch filter index
     // @Description: Yaw Error notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(rate_pid, "_RATE_", 9, AP_YawController, AC_PID),

--- a/libraries/APM_Control/AR_AttitudeControl.cpp
+++ b/libraries/APM_Control/AR_AttitudeControl.cpp
@@ -158,13 +158,13 @@ const AP_Param::GroupInfo AR_AttitudeControl::var_info[] = {
     // @Param: _STR_RAT_NTF
     // @DisplayName: Steering control Target notch filter index
     // @Description: Steering control Target notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     // @Param: _STR_RAT_NEF
     // @DisplayName: Steering control Error notch filter index
     // @Description: Steering control Error notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(_steer_rate_pid, "_STR_RAT_", 1, AR_AttitudeControl, AC_PID),
@@ -259,13 +259,13 @@ const AP_Param::GroupInfo AR_AttitudeControl::var_info[] = {
     // @Param: _SPEED_NTF
     // @DisplayName: Speed control Target notch filter index
     // @Description: Speed control Target notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     // @Param: _SPEED_NEF
     // @DisplayName: Speed control Error notch filter index
     // @Description: Speed control Error notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(_throttle_speed_pid, "_SPEED_", 2, AR_AttitudeControl, AC_PID),
@@ -420,13 +420,13 @@ const AP_Param::GroupInfo AR_AttitudeControl::var_info[] = {
     // @Param: _BAL_NTF
     // @DisplayName: Pitch control Target notch filter index
     // @Description: Pitch control Target notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     // @Param: _BAL_NEF
     // @DisplayName: Pitch control Error notch filter index
     // @Description: Pitch control Error notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(_pitch_to_throttle_pid, "_BAL_", 10, AR_AttitudeControl, AC_PID),
@@ -529,13 +529,13 @@ const AP_Param::GroupInfo AR_AttitudeControl::var_info[] = {
     // @Param: _SAIL_NTF
     // @DisplayName: Sail Heel Target notch filter index
     // @Description: Sail Heel Target notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     // @Param: _SAIL_NEF
     // @DisplayName: Sail Heel Error notch filter index
     // @Description: Sail Heel Error notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(_sailboat_heel_pid, "_SAIL_", 12, AR_AttitudeControl, AC_PID),

--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -358,7 +358,7 @@ const AP_Param::GroupInfo AP_BoardConfig::var_info[] = {
     // @DisplayName: Servo voltage requirement
     // @Description: Minimum voltage on the servo rail to allow the aircraft to arm. 0 to disable the check.
     // @Units: V
-    // @Range: 3.3 12.0
+    // @Range: 0 12.0
     // @Increment: 0.1
     // @User: Advanced
     AP_GROUPINFO("VSERVO_MIN",    16,     AP_BoardConfig, _vservo_min,  0),

--- a/libraries/AP_Gripper/AP_Gripper.cpp
+++ b/libraries/AP_Gripper/AP_Gripper.cpp
@@ -72,7 +72,7 @@ const AP_Param::GroupInfo AP_Gripper::var_info[] = {
     // @DisplayName: Gripper Autoclose time
     // @Description: Time in seconds that gripper close the gripper after opening; 0 to disable
     // @User: Advanced
-    // @Range: 0.25 255
+    // @Range: 0 255
     // @Units: s
     AP_GROUPINFO("AUTOCLOSE",  7, AP_Gripper, config.autoclose_time, GRIPPER_AUTOCLOSE_DEFAULT),
 

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -62,7 +62,8 @@ void SITL_State::_sitl_setup()
         // unloaded (zero) values; parameters present in storage then
         // overwrite the seed, while any absent ones keep it
         const Location &home = sitl_model->get_home();
-        _sitl->precland_sim.set_default_location(home.lat * 1.0e-7f, home.lng * 1.0e-7f, static_cast<int16_t>(sitl_model->get_home_yaw()));
+        // the home yaw is 0-360; SIM_PLD_YAW is documented as -180 to +180:
+        _sitl->precland_sim.set_default_location(home.lat * 1.0e-7f, home.lng * 1.0e-7f, static_cast<int16_t>(wrap_180(sitl_model->get_home_yaw())));
 #endif
 
         if (_use_fg_view) {

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -70,7 +70,8 @@ void SITL_State::_sitl_setup()
         // unloaded (zero) values; parameters present in storage then
         // overwrite the seed, while any absent ones keep it
         const Location &home = sitl_model->get_home();
-        _sitl->precland_sim.set_default_location(home.lat * 1.0e-7f, home.lng * 1.0e-7f, static_cast<int16_t>(sitl_model->get_home_yaw()));
+        // the home yaw is 0-360; SIM_PLD_YAW is documented as -180 to +180:
+        _sitl->precland_sim.set_default_location(home.lat * 1.0e-7f, home.lng * 1.0e-7f, static_cast<int16_t>(wrap_180(sitl_model->get_home_yaw())));
 #endif
 
         if (_use_fg_view) {

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -148,14 +148,14 @@ const AP_Param::GroupInfo AP_MotorsHeli_Single::var_info[] = {
     // @Param: DDFP_BAT_V_MAX
     // @DisplayName: Battery voltage compensation maximum voltage
     // @Description: Battery voltage compensation maximum voltage (voltage above this will have no additional scaling effect on thrust).  Recommend 4.2 * cell count, 0 = Disabled
-    // @Range: 6 53
+    // @Range: 0 53
     // @Units: V
     // @User: Standard
 
     // @Param: DDFP_BAT_V_MIN
     // @DisplayName: Battery voltage compensation minimum voltage
     // @Description: Battery voltage compensation minimum voltage (voltage below this will have no additional scaling effect on thrust).  Recommend 3.3 * cell count, 0 = Disabled
-    // @Range: 6 42
+    // @Range: 0 42
     // @Units: V
     // @User: Standard
     AP_SUBGROUPINFO(thr_lin, "DDFP_", 22, AP_MotorsHeli_Single, Thrust_Linearization),

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -63,7 +63,7 @@ const AP_Param::GroupInfo AP_MotorsMulticopter::var_info[] = {
     // @Param: BAT_VOLT_MAX
     // @DisplayName: Battery voltage compensation maximum voltage
     // @Description: Battery voltage compensation maximum voltage (voltage above this will have no additional scaling effect on thrust).  Recommend 4.2 * cell count, 0 = Disabled
-    // @Range: 6 53
+    // @Range: 0 53
     // @Units: V
     // @Increment: 0.1
     // @User: Advanced
@@ -72,7 +72,7 @@ const AP_Param::GroupInfo AP_MotorsMulticopter::var_info[] = {
     // @Param: BAT_VOLT_MIN
     // @DisplayName: Battery voltage compensation minimum voltage
     // @Description: Battery voltage compensation minimum voltage (voltage below this will have no additional scaling effect on thrust).  Recommend 3.3 * cell count, 0 = Disabled
-    // @Range: 6 42
+    // @Range: 0 42
     // @Units: V
     // @Increment: 0.1
     // @User: Advanced

--- a/libraries/AP_Motors/AP_Motors_Thrust_Linearization.cpp
+++ b/libraries/AP_Motors/AP_Motors_Thrust_Linearization.cpp
@@ -71,7 +71,7 @@ const AP_Param::GroupInfo Thrust_Linearization::var_info[] = {
     // @Param: BAT_V_MAX
     // @DisplayName: Battery voltage compensation maximum voltage
     // @Description: Battery voltage compensation maximum voltage (voltage above this will have no additional scaling effect on thrust).  Recommend 4.2 * cell count, 0 = Disabled
-    // @Range: 6 53
+    // @Range: 0 53
     // @Units: V
     // @User: Standard
     AP_GROUPINFO("BAT_V_MAX", 5, Thrust_Linearization, batt_voltage_max, THRST_LIN_BAT_VOLT_MAX_DEFAULT),
@@ -79,7 +79,7 @@ const AP_Param::GroupInfo Thrust_Linearization::var_info[] = {
     // @Param: BAT_V_MIN
     // @DisplayName: Battery voltage compensation minimum voltage
     // @Description: Battery voltage compensation minimum voltage (voltage below this will have no additional scaling effect on thrust).  Recommend 3.3 * cell count, 0 = Disabled
-    // @Range: 6 42
+    // @Range: 0 42
     // @Units: V
     // @User: Standard
     AP_GROUPINFO("BAT_V_MIN", 6, Thrust_Linearization, batt_voltage_min, THRST_LIN_BAT_VOLT_MIN_DEFAULT),

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -699,7 +699,7 @@ const AP_Param::GroupInfo NavEKF3::var_info2[] = {
     // @Param: DRAG_BCOEF_Y
     // @DisplayName: Ballistic coefficient for Y axis drag
     // @Description: Ratio of mass to drag coefficient measured along the Y body axis. This parameter enables estimation of wind drift for vehicles with bluff bodies and without propulsion forces in the X and Y direction (eg multicopters). The drag produced by this effect scales with speed squared. Set to a positive value > 1.0 to enable. A starting value is the mass in Kg divided by the side area. The predicted drag from the rotors is specified separately by the EK3_DRAG_MCOEF parameter.
-    // @Range: 50.0 1000.0
+    // @Range: 0 1000.0
     // @Units: kg/m/m
     // @User: Advanced
     AP_GROUPINFO("DRAG_BCOEF_Y", 3, NavEKF3, _ballisticCoef_y, 0.0f),

--- a/libraries/AP_Soaring/AP_Soaring.cpp
+++ b/libraries/AP_Soaring/AP_Soaring.cpp
@@ -126,14 +126,14 @@ const AP_Param::GroupInfo SoaringController::var_info[] = {
     // @Param: MAX_DRIFT
     // @DisplayName: (Optional) Maximum drift distance to allow when thermalling.
     // @Description: The previous mode will be restored if the horizontal distance to the thermalling start location exceeds this value. -1 to disable.
-    // @Range: 0 1000
+    // @Range: -1 1000
     // @User: Advanced
     AP_GROUPINFO("MAX_DRIFT", 16, SoaringController, max_drift, -1),
 
     // @Param: MAX_RADIUS
     // @DisplayName: (Optional) Maximum distance from home
     // @Description: RTL will be entered when a thermal is exited and the plane is more than this distance from home. -1 to disable.
-    // @Range: 0 1000
+    // @Range: -1 1000
     // @User: Advanced
     AP_GROUPINFO("MAX_RADIUS", 17, SoaringController, max_radius, -1),
 

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -207,7 +207,7 @@ const AP_Param::GroupInfo AP_TECS::var_info[] = {
     // @Param: LAND_TDAMP
     // @DisplayName: Controller throttle damping when landing
     // @Description: Damping gain for the throttle demand loop during an auto-landing. Same as TECS_THR_DAMP but only in effect during an auto-land. Increase to add throttle activity to dampen oscillations in speed and height. When set to 0 landing throttle damping is controlled by TECS_THR_DAMP.
-    // @Range: 0.1 1.0
+    // @Range: 0 1.0
     // @Increment: 0.1
     // @User: Advanced
     AP_GROUPINFO("LAND_TDAMP", 23, AP_TECS, _land_throttle_damp, 0),
@@ -231,7 +231,7 @@ const AP_Param::GroupInfo AP_TECS::var_info[] = {
     // @Param: LAND_PDAMP
     // @DisplayName: Pitch damping gain when landing
     // @Description: This is the damping gain for the pitch demand loop during landing. Increase to add damping  to correct for oscillations in speed and height. If set to 0 then TECS_PTCH_DAMP will be used instead.
-    // @Range: 0.1 1.0
+    // @Range: 0 1.0
     // @Increment: 0.1
     // @User: Advanced
     AP_GROUPINFO("LAND_PDAMP", 26, AP_TECS, _land_pitch_damp, 0),

--- a/libraries/AP_VideoTX/AP_VideoTX.cpp
+++ b/libraries/AP_VideoTX/AP_VideoTX.cpp
@@ -37,7 +37,7 @@ const AP_Param::GroupInfo AP_VideoTX::var_info[] = {
     // @Param: POWER
     // @DisplayName: Video Transmitter Power Level
     // @Description: Video Transmitter Power Level. Different VTXs support different power levels, the power level chosen will be rounded down to the nearest supported power level
-    // @Range: 1 1000
+    // @Range: 0 1000
     AP_GROUPINFO("POWER",    2, AP_VideoTX, _power_mw, 0),
 
     // @Param: CHANNEL
@@ -59,7 +59,7 @@ const AP_Param::GroupInfo AP_VideoTX::var_info[] = {
     // @Description: Video Transmitter Frequency. The frequency is derived from the setting of BAND and CHANNEL
     // @User: Standard
     // @ReadOnly: True
-    // @Range: 1000 6000
+    // @Range: 0 6000
     AP_GROUPINFO("FREQ",  5, AP_VideoTX, _frequency_mhz, 0),
 
     // @Param: OPTIONS

--- a/libraries/AP_WheelEncoder/AP_WheelRateControl.cpp
+++ b/libraries/AP_WheelEncoder/AP_WheelRateControl.cpp
@@ -58,7 +58,7 @@ const AP_Param::GroupInfo AP_WheelRateControl::var_info[] = {
     // @Param: _RATE_FLTT
     // @DisplayName: Wheel rate control target frequency in Hz
     // @Description: Wheel rate control target frequency in Hz
-    // @Range: 1 50
+    // @Range: 0 50
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -66,7 +66,7 @@ const AP_Param::GroupInfo AP_WheelRateControl::var_info[] = {
     // @Param: _RATE_FLTE
     // @DisplayName: Wheel rate control error frequency in Hz
     // @Description: Wheel rate control error frequency in Hz
-    // @Range: 1 50
+    // @Range: 0 50
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -74,7 +74,7 @@ const AP_Param::GroupInfo AP_WheelRateControl::var_info[] = {
     // @Param: _RATE_FLTD
     // @DisplayName: Wheel rate control derivative frequency in Hz
     // @Description: Wheel rate control derivative frequency in Hz
-    // @Range: 1 50
+    // @Range: 0 50
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -152,7 +152,7 @@ const AP_Param::GroupInfo AP_WheelRateControl::var_info[] = {
     // @Param: 2_RATE_FLTT
     // @DisplayName: Wheel rate control target frequency in Hz
     // @Description: Wheel rate control target frequency in Hz
-    // @Range: 1 50
+    // @Range: 0 50
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -160,7 +160,7 @@ const AP_Param::GroupInfo AP_WheelRateControl::var_info[] = {
     // @Param: 2_RATE_FLTE
     // @DisplayName: Wheel rate control error frequency in Hz
     // @Description: Wheel rate control error frequency in Hz
-    // @Range: 1 50
+    // @Range: 0 50
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -168,7 +168,7 @@ const AP_Param::GroupInfo AP_WheelRateControl::var_info[] = {
     // @Param: 2_RATE_FLTD
     // @DisplayName: Wheel rate control derivative frequency in Hz
     // @Description: Wheel rate control derivative frequency in Hz
-    // @Range: 1 50
+    // @Range: 0 50
     // @Increment: 1
     // @Units: Hz
     // @User: Standard

--- a/libraries/AP_WheelEncoder/AP_WheelRateControl.cpp
+++ b/libraries/AP_WheelEncoder/AP_WheelRateControl.cpp
@@ -58,7 +58,7 @@ const AP_Param::GroupInfo AP_WheelRateControl::var_info[] = {
     // @Param: _RATE_FLTT
     // @DisplayName: Wheel rate control target frequency in Hz
     // @Description: Wheel rate control target frequency in Hz
-    // @Range: 1 50
+    // @Range: 0 50
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -66,7 +66,7 @@ const AP_Param::GroupInfo AP_WheelRateControl::var_info[] = {
     // @Param: _RATE_FLTE
     // @DisplayName: Wheel rate control error frequency in Hz
     // @Description: Wheel rate control error frequency in Hz
-    // @Range: 1 50
+    // @Range: 0 50
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -74,7 +74,7 @@ const AP_Param::GroupInfo AP_WheelRateControl::var_info[] = {
     // @Param: _RATE_FLTD
     // @DisplayName: Wheel rate control derivative frequency in Hz
     // @Description: Wheel rate control derivative frequency in Hz
-    // @Range: 1 50
+    // @Range: 0 50
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -101,13 +101,13 @@ const AP_Param::GroupInfo AP_WheelRateControl::var_info[] = {
     // @Param: _RATE_NTF
     // @DisplayName: Wheel rate Target notch filter index
     // @Description: Wheel rate Target notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     // @Param: _RATE_NEF
     // @DisplayName: Wheel rate Error notch filter index
     // @Description: Wheel rate Error notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(_rate_pid0, "_RATE_", 3, AP_WheelRateControl, AC_PID),
@@ -152,7 +152,7 @@ const AP_Param::GroupInfo AP_WheelRateControl::var_info[] = {
     // @Param: 2_RATE_FLTT
     // @DisplayName: Wheel rate control target frequency in Hz
     // @Description: Wheel rate control target frequency in Hz
-    // @Range: 1 50
+    // @Range: 0 50
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -160,7 +160,7 @@ const AP_Param::GroupInfo AP_WheelRateControl::var_info[] = {
     // @Param: 2_RATE_FLTE
     // @DisplayName: Wheel rate control error frequency in Hz
     // @Description: Wheel rate control error frequency in Hz
-    // @Range: 1 50
+    // @Range: 0 50
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -168,7 +168,7 @@ const AP_Param::GroupInfo AP_WheelRateControl::var_info[] = {
     // @Param: 2_RATE_FLTD
     // @DisplayName: Wheel rate control derivative frequency in Hz
     // @Description: Wheel rate control derivative frequency in Hz
-    // @Range: 1 50
+    // @Range: 0 50
     // @Increment: 1
     // @Units: Hz
     // @User: Standard
@@ -195,13 +195,13 @@ const AP_Param::GroupInfo AP_WheelRateControl::var_info[] = {
     // @Param: 2_RATE_NTF
     // @DisplayName: Wheel rate Target notch filter index
     // @Description: Wheel rate Target notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     // @Param: 2_RATE_NEF
     // @DisplayName: Wheel rate Error notch filter index
     // @Description: Wheel rate Error notch filter index
-    // @Range: 1 8
+    // @Range: 0 8
     // @User: Advanced
 
     AP_SUBGROUPINFO(_rate_pid1, "2_RATE_", 4, AP_WheelRateControl, AC_PID),

--- a/libraries/AR_Motors/AP_MotorsUGV.cpp
+++ b/libraries/AR_Motors/AP_MotorsUGV.cpp
@@ -124,7 +124,7 @@ const AP_Param::GroupInfo AP_MotorsUGV::var_info[] = {
     // @DisplayName: Motor reversal delay
     // @Description: For reversible motors that need a delay before they can change direction. When greater than zero the throttle will go to zero for this amount of time before outputting the new throttle when the demanded motor direction changes.
     // @Units: s
-    // @Range: 0.1 1.0
+    // @Range: 0 1.0
     // @Increment: 0.1
     // @User: Standard
     AP_GROUPINFO("REV_DELAY", 15, AP_MotorsUGV, _reverse_delay, 0),

--- a/libraries/Filter/AP_NotchFilter_params.cpp
+++ b/libraries/Filter/AP_NotchFilter_params.cpp
@@ -11,7 +11,7 @@ const AP_Param::GroupInfo AP_NotchFilter_params::var_info[] = {
     // @Param: NOTCH_FREQ
     // @DisplayName: Notch Filter center frequency
     // @Description: Notch Filter center frequency in Hz.
-    // @Range: 10 495
+    // @Range: 0 495
     // @Units: Hz
     // @User: Advanced
     AP_GROUPINFO("NOTCH_FREQ", 1, AP_NotchFilter_params, _center_freq_hz, 0),

--- a/libraries/SITL/SIM_Buzzer.cpp
+++ b/libraries/SITL/SIM_Buzzer.cpp
@@ -55,7 +55,7 @@ const AP_Param::GroupInfo Buzzer::var_info[] = {
     // @Param: PIN
     // @DisplayName: buzzer pin
     // @Description: The pin number that the Buzzer is connected to (start at 1)
-    // @Range: 0 15
+    // @Range: -1 15
     // @User: Advanced
     AP_GROUPINFO("PIN", 1, Buzzer, _pin, -1),
 

--- a/libraries/SITL/SIM_Gripper_EPM.cpp
+++ b/libraries/SITL/SIM_Gripper_EPM.cpp
@@ -38,7 +38,7 @@ const AP_Param::GroupInfo Gripper_EPM::var_info[] = {
     // @Param: PIN
     // @DisplayName: Gripper emp pin
     // @Description: The pin number that the gripper emp is connected to. (start at 1)
-    // @Range: 0 15
+    // @Range: -1 15
     // @User: Advanced
     AP_GROUPINFO("PIN", 1, Gripper_EPM, gripper_emp_servo_pin, -1),
 

--- a/libraries/SITL/SIM_Gripper_Servo.cpp
+++ b/libraries/SITL/SIM_Gripper_Servo.cpp
@@ -38,7 +38,7 @@ const AP_Param::GroupInfo Gripper_Servo::var_info[] = {
     // @Param: PIN
     // @DisplayName: Gripper servo pin
     // @Description: The pin number that the gripper servo is connected to. (start at 1)
-    // @Range: 0 15
+    // @Range: -1 15
     // @User: Advanced
     AP_GROUPINFO("PIN", 1, Gripper_Servo, gripper_servo_pin, -1),
 

--- a/libraries/SITL/SIM_Parachute.cpp
+++ b/libraries/SITL/SIM_Parachute.cpp
@@ -36,7 +36,7 @@ const AP_Param::GroupInfo Parachute::var_info[] = {
     // @Param: PIN
     // @DisplayName: Parachute pin
     // @Description: The pin number that the Parachute pyrotechnics are connected to. (start at 1)
-    // @Range: 0 15
+    // @Range: -1 15
     // @User: Advanced
     AP_GROUPINFO("PIN", 1, Parachute, parachute_pin, -1),
 

--- a/libraries/SITL/SIM_RichenPower.cpp
+++ b/libraries/SITL/SIM_RichenPower.cpp
@@ -42,7 +42,7 @@ const AP_Param::GroupInfo RichenPower::var_info[] = {
     // @Param: CTRL
     // @DisplayName: Pin RichenPower is connectred to
     // @Description: The pin number that the RichenPower spinner servo is connected to. (start at 1)
-    // @Range: 0 15
+    // @Range: -1 15
     // @User: Advanced
     AP_GROUPINFO("CTRL", 2, RichenPower, _ctrl_pin, -1),
 

--- a/libraries/SITL/SIM_Sprayer.cpp
+++ b/libraries/SITL/SIM_Sprayer.cpp
@@ -37,14 +37,14 @@ const AP_Param::GroupInfo Sprayer::var_info[] = {
     // @Param: PUMP
     // @DisplayName: Sprayer pump pin
     // @Description: The pin number that the Sprayer pump is connected to. (start at 1)
-    // @Range: 0 15
+    // @Range: -1 15
     // @User: Advanced
     AP_GROUPINFO("PUMP", 1, Sprayer, sprayer_pump_pin, -1),
 
     // @Param: SPIN
     // @DisplayName: Sprayer spinner servo pin
     // @Description: The pin number that the Sprayer spinner servo is connected to. (start at 1)
-    // @Range: 0 15
+    // @Range: -1 15
     // @User: Advanced
     AP_GROUPINFO("SPIN", 2, Sprayer, sprayer_spin_pin, -1),
 

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -217,7 +217,7 @@ const AP_Param::GroupInfo SIM::var_info[] = {
     // @Param: SPEEDUP
     // @DisplayName: Sim Speedup
     // @Description: Runs the simulation at multiples of normal speed. Do not use if realtime physics, like RealFlight, is being used
-    // @Range: 1 10
+    // @Range: 1 1000
     // @User: Advanced
     AP_GROUPINFO("SPEEDUP",       52, SIM,  speedup, 1),
     // @Param: IMU_POS

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -224,7 +224,7 @@ const AP_Param::GroupInfo SIM::var_info[] = {
     // @Param: SPEEDUP
     // @DisplayName: Sim Speedup
     // @Description: Runs the simulation at multiples of normal speed. Do not use if realtime physics, like RealFlight, is being used
-    // @Range: 1 10
+    // @Range: 1 1000
     // @User: Advanced
     AP_GROUPINFO("SPEEDUP",       52, SIM,  speedup, 1),
     // @Param: IMU_POS


### PR DESCRIPTION
### Summary

Make the parameter-metadata CI check catch parameters whose default value lies outside their own documented `@Range` - the bug class fixed by #33928 - and fix the 43 existing instances of it.

I am *not* convinced we should be merging the actual CI checks - they might be fragile.

#33928 was the impetus for this.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Testing performed:

- `param_parse.py` runs clean for all seven firmwares (this is the existing
  `param_parse` target in `build_ci.sh`, which already exits non-zero on
  metadata errors, so no new CI job is required).
- Reverting 3d22061e0 (the #33928 fix) makes the check fail with exactly the
  four out-of-range `FOLL_*` defaults that PR fixed:
  ```
  Error in ../libraries/AP_Follow/AP_Follow.cpp
  At param FOLL_ACCEL_D
  Default value of 5 is outside Range of 0 to 2.5
  ```
- Emitted metadata is unchanged: `apm.pdef.json` generated before and after the
  `param_parse.py` change (with the documentation fixes in place both times) is
  byte-identical, so the extracted default never leaks into the output.
- `Tools/scripts/param_check_unittests.py` and `Tools/scripts/param_check_all.py`
  both pass, so no board, SITL or frame default-parameter file conflicts with the
  widened ranges.
- `Tools/scripts/run_flake8.py` is clean.

### Description

#### The check

`param_parse.py` has only ever looked at the `// @...` documentation comments, so
nothing noticed when a parameter's default value was outside its own documented
`@Range`. A user who resets such a parameter to its default is then told by their
GCS that the value is invalid.

It now also extracts each parameter's default value from the parameter-defining
macro which follows the documentation block, and errors if that default is outside
`@Range`:

```
Error in ../libraries/AP_Follow/AP_Follow.cpp
At param FOLL_ACCEL_D
Default value of 5 is outside Range of 0 to 2.5
```

Implementation notes:

- The macros understood are `AP_GROUPINFO`, `AP_GROUPINFO_FLAGS`,
  `AP_GROUPINFO_FRAME`, `AP_GROUPINFO_FLAGS_FRAME`, `GSCALAR`, `ASCALAR` and
  `GARRAY`. Arguments are split with a bracket- and string-aware scanner, so
  multi-line invocations work.
- The name in the macro must match the name in the documentation block. Without
  this, a documentation block whose macro has since been removed (e.g.
  `Q_YAW_RATE_MAX` in `quadplane.cpp`) gets paired with the *next* parameter's
  macro; that alone accounted for five false positives.
- Only plain numeric literals, and casts of them (`(float)5`, `int8_t(-1)`), are
  understood. A `#define`, an enum, an expression or a Lua parameter yields
  "default unknown" and is skipped, so the check never guesses. Cast-stripping is
  restricted to built-in type names so that a call such as `radians(30)` cannot be
  misread as `30`.
- The extracted default is used for validation only and is removed before the
  emitters run.

Coverage: roughly 2900 of ~5950 parameters per vehicle have a default the parser
can determine, covering about 1300 of the ~3100 parameters which document a
`@Range`. The remainder mostly use `#define`d or enum defaults; resolving those is
possible later if wanted.

#### The fixes

The check found 43 pre-existing violations. Almost all are parameters whose
default is a "disabled"/"use something else" sentinel that the documented range
did not admit - typically 0 or -1 - and in most cases the description already says
so. They are fixed one commit per vehicle/library. Two needed more than a widened
bound:

- `AROT_COL_FILT_E`: the default was changed to a hard-coded 0.7 in 691eca7b62
  without updating `@Range: 0.2 0.5`. Upper bound raised to 1.0.
- `AROT_HS_SENSOR`: an RPM sensor *instance* number (RPM1 = 0, RPM2 = 1) which had
  been given the units, range and increment of a time constant
  (`@Units: s`, `@Range: 0.5 3`, `@Increment: 0.1`). Now `@Range: 0 1`,
  `@Increment: 1`, with the bogus units removed.

#### Not included

The same machinery can check defaults against `@Values` and `@Bitmask`, which
flags ~95 further parameters. Most of those hits come from vehicle-tagged
(`@Values{Copter}`) or deliberately partial/appended values lists - e.g.
`RCn_OPTION` when generating AP_Periph metadata, or `BATT_VOLT_PIN` - rather than
from real documentation bugs, so that check is left out of this PR.
