### PR TITLE
SITL: expose multicopter frame model as SIM_FRM_ parameters

### DIFF
--- a/Tools/autotest/param_metadata/param.py
+++ b/Tools/autotest/param_metadata/param.py
@@ -125,6 +125,7 @@ known_units = {
              'kB'      : 'kilobytes'               ,
              'KiB'     : 'kibibytes',
              'MB'      : 'megabyte'                ,
+             'm.m'     : 'square meter',
              'm.m/s/s' : 'square meter per square second',
              'deg/m/s' : 'degrees per meter per second'  ,
              'm/s/m'   : 'meters per second per meter'   , # Why not use Hz here ????

--- a/libraries/SITL/SIM_Frame.cpp
+++ b/libraries/SITL/SIM_Frame.cpp
@@ -20,6 +20,7 @@
 #include <AP_Motors/AP_Motors.h>
 #include <AP_Baro/AP_Baro.h>
 #include <AP_Filesystem/AP_Filesystem.h>
+#include <AP_Vehicle/AP_Vehicle_Type.h>
 #include "SIM_Aircraft.h"
 
 #include "SIM_config.h"
@@ -28,6 +29,147 @@
 #include <sys/stat.h>
 
 using namespace SITL;
+
+#if AP_SIM_ENABLED
+// default to no bluff body or momentum drag on planes, where the
+// plane model handles drag
+#if APM_BUILD_TYPE(APM_BUILD_ArduPlane)
+#define SIM_FRAME_BBDRAG_DEFAULT 0.0
+#define SIM_FRAME_MDRAG_DEFAULT  0.0
+#else
+#define SIM_FRAME_BBDRAG_DEFAULT 1.0
+#define SIM_FRAME_MDRAG_DEFAULT  0.2
+#endif
+
+// user settable multicopter model parameters. Defaults can be
+// overridden by a json model file
+const AP_Param::GroupInfo Frame::var_info[] = {
+    // @Param: MASS
+    // @DisplayName: model mass
+    // @Description: mass of the multicopter model
+    // @Units: kg
+    AP_GROUPINFO("MASS", 1, Frame, model.mass, 3.0),
+
+    // @Param: DIAG_SZ
+    // @DisplayName: model diagonal size
+    // @Description: diagonal motor to motor distance of the model
+    // @Units: m
+    AP_GROUPINFO("DIAG_SZ", 2, Frame, model.diagonal_size, 0.35),
+
+    // @Param: REF_SPD
+    // @DisplayName: reference speed
+    // @Description: airspeed in the drag reference test, at a fixed lean angle
+    // @Units: m/s
+    AP_GROUPINFO("REF_SPD", 3, Frame, model.refSpd, 15.08),
+
+    // @Param: REF_ANG
+    // @DisplayName: reference angle
+    // @Description: lean angle in the drag reference test
+    // @Units: deg
+    AP_GROUPINFO("REF_ANG", 4, Frame, model.refAngle, 45),
+
+    // @Param: REF_VOLT
+    // @DisplayName: reference voltage
+    // @Description: battery voltage in the drag reference test
+    // @Units: V
+    AP_GROUPINFO("REF_VOLT", 5, Frame, model.refVoltage, 12.09),
+
+    // @Param: REF_AMP
+    // @DisplayName: reference current
+    // @Description: battery current in the drag reference test
+    // @Units: A
+    AP_GROUPINFO("REF_AMP", 6, Frame, model.refCurrent, 29.3),
+
+    // @Param: REF_ALT
+    // @DisplayName: reference altitude
+    // @Description: altitude AMSL of the drag reference test
+    // @Units: m
+    AP_GROUPINFO("REF_ALT", 7, Frame, model.refAlt, 593),
+
+    // @Param: BAT_RES
+    // @DisplayName: battery resistance
+    // @Description: battery resistance
+    // @Units: Ohm
+    AP_GROUPINFO("BAT_RES", 8, Frame, model.refBatRes, 0.01),
+
+    // @Param: BAT_VOLT
+    // @DisplayName: battery full voltage
+    // @Description: full pack battery voltage
+    // @Units: V
+    AP_GROUPINFO("BAT_VOLT", 9, Frame, model.maxVoltage, 12.6),
+
+    // @Param: BAT_CAP
+    // @DisplayName: battery capacity
+    // @Description: battery capacity, zero for unlimited
+    // @Units: Ah
+    AP_GROUPINFO("BAT_CAP", 10, Frame, model.battCapacityAh, 0),
+
+    // @Param: HOVR_THR
+    // @DisplayName: hover throttle
+    // @Description: throttle output (CTUN.ThO) at hover at the reference altitude
+    // @Range: 0.05 1
+    AP_GROUPINFO("HOVR_THR", 11, Frame, model.hoverThrOut, 0.39),
+
+    // @Param: EXPO
+    // @DisplayName: thrust expo
+    // @Description: motor thrust expo, matching MOT_THST_EXPO
+    AP_GROUPINFO("EXPO", 12, Frame, model.propExpo, 0.65),
+
+    // @Param: ROT_RATE
+    // @DisplayName: rotation rate
+    // @Description: terminal yaw rotation rate
+    // @Units: deg/s
+    AP_GROUPINFO("ROT_RATE", 13, Frame, model.refRotRate, 120),
+
+    // @Param: PWM_MIN
+    // @DisplayName: minimum PWM
+    // @Description: minimum motor PWM in the reference test, matching MOT_PWM_MIN
+    // @Units: PWM
+    AP_GROUPINFO("PWM_MIN", 14, Frame, model.pwmMin, 1000),
+
+    // @Param: PWM_MAX
+    // @DisplayName: maximum PWM
+    // @Description: maximum motor PWM in the reference test, matching MOT_PWM_MAX
+    // @Units: PWM
+    AP_GROUPINFO("PWM_MAX", 15, Frame, model.pwmMax, 2000),
+
+    // @Param: SPIN_MIN
+    // @DisplayName: motor spin minimum
+    // @Description: minimum motor spin fraction, matching MOT_SPIN_MIN
+    // @Range: 0 1
+    AP_GROUPINFO("SPIN_MIN", 16, Frame, model.spin_min, 0.15),
+
+    // @Param: SPIN_MAX
+    // @DisplayName: motor spin maximum
+    // @Description: maximum motor spin fraction, matching MOT_SPIN_MAX
+    // @Range: 0 1
+    AP_GROUPINFO("SPIN_MAX", 17, Frame, model.spin_max, 0.95),
+
+    // @Param: SLEW_MAX
+    // @DisplayName: motor slew rate
+    // @Description: maximum motor slew rate in throttle fraction per second
+    // @Units: 1/s
+    AP_GROUPINFO("SLEW_MAX", 18, Frame, model.slew_max, 150),
+
+    // @Param: DISCAREA
+    // @DisplayName: rotor disc area
+    // @Description: total rotor disc area. Coaxial rotors count as one rotor only
+    // @Units: m.m
+    AP_GROUPINFO("DISCAREA", 19, Frame, model.disc_area, 0.385),
+
+    // @Param: MDRAG
+    // @DisplayName: momentum drag coefficient
+    // @Description: momentum drag coefficient of the rotors. Defaults to zero on planes where the plane model handles drag
+    AP_GROUPINFO("MDRAG", 20, Frame, model.mdrag_coef, SIM_FRAME_MDRAG_DEFAULT),
+
+    // @Param: BBDRAG
+    // @DisplayName: bluff body drag coefficient
+    // @Description: scaling of the bluff body drag derived from the reference test, zero for no bluff body drag. Defaults to zero on planes where the plane model handles drag
+    AP_GROUPINFO("BBDRAG", 21, Frame, model.bbdrag_coef, SIM_FRAME_BBDRAG_DEFAULT),
+
+    AP_GROUPEND
+};
+#endif // AP_SIM_ENABLED
 
 static Motor quad_plus_motors[] =
 {
@@ -491,6 +633,7 @@ void Frame::load_frame_params(const char *model_json)
 
     enum class VarType {
         FLOAT,
+        AP_FLOAT,
         VECTOR3F,
     };
 
@@ -499,9 +642,9 @@ void Frame::load_frame_params(const char *model_json)
         void *ptr;
         VarType t;
     };
-    
+
     json_search vars[] = {
-#define FRAME_VAR(s) { #s, &model.s, VarType::FLOAT }
+#define FRAME_VAR(s) { #s, &model.s, VarType::AP_FLOAT }
         FRAME_VAR(mass),
         FRAME_VAR(diagonal_size),
         FRAME_VAR(refSpd),
@@ -509,7 +652,6 @@ void Frame::load_frame_params(const char *model_json)
         FRAME_VAR(refVoltage),
         FRAME_VAR(refCurrent),
         FRAME_VAR(refAlt),
-        FRAME_VAR(refTempC),
         FRAME_VAR(maxVoltage),
         FRAME_VAR(battCapacityAh),
         FRAME_VAR(refBatRes),
@@ -523,8 +665,10 @@ void Frame::load_frame_params(const char *model_json)
         FRAME_VAR(slew_max),
         FRAME_VAR(disc_area),
         FRAME_VAR(mdrag_coef),
+        FRAME_VAR(bbdrag_coef),
         {"moment_inertia", &model.moment_of_inertia, VarType::VECTOR3F},
-        FRAME_VAR(num_motors),
+        {"refTempC", &model.refTempC, VarType::FLOAT},
+        {"num_motors", &model.num_motors, VarType::FLOAT},
     };
 
     for (uint8_t i=0; i<ARRAY_SIZE(vars); i++) {
@@ -535,6 +679,12 @@ void Frame::load_frame_params(const char *model_json)
         }
         if (vars[i].t == VarType::FLOAT) {
             parse_float(v, vars[i].label, *((float *)vars[i].ptr));
+
+        } else if (vars[i].t == VarType::AP_FLOAT) {
+            // json model values become the defaults for the SIM_FRM_ parameters
+            float value;
+            parse_float(v, vars[i].label, value);
+            ((AP_Float *)vars[i].ptr)->set_default(value);
 
         } else if (vars[i].t == VarType::VECTOR3F) {
             parse_vector3(v, vars[i].label, *(Vector3f *)vars[i].ptr);
@@ -593,70 +743,117 @@ void Frame::parse_vector3(AP_JSON::value val, const char* label, Vector3f &param
  */
 void Frame::init(const char *frame_str)
 {
-    model = default_model;
+    auto *sitl = AP::sitl();
+    if (sitl != nullptr) {
+        sitl->models.simframe_ptr = this;
+    }
+    AP_Param::setup_object_defaults(this, var_info);
 
     const char *colon = strchr(frame_str, ':');
     size_t slen = strlen(frame_str);
     if (colon != nullptr && slen > 5 && strcmp(&frame_str[slen-5], ".json") == 0) {
         load_frame_params(colon+1);
     }
-    mass = model.mass;
+
+    if (uint8_t(model.num_motors) != num_motors) {
+        ::printf("Warning model expected %u motors and got %u\n", uint8_t(model.num_motors), num_motors);
+    }
+
+    update_parameters();
+}
+
+/*
+  apply settings from the model parameters. Called on each physics
+  step so changes to SIM_FRM_ parameters take effect. Note that
+  parameters loaded from eeprom are only applied after the frame is
+  created, so this cannot be done just once in init()
+ */
+void Frame::update_parameters(void)
+{
+    mass = model.mass * mass_scale;
 
     const float drag_force = model.mass * GRAVITY_MSS * tanf(radians(model.refAngle));
 
     const float cos_tilt = cosf(radians(model.refAngle));
     const float airspeed_bf = model.refSpd * cos_tilt;
     const float ref_thrust = model.mass * GRAVITY_MSS / cos_tilt;
-    float ref_air_density = get_air_density(model.refAlt);
+    const float ref_air_density = get_air_density(model.refAlt);
 
-    const float momentum_drag = cos_tilt * model.mdrag_coef * airspeed_bf * sqrtf(ref_thrust * ref_air_density * model.disc_area);
+    mdrag_coef = model.mdrag_coef;
+    const float momentum_drag = cos_tilt * mdrag_coef * airspeed_bf * sqrtf(ref_thrust * ref_air_density * model.disc_area);
 
     if (momentum_drag > drag_force) {
-        model.mdrag_coef *= drag_force / momentum_drag;
+        mdrag_coef *= drag_force / momentum_drag;
         areaCd = 0.0;
-        ::printf("Suggested EK3_DRAG_BCOEF_* = 0, EK3_DRAG_MCOEF = %.3f\n", (momentum_drag / (model.mass * airspeed_bf)) * sqrtf(1.225f / ref_air_density));
     } else {
-        areaCd = (drag_force - momentum_drag) / (0.5f * ref_air_density * sq(model.refSpd));
-        ::printf("Suggested EK3_DRAG_BCOEF_* = %.3f, EK3_DRAG_MCOEF = %.3f\n", model.mass / areaCd, (momentum_drag / (model.mass * airspeed_bf)) * sqrtf(1.225f / ref_air_density));
+        areaCd = model.bbdrag_coef * (drag_force - momentum_drag) / (0.5f * ref_air_density * sq(model.refSpd));
+    }
+    const float drag_bcoef = is_positive(areaCd) ? model.mass / areaCd : 0.0;
+    const float drag_mcoef = (momentum_drag / (model.mass * airspeed_bf)) * sqrtf(1.225f / ref_air_density);
+    if ((!is_equal(drag_bcoef, last_drag_bcoef) || !is_equal(drag_mcoef, last_drag_mcoef)) &&
+        isfinite(drag_bcoef) && isfinite(drag_mcoef)) {
+        last_drag_bcoef = drag_bcoef;
+        last_drag_mcoef = drag_mcoef;
+        ::printf("Suggested EK3_DRAG_BCOEF_* = %.3f, EK3_DRAG_MCOEF = %.3f\n", drag_bcoef, drag_mcoef);
     }
 
     terminal_rotation_rate = model.refRotRate;
 
-    float hover_thrust = mass * GRAVITY_MSS;
-    float hover_power = model.refCurrent * model.refVoltage;
-    float hover_velocity_out = 2 * hover_power / hover_thrust;
-    float effective_disc_area = hover_thrust / (0.5 * ref_air_density * sq(hover_velocity_out));
-    float velocity_max = hover_velocity_out / sqrtf(model.hoverThrOut);
-    float effective_prop_area = effective_disc_area / num_motors;
-    float true_prop_area = model.disc_area / num_motors;
+    const float hover_thrust = model.mass * GRAVITY_MSS;
+    const float hover_power = model.refCurrent * model.refVoltage;
+    const float hover_velocity_out = 2 * hover_power / hover_thrust;
+    const float effective_disc_area = hover_thrust / (0.5 * ref_air_density * sq(hover_velocity_out));
+    const float velocity_max = hover_velocity_out / sqrtf(MAX(model.hoverThrOut.get(), 0.01f));
+    const float effective_prop_area = effective_disc_area / num_motors;
+    const float true_prop_area = model.disc_area / num_motors;
 
     // power_factor is ratio of power consumed per newton of thrust
-    float power_factor = hover_power / hover_thrust;
-
-    if (uint8_t(model.num_motors) != num_motors) {
-        ::printf("Warning model expected %u motors and got %u\n", uint8_t(model.num_motors), num_motors);
-    }
+    const float power_factor = hover_power / hover_thrust;
 
     for (uint8_t i=0; i<num_motors; i++) {
-        motors[i].setup_params(model.pwmMin, model.pwmMax, model.spin_min, model.spin_max, model.propExpo, model.slew_max,
+        motors[i].setup_params(model.pwmMin.get(), model.pwmMax.get(), model.spin_min, model.spin_max, model.propExpo, model.slew_max,
                                model.diagonal_size, power_factor, model.maxVoltage, effective_prop_area, velocity_max,
                                model.motor_pos[i], model.motor_thrust_vec[i], model.yaw_factor[i], true_prop_area,
-                               model.mdrag_coef);
+                               mdrag_coef);
     }
 
     if (is_zero(model.moment_of_inertia.x) || is_zero(model.moment_of_inertia.y) || is_zero(model.moment_of_inertia.z)) {
         // if no inertia provided, assume 50% of mass on ring around center
-        model.moment_of_inertia.x = model.mass * 0.25 * sq(model.diagonal_size*0.5);
-        model.moment_of_inertia.y = model.moment_of_inertia.x;
-        model.moment_of_inertia.z = model.mass * 0.5 * sq(model.diagonal_size*0.5);
+        moment_of_inertia.x = model.mass * 0.25 * sq(model.diagonal_size*0.5);
+        moment_of_inertia.y = moment_of_inertia.x;
+        moment_of_inertia.z = model.mass * 0.5 * sq(model.diagonal_size*0.5);
+    } else {
+        moment_of_inertia = model.moment_of_inertia;
     }
 
-    // setup reasonable defaults for battery
-    AP_Param::set_default_by_name("SIM_BATT_VOLTAGE", model.maxVoltage);
-    AP_Param::set_default_by_name("SIM_BATT_CAP_AH", model.battCapacityAh);
-    if (model.battCapacityAh > 0) {
-        AP_Param::set_default_by_name("BATT_CAPACITY", model.battCapacityAh*1000);
+    if (!is_equal(last_batt_voltage, model.maxVoltage.get()) ||
+        !is_equal(last_batt_cap, model.battCapacityAh.get()) ||
+        !is_equal(last_batt_res, model.refBatRes.get())) {
+        const float prev_cap = last_batt_cap;
+        last_batt_voltage = model.maxVoltage;
+        last_batt_cap = model.battCapacityAh;
+        last_batt_res = model.refBatRes;
+        battery_dirty = true;
+
+        // setup reasonable defaults for battery
+        AP_Param::set_default_by_name("SIM_BATT_VOLTAGE", model.maxVoltage);
+        AP_Param::set_default_by_name("SIM_BATT_CAP_AH", model.battCapacityAh);
+        if (model.battCapacityAh > 0) {
+            AP_Param::set_default_by_name("BATT_CAPACITY", model.battCapacityAh*1000);
+        } else if (prev_cap > 0) {
+            // returning to unlimited capacity, mark vehicle capacity unknown
+            AP_Param::set_default_by_name("BATT_CAPACITY", 0);
+        }
     }
+}
+
+// returns true once when the battery model values have changed, so
+// the vehicle can re-setup the simulated battery
+bool Frame::battery_changed(void)
+{
+    bool ret = battery_dirty;
+    battery_dirty = false;
+    return ret;
 }
 
 /*
@@ -679,11 +876,12 @@ void Frame::calculate_forces(const Aircraft &aircraft,
                              const struct sitl_input &input,
                              Vector3f &rot_accel,
                              Vector3f &body_accel,
-                             float* rpm,
-                             bool use_drag)
+                             float* rpm)
 {
     Vector3f thrust; // newtons
     Vector3f torque;
+
+    update_parameters();
 
     const float air_density = get_air_density(aircraft.get_location().alt*0.01);
     const Vector3f gyro = aircraft.get_gyro();
@@ -694,7 +892,7 @@ void Frame::calculate_forces(const Aircraft &aircraft,
     for (uint8_t i=0; i<num_motors; i++) {
         Vector3f mtorque, mthrust;
         motors[i].calculate_forces(input, motor_offset, mtorque, mthrust, vel_air_bf,
-                                   gyro, air_density, aircraft.get_battery_voltage(), use_drag);
+                                   gyro, air_density, aircraft.get_battery_voltage(), true);
         torque += mtorque;
         thrust += mthrust;
         // simulate motor rpm
@@ -704,9 +902,9 @@ void Frame::calculate_forces(const Aircraft &aircraft,
     }
 
     // calculate total rotational acceleration
-    rot_accel.x = torque.x / model.moment_of_inertia.x;
-    rot_accel.y = torque.y / model.moment_of_inertia.y;
-    rot_accel.z = torque.z / model.moment_of_inertia.z;
+    rot_accel.x = torque.x / moment_of_inertia.x;
+    rot_accel.y = torque.y / moment_of_inertia.y;
+    rot_accel.z = torque.z / moment_of_inertia.z;
 
     if (terminal_rotation_rate > 0) {
         // rotational air resistance
@@ -715,7 +913,7 @@ void Frame::calculate_forces(const Aircraft &aircraft,
         rot_accel.z -= gyro.z * radians(400.0) / terminal_rotation_rate;
     }
 
-    if (use_drag) {
+    if (is_positive(areaCd)) {
         // use the model params to calculate drag
         Vector3f drag_bf;
         drag_bf.x = areaCd * 0.5f * air_density * sq(vel_air_bf.x);

--- a/libraries/SITL/SIM_Frame.h
+++ b/libraries/SITL/SIM_Frame.h
@@ -21,6 +21,7 @@
 #include "SIM_Aircraft.h"
 #include "SIM_Motor.h"
 #include <AP_JSON/AP_JSON.h>
+#include <AP_Param/AP_Param.h>
 
 #ifndef SIM_FRAME_MAX_ACTUATORS
 #define SIM_FRAME_MAX_ACTUATORS 32
@@ -54,9 +55,10 @@ public:
     // calculate rotational and linear accelerations
     void calculate_forces(const Aircraft &aircraft,
                           const struct sitl_input &input,
-                          Vector3f &rot_accel, Vector3f &body_accel, float* rpm,
-                          bool use_drag=true);
+                          Vector3f &rot_accel, Vector3f &body_accel, float* rpm);
 #endif // AP_SIM_ENABLED
+
+    static const struct AP_Param::GroupInfo var_info[];
 
     float terminal_velocity;
     float terminal_rotation_rate;
@@ -69,74 +71,81 @@ public:
         return mass;
     }
 
-    // set mass in kg
-    void set_mass(float new_mass) {
-        mass = new_mass;
+    // scale factor on model mass, used by quadplane to allow for plane components
+    void set_mass_scale(float scale) {
+        mass_scale = scale;
     }
 
     float get_model_batt_max_voltage(void) const { return model.maxVoltage; }
     float get_model_batt_capacity_ah(void) const { return model.battCapacityAh; }
     float get_model_batt_resistance_ohm(void) const { return model.refBatRes; }
+
+    // returns true once when the battery model values have changed
+    bool battery_changed(void);
     
 private:
     /*
-      parameters that define the multicopter model. Can be loaded from
-      a json file to give a custom model
+      parameters that define the multicopter model. The scalars are
+      exposed as SIM_FRM_ parameters, defaults come from the parameter
+      table and can be overridden by loading a json model file
      */
-    const struct Model {
+    struct Model {
         // model mass kg
-        float mass = 3.0;
+        AP_Float mass;
 
         // diameter of model
-        float diagonal_size = 0.35;
+        AP_Float diagonal_size;
 
         /*
           the ref values are for a test at fixed angle, used to estimate drag
          */
-        float refSpd = 15.08; // m/s
-        float refAngle = 45;  // degrees
-        float refVoltage = 12.09; // Volts
-        float refCurrent = 29.3; // Amps
-        float refAlt = 593; // altitude AMSL
-        float refTempC = 25; // temperature C
+        AP_Float refSpd; // m/s
+        AP_Float refAngle;  // degrees
+        AP_Float refVoltage; // Volts
+        AP_Float refCurrent; // Amps
+        AP_Float refAlt; // altitude AMSL
+        float refTempC = 25; // temperature C, unused
 
         // battery resistance reference value in Ohms
-        float refBatRes = 0.01;
+        AP_Float refBatRes;
 
         // full pack voltage
-        float maxVoltage = 4.2*3;
+        AP_Float maxVoltage;
 
         // battery capacity in Ah. Use zero for unlimited
-        float battCapacityAh = 0.0;
+        AP_Float battCapacityAh;
 
         // CTUN.ThO at hover at refAlt
-        float hoverThrOut = 0.39;
+        AP_Float hoverThrOut;
 
         // MOT_THST_EXPO
-        float propExpo = 0.65;
+        AP_Float propExpo;
 
         // scaling factor for yaw response, deg/sec
-        float refRotRate = 120;
+        AP_Float refRotRate;
 
         // MOT params are from the reference test
         // MOT_PWM_MIN
-        float pwmMin = 1000;
+        AP_Float pwmMin;
         // MOT_PWM_MAX
-        float pwmMax = 2000;
+        AP_Float pwmMax;
         // MOT_SPIN_MIN
-        float spin_min = 0.15;
+        AP_Float spin_min;
         // MOT_SPIN_MAX
-        float spin_max = 0.95;
+        AP_Float spin_max;
 
         // maximum slew rate of motors
-        float slew_max = 150;
+        AP_Float slew_max;
 
-        // rotor disc area in m**2 for 4 x 0.35m dia rotors
+        // rotor disc area in m**2
         // Note that coaxial rotors count as one rotor only when calculating effective disc area
-        float disc_area = 0.385;
+        AP_Float disc_area;
 
         // momentum drag coefficient
-        float mdrag_coef = 0.2;
+        AP_Float mdrag_coef;
+
+        // bluff body drag scaling
+        AP_Float bbdrag_coef;
 
         // if zero value will be estimated from mass
         Vector3f moment_of_inertia;
@@ -147,8 +156,7 @@ private:
 
         // number of motors
         float num_motors = 4;
-
-    } default_model;
+    };
 
 protected:
     // load frame parameters from a json model file
@@ -160,9 +168,30 @@ protected:
     struct Model model;
 
 private:
+    // apply parameter based settings, called on each physics step so
+    // that SIM_FRM_ parameter changes take effect
+    void update_parameters(void);
+
     // exposed area times coefficient of drag
     float areaCd;
     float mass;
+    float mass_scale = 1.0;
+
+    // effective momentum drag coefficient, possibly scaled down from model.mdrag_coef
+    float mdrag_coef;
+
+    // moment of inertia in use, from model or estimated from mass
+    Vector3f moment_of_inertia;
+
+    // last printed EK3 drag suggestions
+    float last_drag_bcoef;
+    float last_drag_mcoef;
+
+    // battery model change detection
+    bool battery_dirty;
+    float last_batt_voltage;
+    float last_batt_cap;
+    float last_batt_res;
 
     // json parsing helpers
     void parse_float(AP_JSON::value val, const char* label, float &param);

--- a/libraries/SITL/SIM_Motor.cpp
+++ b/libraries/SITL/SIM_Motor.cpp
@@ -127,18 +127,16 @@ void Motor::calculate_forces(const struct sitl_input &input,
     }
 
     if (use_drag) {
-        // calculate momentum drag per motor
-        const float momentum_drag_factor = momentum_drag_coefficient * sqrtf(air_density * true_prop_area);
-        Vector3f momentum_drag;
-        momentum_drag.x = momentum_drag_factor * motor_vel.x * (sqrtf(fabsf(thrust.y)) + sqrtf(fabsf(thrust.z)));
-        momentum_drag.y = momentum_drag_factor * motor_vel.y * (sqrtf(fabsf(thrust.x)) + sqrtf(fabsf(thrust.z)));
-        // The application of momentum drag to the Z axis is a 'hack' to compensate for incorrect modelling
-        // of the variation of thust with inflow velocity. If not applied, the vehicle will
-        // climb at an unrealistic rate during operation in STABILIZE. TODO replace prop and motor model in
-        // with one based on DC motor, momentum disc and blade element theory.
-        momentum_drag.z = momentum_drag_factor * motor_vel.z * (sqrtf(fabsf(thrust.x)) + sqrtf(fabsf(thrust.y)) + sqrtf(fabsf(thrust.z)));
-
-        thrust -= momentum_drag;
+        // Momentum drag is modelled as isotropic, scaled by the total
+        // thrust, which handles tilted motors correctly. The component
+        // along the rotor axis is really a 'hack' to compensate for
+        // incorrect modelling of the variation of thrust with inflow
+        // velocity. If not applied, the vehicle will climb at an
+        // unrealistic rate during operation in STABILIZE. TODO replace
+        // prop and motor model with one based on DC motor, momentum
+        // disc and blade element theory.
+        const float momentum_drag_factor = momentum_drag_coefficient * sqrtf(air_density * true_prop_area * thrust.length());
+        thrust -= motor_vel * momentum_drag_factor;
     }
 
     // calculate total torque in newton-meters

--- a/libraries/SITL/SIM_Multicopter.cpp
+++ b/libraries/SITL/SIM_Multicopter.cpp
@@ -62,6 +62,9 @@ void MultiCopter::calculate_forces(const struct sitl_input &input, Vector3f &rot
  */
 void MultiCopter::update(const struct sitl_input &input)
 {
+    // refresh mass in case SIM_FRM_ parameters have changed
+    mass = frame->get_mass();
+
     // get wind vector setup
     update_wind(input);
 
@@ -87,6 +90,13 @@ void MultiCopter::update(const struct sitl_input &input)
 }
 
 void MultiCopter::update_battery() {
+    if (frame->battery_changed()) {
+        // battery model changed via SIM_FRM_ parameters
+        battery.setup(frame->get_model_batt_capacity_ah(),
+                      frame->get_model_batt_resistance_ohm(),
+                      frame->get_model_batt_max_voltage(),
+                      ambient_outside_temperature_degC());
+    }
     battery.maybe_reset(sitl->batt_voltage, sitl->batt_capacity_ah, sitl->batt_resistance);
     battery_voltage = battery.get_voltage();
     battery_current = frame->get_current_amp();

--- a/libraries/SITL/SIM_QuadPlane.cpp
+++ b/libraries/SITL/SIM_QuadPlane.cpp
@@ -100,16 +100,16 @@ QuadPlane::QuadPlane(const char *frame_str) :
     // leave first 4 servos free for plane
     frame->motor_offset = motor_offset;
 
-    // we use zero terminal velocity to let the plane model handle the drag
+    // increase mass for plane components
+    frame->set_mass_scale(1.5);
+
     frame->init(frame_str);
     battery.setup(frame->get_model_batt_capacity_ah(),
                   frame->get_model_batt_resistance_ohm(),
                   frame->get_model_batt_max_voltage(),
                   ambient_outside_temperature_degC());
 
-    // increase mass for plane components
-    mass = frame->get_mass() * 1.5;
-    frame->set_mass(mass);
+    mass = frame->get_mass();
 
     lock_step_scheduled = true;
 }
@@ -119,6 +119,9 @@ QuadPlane::QuadPlane(const char *frame_str) :
  */
 void QuadPlane::update(const struct sitl_input &input)
 {
+    // refresh mass in case SIM_FRM_ parameters have changed
+    mass = frame->get_mass();
+
     // get wind vector setup
     update_wind(input);
 
@@ -131,7 +134,7 @@ void QuadPlane::update(const struct sitl_input &input)
     Vector3f quad_accel_body;
 
     motor_mask |= ((1U<<frame->num_motors)-1U) << frame->motor_offset;
-    frame->calculate_forces(*this, input, quad_rot_accel, quad_accel_body, rpm, false);
+    frame->calculate_forces(*this, input, quad_rot_accel, quad_accel_body, rpm);
 
     // rotate frames for copter tailsitters
     if (copter_tailsitter) {
@@ -139,6 +142,13 @@ void QuadPlane::update(const struct sitl_input &input)
         quad_accel_body.rotate(ROTATION_PITCH_270);
     }
 
+    if (frame->battery_changed()) {
+        // battery model changed via SIM_FRM_ parameters
+        battery.setup(frame->get_model_batt_capacity_ah(),
+                      frame->get_model_batt_resistance_ohm(),
+                      frame->get_model_batt_max_voltage(),
+                      ambient_outside_temperature_degC());
+    }
     battery.maybe_reset(sitl->batt_voltage, sitl->batt_capacity_ah, sitl->batt_resistance);
     battery_voltage = battery.get_voltage();
     battery_current = frame->get_current_amp();

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -40,6 +40,7 @@
 #include "SIM_StratoBlimp.h"
 #include "SIM_Glider.h"
 #include "SIM_FlightAxis.h"
+#include "SIM_Frame.h"
 
 extern const AP_HAL::HAL& hal;
 
@@ -1617,6 +1618,10 @@ const AP_Param::GroupInfo SIM::ModelParm::var_info[] = {
     // @Path: ./SIM_AIS.cpp
     AP_SUBGROUPPTR(ais_ptr, "AIS_", 7, SIM::ModelParm, AIS),
 #endif  // AP_SIM_AIS_ENABLED
+
+    // @Group: FRM_
+    // @Path: ./SIM_Frame.cpp
+    AP_SUBGROUPPTR(simframe_ptr, "FRM_", 8, SIM::ModelParm, Frame),
 
     AP_GROUPEND
 };

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -389,6 +389,8 @@ public:
 #if AP_SIM_GLIDER_ENABLED
         Glider *glider_ptr;
 #endif
+        // multicopter/quadplane VTOL frame model
+        class Frame *simframe_ptr;
 #if AP_SIM_SLUNGPAYLOAD_ENABLED
         SlungPayloadSim slung_payload_sim;
 #endif


### PR DESCRIPTION
### Summary

Exposes the SITL multicopter frame model scalars (mass, disc area, drag coefficients etc) as SIM_FRM_* parameters for copters and quadplanes, and corrects momentum drag for tilted motors.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Tested in SITL: parameter defaults per vehicle build, json model files (eg. Callisto) setting parameter defaults with user-set values persisting over restart, battery model changes reaching the simulated battery, and hover in wind. Copter and QuadPlane autotests pass unchanged.

### Description

The SIM_FRM_* parameters directly reference the frame model variables, so loading a json model file sets the parameter defaults and users can override individual values. The SIM_FRM_BBDRAG and SIM_FRM_MDRAG drag coefficients default to zero on plane builds so the plane model alone handles drag and existing quadplane tuning is unaffected; setting them on a quadplane gives more realistic airbraking in VTOL modes.

The motor momentum drag calculation is now isotropic, scaled by total thrust, which handles tilted motors correctly (the previous per-axis form over-estimated lateral drag mid-tilt and lost axial inflow damping when a rotor tilted forward).

Note that this doesn't actually enable the momentum drag and bluff body drag for quadplanes yet. That would require changes to a lot of tests. That would be worth doing but this at least makes it just a parameter change so we can experiment with values and try to get some realistic values for a future update where all the quadplane models start enabling drag.
