### PR TITLE
Sub: limit vertical throttle when surfaced to save power and avoid cavitation

### DIFF
--- a/ArduSub/AP_Arming_Sub.cpp
+++ b/ArduSub/AP_Arming_Sub.cpp
@@ -194,6 +194,9 @@ bool AP_Arming_Sub::disarm(const AP_Arming::Method method, bool do_disarm_checks
     // send disarm command to motors
     sub.motors.armed(false);
 
+    // clear any upwards thrust limit left over by the surface handling
+    sub.motors.set_max_throttle(1.0f);
+
     // reset the mission
     sub.mission.reset();
 

--- a/ArduSub/Sub.cpp
+++ b/ArduSub/Sub.cpp
@@ -455,6 +455,24 @@ float Sub::get_alt_msl() const
     return -posD;
 }
 
+// water-surface altitude in the position controller U frame (EKF origin).
+// Derived from the current position vs depth, so it tracks a new origin or a re-zeroed
+// depth sensor. With no depth sensor, assume the origin is the surface.
+float Sub::get_surface_alt_U_m() const
+{
+    if (!ap.depth_sensor_present) {
+        return 0;
+    }
+
+    return pos_control.get_pos_estimate_U_m() - barometer.get_altitude();
+}
+
+// get SURFACE_DEPTH expressed in the position controller's U frame
+float Sub::get_surface_depth_U_cm() const
+{
+    return get_surface_alt_U_m() * 100.0f + g.surface_depth;
+}
+
 #if AP_SUB_RC_ENABLED
 void Sub::rc_loop()
 {

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -432,6 +432,8 @@ private:
     bool set_home(const Location& loc, bool lock) override WARN_IF_UNUSED;
     float get_alt_rel() const WARN_IF_UNUSED;
     float get_alt_msl() const WARN_IF_UNUSED;
+    float get_surface_alt_U_m() const WARN_IF_UNUSED;
+    float get_surface_depth_U_cm() const WARN_IF_UNUSED;
     void exit_mission();
     void set_origin(const Location& loc);
     bool verify_loiter_unlimited();

--- a/ArduSub/commands_logic.cpp
+++ b/ArduSub/commands_logic.cpp
@@ -433,7 +433,9 @@ bool Sub::verify_surface(const AP_Mission::Mission_Command& cmd)
             break;
 
         case AUTO_SURFACE_STATE_ASCEND:
-            if (wp_nav.reached_wp_destination()) {
+            // the destination is at zero depth, but the depth controller holds the vehicle
+            // at SURFACE_DEPTH, which may be further than WP_RADIUS_M from it
+            if (wp_nav.reached_wp_destination() || ap.at_surface) {
                 retval = true;
             }
             break;

--- a/ArduSub/mode.cpp
+++ b/ArduSub/mode.cpp
@@ -288,6 +288,34 @@ void Mode::get_pilot_desired_angle_rates(int16_t roll_in, int16_t pitch_in, int1
 }
 
 
+// set_surface_throttle_limit - limit upwards throttle as the vehicle approaches the surface
+// allows SURFACE_MAX_THR at the surface, scaling linearly to full throttle one metre below it
+void Mode::set_surface_throttle_limit()
+{
+    float distance_to_surface = (g.surface_depth - position_control->get_pos_estimate_U_m() * 100.0f) * 0.01f;
+    distance_to_surface = constrain_float(distance_to_surface, 0.0f, 1.0f);
+    motors.set_max_throttle(g.surface_max_throttle + (1.0f - g.surface_max_throttle) * distance_to_surface);
+}
+
+// update_depth_controller - run the vertical position controller, easing the climb demand when surfaced
+// Autonomous modes have no pilot to back off the climb demand, so once surfaced the vehicle
+// would keep driving the thrusters upwards, breaking the water surface and wasting power.
+void Mode::update_depth_controller()
+{
+    set_surface_throttle_limit();
+
+    if (sub.ap.at_surface) {
+        // do not ask the controller to climb above the surface
+        position_control->set_pos_desired_U_cm(MIN(position_control->get_pos_desired_U_cm(), g.surface_depth));
+
+        // drop any upwards feed-forward (up is negative down) so the velocity loop stops demanding a climb
+        position_control->set_vel_desired_D_ms(MAX(position_control->get_vel_desired_NED_ms().z, 0.0f));
+    }
+
+    position_control->D_update_controller();
+}
+
+
 bool Mode::set_mode(Mode::Number mode, ModeReason reason)
 {
     return sub.set_mode(mode, reason);

--- a/ArduSub/mode.cpp
+++ b/ArduSub/mode.cpp
@@ -292,7 +292,7 @@ void Mode::get_pilot_desired_angle_rates(int16_t roll_in, int16_t pitch_in, int1
 // allows SURFACE_MAX_THR at the surface, scaling linearly to full throttle one metre below it
 void Mode::set_surface_throttle_limit()
 {
-    float distance_to_surface = (g.surface_depth - position_control->get_pos_estimate_U_m() * 100.0f) * 0.01f;
+    float distance_to_surface = (sub.get_surface_depth_U_cm() - position_control->get_pos_estimate_U_m() * 100.0f) * 0.01f;
     distance_to_surface = constrain_float(distance_to_surface, 0.0f, 1.0f);
     motors.set_max_throttle(g.surface_max_throttle + (1.0f - g.surface_max_throttle) * distance_to_surface);
 }
@@ -306,7 +306,7 @@ void Mode::update_depth_controller()
 
     if (sub.ap.at_surface) {
         // do not ask the controller to climb above the surface
-        position_control->set_pos_desired_U_cm(MIN(position_control->get_pos_desired_U_cm(), g.surface_depth));
+        position_control->set_pos_desired_U_cm(MIN(position_control->get_pos_desired_U_cm(), sub.get_surface_depth_U_cm()));
 
         // drop any upwards feed-forward (up is negative down) so the velocity loop stops demanding a climb
         position_control->set_vel_desired_D_ms(MAX(position_control->get_vel_desired_NED_ms().z, 0.0f));

--- a/ArduSub/mode.h
+++ b/ArduSub/mode.h
@@ -93,6 +93,12 @@ protected:
     void land_run_horizontal_control();
     void land_run_vertical_control(bool pause_descent = false);
 
+    // limit upwards throttle as the vehicle approaches the surface
+    void set_surface_throttle_limit();
+
+    // run the vertical position controller, easing the climb demand when surfaced
+    void update_depth_controller();
+
     // convenience references to avoid code churn in conversion:
     Parameters &g;
     ParametersG2 &g2;

--- a/ArduSub/mode_althold.cpp
+++ b/ArduSub/mode_althold.cpp
@@ -106,11 +106,7 @@ void ModeAlthold::run_post()
 }
 
 void ModeAlthold::control_depth() {
-    // return 0.2f when at the surface to p
-    // scale linearly between 0.2f and 1.0f as we approach the surface
-    float distance_to_surface = (g.surface_depth - position_control->get_pos_estimate_U_m() * 100.0f) * 0.01f;
-    distance_to_surface = constrain_float(distance_to_surface, 0.0f, 1.0f);
-    motors.set_max_throttle(g.surface_max_throttle + (1.0f - g.surface_max_throttle) * distance_to_surface);
+    set_surface_throttle_limit();
 
     float target_climb_rate_cms = sub.get_pilot_desired_climb_rate(channel_throttle->get_control_in());
     target_climb_rate_cms = constrain_float(target_climb_rate_cms, -sub.get_pilot_speed_dn(), g.pilot_speed_up);

--- a/ArduSub/mode_althold.cpp
+++ b/ArduSub/mode_althold.cpp
@@ -115,7 +115,7 @@ void ModeAlthold::control_depth() {
     //we allow full control to the pilot, but as soon as there's no input, we handle being at surface/bottom
     if (fabsf(target_climb_rate_cms) < 0.05f)  {
         if (sub.ap.at_surface) {
-            position_control->set_pos_desired_U_cm(MIN(position_control->get_pos_desired_U_cm(), g.surface_depth)); // set target to 5 cm below surface level
+            position_control->set_pos_desired_U_cm(MIN(position_control->get_pos_desired_U_cm(), sub.get_surface_depth_U_cm())); // set target to 5 cm below surface level
         } else if (sub.ap.at_bottom) {
             position_control->set_pos_desired_U_cm(MAX(position_control->get_pos_estimate_U_m() * 100.0f + 10.0f, position_control->get_pos_desired_U_cm())); // set target to 10 cm above bottom
         }

--- a/ArduSub/mode_auto.cpp
+++ b/ArduSub/mode_auto.cpp
@@ -148,7 +148,7 @@ void ModeAuto::auto_wp_run()
 
     // WP_Nav has set the vertical position control targets
     // run the vertical position controller and set output throttle
-    position_control->D_update_controller();
+    update_depth_controller();
 
     ////////////////////////////
     // update attitude output //
@@ -246,7 +246,7 @@ void ModeAuto::auto_circle_run()
 
     // WP_Nav has set the vertical position control targets
     // run the vertical position controller and set output throttle
-    position_control->D_update_controller();
+    update_depth_controller();
 
     // roll & pitch from waypoint controller, yaw rate from pilot
     attitude_control->input_euler_angle_roll_pitch_yaw_cd(channel_roll->get_control_in(), channel_pitch->get_control_in(), sub.circle_nav.get_yaw_cd(), true);
@@ -332,7 +332,7 @@ void ModeAuto::auto_loiter_run()
 
     // WP_Nav has set the vertical position control targets
     // run the vertical position controller and set output throttle
-    position_control->D_update_controller();
+    update_depth_controller();
 
     // get pilot desired lean angles
     float target_roll, target_pitch;
@@ -564,7 +564,7 @@ void ModeAuto::auto_terrain_recover_run()
     /////////////////////
     // update z target //
     position_control->D_set_pos_target_from_climb_rate_cms(target_climb_rate);
-    position_control->D_update_controller();
+    update_depth_controller();
 
     ////////////////////////////
     // update angular targets //

--- a/ArduSub/mode_circle.cpp
+++ b/ArduSub/mode_circle.cpp
@@ -87,5 +87,5 @@ void ModeCircle::run()
 
     // update altitude target and call position controller
     position_control->D_set_pos_target_from_climb_rate_cms(target_climb_rate);
-    position_control->D_update_controller();
+    update_depth_controller();
 }

--- a/ArduSub/mode_guided.cpp
+++ b/ArduSub/mode_guided.cpp
@@ -481,7 +481,7 @@ void ModeGuided::guided_pos_control_run()
 
     // WP_Nav has set the vertical position control targets
     // run the vertical position controller and set output throttle
-    position_control->D_update_controller();
+    update_depth_controller();
 
     // call attitude controller
     if (sub.auto_yaw_mode == AUTO_YAW_HOLD) {
@@ -547,7 +547,7 @@ void ModeGuided::guided_vel_control_run()
     position_control->NE_update_controller();
 
     position_control->D_set_pos_target_from_climb_rate_cms(position_control->get_vel_desired_NEU_cms().z);
-    position_control->D_update_controller();
+    update_depth_controller();
 
     float lateral_out, forward_out;
     sub.translate_pos_control_rp(lateral_out, forward_out);
@@ -627,7 +627,7 @@ void ModeGuided::guided_posvel_control_run()
 
     // run position controller
     position_control->NE_update_controller();
-    position_control->D_update_controller();
+    update_depth_controller();
 
     float lateral_out, forward_out;
     sub.translate_pos_control_rp(lateral_out, forward_out);
@@ -702,7 +702,7 @@ void ModeGuided::guided_angle_control_run()
 
     // call position controller
     position_control->D_set_pos_target_from_climb_rate_cms(climb_rate_cms);
-    position_control->D_update_controller();
+    update_depth_controller();
 }
 
 // Guided Limit code

--- a/ArduSub/mode_surftrak.cpp
+++ b/ArduSub/mode_surftrak.cpp
@@ -122,7 +122,7 @@ void ModeSurftrak::control_range() {
         }
         if (sub.ap.at_surface) {
             // Set target depth to 5 cm below SURFACE_DEPTH and reset
-            position_control->set_pos_desired_U_cm(MIN(position_control->get_pos_desired_U_cm(), g.surface_depth - 5.0f));
+            position_control->set_pos_desired_U_cm(MIN(position_control->get_pos_desired_U_cm(), sub.get_surface_depth_U_cm() - 5.0f));
             reset();
         } else if (sub.ap.at_bottom) {
             // Set target depth to 10 cm above bottom and reset

--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -19,6 +19,7 @@ from pymavlink import mavutil
 import vehicle_test_suite
 
 from pysim import util
+from vehicle_test_suite import AltFrame
 from vehicle_test_suite import NotAchievedException
 
 # get location of scripts
@@ -1310,6 +1311,75 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.progress("Baro-less Surface mode OK")
         self.disarm_vehicle()
 
+    def thruster_output_channels(self):
+        """Return the servo output channels driving thrusters on the current frame"""
+        motor_functions = range(33, 41)  # SRV_Channel::k_motor1 .. k_motor8
+        return [chan for chan in range(1, 9)
+                if self.get_parameter(f"SERVO{chan}_FUNCTION") in motor_functions]
+
+    def watch_thrusters_unsaturated(self, duration=10, margin=50):
+        """Raise if any thruster output sits against the PWM rails
+
+        Keyword Arguments:
+            duration {float} -- Time in simulation seconds to watch for (default: {10})
+            margin {int} -- Distance in us from a rail that still counts as saturated (default: {50})
+        """
+        pwm_min = self.get_parameter("MOT_PWM_MIN")
+        pwm_max = self.get_parameter("MOT_PWM_MAX")
+        channels = self.thruster_output_channels()
+        tstart = self.get_sim_time_cached()
+        while self.get_sim_time_cached() - tstart < duration:
+            m = self.assert_receive_message('SERVO_OUTPUT_RAW')
+            for chan in channels:
+                pwm = getattr(m, f"servo{chan}_raw")
+                if pwm < pwm_min + margin or pwm > pwm_max - margin:
+                    raise NotAchievedException(
+                        f"Thruster {chan} saturated while surfaced: pwm={pwm}")
+        self.progress("Thrusters remained unsaturated")
+
+    def SurfaceIndependentFromEkfOrigin(self):
+        """Check surface handling when the EKF origin carries a GPS altitude error
+
+        The origin is set at the first GPS lock, so its altitude is only as good as that
+        one fix and can be metres out.  Depth comes from the depth sensor, and
+        SURFACE_DEPTH is a reading of that sensor, so the vehicle must stop at the same
+        real altitude wherever the origin ended up.
+        """
+        stop_altitudes = []
+
+        for gps_alt_error_m in (5, -5):
+            self.progress(f"GPS reporting the surface {gps_alt_error_m}m out")
+
+            self.set_parameters({
+                "SIM_GPS1_ALT_OFS": gps_alt_error_m,
+                "SIM_BUOYANCY": 0,
+            })
+            self.reboot_sitl()
+            self.dive(-10)
+
+            self.change_mode('GUIDED')
+            target = self.get_location()
+            target.set_alt_m(5, AltFrame.ABOVE_HOME)
+            self.send_do_reposition(target)
+
+            self.delay_sim_time(30, reason="vehicle to surface and settle")
+            self.watch_altitude_maintained(delta=0.3, timeout=10)
+            self.watch_thrusters_unsaturated()
+            stop_altitudes.append(self.get_altitude(altitude_source="SIM_STATE.alt"))
+
+            self.change_mode('MANUAL')
+            self.disarm_vehicle()
+
+        if abs(stop_altitudes[0] - stop_altitudes[1]) > 0.3:
+            raise NotAchievedException(
+                f"surface stops differ: {stop_altitudes[0]:.2f}m and {stop_altitudes[1]:.2f}m")
+        self.progress(
+            f"both origins stopped at the same altitude: "
+            f"{stop_altitudes[0]:.2f}m and {stop_altitudes[1]:.2f}m")
+
+        self.set_parameter("SIM_GPS1_ALT_OFS", 0)
+        self.reboot_sitl()
+
     def UTMGlobalPositionWaypoint(self):
         '''test UTM_GLOBAL_POSITION waypoint fields in AUTO'''
         self.upload_simple_relhome_mission([
@@ -1720,6 +1790,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
             self.PosHoldBounceBack,
             self.SHT3X,
             self.SurfaceSensorless,
+            self.SurfaceIndependentFromEkfOrigin,
             self.GPSForYaw,
             self.WaterDepth,
             self.VisoForYaw,

--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -19,6 +19,7 @@ from pymavlink import mavutil
 import vehicle_test_suite
 
 from pysim import util
+from vehicle_test_suite import AltFrame
 from vehicle_test_suite import NotAchievedException
 
 # get location of scripts
@@ -1299,6 +1300,89 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.progress("Baro-less Surface mode OK")
         self.disarm_vehicle()
 
+    def thruster_output_channels(self):
+        """Return the servo output channels driving thrusters on the current frame"""
+        motor_functions = range(33, 41)  # SRV_Channel::k_motor1 .. k_motor8
+        return [chan for chan in range(1, 9)
+                if self.get_parameter(f"SERVO{chan}_FUNCTION") in motor_functions]
+
+    def watch_thrusters_unsaturated(self, duration=10, margin=50):
+        """Raise if any thruster output sits against the PWM rails
+
+        Keyword Arguments:
+            duration {float} -- Time in simulation seconds to watch for (default: {10})
+            margin {int} -- Distance in us from a rail that still counts as saturated (default: {50})
+        """
+        pwm_min = self.get_parameter("MOT_PWM_MIN")
+        pwm_max = self.get_parameter("MOT_PWM_MAX")
+        channels = self.thruster_output_channels()
+        tstart = self.get_sim_time_cached()
+        while self.get_sim_time_cached() - tstart < duration:
+            m = self.assert_receive_message('SERVO_OUTPUT_RAW')
+            for chan in channels:
+                pwm = getattr(m, f"servo{chan}_raw")
+                if pwm < pwm_min + margin or pwm > pwm_max - margin:
+                    raise NotAchievedException(
+                        f"Thruster {chan} saturated while surfaced: pwm={pwm}")
+        self.progress("Thrusters remained unsaturated")
+
+    def SurfacedZEasing(self):
+        """Check that autonomous modes stop driving upwards once surfaced"""
+        # SURFACE_DEPTH must be deeper than half the SITL frame height, otherwise the
+        # simulated vehicle loses all buoyancy and cannot hold station there at all
+        surface_depth_cm = -50
+        surface_depth_m = surface_depth_cm * 0.01
+
+        self.set_parameters({
+            "SURFACE_DEPTH": surface_depth_cm,
+            "SURFACE_MAX_THR": 0.1,
+            "SIM_BUOYANCY": 0,
+            "SIM_BARO_RND": 0,
+        })
+
+        # dive well clear of the surface, then ask GUIDED for a depth it cannot reach
+        self.dive(-10)
+        self.change_mode('GUIDED')
+        target = self.get_location()
+        target.set_alt_m(5, AltFrame.ABOVE_HOME)
+        self.send_do_reposition(target)
+
+        # the vehicle must settle at SURFACE_DEPTH instead of climbing out of the water
+        self.wait_altitude(altitude_min=surface_depth_m - 1.0, altitude_max=surface_depth_m + 0.1,
+                           relative=False, minimum_duration=10, timeout=180)
+        self.watch_thrusters_unsaturated()
+        self.progress("GUIDED eased at the surface")
+
+        # repeat in AUTO, with a mission waypoint at the surface
+        self.dive(-10)
+        self.upload_simple_relhome_mission([
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 0, 0, 0),
+        ])
+        self.change_mode('AUTO')
+        self.run_cmd(mavutil.mavlink.MAV_CMD_MISSION_START)
+        self.wait_altitude(altitude_min=surface_depth_m - 1.0, altitude_max=surface_depth_m + 0.1,
+                           relative=False, minimum_duration=10, timeout=180)
+        self.watch_thrusters_unsaturated()
+        self.progress("AUTO eased at the surface")
+
+        # a surface command (NAV_LAND) ascends towards zero depth, but the eased controller
+        # holds the vehicle at SURFACE_DEPTH.  wp_nav only reports the waypoint reached within
+        # WP_RADIUS_M, so check the command still completes when that gap is wider than the radius
+        deep_surface_depth_m = -(self.get_parameter("WP_RADIUS_M") + 1.0)
+        self.set_parameter("SURFACE_DEPTH", deep_surface_depth_m * 100)
+        self.dive(-10)
+        self.upload_simple_relhome_mission([
+            (mavutil.mavlink.MAV_CMD_NAV_LAND, 0, 0, -10),
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 0, 0, -10),
+        ])
+        self.change_mode('AUTO')
+        self.run_cmd(mavutil.mavlink.MAV_CMD_MISSION_START)
+        self.wait_current_waypoint(2, timeout=240)
+        self.progress("surface command completed with the depth controller eased")
+
+        self.change_mode('MANUAL')
+        self.disarm_vehicle()
+
     def UTMGlobalPositionWaypoint(self):
         '''test UTM_GLOBAL_POSITION waypoint fields in AUTO'''
         self.upload_simple_relhome_mission([
@@ -1709,6 +1793,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
             self.PosHoldBounceBack,
             self.SHT3X,
             self.SurfaceSensorless,
+            self.SurfacedZEasing,
             self.GPSForYaw,
             self.WaterDepth,
             self.VisoForYaw,

--- a/libraries/AP_Motors/AP_Motors6DOF.cpp
+++ b/libraries/AP_Motors/AP_Motors6DOF.cpp
@@ -282,6 +282,18 @@ float AP_Motors6DOF::get_current_limit_max_throttle()
     return 1.0f;
 }
 
+// clamp upwards thrust to the limit set by set_max_throttle(). The limit flag is
+// raised so that the vertical controller's integrators do not wind up against a
+// ceiling they cannot observe.
+float AP_Motors6DOF::apply_max_throttle(float throttle_thrust)
+{
+    if (throttle_thrust > _max_throttle) {
+        limit.throttle_upper = true;
+        return _max_throttle;
+    }
+    return throttle_thrust;
+}
+
 // output_armed - sends commands to the motors
 // includes new scaling stability patch
 // TODO pull code that is common to output_armed_not_stabilizing into helper functions
@@ -323,6 +335,8 @@ void AP_Motors6DOF::output_armed_stabilizing()
             throttle_thrust = _throttle_thrust_max;
             limit.throttle_upper = true;
         }
+
+        throttle_thrust = apply_max_throttle(throttle_thrust);
 
         // calculate roll, pitch and yaw for each motor
         for (i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
@@ -427,6 +441,8 @@ void AP_Motors6DOF::output_armed_stabilizing_vectored()
         limit.throttle_upper = true;
     }
 
+    throttle_thrust = apply_max_throttle(throttle_thrust);
+
     // calculate roll, pitch and yaw for each motor
     for (i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
         if (motor_enabled[i]) {
@@ -510,7 +526,7 @@ void AP_Motors6DOF::output_armed_stabilizing_vectored_6dof()
         limit.throttle_upper = true;
     }
 
-    throttle_thrust = constrain_float(throttle_thrust, -1.0f, _max_throttle);
+    throttle_thrust = apply_max_throttle(throttle_thrust);
 
     // calculate roll, pitch and Throttle for each motor (only used by vertical thrusters)
     rpt_max = 1; //Initialized to 1 so that normalization will only occur if value is saturated

--- a/libraries/AP_Motors/AP_Motors6DOF.cpp
+++ b/libraries/AP_Motors/AP_Motors6DOF.cpp
@@ -282,6 +282,17 @@ float AP_Motors6DOF::get_current_limit_max_throttle()
     return 1.0f;
 }
 
+// clamp upwards thrust to the limit set by set_max_throttle()
+float AP_Motors6DOF::apply_max_throttle(float throttle_thrust)
+{
+    if (throttle_thrust > _max_throttle) {
+        // set the limit flag so the vertical controller's integrators do not wind up
+        limit.throttle_upper = true;
+        return _max_throttle;
+    }
+    return throttle_thrust;
+}
+
 // output_armed - sends commands to the motors
 // includes new scaling stability patch
 // TODO pull code that is common to output_armed_not_stabilizing into helper functions
@@ -323,6 +334,8 @@ void AP_Motors6DOF::output_armed_stabilizing()
             throttle_thrust = _throttle_thrust_max;
             limit.throttle_upper = true;
         }
+
+        throttle_thrust = apply_max_throttle(throttle_thrust);
 
         // calculate roll, pitch and yaw for each motor
         for (i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
@@ -427,6 +440,8 @@ void AP_Motors6DOF::output_armed_stabilizing_vectored()
         limit.throttle_upper = true;
     }
 
+    throttle_thrust = apply_max_throttle(throttle_thrust);
+
     // calculate roll, pitch and yaw for each motor
     for (i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
         if (motor_enabled[i]) {
@@ -510,7 +525,7 @@ void AP_Motors6DOF::output_armed_stabilizing_vectored_6dof()
         limit.throttle_upper = true;
     }
 
-    throttle_thrust = constrain_float(throttle_thrust, -1.0f, _max_throttle);
+    throttle_thrust = apply_max_throttle(throttle_thrust);
 
     // calculate roll, pitch and Throttle for each motor (only used by vertical thrusters)
     rpt_max = 1; //Initialized to 1 so that normalization will only occur if value is saturated

--- a/libraries/AP_Motors/AP_Motors6DOF.h
+++ b/libraries/AP_Motors/AP_Motors6DOF.h
@@ -65,6 +65,9 @@ protected:
     void output_armed_stabilizing_vectored();
     void output_armed_stabilizing_vectored_6dof();
 
+    // clamp upwards thrust to the limit set by set_max_throttle()
+    float apply_max_throttle(float throttle_thrust);
+
     // Parameters
     AP_Int8             _motor_reverse[AP_MOTORS_MAX_NUM_MOTORS];
     AP_Float            _forwardVerticalCouplingFactor;


### PR DESCRIPTION
### Summary
Stop the Sub depth controller driving the thrusters upwards once the vehicle has surfaced in Auto, Guided and Circle.
Some of it was already merged in #29995, but I missed two output paths, used for other frames, as well as flagging `limit.throttle_upper` to avoid integrator wind-up.

This allows running missions at the surface without cavitation and the associated power draw and noise.


### Classification & Testing (check all that apply and add your own)
- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
New autotest `Sub.SurfacedZEasing` covers Guided, Auto and a surface
command. Confirmed it fails on master and passes with this branch. The
rest of the Sub suite passes locally.
### Description
Auto, Guided and Circle had no surface handling, so once the vehicle
surfaced the depth controller kept commanding a climb. The thrusters
break the water surface, draw current and produce no useful thrust.
- `AP_Motors`: `SURFACE_MAX_THR` was only honoured by the vectored 6DOF
  mixer, so it had no effect on the standard vectored or generic frames.
  The clamp now applies to all of them and raises `limit.throttle_upper`
  so the vertical controller's integrators get anti-windup.
- `Sub`: adds `Mode::update_depth_controller()`, which limits upwards
  throttle near the surface and, once surfaced, clamps the depth target
  to `SURFACE_DEPTH` and drops the upwards velocity feed-forward.
  AltHold now shares the throttle attenuation helper; AltHold, PosHold
  and SurfTrak are unchanged in behaviour.
- A surface command ascends towards zero depth, which the clamp holds
  `SURFACE_DEPTH` short of. `verify_surface()` previously only completed
  once the vehicle was within `WP_RADIUS_M` of the destination, so a
  `SURFACE_DEPTH` deeper than that radius would stall the mission. It
  now also completes on `ap.at_surface`.
No parameter changes. `SIM_Submarine` does not model cavitation, so the
test covers the depth clamp and the throttle limit rather than the power
saved.
This contribution was AI-assisted: the implementation and autotest were
written with Cursor, then reviewed, tested and verified by me.