### PR TITLE
autotest: retry connections more rapidly

### DIFF
--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -35,6 +35,7 @@ import traceback
 from datetime import datetime
 from inspect import currentframe
 from inspect import getframeinfo
+from inspect import signature
 from pathlib import Path
 from typing import Dict
 from typing import List
@@ -2578,8 +2579,12 @@ class TestSuite(abc.ABC):
             if time.time() - tstart > timeout:
                 raise AutoTestTimeoutException("Did not detect reboot")
             try:
+                # any request we send while the autopilot is restarting
+                # is lost along with the old connection, so poll often
+                # rather than waiting a long time for a reply which will
+                # never come:
                 current_bootcount = self.get_parameter('STAT_BOOTCNT',
-                                                       timeout=1,
+                                                       timeout=0.1,
                                                        attempts=1,
                                                        verbose=True,
                                                        timeout_in_wallclock=True)
@@ -9509,20 +9514,40 @@ Also, ignores heartbeats not from our target system'''
         except OSError:
             pass
 
+    def mavlink_connection_supports_reconnect_delay(self):
+        '''returns True if pymavlink lets us choose how long it waits
+        between connection attempts.  This probe exists only so that
+        autotest keeps working (just more slowly) against an older
+        pymavlink.
+        '''
+        return 'reconnect_delay' in signature(mavutil.mavlink_connection).parameters
+
     def get_mavlink_connection_going(self):
         # get a mavlink connection going
         try:
-            retries = 20
+            # SITL's listening socket is only gone for the few
+            # milliseconds it takes the process to re-exec itself on
+            # reboot, so retry rapidly rather than at pymavlink's
+            # default of once a second.  retries is a count of
+            # attempts, so scale it to keep the same overall budget.
+            # The fallback here is for older pymavlinks.
+            extra_connection_args = {}
+            reconnect_delay = 1
+            if self.mavlink_connection_supports_reconnect_delay():
+                reconnect_delay = 0.05
+                extra_connection_args["reconnect_delay"] = reconnect_delay
+            timeout = 20
             if self.gdb:
-                retries = 20000
+                timeout = 20000
             self.mav = mavutil.mavlink_connection(
                 self.autotest_connection_string_to_ardupilot(),
-                retries=retries,
+                retries=int(timeout/reconnect_delay),
                 robust_parsing=True,
                 source_system=250,
                 source_component=250,
                 autoreconnect=True,
                 dialect="all",  # if we don't pass this in we end up with the wrong mavlink version...
+                **extra_connection_args,
             )
         except Exception as msg:
             self.progress("Failed to start mavlink connection on %s: %s" %


### PR DESCRIPTION
### Summary

Speed up the autotest suite by making reconnects much, much faster.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Pokes pymavlink to retry its connection faster (1s -> 0.05s).

Adjusts our parameter probing which we use to determine reboot to also be faster.

When combined with https://github.com/ArduPilot/pymavlink/pull/1249 provides some quite remarkable speedups

```
# time ./Tools/autotest/autotest.py --show-test-timings build.Rover test.Rover

## master

real    11m42.187s
user    10m14.809s
sys     3m5.942s

real    11m44.624s
user    10m10.686s
sys     3m7.036s

## new

real    8m48.670s
user    10m11.804s
sys     3m8.589s

real    8m44.090s
user    10m14.494s
sys     3m6.032s

## master

real    23m28.128s
user    23m50.065s
sys     5m24.433s

## new

real    17m48.694s
user    24m0.245s
sys     5m29.025s

# time ./Tools/autotest/autotest.py --show-test-timings build.Plane test.Plane

## master

real    23m28.128s
user    23m50.065s
sys     5m24.433s

## new

real    17m48.694s
user    24m0.245s
sys     5m29.025s
```
