### PR TITLE
AP_Filesystem: fix out-of-bounds write in FATFS readdir

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem_FATFS.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_FATFS.cpp
@@ -655,7 +655,7 @@ struct dirent *AP_Filesystem_FATFS::readdir(void *dirp_void)
         errno = fatfs_to_errno((FRESULT)res);
         return nullptr;
     }
-    len = strlen(fno.fname);
+    len = MIN(strlen(fno.fname),sizeof(d->de.d_name)-1);
     strncpy_noterm(d->de.d_name,fno.fname,len);
     d->de.d_name[len] = 0;
     if (fno.fattrib & AM_DIR) {


### PR DESCRIPTION
### Summary

`AP_Filesystem_FATFS::readdir()` writes one byte past the end of `d_name` for
maximum-length filenames, leaving the string unterminated.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer **(new to cpp)**
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Compiled for CubeOrange; FATFS isn't built on SITL. Reproduced on the host by
building ff.c against our ffconf.h and running readdir()'s logic under ASan with
a 255 char filename — before: strlen() reads 257 bytes, 0 past a 344-byte
allocation. After: clean, strlen 254.

### Description

`d_name` is 255 bytes and `FF_LFN_BUF` is 255. At 255 chars `strncpy_noterm()`
writes no terminator — it only adds one when the source is shorter than the
limit — and `d_name[len] = 0` then lands on `d_type`, which is reassigned two
lines later.

`de` is the last member of `DIR_Wrapper`, so `AP_Logger_File.cpp:230` and the
`%s` in `gen_dir_entry()` read past the allocation. The log directory scan at
boot is enough to hit it.

Truncates names of exactly 255 chars by one character. Widening `MAX_NAME_LEN`
to 256 avoids that but touches `struct dirent` for every backend — happy to do
that instead.

Same class as CVE-2026-6688 from the runZero FatFs disclosure, though ArduPilot
isn't listed under it and this is a narrower variant.