### PR TITLE
Copter: FlowHold: do not apply flow P term twice

### DIFF
--- a/ArduCopter/mode_flowhold.cpp
+++ b/ArduCopter/mode_flowhold.cpp
@@ -178,7 +178,7 @@ void ModeFlowHold::flowhold_flow_to_angle(Vector2f &bf_angles_rad, bool stick_in
             xy_I = flow_pi_xy.get_i_shrink();
         } else {
             // normal I term operation
-            xy_I = flow_pi_xy.get_pi();
+            xy_I = flow_pi_xy.get_i();
         }
     }
 

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -4256,6 +4256,41 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         if drift_m > 3:
             raise NotAchievedException("Drifted %.2fm in FlowHold" % drift_m)
 
+        self.start_subtest("FHLD.I is the integrator alone, not P+I")
+        # with FHLD_XY_I=0 the integrator is identically zero, so a non-zero
+        # FHLD.Ix/Iy means the P term has leaked into the term added on top of P
+        self.context_push()
+        self.set_parameter("FHLD_XY_I", 0)
+        tstart_us = self.get_sim_time() * 1.0e6
+        self.delay_sim_time(10, "gather FHLD log messages")
+        dfreader = self.dfreader_for_current_onboard_log()
+        max_abs_I = 0
+        max_abs_flow = 0
+        count = 0
+        while True:
+            m = dfreader.recv_match(type='FHLD')
+            if m is None:
+                break
+            if m.TimeUS < tstart_us:
+                continue
+            count += 1
+            max_abs_I = max(max_abs_I, abs(m.Ix), abs(m.Iy))
+            max_abs_flow = max(max_abs_flow, abs(m.SFx), abs(m.SFy))
+        if count == 0:
+            raise NotAchievedException("Found no FHLD log messages")
+        self.progress("%u FHLD samples, max |I| %f, max |flow| %fm/s" %
+                      (count, max_abs_I, max_abs_flow))
+        # a zero P term would make the check below pass vacuously
+        if max_abs_flow < 0.05:
+            raise NotAchievedException(
+                "Flow rate %fm/s too small to exercise the P term" %
+                max_abs_flow)
+        if max_abs_I > 0:
+            raise NotAchievedException(
+                "FHLD.I is %f with FHLD_XY_I=0; P term leaking into I term" %
+                max_abs_I)
+        self.context_pop()
+
         self.start_subtest("height estimate recovers from EKF height error")
         # FlowHold scales flow to a velocity using its own height
         # estimate, broadcast as named float HEST.  Check it currently


### PR DESCRIPTION
### Summary

FlowHold added the flow controller's P term to the commanded lean angle twice, so the output was
2P + I instead of P + I. Fixes #31043.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

New autotest in `Tools/autotest/arducopter.py`: with `FHLD_XY_I` zeroed the integrator is identically
zero, so a non-zero `FHLD.Ix`/`Iy` means the P term leaked into the term added on top of P. It also
asserts the flow rate is non-trivial, so a zero P term cannot make the check pass vacuously.

```
./waf build --target bin/arducopter
python3 Tools/autotest/autotest.py --speedup=1 test.Copter.ModeFlowHold
```

Passes locally, and on Linux in the `CopterTests1d` shard on my fork:

```
94 FHLD samples, max |I| 0.000000, max |flow| 0.100584m/s
PASSED: "ModeFlowHold"
```

### Description

`flowhold_flow_to_angle()` takes the P term from `flow_pi_xy` into `ef_output`
(`ArduCopter/mode_flowhold.cpp:157`), then adds `xy_I` on top (:200). The non-limited branch filled
`xy_I` with `get_pi()`, which is P + I (`AC_PI_2D.cpp:123`), so the commanded lean angle was **2P + I**.
`get_i()` makes it P + I.

This also makes the two branches consistent: the limited branch already used `get_i_shrink()`, which
returns the integrator only, so the output previously stepped by a whole P term whenever the `limited`
flag toggled. That asymmetry is why this reads as a defect rather than a tuning choice. The FHLD log's
`Ix`/`Iy` fields are documented as the integrator, which is now what they contain.

Credit to @Shashwatt-git, who identified this same arithmetic on #31043 in March and proposed this
`get_i()` substitution.

**One metric gets worse:** The existing `ModeFlowHold` test reports position drift while holding:
**0.02 m** on master, **0.13–0.17 m** with this fix (four macOS runs plus Linux CI). All pass, well
under the test's 3 m threshold. This is expected, as effective P authority on the correction path halves,
so the loop is less stiff. If that is considered a real loss rather than the correction of an over-gained
loop, the remedy is to raise the `FHLD_XY_P` default, but that is a tuning decision I did not want to
bundle with a correctness fix.

Checked the four open PRs touching `mode_flowhold.cpp` (#33947, #33580, #33510, #33014); none touches
the I-term branches.

---
AI assistance was used in developing this change: investigation, validation, additional testing (apart from the included unit test)
