### PR TITLE
Filter: HarmonicNotch: fix Quintuple Notch

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -9031,6 +9031,28 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         esc_hz = rpm_total / (rpm_count * 60)
         return esc_hz
 
+    def assert_notch_filter_count(self, expected, instance=0):
+        '''check the number of notch filters allocated for a harmonic notch
+        instance, as logged in the NF field of FCN.  Note that FCN is only
+        logged when the notch has more than one frequency source, so
+        notch-per-motor must be enabled'''
+        mlog = self.dfreader_for_current_onboard_log()
+        count = None
+        while True:
+            m = mlog.recv_match(type="FCN")
+            if m is None:
+                break
+            if m.I != instance:
+                continue
+            count = m.NF
+        if count is None:
+            raise NotAchievedException("Did not find a FCN message for notch %u" % instance)
+        if count != expected:
+            raise NotAchievedException(
+                "Expected %u notch filters for notch %u, got %u" %
+                (expected, instance, count))
+        self.progress("Notch %u has %u filters" % (instance, count))
+
     def DynamicNotches(self):
         """Use dynamic harmonic notch to control motor noise."""
         self.progress("Flying with dynamic notches")
@@ -9067,12 +9089,23 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         freq, hover_throttle, peakdb1 = \
             self.hover_and_check_matched_frequency_with_fft(-10, 20, 350, reverse=True)
 
+        # a peak check alone cannot tell a quintuple notch from a triple one, so
+        # notch-per-motor is enabled for the composite notch runs below.  That
+        # makes the number of allocated filters visible in the NF field of FCN,
+        # which is only logged for a multi-source notch.  Note this also moves
+        # throttle tracking onto per-motor thrust, so the runs below fly a notch
+        # per motor rather than a single throttle-derived notch.
+        motors = 4      # the default frame is a quad
+        harmonics = 2   # INS_HNTCH_HMNCS is 5, the first and third harmonic
+
         # now add double dynamic notches and check that the peak is squashed
-        self.set_parameter("INS_HNTCH_OPTS", 1)
+        self.set_parameter("INS_HNTCH_OPTS", 3)  # double-notch, notch-per-motor
         self.reboot_sitl()
 
         freq, hover_throttle, peakdb2 = \
             self.hover_and_check_matched_frequency_with_fft(-15, 20, 350, reverse=True)
+
+        self.assert_notch_filter_count(motors * harmonics * 2)
 
         # double-notch should do better, but check for within 5%
         if peakdb2 * 1.05 > peakdb1:
@@ -9081,11 +9114,13 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 (peakdb2, peakdb1))
 
         # now add triple dynamic notches and check that the peak is squashed
-        self.set_parameter("INS_HNTCH_OPTS", 16)
+        self.set_parameter("INS_HNTCH_OPTS", 18)  # triple-notch, notch-per-motor
         self.reboot_sitl()
 
         freq, hover_throttle, peakdb2 = \
             self.hover_and_check_matched_frequency_with_fft(-15, 20, 350, reverse=True)
+
+        self.assert_notch_filter_count(motors * harmonics * 3)
 
         # triple-notch should do better, but check for within 5%
         if peakdb2 * 1.05 > peakdb1:
@@ -9094,13 +9129,15 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 (peakdb2, peakdb1))
 
         # now add quintuple dynamic notches and check that the peak is squashed
-        self.set_parameter("INS_HNTCH_OPTS", 64)
+        self.set_parameter("INS_HNTCH_OPTS", 66)  # quintuple-notch, notch-per-motor
         self.reboot_sitl()
 
         freq, hover_throttle, peakdb2 = \
             self.hover_and_check_matched_frequency_with_fft(-15, 20, 350, reverse=True)
 
-        # triple-notch should do better, but check for within 5%
+        self.assert_notch_filter_count(motors * harmonics * 5)
+
+        # quintuple-notch should do better, but check for within 5%
         if peakdb2 * 1.05 > peakdb1:
             raise NotAchievedException(
                 "Quintuple-notch peak was higher than single-notch peak %fdB > %fdB" %

--- a/libraries/Filter/Filter.h
+++ b/libraries/Filter/Filter.h
@@ -15,6 +15,12 @@
   analysis tools, so they can display the right filter formulas for
   this version of the code
   This should be incremented on significant filtering changes
+
+  1 - Original filters, version was not logged
+  2 - large rework, filters reduce in amplitude as they track under the configured min frequency.
+  3 - Quintuple notch added but not functional
+  4 - Quintuple notch fixed
  */
-#define AP_FILTER_VERSION 3
+
+#define AP_FILTER_VERSION 4
 

--- a/libraries/Filter/HarmonicNotchFilter.cpp
+++ b/libraries/Filter/HarmonicNotchFilter.cpp
@@ -205,6 +205,24 @@ void HarmonicNotchFilter<T>::init(float sample_freq_hz, HarmonicNotchFilterParam
 }
 
 /*
+  calculate the number of notch filters needed for the given config,
+  clamped to HAL_HNF_MAX_FILTERS and rounded down to a whole number of composite
+  groups so update() never writes past the end of the filter array
+ */
+template <class T>
+uint16_t HarmonicNotchFilter<T>::notch_count(uint8_t num_sources, uint8_t num_harmonics, uint8_t composite_notches) const
+{
+    if (num_sources == 0 || num_harmonics == 0 || composite_notches == 0) {
+        return 0;
+    }
+
+    // This relies on integer division to round the result down
+    const uint16_t max_notches = HAL_HNF_MAX_FILTERS / composite_notches;
+    const uint16_t notches = MIN(num_sources * num_harmonics, max_notches);
+    return notches * composite_notches;
+}
+
+/*
   allocate a collection of, at most HAL_HNF_MAX_FILTERS, notch filters to be managed by this harmonic notch filter
  */
 template <class T>
@@ -212,7 +230,7 @@ void HarmonicNotchFilter<T>::allocate_filters(uint8_t num_notches, uint32_t harm
 {
     _composite_notches = composite_notches;
     _num_harmonics = __builtin_popcount(harmonics);
-    _num_filters = MIN(_num_harmonics * num_notches * _composite_notches, HAL_HNF_MAX_FILTERS);
+    _num_filters = notch_count(num_notches, _num_harmonics, _composite_notches);
     _harmonics = harmonics;
 
     if (_num_filters > 0) {
@@ -357,7 +375,7 @@ void HarmonicNotchFilter<T>::update(uint8_t num_centers, const float center_freq
     // adjust the frequencies to be in the allowable range
     const float nyquist_limit = _sample_freq_hz * HARMONIC_NYQUIST_CUTOFF;
 
-    const uint16_t total_notches = MIN(num_centers * _num_harmonics * _composite_notches, HAL_HNF_MAX_FILTERS);
+    const uint16_t total_notches = notch_count(num_centers, _num_harmonics, _composite_notches);
     if (total_notches > _num_filters) {
         // alloc realloc of filters
         expand_filter_count(total_notches);

--- a/libraries/Filter/HarmonicNotchFilter.cpp
+++ b/libraries/Filter/HarmonicNotchFilter.cpp
@@ -210,7 +210,7 @@ void HarmonicNotchFilter<T>::init(float sample_freq_hz, HarmonicNotchFilterParam
 template <class T>
 void HarmonicNotchFilter<T>::allocate_filters(uint8_t num_notches, uint32_t harmonics, uint8_t composite_notches)
 {
-    _composite_notches = MIN(composite_notches, 3);
+    _composite_notches = composite_notches;
     _num_harmonics = __builtin_popcount(harmonics);
     _num_filters = MIN(_num_harmonics * num_notches * _composite_notches, HAL_HNF_MAX_FILTERS);
     _harmonics = harmonics;

--- a/libraries/Filter/HarmonicNotchFilter.h
+++ b/libraries/Filter/HarmonicNotchFilter.h
@@ -85,6 +85,9 @@ private:
     // have we failed to expand filters?
     bool _alloc_has_failed;
 
+    // calculate the number of notch filters needed for the given config,
+    uint16_t notch_count(uint8_t num_sources, uint8_t num_harmonics, uint8_t composite_notches) const;
+
     // minimum frequency (from INS_HNTCH_FREQ * INS_HNTCH_FM_RAT)
     float _minimum_freq;
 

--- a/libraries/Filter/tests/test_notchfilter.cpp
+++ b/libraries/Filter/tests/test_notchfilter.cpp
@@ -363,4 +363,45 @@ TEST(NotchFilterTest, HarmonicNotchTest5)
     fclose(f);
 }
 
+/*
+  test that a composite notch which needs more filters than
+  HAL_HNF_MAX_FILTERS stays inside the filter array.
+
+  update() checks that there is a spare filter once per harmonic, but
+  then writes one filter per notch of the composite, so a filter count
+  clamped to a value which is not a whole number of composites runs off
+  the end of the array.  Neither 78 nor 39 is a multiple of 5.
+ */
+TEST(NotchFilterTest, HarmonicNotchMaxFilters)
+{
+    const uint16_t rate_hz = 2000;
+    // the fundamental and the third harmonic
+    const uint16_t harmonics = 5;
+    // more sources than were allocated for, as happens when ESC
+    // telemetry arrives from more ESCs than there are motors.  This is
+    // INS_MAX_NOTCHES, the most AP_InertialSensor will ever pass in
+    const uint8_t num_centers = 12;
+
+    HarmonicNotchFilterParams notch_params {};
+    notch_params.set_options(uint16_t(HarmonicNotchFilterParams::Options::QuintupleNotch));
+    notch_params.set_attenuation(30);
+    notch_params.set_bandwidth_hz(25);
+    notch_params.set_center_freq_hz(50);
+    notch_params.set_freq_min_ratio(1.0);
+
+    HarmonicNotchFilter<float> filter {};
+    filter.allocate_filters(4, harmonics, notch_params.num_composite_notches());
+    filter.init(rate_hz, notch_params);
+
+    float centers[num_centers];
+    for (uint8_t i=0; i<num_centers; i++) {
+        centers[i] = 50 + i;
+    }
+    filter.update(num_centers, centers);
+
+    // run a sample through so that any filter written past the end of
+    // the array is used as well as written
+    filter.apply(1.0);
+}
+
 AP_GTEST_MAIN()


### PR DESCRIPTION
### Summary

As far as I can tell Quintuple Notch has never worked, this constrain resulted in them being silently converted to a triple notch. Found when writing https://github.com/ArduPilot/WebTools/pull/332

They were added in https://github.com/ArduPilot/ardupilot/pull/30994 and supposedly were tested and have a autotest.

<!-- Put a one or two line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
