### PR TITLE
AP_Bootloader: add BrahmaH7 board ID

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -349,6 +349,7 @@ AP_HW_SIMPLIFLYH7                    1221
 
 AP_HW_MUPilot                        1222
 AP_HW_HWH7                           1223
+AP_HW_BrahmaH7                       1224
 
 AP_HW_ATLAS_CONTROL                  1227
 AP_HW_MatekH7A3_Wing                 1228


### PR DESCRIPTION
### Summary

Reserve a board ID for BrahmaH7

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Reserves an ID for a board.  I already had to rebuild the bootloader on the relevant PR because of a conflict
