### PR TITLE
Correct LASTLOG.TXT on wrapping of log number from 500 back to 0

### DIFF
--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -9643,7 +9643,9 @@ Also, ignores heartbeats not from our target system'''
         path = None
         try:
             path = self.current_onboard_log_filepath()
-        except IndexError:
+        except (FileNotFoundError, ValueError):
+            # no log yet, or we can't understand LASTLOG.TXT; either way
+            # don't mask the exception we are in the middle of reporting
             pass
         self.progress("Most recent logfile: %s" % (path, ), send_statustext=send_statustext)
 
@@ -13380,11 +13382,23 @@ switch value'''
         return sorted(logs.keys())[-1]
 
     def current_onboard_log_filepath(self):
-        '''return filepath to currently open dataflash log.  We assume that's
-        the latest log...'''
-        logs = self.log_list()
-        latest = logs[-1]
-        return latest
+        '''return filepath to currently open dataflash log.'''
+        logs_dirpath = pathlib.Path("logs")
+        lastlog_filepath = logs_dirpath / "LASTLOG.TXT"
+
+        with lastlog_filepath.open(newline="") as f:
+            content = f.read()
+
+        m = re.match(r"([0-9]+)(D?)\r\n\Z", content)
+        if m is None:
+            raise ValueError("Unable to parse %s (%r)" %
+                             (lastlog_filepath, content))
+
+        (num, discard_marker) = m.groups()
+        if discard_marker:
+            self.progress("Vehicle has marked log %s for discard" % num)
+
+        return str(logs_dirpath / ("%08u.BIN" % int(num)))
 
     def dfreader_for_path(self, path):
         '''return a DFReader for path.  The reader holds an open filehandle

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -9965,7 +9965,9 @@ Also, ignores heartbeats not from our target system'''
         path = None
         try:
             path = self.current_onboard_log_filepath()
-        except IndexError:
+        except (FileNotFoundError, ValueError):
+            # no log yet, or we can't understand LASTLOG.TXT; either way
+            # don't mask the exception we are in the middle of reporting
             pass
         self.progress("Most recent logfile: %s" % (path, ), send_statustext=send_statustext)
 
@@ -13773,11 +13775,23 @@ switch value'''
         return sorted(logs.keys())[-1]
 
     def current_onboard_log_filepath(self):
-        '''return filepath to currently open dataflash log.  We assume that's
-        the latest log...'''
-        logs = self.log_list()
-        latest = logs[-1]
-        return latest
+        '''return filepath to currently open dataflash log.'''
+        logs_dirpath = pathlib.Path("logs")
+        lastlog_filepath = logs_dirpath / "LASTLOG.TXT"
+
+        with lastlog_filepath.open(newline="") as f:
+            content = f.read()
+
+        m = re.match(r"([0-9]+)(D?)\r\n\Z", content)
+        if m is None:
+            raise ValueError("Unable to parse %s (%r)" %
+                             (lastlog_filepath, content))
+
+        (num, discard_marker) = m.groups()
+        if discard_marker:
+            self.progress("Vehicle has marked log %s for discard" % num)
+
+        return str(logs_dirpath / ("%08u.BIN" % int(num)))
 
     def dfreader_for_path(self, path):
         '''return a DFReader for path.  The reader holds an open filehandle

--- a/libraries/AP_Logger/AP_Logger_File.cpp
+++ b/libraries/AP_Logger/AP_Logger_File.cpp
@@ -864,7 +864,7 @@ bool AP_Logger_File::write_lastlog_file(uint16_t log_num)
     char *fname = _lastlog_file_name();
 
     EXPECT_DELAY_MS(3000);
-    int fd = AP::FS().open(fname, O_WRONLY|O_CREAT);
+    int fd = AP::FS().open(fname, O_WRONLY|O_CREAT|O_TRUNC);
     free(fname);
     if (fd == -1) {
         return false;

--- a/libraries/AP_Logger/AP_Logger_File.cpp
+++ b/libraries/AP_Logger/AP_Logger_File.cpp
@@ -866,7 +866,7 @@ bool AP_Logger_File::write_lastlog_file(uint16_t log_num)
     char *fname = _lastlog_file_name();
 
     EXPECT_DELAY_MS(3000);
-    int fd = AP::FS().open(fname, O_WRONLY|O_CREAT);
+    int fd = AP::FS().open(fname, O_WRONLY|O_CREAT|O_TRUNC);
     free(fname);
     if (fd == -1) {
         return false;


### PR DESCRIPTION
### Summary

We failed to overwrite all of the bytes in the file, so garbage was left in there on wrap...

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Also fixes the autotest suite to cope with the wrap.

We need to fix this to not wrap the file number if you hit your log limit - you should only ever have 500 on the card, but we should keep counting up in the log number!
