### PR TITLE
AP_InertialSensor: don't clear sensor health mid-cycle

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor.cpp
@@ -1937,11 +1937,9 @@ void AP_InertialSensor::update(void)
     wait_for_sample();
 
         for (uint8_t i=0; i<INS_MAX_INSTANCES; i++) {
-            // mark sensors unhealthy and let update() in each backend
-            // mark them healthy via _publish_gyro() and
-            // _publish_accel()
-            _gyro_healthy[i] = false;
-            _accel_healthy[i] = false;
+            // health flags are deliberately not cleared here: they are read
+            // from other threads, and clearing before the backends republish
+            // leaves a window in which a healthy sensor reads unhealthy
             _delta_velocity_valid[i] = false;
             _delta_angle_valid[i] = false;
         }

--- a/libraries/AP_InertialSensor/AP_InertialSensor_ADIS16607.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_ADIS16607.cpp
@@ -107,9 +107,75 @@ AP_InertialSensor_ADIS16607::probe(AP_InertialSensor &imu,
 
 void AP_InertialSensor_ADIS16607::start()
 {
+    // pre-fetch instance numbers for checking fast sampling settings
+    if (!_imu.get_gyro_instance(gyro_instance) || !_imu.get_accel_instance(accel_instance)) {
+        return;
+    }
+
+    backend_rate_hz = 1000;
+    if (enable_fast_sampling(accel_instance) && (get_fast_sampling_rate() > 1) && (dev->bus_type() == AP_HAL::Device::BUS_TYPE_SPI)) {
+        // constrain the gyro rate to be at least the loop rate
+        uint8_t loop_limit = 1;
+        if (get_loop_rate_hz() > 1000) {
+            loop_limit = 2;
+        }
+        if (get_loop_rate_hz() > 2000) {
+            loop_limit = 4;
+        }
+        // constrain the gyro rate to be a 2^N multiple
+        uint8_t fast_sampling_rate = constrain_int16(get_fast_sampling_rate(), loop_limit, 8);
+        backend_rate_hz *= fast_sampling_rate;
+    }
+
+    switch (backend_rate_hz) {
+    case 2000:
+        expected_sample_rate_hz = 2390;
+        dec_rate = DEC_RATE_2390HZ;
+        break;
+    case 4000:
+        expected_sample_rate_hz = 4780;
+        dec_rate = DEC_RATE_4780HZ;
+        break;
+    case 8000:
+        expected_sample_rate_hz = 9560;
+        dec_rate = DEC_RATE_9560HZ;
+        break;
+    default:
+        expected_sample_rate_hz = 1195;
+        dec_rate = DEC_RATE_1195HZ;
+        break;
+    }
+
     if (!_imu.register_accel(accel_instance, expected_sample_rate_hz, dev->get_bus_id_devtype(DEVTYPE_INS_ADIS16607)) ||
         !_imu.register_gyro(gyro_instance, expected_sample_rate_hz, dev->get_bus_id_devtype(DEVTYPE_INS_ADIS16607))) {
         return;
+    }
+
+    {
+        WITH_SEMAPHORE(dev->get_semaphore());
+
+        // Enable SPI Writes to Register Map
+        write_reg16(REG_WRITE_LOCK, 0xAAAA, false);
+        write_reg16(REG_WRITE_LOCK, 0x5555, false);
+
+        /**
+         * Bring rate down
+         * The actual decimation rate, D, is the DEC_RATE+1. Note that when changing the decimation rate, it is
+         * recommended to first reset DEC_RATE to 0x000 before entering the new value. This
+         * allows the decimation accumulator to reset.
+         */
+        const bool rate_ok = write_reg16(REG_DEC_RATE, 0, true) && write_reg16(REG_DEC_RATE, dec_rate, true);
+
+        // discard samples taken at the old rate
+        write_reg16(REG_USER_FIFO_CFG, USER_FIFO_CFG_CLEAR_FIFO_B | (ADIS16607_FIFO_THRESHOLD << 0), false);
+
+        // Write lock
+        write_reg16(REG_WRITE_LOCK, 0x5555, false);
+        write_reg16(REG_WRITE_LOCK, 0xAAAA, false);
+
+        if (!rate_ok) {
+            return;
+        }
     }
 
     // setup sensor rotations from probe()
@@ -134,44 +200,10 @@ bool AP_InertialSensor_ADIS16607::check_dev_id()
     // Lock the SPI mode
     write_reg16(REG_SPI_HALFDUPLEX_KEY, 0xB4B4, false);
 
-    backend_rate_hz = 1000;
-    if (enable_fast_sampling(accel_instance) && (get_fast_sampling_rate() > 1) && (dev->bus_type() == AP_HAL::Device::BUS_TYPE_SPI)) {
-        // constrain the gyro rate to be at least the loop rate
-        uint8_t loop_limit = 1;
-        if (get_loop_rate_hz() > 1000) {
-            loop_limit = 2;
-        }
-        if (get_loop_rate_hz() > 2000) {
-            loop_limit = 4;
-        }
-        // constrain the gyro rate to be a 2^N multiple
-        uint8_t fast_sampling_rate = constrain_int16(get_fast_sampling_rate(), loop_limit, 8);
-        backend_rate_hz *= fast_sampling_rate;
-    }
-
     if (read_reg16(REG_DEV_ID) == DEV_ID_16607) {
         accel_scale = GRAVITY_MSS / 200000.0f;  // Accel: Dynamic Range ±40g. 24-bit data format 200000.0 LSB/g
         gyro_scale = radians(1.0 / 4000.0);     // Gyro: ADIS16607-3, 24-bit data format 4000.0 LSB/°/sec
         _clip_limit = 39.5f * GRAVITY_MSS;
-
-        switch (backend_rate_hz) {
-            case 2000:
-                expected_sample_rate_hz = 2390;
-                dec_rate = DEC_RATE_2390HZ;
-                break;
-            case 4000:
-                expected_sample_rate_hz = 4780;
-                dec_rate = DEC_RATE_4780HZ;
-                break;
-            case 8000:
-                expected_sample_rate_hz = 9560;
-                dec_rate = DEC_RATE_9560HZ;
-                break;
-            default:
-                expected_sample_rate_hz = 1195;
-                dec_rate = DEC_RATE_1195HZ;
-                break;
-        }
 
         return true;
     }
@@ -232,20 +264,6 @@ bool AP_InertialSensor_ADIS16607::init()
 
     // Filter BW. fC=500Hz.
     if (!write_reg16(REG_MSC_CTRL, 0x100, true)) {
-        return false;
-    }
-
-    /**
-     * Bring rate down
-     * The actual decimation rate, D, is the DEC_RATE+1. Note that when changing the decimation rate, it is 
-     * recommended to first reset DEC_RATE to 0x000 before entering the new value. This 
-     * allows the decimation accumulator to reset.
-     */
-    if (!write_reg16(REG_DEC_RATE, 0, true)) {
-        return false;
-    }
-
-    if (!write_reg16(REG_DEC_RATE, dec_rate, true)) {
         return false;
     }
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_ADIS16607.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_ADIS16607.h
@@ -71,8 +71,6 @@ private:
     AP_HAL::OwnPtr<AP_HAL::Device> dev;
     AP_HAL::Device::PeriodicHandle periodic_handle;
 
-    uint8_t accel_instance;
-    uint8_t gyro_instance;
     enum Rotation rotation;
     uint16_t dec_rate;
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.cpp
@@ -30,6 +30,10 @@ AP_InertialSensor_Backend::AP_InertialSensor_Backend(AP_InertialSensor &imu) :
  */
 void AP_InertialSensor_Backend::notify_accel_fifo_reset(uint8_t instance)
 {
+    if (instance >= INS_MAX_INSTANCES) {
+        // can be called from probe() before registration
+        return;
+    }
     _imu._sample_accel_count[instance] = 0;
     _imu._sample_accel_start_us[instance] = 0;    
 }
@@ -39,6 +43,10 @@ void AP_InertialSensor_Backend::notify_accel_fifo_reset(uint8_t instance)
  */
 void AP_InertialSensor_Backend::notify_gyro_fifo_reset(uint8_t instance)
 {
+    if (instance >= INS_MAX_INSTANCES) {
+        // can be called from probe() before registration
+        return;
+    }
     _imu._sample_gyro_count[instance] = 0;
     _imu._sample_gyro_start_us[instance] = 0;
 }
@@ -776,6 +784,10 @@ void AP_InertialSensor_Backend::_inc_gyro_error_count(uint8_t instance)
  */
 void AP_InertialSensor_Backend::_publish_temperature(uint8_t instance, float temperature) /* front end */
 {
+    if (instance >= INS_MAX_INSTANCES) {
+        // registration failed, this backend owns no instance
+        return;
+    }
     if (has_been_killed(instance)) {
         return;
     }
@@ -802,7 +814,13 @@ void AP_InertialSensor_Backend::update_gyro(uint8_t instance) /* front end */
 {    
     WITH_SEMAPHORE(_sem);
 
+    if (instance >= INS_MAX_INSTANCES) {
+        // registration failed, this backend owns no instance
+        return;
+    }
+
     if (has_been_killed(instance)) {
+        _imu._gyro_healthy[instance] = false;
         return;
     }
 
@@ -813,6 +831,10 @@ void AP_InertialSensor_Backend::update_gyro(uint8_t instance) /* front end */
         _imu._gyro_for_fft[instance] = _imu._last_gyro_for_fft[instance];
 #endif
         _imu._new_gyro_data[instance] = false;
+    } else {
+        // no fresh sample this cycle. _publish_gyro() sets the flag true, so
+        // a healthy sensor never sees it transiently cleared
+        _imu._gyro_healthy[instance] = false;
     }
 
     update_gyro_filters(instance);
@@ -838,6 +860,10 @@ void AP_InertialSensor_Backend::update_primary()
  */
 void AP_InertialSensor_Backend::update_gyro_filters(uint8_t instance) /* front end */
 {
+    if (instance >= INS_MAX_INSTANCES) {
+        // registration failed, this backend owns no instance
+        return;
+    }
     // possibly update filter frequency
     const float gyro_rate = _gyro_raw_sample_rate(instance);
 
@@ -865,12 +891,21 @@ void AP_InertialSensor_Backend::update_accel(uint8_t instance) /* front end */
 {    
     WITH_SEMAPHORE(_sem);
 
+    if (instance >= INS_MAX_INSTANCES) {
+        // registration failed, this backend owns no instance
+        return;
+    }
+
     if (has_been_killed(instance)) {
+        _imu._accel_healthy[instance] = false;
         return;
     }
     if (_imu._new_accel_data[instance]) {
         _publish_accel(instance, _imu._accel_filtered[instance]);
         _imu._new_accel_data[instance] = false;
+    } else {
+        // as for the gyro above
+        _imu._accel_healthy[instance] = false;
     }
 
     update_accel_filters(instance);
@@ -881,6 +916,10 @@ void AP_InertialSensor_Backend::update_accel(uint8_t instance) /* front end */
  */
 void AP_InertialSensor_Backend::update_accel_filters(uint8_t instance) /* front end */
 {
+    if (instance >= INS_MAX_INSTANCES) {
+        // registration failed, this backend owns no instance
+        return;
+    }
     // possibly update filter frequency
     if (_last_accel_filter_hz != _accel_filter_cutoff()) {
         _imu._accel_filter[instance].set_cutoff_frequency(_accel_raw_sample_rate(instance), _accel_filter_cutoff());

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Backend.h
@@ -104,6 +104,9 @@ public:
     // if the backend polling rate is the same as the sample rate or higher, return raw sample rate
     // override and return the backend rate in Hz if it is lower than the sample rate
     virtual uint16_t get_gyro_backend_rate_hz() const {
+        if (gyro_instance >= INS_MAX_INSTANCES) {
+            return 0;
+        }
         return _gyro_raw_sample_rate(gyro_instance);
     }
 
@@ -189,9 +192,10 @@ protected:
     //Default Clip Limit
     float _clip_limit = (16.0f - 0.5f) * GRAVITY_MSS;
 
-    // instance numbers of accel and gyro data
-    uint8_t gyro_instance;
-    uint8_t accel_instance;
+    // instance numbers of accel and gyro data. INS_MAX_INSTANCES means
+    // registration failed and this backend owns no frontend instance
+    uint8_t gyro_instance = INS_MAX_INSTANCES;
+    uint8_t accel_instance = INS_MAX_INSTANCES;
     bool is_primary = true;
     uint32_t last_primary_update_us;
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_NONE.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_NONE.h
@@ -41,8 +41,6 @@ private:
     const uint16_t gyro_sample_hz;
     const uint16_t accel_sample_hz;
 
-    uint8_t gyro_instance;
-    uint8_t accel_instance;
     uint64_t next_gyro_sample;
     uint64_t next_accel_sample;
     float gyro_time;


### PR DESCRIPTION
### Summary

`update()` cleared the IMU health flags every main loop and relied on the backends to set them true again a few microseconds later. Those flags are read from other threads, so the window is observable, and at ELRS telemetry rates it produces a continuous "Bad Gyro Health" on a vehicle whose gyro never missed a sample.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Tested on hardware

Reproduced with CRSF telemetry at 199Hz: constant "Bad Gyro Health" on the transmitter with no corresponding fault anywhere. Gone after the change. Builds and runs in SITL.

### Description

`AP_InertialSensor::update()` set `_gyro_healthy`/`_accel_healthy` false for every instance at the top of the loop, on the assumption that the backends would republish immediately afterwards. That assumption holds for readers on the main loop, but `AP_RCTelemetry::check_sensor_status_flags()` runs from the CRSF frame handler on the RC input thread and samples the flags asynchronously. The higher the telemetry rate, the more often it lands inside the window.

It cannot be seen in a log. `IMU.GH` is written from the main loop, which by construction is not inside `update()` at the same time, so it reads 1 even when logged at loop rate - the flag is only ever false while nothing that logs it can look.

Rather than lock a flag that has no reason to change, the central clear is dropped and `update_gyro()`/`update_accel()` set the flag false only when there is no fresh sample or the instance has been killed; `_publish_gyro()`/`_publish_accel()` set it true as before. A healthy sensor therefore never sees the flag transiently cleared. The error-count preference later in `update()` can still demote a sensor in the same cycle; that path is unchanged.

A backend whose `start()` failed to register stays in `_backends[]` with `gyro_instance`/`accel_instance` at their default, and still gets `update()` and `update_filters()` every cycle. Those now default to `INS_MAX_INSTANCES` and the frontend helpers that index by them are bounds-checked, so the new clear cannot land on instance 0 and nothing indexes past the end. ADIS16607 and NONE had shadowing redeclarations of those members; they are removed so the default applies there too.


ADIS16607 also tested `enable_fast_sampling(accel_instance)` from `probe()`, before the instance is known; the rate decision and DEC_RATE write move into `start()` after the instance is pre-fetched, as the Invensense drivers do.
