### PR TITLE
SITL: fix the ROMFS fallback when loading json models

### DIFF
--- a/libraries/SITL/SIM_Frame.cpp
+++ b/libraries/SITL/SIM_Frame.cpp
@@ -619,16 +619,16 @@ void Frame::load_frame_params(const char *model_json)
         fname = strdup(model_json);
     } else {
         IGNORE_RETURN(asprintf(&fname, "@ROMFS/models/%s", model_json));
-        if (AP::FS().stat(model_json, &st) != 0) {
+        if (fname == nullptr || AP::FS().stat(fname, &st) != 0) {
             AP_HAL::panic("%s failed to load", model_json);
         }
     }
     if (fname == nullptr) {
         AP_HAL::panic("%s failed to load", model_json);
     }
-    AP_JSON::value *obj = AP_JSON::load_json(model_json);
+    AP_JSON::value *obj = AP_JSON::load_json(fname);
     if (obj == nullptr) {
-        AP_HAL::panic("%s failed to load", model_json);
+        AP_HAL::panic("%s failed to load", fname);
     }
 
     enum class VarType {
@@ -717,7 +717,8 @@ void Frame::load_frame_params(const char *model_json)
 
     delete obj;
 
-    ::printf("Loaded model params from %s\n", model_json);
+    ::printf("Loaded model params from %s\n", fname);
+    free(fname);
 }
 
 void Frame::parse_float(AP_JSON::value val, const char* label, float &param) {

--- a/libraries/SITL/SIM_Plane.cpp
+++ b/libraries/SITL/SIM_Plane.cpp
@@ -129,16 +129,16 @@ void Plane::load_coeffs(const char *model_json)
         fname = strdup(model_json);
     } else {
         IGNORE_RETURN(asprintf(&fname, "@ROMFS/models/%s", model_json));
-        if (AP::FS().stat(model_json, &st) != 0) {
+        if (fname == nullptr || AP::FS().stat(fname, &st) != 0) {
             AP_HAL::panic("%s failed to load", model_json);
         }
     }
     if (fname == nullptr) {
         AP_HAL::panic("%s failed to load", model_json);
     }
-    AP_JSON::value *obj = AP_JSON::load_json(model_json);
+    AP_JSON::value *obj = AP_JSON::load_json(fname);
     if (obj == nullptr) {
-        AP_HAL::panic("%s failed to load", model_json);
+        AP_HAL::panic("%s failed to load", fname);
     }
 
     enum class VarType {
@@ -212,7 +212,8 @@ void Plane::load_coeffs(const char *model_json)
 
     delete obj;
 
-    ::printf("Loaded plane aero coefficients from %s\n", model_json);
+    ::printf("Loaded plane aero coefficients from %s\n", fname);
+    free(fname);
 }
 
 void Plane::parse_float(AP_JSON::value val, const char* label, float &param) {


### PR DESCRIPTION
### Summary
Fixes the `@ROMFS/models/` fallback in the SITL model loaders: it built the
fallback path but never used it, so any model not present on the filesystem
panicked instead of loading from ROMFS.

### Classification & Testing (check all that apply and add your own)
- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Built `--board sitl` and ran both loaders from an empty directory, so that
only the ROMFS copies are reachable:

    ./waf configure --board sitl && ./waf plane copter
    cd "$(mktemp -d)"
    <builddir>/build/sitl/bin/arduplane --model plane:skywalker_2013.json
    <builddir>/build/sitl/bin/arducopter --model quad:Callisto.json

Before: both panic with `skywalker_2013.json failed to load` /
`Callisto.json failed to load`.
After: both print `Loaded ... from @ROMFS/models/<name>.json` and start
normally.

The on-filesystem path is unchanged: `sim_vehicle.py -v ArduPlane
--model plane:Tools/autotest/models/skywalker_2013.json` behaves as before,
and a nonexistent filename still panics.

### Description
`Frame::load_frame_params()` and `Plane::load_coeffs()` both fall back to
`@ROMFS/models/<name>` when the model file is not on the filesystem. The
fallback cannot succeed as written. The composed path goes into `fname`, but
the check that follows stats `model_json` again -- the path already known to
be missing -- so the fallback always reaches the panic. `load_json()` was then
given `model_json` rather than `fname` as well, so even a successful stat
would have loaded the wrong path. `fname` was never freed.

This matters because `Tools/autotest/models/*.json` are embedded into ROMFS
for the sitl board (`Tools/ardupilotwaf/boards.py`), alongside
`vehicleinfo.json` and the default parameter files, so that a SITL binary can
run without the source tree next to it. That is the code path which consumes
them.

The fix stats and loads `fname`, guards it against a failed `asprintf()`, and
frees it. The panic paths do not return, so they need no free.