### PR TITLE
AP_BattMonitor: report critical before low in PreArm checks

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor_Backend.cpp
@@ -227,10 +227,10 @@ bool AP_BattMonitor_Backend::arming_checks(char * buffer, size_t buflen) const
     bool result = update_check(buflen, buffer, !_state.healthy, "unhealthy");
     result = result && update_check(buflen, buffer, below_arming_voltage, "below minimum arming voltage");
     result = result && update_check(buflen, buffer, below_arming_capacity, "below minimum arming capacity");
-    result = result && update_check(buflen, buffer, low_voltage,  "low voltage failsafe");
-    result = result && update_check(buflen, buffer, low_capacity, "low capacity failsafe");
     result = result && update_check(buflen, buffer, critical_voltage, "critical voltage failsafe");
     result = result && update_check(buflen, buffer, critical_capacity, "critical capacity failsafe");
+    result = result && update_check(buflen, buffer, low_voltage,  "low voltage failsafe");
+    result = result && update_check(buflen, buffer, low_capacity, "low capacity failsafe");
     result = result && update_check(buflen, buffer, fs_capacity_inversion, "capacity failsafe critical >= low");
     result = result && update_check(buflen, buffer, fs_voltage_inversion, "voltage failsafe critical >= low");
 


### PR DESCRIPTION
### Summary

Reorder PreArm battery arming checks so critical voltage/capacity is preferred over low when both are true.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Code review / logic check only. Change is a check reordering in `arming_checks()`; arming remains blocked either way.

### Description

When battery voltage is below both `BATT_LOW_VOLT` and `BATT_CRT_VOLT`, PreArm previously reported only `low voltage failsafe` because `arming_checks()` tested low before critical and used short-circuit `&&` (one message in the buffer).

This PR reorders the checks so critical is evaluated first, matching the priority used by `update_failsafes()`. The `&&` short-circuit behaviour is intentionally unchanged, as requested in #33961.

Fixes #33961