### PR TITLE
Use trim-less RC channel values when manipulating devices via MSP

### DIFF
--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -15618,8 +15618,95 @@ switch value'''
             "pitmode": 0, "freq": 5769, "deviceIsReady": 1,
         })
 
+    def wait_msp_rc(self, msp, want, epsilon=2, timeout=10):
+        '''poll MSP_RC until the reported channels match want, a 4-tuple of
+        microseconds in MSP's AERT order with None meaning "don't care";
+        polling rather than reading one frame drains frames buffered before
+        the RC override took effect. Returns the matching tuple'''
+        MSP_RC = 105
+        last = {}
+
+        def collect(cmd, data):
+            if cmd == MSP_RC and len(data) >= 8:
+                last['rc'] = struct.unpack("<HHHH", bytes(data[:8]))
+        msp.callback = collect
+        tstart = self.get_sim_time()
+        try:
+            while True:
+                # pace the requests; an unanswered poll loop running flat out
+                # fills the socket buffer and fails the write before the timeout
+                self.drain_mav()
+                time.sleep(0.05)
+                if self.get_sim_time_cached() - tstart > timeout:
+                    raise NotAchievedException("MSP_RC never matched %s (last %s)" % (str(want), str(last.get('rc'))))
+                msp.send_command(MSP_RC)
+                msp.update()
+                rc = last.get('rc')
+                if rc is not None and all(w is None or abs(rc[i] - w) <= epsilon for (i, w) in enumerate(want)):
+                    return rc
+        finally:
+            msp.callback = None
+
+    def check_msp_rc(self, msp):
+        '''check the RC channel values the FC reports over MSP_RC. This is what
+        a betaflight-style VTX (e.g. HDZero) reads to detect the stick gestures
+        that open its menus, so the axes must span the 1000-2000us range
+        betaflight uses, independently of this vehicle's RC trims'''
+        # ArduPilot's roll/pitch/throttle/yaw are RC1/2/3/4; MSP's order is AERT
+        (A, E, R, T) = (0, 1, 2, 3)
+
+        self.progress("Checking centred sticks report mid-stick")
+        self.set_rc_from_map({1: 1500, 2: 1500, 3: 1500, 4: 1500})
+        self.wait_msp_rc(msp, (1500, 1500, 1500, 1500))
+
+        # a gesture keyed on a low or centred throttle only works if the
+        # throttle axis spans the same range as every other channel
+        self.progress("Checking the throttle axis spans 1000-2000")
+        for pwm in [1000, 1250, 1500, 1750, 2000]:
+            want = [None] * 4
+            want[T] = pwm
+            self.set_rc(3, pwm)
+            self.wait_msp_rc(msp, tuple(want))
+
+        self.progress("Checking the roll axis spans 1000-2000")
+        for pwm in [1000, 1500, 2000]:
+            want = [None] * 4
+            want[A] = pwm
+            self.set_rc(1, pwm)
+            self.wait_msp_rc(msp, tuple(want))
+        self.set_rc(1, 1500)
+
+        # pitch is deliberately inverted on the wire: ArduPilot's pitch channel
+        # and betaflight's elevator run in opposite directions
+        self.progress("Checking the pitch axis is inverted")
+        for (pwm, elevator) in [(1000, 2000), (1500, 1500), (2000, 1000)]:
+            want = [None] * 4
+            want[E] = elevator
+            self.set_rc(2, pwm)
+            self.wait_msp_rc(msp, tuple(want))
+        self.set_rc(2, 1500)
+
+        self.progress("Checking the yaw axis spans 1000-2000")
+        for pwm in [1000, 1500, 2000]:
+            want = [None] * 4
+            want[R] = pwm
+            self.set_rc(4, pwm)
+            self.wait_msp_rc(msp, tuple(want))
+        self.set_rc(4, 1500)
+
+        # the reported values describe stick position, so moving a trim must not
+        # move them; a VTX has no way to learn this vehicle's trims
+        self.progress("Checking the reported values do not depend on the RC trims")
+        for trim in [1000, 1500, 1900]:
+            self.set_parameters({"RC2_TRIM": trim, "RC3_TRIM": trim})
+            for (pwm, elevator) in [(1000, 2000), (1500, 1500), (2000, 1000)]:
+                self.set_rc_from_map({2: pwm, 3: pwm})
+                self.wait_msp_rc(msp, (None, elevator, None, pwm))
+
+        self.set_rc_default()
+
     def MSPVTXConfig(self):
-        '''test changing VTX band/channel/frequency via MSP_SET_VTX_CONFIG'''
+        '''test the VTX config and RC channels a VTX reads over an MSP link'''
         self.set_parameters({
             "SERIAL5_PROTOCOL": 32,  # MSP
             "VTX_ENABLE": 1,
@@ -15631,6 +15718,11 @@ switch value'''
         self.wait_ready_to_arm()
         msp = self.msp_connect(port)
         self.check_msp_set_vtx_config(msp)
+        # note: not also checked on the DisplayPort link, which does not answer
+        # requests in SITL; the OSD saturates that port's transmit buffer and
+        # SITL's tx_pending() is hardcoded false, so msp_serial_send_frame()
+        # discards every reply
+        self.check_msp_rc(msp)
         self.reboot_sitl()
 
     def MSPDisplayPortVTXConfig(self):

--- a/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
+++ b/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
@@ -1140,10 +1140,15 @@ MSPCommandResult AP_MSP_Telem_Backend::msp_process_out_rtc(sbuf_t *dst)
 #if AP_RC_CHANNEL_ENABLED
 MSPCommandResult AP_MSP_Telem_Backend::msp_process_out_rc(sbuf_t *dst)
 {
-    float roll = rc().get_roll_channel().norm_input_dz();
-    float pitch = -rc().get_pitch_channel().norm_input_dz();
-    float yaw = rc().get_yaw_channel().norm_input_dz();
-    float throttle = rc().get_throttle_channel().norm_input_dz();
+    // ignore the trims and deadzones: these values describe stick position to a
+    // device which knows nothing of this vehicle's RC setup, and which expects
+    // every axis to span 1000-2000us as betaflight's do. Honouring the throttle
+    // trim in particular put mid-stick at 1000us, breaking the stick gestures a
+    // VTX uses to open its menus
+    float roll = rc().get_roll_channel().norm_input_ignore_trim();
+    float pitch = -rc().get_pitch_channel().norm_input_ignore_trim();
+    float yaw = rc().get_yaw_channel().norm_input_ignore_trim();
+    float throttle = rc().get_throttle_channel().norm_input_ignore_trim();
 
     const struct PACKED {
         uint16_t a;
@@ -1155,7 +1160,7 @@ MSPCommandResult AP_MSP_Telem_Backend::msp_process_out_rc(sbuf_t *dst)
         a : uint16_t(roll*500+1500),       // A
         e : uint16_t(pitch*500+1500),      // E
         r : uint16_t(yaw*500+1500),        // R
-        t : uint16_t(throttle*1000+1000)    // T
+        t : uint16_t(throttle*500+1500)    // T
     };
 
     sbuf_write_data(dst, &rc, sizeof(rc));


### PR DESCRIPTION
### Summary

Fixes problems manipulating camera/vtx stuff using the sticks

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

```
1:17 PM]spova: Ok after some swapping around and testing it appears there is something wrong with ardupilot stick commands for HDZ. Reading through docs they used to work at some point but I dont know what changed.

stick commands to enter VTX menu seem to work on both my VTX but stick commands to enter camera menu do not in arudpilot. I tested the same two VTX in betaflight and both respond to the camera stick command as well as VTX menu.
```