### PR TITLE
Rover: update servo output ranges even when armed

### DIFF
--- a/Rover/radio.cpp
+++ b/Rover/radio.cpp
@@ -38,9 +38,12 @@ void Rover::set_control_channels(void)
     // sailboat rc input init
     g2.sailboat.init_rc_in();
 
-    // Allow to reconfigure output when not armed
+    // update output ranges even if armed so a SERVOx_FUNCTION change
+    // while armed takes effect immediately
+    g2.motors.setup_servo_output();
+
+    // Allow to reconfigure safety output when not armed
     if (!arming.is_armed()) {
-        g2.motors.setup_servo_output();
         // For a rover safety is TRIM throttle
         g2.motors.setup_safety_output();
     }


### PR DESCRIPTION
Fixes #9478

setup_servo_output() was only called from Rover::set_control_channels() while disarmed, so changing a SERVOx_FUNCTION parameter while armed left the corresponding output using the previous angle/range limits until the next disarm.

setup_servo_output() only writes angle/range metadata for the configured output functions, it does not touch actual output values, so it is safe to call unconditionally. This change moves the setup_servo_output() call outside the arming check while keeping setup_safety_output() gated on disarm, since that one sets the TRIM safety output for a rover and should only run when disarmed.

As pointed out by IamPete1 in the issue, the fix is just removing the armed check around the servo output range setup.