### PR TITLE
Copter: move save_trim from RC_Channels_Copter to Copter class

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -987,6 +987,7 @@ private:
     void set_throttle_zero_flag(int16_t throttle_control);
     void radio_passthrough_to_motors();
     int16_t get_throttle_mid(void);
+    void save_trim();
 
     // sensors.cpp
     void read_barometer(void);

--- a/ArduCopter/RC_Channel_Copter.cpp
+++ b/ArduCopter/RC_Channel_Copter.cpp
@@ -226,7 +226,7 @@ bool RC_Channel_Copter::do_aux_function(const AuxFuncTrigger &trigger)
             if ((ch_flag == AuxSwitchPos::HIGH) &&
                 (copter.flightmode->allows_save_trim()) &&
                 (copter.channel_throttle->get_control_in() == 0)) {
-                copter.g2.rc_channels.save_trim();
+                copter.save_trim();
             }
             break;
 
@@ -730,33 +730,6 @@ void RC_Channel_Copter::do_aux_function_change_force_flying(const AuxSwitchPos c
     }
 }
 
-// note that this is a method on the RC_Channels object, not the
-// individual channel
-// save_trim - adds roll and pitch trims from the radio to ahrs
-void RC_Channels_Copter::save_trim()
-{
-    float roll_trim_rad = 0.0;
-    float pitch_trim_rad = 0.0;
-
-#if AP_COPTER_AHRS_AUTO_TRIM_ENABLED
-    if (auto_trim.running) {
-        auto_trim.running = false;
-    } else {
-#endif
-
-    // get roll and pitch trim adjustment
-    copter.flightmode->get_pilot_desired_lean_angles_rad(roll_trim_rad, pitch_trim_rad, copter.attitude_control->lean_angle_max_rad(), copter.attitude_control->get_althold_lean_angle_max_rad());
-
-#if AP_COPTER_AHRS_AUTO_TRIM_ENABLED
-    }
-#endif
-
-    // save roll and pitch trim
-    AP::ahrs().add_trim(roll_trim_rad, pitch_trim_rad);
-    LOGGER_WRITE_EVENT(LogEvent::SAVE_TRIM);
-    gcs().send_text(MAV_SEVERITY_INFO, "Trim saved");
-}
-
 #if AP_COPTER_AHRS_AUTO_TRIM_ENABLED
 // start/stop ahrs auto trim
 void RC_Channels_Copter::do_aux_function_ahrs_auto_trim(const RC_Channel::AuxSwitchPos ch_flag)
@@ -777,7 +750,7 @@ void RC_Channels_Copter::do_aux_function_ahrs_auto_trim(const RC_Channel::AuxSwi
     case RC_Channel::AuxSwitchPos::LOW:
         if (auto_trim.running) {
             AP_Notify::flags.save_trim = false;
-            save_trim();
+            copter.save_trim();
         }
         break;
     }

--- a/ArduCopter/RC_Channel_Copter.h
+++ b/ArduCopter/RC_Channel_Copter.h
@@ -62,7 +62,6 @@ public:
     void auto_trim_run();
     void auto_trim_cancel();
 #endif  // AP_COPTER_AHRS_AUTO_TRIM_ENABLED
-    void save_trim();
 
 protected:
 

--- a/ArduCopter/radio.cpp
+++ b/ArduCopter/radio.cpp
@@ -217,3 +217,28 @@ int16_t Copter::get_throttle_mid(void)
 #endif
     return channel_throttle->get_control_mid();
 }
+
+// save_trim - adds roll and pitch trims from the radio to ahrs
+void Copter::save_trim()
+{
+    float roll_trim_rad = 0.0;
+    float pitch_trim_rad = 0.0;
+
+#if AP_COPTER_AHRS_AUTO_TRIM_ENABLED
+    if (g2.rc_channels.auto_trim.running) {
+        g2.rc_channels.auto_trim.running = false;
+    } else {
+#endif
+
+    // get roll and pitch trim adjustment
+    flightmode->get_pilot_desired_lean_angles_rad(roll_trim_rad, pitch_trim_rad, attitude_control->lean_angle_max_rad(), attitude_control->get_althold_lean_angle_max_rad());
+
+#if AP_COPTER_AHRS_AUTO_TRIM_ENABLED
+    }
+#endif
+
+    // save roll and pitch trim
+    AP::ahrs().add_trim(roll_trim_rad, pitch_trim_rad);
+    LOGGER_WRITE_EVENT(LogEvent::SAVE_TRIM);
+    gcs().send_text(MAV_SEVERITY_INFO, "Trim saved");
+}


### PR DESCRIPTION
Fixes #32279

Moves save_trim() out of RC_Channels_Copter and into the Copter class, following the pattern used for the rest of the vehicle-level RC handling in radio.cpp.

- Removed the RC_Channels_Copter::save_trim() declaration and implementation from RC_Channel_Copter.h/.cpp
- Added Copter::save_trim() in radio.cpp, declared in Copter.h under the radio.cpp section
- Updated the two call sites in RC_Channel_Copter.cpp (do_aux_function and do_aux_function_ahrs_auto_trim) to call copter.save_trim()
- auto_trim.running remains on RC_Channels_Copter, so save_trim() now reaches it via g2.rc_channels.auto_trim.running

Pure refactor, no behavior change.