### PR TITLE
AP_Proximity: apply orientation correction in TeraRanger Tower backends

### DIFF
--- a/libraries/AP_Proximity/AP_Proximity_TeraRangerTower.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_TeraRangerTower.cpp
@@ -100,12 +100,15 @@ bool AP_Proximity_TeraRangerTower::read_sensor_data()
 // process reply
 void AP_Proximity_TeraRangerTower::update_sector_data(int16_t angle_deg, uint16_t distance_mm)
 {
+    // correct angle for sensor orientation
+    const float corrected_angle_deg = correct_angle_for_orientation(angle_deg);
+
     // Get location on 3-D boundary based on angle to the object
-    const AP_Proximity_Boundary_3D::Face face = frontend.boundary.get_face(angle_deg);
-    if ((distance_mm != 0xffff) && !ignore_reading(angle_deg, distance_mm * 0.001f, false)) {
-        frontend.boundary.set_face_attributes(face, angle_deg, ((float) distance_mm) / 1000, state.instance);
+    const AP_Proximity_Boundary_3D::Face face = frontend.boundary.get_face(corrected_angle_deg);
+    if ((distance_mm != 0xffff) && !ignore_reading(corrected_angle_deg, distance_mm * 0.001f, false)) {
+        frontend.boundary.set_face_attributes(face, corrected_angle_deg, ((float) distance_mm) / 1000, state.instance);
         // update OA database
-        database_push(angle_deg, ((float) distance_mm) / 1000);
+        database_push(corrected_angle_deg, ((float) distance_mm) / 1000);
     } else {
         frontend.boundary.reset_face(face, state.instance);
     }

--- a/libraries/AP_Proximity/AP_Proximity_TeraRangerTowerEvo.cpp
+++ b/libraries/AP_Proximity/AP_Proximity_TeraRangerTowerEvo.cpp
@@ -153,14 +153,17 @@ bool AP_Proximity_TeraRangerTowerEvo::read_sensor_data()
 // process reply
 void AP_Proximity_TeraRangerTowerEvo::update_sector_data(int16_t angle_deg, uint16_t distance_mm)
 {
+    // correct angle for sensor orientation
+    const float corrected_angle_deg = correct_angle_for_orientation(angle_deg);
+
     // Get location on 3-D boundary based on angle to the object
-    const AP_Proximity_Boundary_3D::Face face = frontend.boundary.get_face(angle_deg);
+    const AP_Proximity_Boundary_3D::Face face = frontend.boundary.get_face(corrected_angle_deg);
     //check for target too far, target too close and sensor not connected
     const bool valid = (distance_mm != 0xffff) && (distance_mm > 0x0001);
-    if (valid && !ignore_reading(angle_deg, distance_mm * 0.001f, false)) {
-        frontend.boundary.set_face_attributes(face, angle_deg, ((float) distance_mm) / 1000, state.instance);
+    if (valid && !ignore_reading(corrected_angle_deg, distance_mm * 0.001f, false)) {
+        frontend.boundary.set_face_attributes(face, corrected_angle_deg, ((float) distance_mm) / 1000, state.instance);
         // update OA database
-        database_push(angle_deg, ((float) distance_mm) / 1000);
+        database_push(corrected_angle_deg, ((float) distance_mm) / 1000);
     } else {
         frontend.boundary.reset_face(face, state.instance);
     }


### PR DESCRIPTION
### Summary

Fixes #9843. `PRX_ORIENT` had no effect on the TeraRanger Tower and TeraRanger Tower Evo proximity backends.

### Description

`update_sector_data()` in both `AP_Proximity_TeraRangerTower` and `AP_Proximity_TeraRangerTowerEvo` used the raw sector angle reported by the sensor for the face lookup, ignore-area check, and OA database push. `correct_angle_for_orientation()` was never called, so setting `PRX_ORIENT` (e.g. to mount the sensor upside down) had no effect on which face a reading was attributed to.

The fix corrects the angle once at the top of `update_sector_data()` and uses the corrected value everywhere the raw angle was previously used, matching the pattern already used in the other proximity backends (`AP_Proximity_Cygbot_D1`, `AP_Proximity_LD06`, `AP_Proximity_LightWareSF45B`, `AP_Proximity_MR72_CAN`, `AP_Proximity_Scripting`).

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

No hardware available to test against a physical TeraRanger Tower; change is a straightforward application of the existing, already-used `correct_angle_for_orientation()` helper.