### PR TITLE
AP_TemperatureSensor: add TEMPn_DEVID parameter

### DIFF
--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -1184,6 +1184,25 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
             raise NotAchievedException(
                 f"Did not get good TEMP message (want {temp_min} < Temp < {temp_max})")
 
+    def TemperatureSensorDevID(self):
+        '''test TEMPn_DEV_ID is populated on detection and cleared when the sensor is missing'''
+        self.set_parameters({
+            'TEMP1_TYPE': 8,      # SHT3X
+            'TEMP1_BUS': 1,       # SITL provides the SHT3X on I2C bus 1
+            'TEMP1_ADDR': 0x44,   # SHT3X I2C address
+        })
+        self.reboot_sitl()
+
+        # bus type (1 for I2C), bus, address and sensor type packed as per
+        # AP_HAL::Device::make_bus_id
+        self.assert_parameter_value('TEMP1_DEV_ID', 1 | (1 << 3) | (0x44 << 8) | (8 << 16))
+
+        self.progress("Moving sensor to an address nothing responds on")
+        self.set_parameter('TEMP1_ADDR', 0x45)
+        self.reboot_sitl()
+
+        self.assert_parameter_value('TEMP1_DEV_ID', 0)
+
     def MAV_mgs(self):
         '''test individual GCS backends timestamps'''
         self.reboot_sitl()
@@ -1711,6 +1730,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
             self.INA3221,
             self.PosHoldBounceBack,
             self.SHT3X,
+            self.TemperatureSensorDevID,
             self.SurfaceSensorless,
             self.GPSForYaw,
             self.WaterDepth,

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor.cpp
@@ -298,6 +298,9 @@ void AP_TemperatureSensor::init()
     for (uint8_t instance = 0; instance < AP_TEMPERATURE_SENSOR_MAX_INSTANCES; instance++) {
         _state[instance].instance = instance;
 
+        // clear the device ID, the backend sets it once the sensor has been detected.
+        _params[instance].bus_id.set_and_save(0);
+
         switch (get_type(instance)) {
 #if AP_TEMPERATURE_SENSOR_TSYS01_ENABLED
             case AP_TemperatureSensor_Params::Type::TSYS01:

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Analog.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Analog.cpp
@@ -18,6 +18,7 @@
 #if AP_TEMPERATURE_SENSOR_ANALOG_ENABLED
 
 #include "AP_TemperatureSensor_Analog.h"
+#include <AP_HAL/Device.h>
 
 
 extern const AP_HAL::HAL &hal;
@@ -75,6 +76,12 @@ AP_TemperatureSensor_Analog::AP_TemperatureSensor_Analog(AP_TemperatureSensor &f
     AP_Param::setup_object_defaults(this, var_info);
     _state.var_info = var_info;
     _analog_source = hal.analogin->channel(_pin);
+    set_bus_id(AP_HAL::Device::make_bus_id(
+        AP_HAL::Device::BUS_TYPE_UNKNOWN,
+        0,
+        0,
+        uint8_t(DevType::ANALOG)
+    ));
 }
 
 // Update function called at 5Hz

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Analog.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Analog.cpp
@@ -18,6 +18,7 @@
 #if AP_TEMPERATURE_SENSOR_ANALOG_ENABLED
 
 #include "AP_TemperatureSensor_Analog.h"
+#include <AP_HAL/Device.h>
 
 
 extern const AP_HAL::HAL &hal;
@@ -75,6 +76,12 @@ AP_TemperatureSensor_Analog::AP_TemperatureSensor_Analog(AP_TemperatureSensor &f
     AP_Param::setup_object_defaults(this, var_info);
     _state.var_info = var_info;
     _analog_source = hal.analogin->channel(_pin);
+    set_bus_id(AP_HAL::Device::make_bus_id(
+        AP_HAL::Device::BUS_TYPE_UNKNOWN,
+        0,
+        0,
+        uint8_t(AP_TemperatureSensor_Params::Type::ANALOG)
+    ));
 }
 
 // Update function called at 5Hz

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Backend.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Backend.cpp
@@ -54,6 +54,11 @@ bool AP_TemperatureSensor_Backend::healthy(void) const
     return (_state.last_time_ms > 0) && (AP_HAL::millis() - _state.last_time_ms < 5000);
 }
 
+void AP_TemperatureSensor_Backend::set_bus_id(uint32_t id)
+{
+    _params.bus_id.set_and_save(int32_t(id));
+}
+
 #if HAL_LOGGING_ENABLED
 void AP_TemperatureSensor_Backend::Log_Write_TEMP() const
 {

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Backend.h
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Backend.h
@@ -49,6 +49,9 @@ protected:
     void set_temperature(const float temperature);
     void update_external_libraries(const float temperature);
 
+    // set bus ID of this instance, for TEMPn_DEVID parameters
+    void set_bus_id(uint32_t id);
+
     AP_TemperatureSensor                            &_front;    // reference to front-end
     AP_TemperatureSensor::TemperatureSensor_State   &_state;    // reference to this instance's state (held in the front-end)
     AP_TemperatureSensor_Params                     &_params;   // reference to this instance's parameters (held in the front-end)

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Backend.h
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Backend.h
@@ -49,6 +49,21 @@ protected:
     void set_temperature(const float temperature);
     void update_external_libraries(const float temperature);
 
+    // set bus ID of this instance, for TEMPn_DEVID parameters
+    void set_bus_id(uint32_t id);
+
+    enum class DevType {
+        TSYS01   = 0x01,
+        MCP9600  = 0x02,
+        MAX31865 = 0x03,
+        TSYS03   = 0x04,
+        ANALOG   = 0x05,
+        DRONECAN = 0x06,
+        MLX90614 = 0x07,
+        SHT3x    = 0x08,
+        TMP119   = 0x09,
+    };
+
     AP_TemperatureSensor                            &_front;    // reference to front-end
     AP_TemperatureSensor::TemperatureSensor_State   &_state;    // reference to this instance's state (held in the front-end)
     AP_TemperatureSensor_Params                     &_params;   // reference to this instance's parameters (held in the front-end)

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_DroneCAN.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_DroneCAN.cpp
@@ -19,6 +19,7 @@
 
 #include "AP_TemperatureSensor_DroneCAN.h"
 #include <AP_BoardConfig/AP_BoardConfig.h>
+#include <AP_HAL/Device.h>
 #include <AP_Math/AP_Math.h>
 
 AP_TemperatureSensor_DroneCAN* AP_TemperatureSensor_DroneCAN::_drivers[];
@@ -54,6 +55,17 @@ AP_TemperatureSensor_DroneCAN::AP_TemperatureSensor_DroneCAN(AP_TemperatureSenso
     WITH_SEMAPHORE(_driver_sem);
     _drivers[_driver_instance] = this;
     _driver_instance++;
+}
+
+void AP_TemperatureSensor_DroneCAN::init()
+{
+    // _ID is loaded from EEPROM before init(); use low 8 bits as the address field
+    set_bus_id(AP_HAL::Device::make_bus_id(
+        AP_HAL::Device::BUS_TYPE_UAVCAN,
+        0,
+        uint8_t(_ID.get()),
+        uint8_t(DevType::DRONECAN)
+    ));
 }
 
 // Subscript to incoming temperature messages

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_DroneCAN.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_DroneCAN.cpp
@@ -19,6 +19,7 @@
 
 #include "AP_TemperatureSensor_DroneCAN.h"
 #include <AP_BoardConfig/AP_BoardConfig.h>
+#include <AP_HAL/Device.h>
 #include <AP_Math/AP_Math.h>
 
 AP_TemperatureSensor_DroneCAN* AP_TemperatureSensor_DroneCAN::_drivers[];
@@ -54,6 +55,17 @@ AP_TemperatureSensor_DroneCAN::AP_TemperatureSensor_DroneCAN(AP_TemperatureSenso
     WITH_SEMAPHORE(_driver_sem);
     _drivers[_driver_instance] = this;
     _driver_instance++;
+}
+
+void AP_TemperatureSensor_DroneCAN::init()
+{
+    // _ID is loaded from EEPROM before init(); use low 8 bits as the address field
+    set_bus_id(AP_HAL::Device::make_bus_id(
+        AP_HAL::Device::BUS_TYPE_UAVCAN,
+        0,
+        uint8_t(_ID.get()),
+        uint8_t(AP_TemperatureSensor_Params::Type::DRONECAN)
+    ));
 }
 
 // Subscript to incoming temperature messages

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_DroneCAN.h
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_DroneCAN.h
@@ -30,6 +30,8 @@ public:
 
     static bool subscribe_msgs(AP_DroneCAN* ap_dronecan);
 
+    void init() override;
+
     // Don't do anything in update, but still need to override the pure virtual method.
     void update(void) override {};
 

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_MAX31865.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_MAX31865.cpp
@@ -121,6 +121,9 @@ void AP_TemperatureSensor_MAX31865::init()
 
     _dev->set_speed(AP_HAL::Device::SPEED_HIGH);
 
+    _dev->set_device_type(uint8_t(_params.type));
+    set_bus_id(_dev->get_bus_id());
+
     /* Request 5Hz update */
     _dev->register_periodic_callback(200 * AP_USEC_PER_MSEC,
                                      FUNCTOR_BIND_MEMBER(&AP_TemperatureSensor_MAX31865::thread_tick, void));

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_MAX31865.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_MAX31865.cpp
@@ -121,6 +121,9 @@ void AP_TemperatureSensor_MAX31865::init()
 
     _dev->set_speed(AP_HAL::Device::SPEED_HIGH);
 
+    _dev->set_device_type(uint8_t(DevType::MAX31865));
+    set_bus_id(_dev->get_bus_id());
+
     /* Request 5Hz update */
     _dev->register_periodic_callback(200 * AP_USEC_PER_MSEC,
                                      FUNCTOR_BIND_MEMBER(&AP_TemperatureSensor_MAX31865::thread_tick, void));

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_MCP9600.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_MCP9600.cpp
@@ -91,6 +91,9 @@ void AP_TemperatureSensor_MCP9600::init()
     // lower retries for run
     _dev->set_retries(3);
 
+    _dev->set_device_type(uint8_t(AP_TemperatureSensor_Params::Type::MCP9600));
+    set_bus_id(_dev->get_bus_id());
+
     /* Request 5Hz update */
     _dev->register_periodic_callback(200 * AP_USEC_PER_MSEC,
                                      FUNCTOR_BIND_MEMBER(&AP_TemperatureSensor_MCP9600::_timer, void));

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_MCP9600.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_MCP9600.cpp
@@ -91,6 +91,9 @@ void AP_TemperatureSensor_MCP9600::init()
     // lower retries for run
     _dev->set_retries(3);
 
+    _dev->set_device_type(uint8_t(DevType::MCP9600));
+    set_bus_id(_dev->get_bus_id());
+
     /* Request 5Hz update */
     _dev->register_periodic_callback(200 * AP_USEC_PER_MSEC,
                                      FUNCTOR_BIND_MEMBER(&AP_TemperatureSensor_MCP9600::_timer, void));

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_MLX90614.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_MLX90614.cpp
@@ -32,6 +32,9 @@ void AP_TemperatureSensor_MLX90614::init()
 
     WITH_SEMAPHORE(_dev->get_semaphore());
 
+    _dev->set_device_type(uint8_t(AP_TemperatureSensor_Params::Type::MLX90614));
+    set_bus_id(_dev->get_bus_id());
+
     _dev->register_periodic_callback(50 * AP_USEC_PER_MSEC,
                                      FUNCTOR_BIND_MEMBER(&AP_TemperatureSensor_MLX90614::_timer, void));
 }

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_MLX90614.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_MLX90614.cpp
@@ -32,6 +32,9 @@ void AP_TemperatureSensor_MLX90614::init()
 
     WITH_SEMAPHORE(_dev->get_semaphore());
 
+    _dev->set_device_type(uint8_t(DevType::MLX90614));
+    set_bus_id(_dev->get_bus_id());
+
     _dev->register_periodic_callback(50 * AP_USEC_PER_MSEC,
                                      FUNCTOR_BIND_MEMBER(&AP_TemperatureSensor_MLX90614::_timer, void));
 }

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Params.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Params.cpp
@@ -67,6 +67,13 @@ const AP_Param::GroupInfo AP_TemperatureSensor_Params::var_info[] = {
     // @Description: Sensor Source Identification is used to replace a specific instance of a system component's temperature report with the temp sensor's. Examples: TEMP_SRC = 1 (ESC), TEMP_SRC_ID = 1 will set the temp of ESC1. TEMP_SRC = 3 (BatteryIndex),TEMP_SRC_ID = 2 will set the temp of BATT2. TEMP_SRC = 4 (BatteryId/SerialNum),TEMP_SRC_ID=42 will set the temp of all batteries that have param BATTn_SERIAL = 42.
     AP_GROUPINFO("SRC_ID", 5, AP_TemperatureSensor_Params, source_id, AP_TEMPERATURE_SENSOR_SOURCE_ID_DEFAULT),
 
+    // @Param: DEV_ID
+    // @DisplayName: Temperature sensor ID
+    // @Description: Temperature sensor ID, taking into account its type, bus and instance
+    // @ReadOnly: True
+    // @User: Advanced
+    AP_GROUPINFO_FLAGS("DEV_ID", 6, AP_TemperatureSensor_Params, bus_id, 0, AP_PARAM_FLAG_INTERNAL_USE_ONLY),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Params.h
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_Params.h
@@ -60,4 +60,5 @@ public:
     
     AP_Enum<Source> source;         // library mapping
     AP_Int32 source_id;             // library instance mapping
+    AP_Int32 bus_id;                // device id (type/bus/address)
 };

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_SHT3x.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_SHT3x.cpp
@@ -67,6 +67,9 @@ void AP_TemperatureSensor_SHT3x::init()
     // lower retries for run
     _dev->set_retries(3);
 
+    _dev->set_device_type(uint8_t(DevType::SHT3x));
+    set_bus_id(_dev->get_bus_id());
+
     /* Request 20Hz update */
     _dev->register_periodic_callback(50 * AP_USEC_PER_MSEC,
                                      FUNCTOR_BIND_MEMBER(&AP_TemperatureSensor_SHT3x::_timer, void));

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_SHT3x.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_SHT3x.cpp
@@ -67,6 +67,9 @@ void AP_TemperatureSensor_SHT3x::init()
     // lower retries for run
     _dev->set_retries(3);
 
+    _dev->set_device_type(uint8_t(AP_TemperatureSensor_Params::Type::SHT3x));
+    set_bus_id(_dev->get_bus_id());
+
     /* Request 20Hz update */
     _dev->register_periodic_callback(50 * AP_USEC_PER_MSEC,
                                      FUNCTOR_BIND_MEMBER(&AP_TemperatureSensor_SHT3x::_timer, void));

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_TMP119.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_TMP119.cpp
@@ -73,6 +73,9 @@ void AP_TemperatureSensor_TMP119::init()
     // lower retries for run
     _dev->set_retries(3);
 
+    _dev->set_device_type(uint8_t(AP_TemperatureSensor_Params::Type::TMP119));
+    set_bus_id(_dev->get_bus_id());
+
     // poll the temperature register at 20Hz
     _dev->register_periodic_callback(50 * AP_USEC_PER_MSEC,
                                      FUNCTOR_BIND_MEMBER(&AP_TemperatureSensor_TMP119::_timer, void));

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_TMP119.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_TMP119.cpp
@@ -73,6 +73,9 @@ void AP_TemperatureSensor_TMP119::init()
     // lower retries for run
     _dev->set_retries(3);
 
+    _dev->set_device_type(uint8_t(DevType::TMP119));
+    set_bus_id(_dev->get_bus_id());
+
     // poll the temperature register at 20Hz
     _dev->register_periodic_callback(50 * AP_USEC_PER_MSEC,
                                      FUNCTOR_BIND_MEMBER(&AP_TemperatureSensor_TMP119::_timer, void));

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_TSYS01.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_TSYS01.cpp
@@ -72,6 +72,9 @@ void AP_TemperatureSensor_TSYS01::init()
     // lower retries for run
     _dev->set_retries(3);
 
+    _dev->set_device_type(uint8_t(DevType::TSYS01));
+    set_bus_id(_dev->get_bus_id());
+
     /* Request 20Hz update */
     // Max conversion time is 9.04 ms
     _dev->register_periodic_callback(50 * AP_USEC_PER_MSEC,

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_TSYS01.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_TSYS01.cpp
@@ -72,6 +72,9 @@ void AP_TemperatureSensor_TSYS01::init()
     // lower retries for run
     _dev->set_retries(3);
 
+    _dev->set_device_type(uint8_t(AP_TemperatureSensor_Params::Type::TSYS01));
+    set_bus_id(_dev->get_bus_id());
+
     /* Request 20Hz update */
     // Max conversion time is 9.04 ms
     _dev->register_periodic_callback(50 * AP_USEC_PER_MSEC,

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_TSYS03.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_TSYS03.cpp
@@ -69,6 +69,9 @@ void AP_TemperatureSensor_TSYS03::init()
     // lower retries for run
     _dev->set_retries(3);
 
+    _dev->set_device_type(uint8_t(DevType::TSYS03));
+    set_bus_id(_dev->get_bus_id());
+
     /* Request 20Hz update */
     // Max conversion time is 9.04 ms
     _dev->register_periodic_callback(50 * AP_USEC_PER_MSEC,

--- a/libraries/AP_TemperatureSensor/AP_TemperatureSensor_TSYS03.cpp
+++ b/libraries/AP_TemperatureSensor/AP_TemperatureSensor_TSYS03.cpp
@@ -69,6 +69,9 @@ void AP_TemperatureSensor_TSYS03::init()
     // lower retries for run
     _dev->set_retries(3);
 
+    _dev->set_device_type(uint8_t(AP_TemperatureSensor_Params::Type::TSYS03));
+    set_bus_id(_dev->get_bus_id());
+
     /* Request 20Hz update */
     // Max conversion time is 9.04 ms
     _dev->register_periodic_callback(50 * AP_USEC_PER_MSEC,


### PR DESCRIPTION
Expose a read-only packed device ID for each temperature sensor instance, populated from backends after successful init.

I can detect it in BlueOS!
<img width="754" height="315" alt="Screenshot 2026-08-06 at 16 12 14" src="https://github.com/user-attachments/assets/2bbe5034-9400-4c90-a298-d8aecb1cc915" />


### Summary

Adds DEV_ID parameters for temperature sensors. This gets them on line with other sensors such as INS, gyro, baro, and compasses.

The code was AI-generated but I've reviewed and it makes sense to me. I'm just not sure about the DroneCAN parts

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
