### PR TITLE
Plane: quadplane: transition: only set TECS throttle min in auto throttle modes

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -1501,7 +1501,9 @@ void SLT_Transition::update()
             if (plane.quadplane.tiltrotor.get_forward_throttle(throttle)) {
                 // Reset the TECS minimum throttle to match throttle of forward thrust motors
                 // and set the throttle channel slew rate limiter to prevent a sudden drop in throttle
-                plane.TECS_controller.set_throttle_min(throttle, true);
+                if (plane.control_mode->does_auto_throttle()) {
+                    plane.TECS_controller.set_throttle_min(throttle, true);
+                }
                 SRV_Channels::set_slew_last_scaled_output(SRV_Channel::k_throttle, throttle * 100);
                 SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, throttle * 100);
             }
@@ -1620,7 +1622,9 @@ void SLT_Transition::update()
             if (plane.quadplane.tiltrotor.get_forward_throttle(throttle)) {
                 // Reset the TECS minimum throttle to match throttle of forward thrust motors
                 // and set the throttle channel slew rate limiter to prevent a sudden drop in throttle
-                plane.TECS_controller.set_throttle_min(throttle, true);
+                if (plane.control_mode->does_auto_throttle()) {
+                    plane.TECS_controller.set_throttle_min(throttle, true);
+                }
                 SRV_Channels::set_slew_last_scaled_output(SRV_Channel::k_throttle, throttle * 100);
                 SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, throttle * 100);
             }

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -3418,6 +3418,62 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         })
         self.do_RTL()
 
+    def TECSThrSpikeOnModeChange(self):
+        ''' Regression test for issue #33871. '''
+
+        # The bug only affects vectored tiltrotors.
+        self.customise_SITL_commandline(
+            [],
+            model="quadplane-tilthvec",
+            wipe=True,
+        )
+
+        # Turn off throttle slew limit
+        self.set_parameter("THR_SLEWRATE", 0)
+
+        # Take off and transition to fixed-wing flight.
+        self.takeoff(25, mode='QHOVER', timeout=120)
+        self.context_collect('STATUSTEXT')
+        self.change_mode('FBWA')
+        self.set_rc(3, 2000)
+        self.wait_statustext('Transition FW done', timeout=60)
+
+        # Add hook to check throttle level
+        class DetectThrottleSpike(vehicle_test_suite.TestSuite.MessageHook):
+            '''Checks for spikes in throttle output'''
+            def __init__(self, suite):
+                super(DetectThrottleSpike, self).__init__(suite)
+                self.num_samples = 0
+
+            def hook_removed(self):
+                if self.num_samples == 0:
+                    raise NotAchievedException("Did not get SERVO_OUTPUT_RAW")
+
+            def process(self, mav, m):
+                if m.get_type() != 'SERVO_OUTPUT_RAW':
+                    return
+
+                self.num_samples += 1
+                if m.servo3_raw > 1750:
+                    raise NotAchievedException("Throttle spike (%u)" % (m.servo3_raw))
+
+        self.set_message_rate_hz('SERVO_OUTPUT_RAW', 200)
+
+        # Install a hook to check for throttle spike
+        self.context_push()
+        self.install_message_hook_context(DetectThrottleSpike(self))
+
+        # Fly in CRUISE so TECS runs and _throttle_dem converges toward 80%
+        # (TRIM_THROTTLE feed-forward keeps _throttle_dem well above 40%).
+        self.set_rc(3, 1000)
+        self.delay_sim_time(1, reason="Allow vehicle to stabilize at low throttle")
+        self.change_mode('CRUISE')
+
+        self.delay_sim_time(5, reason="Check throttle output")
+        self.context_pop()
+
+        self.do_RTL()
+
     def tests(self):
         '''return list of all tests'''
 
@@ -3503,5 +3559,6 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             self.PlaneWindFailsafe,
             self.HighServoFunctionDefault,
             self.WPSpdChange,
+            self.TECSThrSpikeOnModeChange,
         ])
         return ret

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -3393,6 +3393,63 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         })
         self.do_RTL()
 
+    def TECSThrSpikeOnModeChange(self):
+        ''' Regression test for issue #33871. '''
+
+        # The bug only affects vectored tiltrotors.
+        self.customise_SITL_commandline(
+            [],
+            model="quadplane-tilthvec",
+            wipe=True,
+        )
+        self.reboot_sitl()
+
+        # Turn off throttle slew limit
+        self.set_parameter("THR_SLEWRATE", 0)
+
+        # Take off and transition to fixed-wing flight.
+        self.takeoff(25, mode='QHOVER', timeout=120)
+        self.context_collect('STATUSTEXT')
+        self.change_mode('FBWA')
+        self.set_rc(3, 2000)
+        self.wait_statustext('Transition FW done', timeout=60)
+
+        # Add hook to check throttle level
+        class DetectThrottleSpike(vehicle_test_suite.TestSuite.MessageHook):
+            '''Checks for steps in roll demand'''
+            def __init__(self, suite):
+                super(DetectThrottleSpike, self).__init__(suite)
+                self.num_samples = 0
+
+            def hook_removed(self):
+                if self.num_samples == 0:
+                    raise NotAchievedException("Did not get SERVO_OUTPUT_RAW")
+
+            def process(self, mav, m):
+                if m.get_type() != 'SERVO_OUTPUT_RAW':
+                    return
+
+                self.num_samples += 1
+                if m.servo3_raw > 1750:
+                    raise Exception("Throttle spike (%u)" % (m.servo3_raw))
+
+        self.set_message_rate_hz('SERVO_OUTPUT_RAW', 200)
+
+        # Install a hook to check for the steppy roll output
+        hook = DetectThrottleSpike(self)
+        self.install_message_hook(hook)
+
+        # Fly in CRUISE so TECS runs and _throttle_dem converges toward 80%
+        # (TRIM_THROTTLE feed-forward keeps _throttle_dem well above 40%).
+        self.set_rc(3, 1000)
+        self.delay_sim_time(1, reason="Allow vehicle to stabilize at low throttle")
+        self.change_mode('CRUISE')
+
+        self.delay_sim_time(5, reason="Check throttle output")
+        self.remove_message_hook(hook)
+
+        self.do_RTL()
+
     def tests(self):
         '''return list of all tests'''
 
@@ -3477,5 +3534,6 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             self.FenceRelativeToTerrainMinAlt,
             self.PlaneWindFailsafe,
             self.HighServoFunctionDefault,
+            self.TECSThrSpikeOnModeChange,
         ])
         return ret


### PR DESCRIPTION
### Summary

Fixes https://github.com/ArduPilot/ardupilot/issues/33871 

This changes to only set TECS throttle min in auto throttle modes where TECS is run. Currently thottle min is set in all cases, if there transition is into a mode which does not use TESC that throttle min does not apply until the next mode change.

<!-- Put a one or two line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
