### PR TITLE
autotest: install terrain handler in Plane DO_CHANGE_ALTITUDE

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -7806,6 +7806,8 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
     def DO_CHANGE_ALTITUDE(self):
         '''test DO_CHANGE_ALTITUDE mavlink command'''
+        self.install_terrain_handlers_context()
+
         takeoff_alt = 30
         self.takeoff(alt=takeoff_alt, mode='TAKEOFF')
         self.wait_altitude(takeoff_alt-1, takeoff_alt+1, minimum_duration=10, relative=True, timeout=60)


### PR DESCRIPTION
### Summary

Installs a terrain handler so the test works without some other test first priming the autopilot's terrain cache

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

The test's terrain-frame subtest commands an altitude in MAV_FRAME_GLOBAL_TERRAIN_ALT and then checks
TERRAIN_REPORT.current_height, but never installs the handler which answers the vehicle's TERRAIN_REQUESTs.  With no terrain data the vehicle reports its height above a terrain altitude of zero, so the check sees an amsl-like altitude and fails with e.g. "Failed to attain Altitude want 80.285, reached 665.4" (home is at 585m).

The test only passed because an earlier test run in the same working directory left populated terrain/*.DAT behind for it; run on its own, after remove_ardupilot_terrain_cache(), or in a parallel worker - which has its own working directory and so its own empty terrain cache - there is no terrain data and it fails.  Install the handler so the test brings its own terrain data, as the other terrain-requiring Plane tests do.
