### PR TITLE
AP_InertialSensor: keep the board rotation on the accel during gyro cal

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -1744,12 +1744,8 @@ AP_InertialSensor::_init_gyro()
     // cold start
     DEV_PRINTF("Init Gyro");
 
-    /*
-      we do the gyro calibration with no board rotation. This avoids
-      having to rotate readings during the calibration
-    */
-    enum Rotation saved_orientation = _board_orientation;
-    _board_orientation = ROTATION_NONE;
+    // the gyro backend leaves the board rotation off while _calibrating_gyro
+    // is set, so the samples below are already in board frame
 
     // remove existing gyro offsets
     for (uint8_t k=0; k<num_gyros; k++) {
@@ -1864,9 +1860,6 @@ AP_InertialSensor::_init_gyro()
 #endif
         }
     }
-
-    // restore orientation
-    _board_orientation = saved_orientation;
 
     // record calibration complete
     _calibrating_gyro = false;

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -164,9 +164,13 @@ void AP_InertialSensor_Backend::_rotate_and_correct_gyro(uint8_t instance, Vecto
 
         // gyro calibration is always assumed to have been done in sensor frame
         gyro -= _imu._gyro_offset(instance);
-    }
 
-    gyro.rotate(_imu._board_orientation);
+        // calibration samples are wanted in board frame, so the vehicle
+        // rotation is applied only outside it. Zeroing _board_orientation for
+        // the duration instead would also strip it from the accel, which DCM
+        // reads for its startup alignment.
+        gyro.rotate(_imu._board_orientation);
+    }
 }
 
 /*


### PR DESCRIPTION
### Summary

Gyro calibration zeroed `_board_orientation` so its own samples came out in board frame, but that field is global, so the accel lost its rotation too. DCM's startup alignment reads the last accel published in that window, so on a board whose orientation flips Z it aligns 180 degrees out and takes minutes of drift correction to walk back, failing the attitude pre-arm throughout.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Tested on hardware

Found on a board with an `AHRS_ORIENTATION` that flips Z, where the DCM attitude pre-arm failed for minutes after every boot. With the change it passes immediately. Builds and runs in SITL.

### Description

`_init_gyro()` saved `_board_orientation`, set it to `ROTATION_NONE` for the duration of the calibration and restored it afterwards. The intent was to keep the calibration samples in board frame, but `_board_orientation` is also applied by `_rotate_and_correct_accel()`, so every accel published during the calibration is unrotated as well.

That matters because the value outlives the calibration. `_accel[0]` holds the last one, and `AP_AHRS_DCM::reset()` reads it a few lines later in `init_ardupilot()` to set the initial attitude, gating only on the vector magnitude - a board-frame 9.81 passes. On an upright board the two frames agree and nothing shows, which is why it has gone unnoticed; it needs an orientation that flips Z to be visible at all.

The gyro backend already skips the offset subtraction while `_calibrating_gyro` is set, so the rotation is now skipped in the same place and `_board_orientation` is left alone. The accel is then never published in board frame, and DCM aligns level whether the value it reads is fresh or stale.

Teaching DCM to reject a stale accel instead would leave the board-frame value visible to everything else that reads the accel during calibration, so it treats the symptom rather than the cause.
