### PR TITLE
AP_HAL_ChibiOS: reject invalid GCR quintets in DShot telemetry

### DIFF
--- a/libraries/AP_HAL_ChibiOS/RCOutput.h
+++ b/libraries/AP_HAL_ChibiOS/RCOutput.h
@@ -739,6 +739,7 @@ private:
      */
     void bdshot_ic_dma_allocate(Shared_DMA *ctx);
     void bdshot_ic_dma_deallocate(Shared_DMA *ctx);
+    static uint32_t bdshot_decode_gcr_erpm(uint32_t value);
     static uint32_t bdshot_decode_telemetry_packet(dmar_uint_t* buffer, uint32_t count);
     static uint32_t bdshot_decode_telemetry_packet_f1(dmar_uint_t* buffer, uint32_t count, bool reversed);
     bool bdshot_decode_telemetry_from_erpm(uint16_t erpm, uint8_t chan);

--- a/libraries/AP_HAL_ChibiOS/RCOutput_bdshot.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput_bdshot.cpp
@@ -738,14 +738,23 @@ uint32_t RCOutput::bdshot_decode_telemetry_packet(dmar_uint_t* buffer, uint32_t 
         return INVALID_ERPM;
     }
 
+    // 0xff marks the sixteen quintets GCR never emits. Using 0 for those made a
+    // corrupt quintet decode to nibble 0, indistinguishable from the legitimate
+    // 0 at index 25, leaving only the four bit checksum to catch it
     static const uint32_t decode[32] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 9, 10, 11, 0, 13, 14, 15,
-        0, 0, 2, 3, 0, 5, 6, 7, 0, 0, 8, 1, 0, 4, 12, 0 };
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 9, 10, 11, 0xff, 13, 14, 15,
+        0xff, 0xff, 2, 3, 0xff, 5, 6, 7, 0xff, 0, 8, 1, 0xff, 4, 12, 0xff };
 
-    uint32_t decodedValue = decode[value & 0x1fU];
-    decodedValue |= decode[(value >> 5U) & 0x1fU] << 4U;
-    decodedValue |= decode[(value >> 10U) & 0x1fU] << 8U;
-    decodedValue |= decode[(value >> 15U) & 0x1fU] << 12U;
+    const uint32_t n0 = decode[value & 0x1fU];
+    const uint32_t n1 = decode[(value >> 5U) & 0x1fU];
+    const uint32_t n2 = decode[(value >> 10U) & 0x1fU];
+    const uint32_t n3 = decode[(value >> 15U) & 0x1fU];
+
+    if ((n0 | n1 | n2 | n3) > 0x0fU) {
+        return INVALID_ERPM;
+    }
+
+    uint32_t decodedValue = n0 | (n1 << 4U) | (n2 << 8U) | (n3 << 12U);
 
     uint32_t csum = decodedValue;
     csum = csum ^ (csum >> 8U); // xor bytes

--- a/libraries/AP_HAL_ChibiOS/RCOutput_bdshot.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput_bdshot.cpp
@@ -711,7 +711,7 @@ uint32_t RCOutput::bdshot_get_output_rate_hz(const enum output_mode mode)
 uint32_t RCOutput::bdshot_decode_gcr_erpm(uint32_t value)
 {
     // 0xff marks the sixteen quintets GCR never emits
-    static const uint32_t decode[32] = {
+    static const uint8_t decode[32] = {
         0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 9, 10, 11, 0xff, 13, 14, 15,
         0xff, 0xff, 2, 3, 0xff, 5, 6, 7, 0xff, 0, 8, 1, 0xff, 4, 12, 0xff };
 

--- a/libraries/AP_HAL_ChibiOS/RCOutput_bdshot.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput_bdshot.cpp
@@ -707,6 +707,37 @@ uint32_t RCOutput::bdshot_get_output_rate_hz(const enum output_mode mode)
     }
 }
 
+// decode the four GCR quintets of a 20 bit telemetry word and verify the checksum
+uint32_t RCOutput::bdshot_decode_gcr_erpm(uint32_t value)
+{
+    // 0xff marks the sixteen quintets GCR never emits
+    static const uint32_t decode[32] = {
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 9, 10, 11, 0xff, 13, 14, 15,
+        0xff, 0xff, 2, 3, 0xff, 5, 6, 7, 0xff, 0, 8, 1, 0xff, 4, 12, 0xff };
+
+    const uint32_t n0 = decode[value & 0x1fU];
+    const uint32_t n1 = decode[(value >> 5U) & 0x1fU];
+    const uint32_t n2 = decode[(value >> 10U) & 0x1fU];
+    const uint32_t n3 = decode[(value >> 15U) & 0x1fU];
+
+    if ((n0 | n1 | n2 | n3) > 0x0fU) {
+        return INVALID_ERPM;
+    }
+
+    uint32_t decodedValue = n0 | (n1 << 4U) | (n2 << 8U) | (n3 << 12U);
+
+    uint32_t csum = decodedValue;
+    csum = csum ^ (csum >> 8U); // xor bytes
+    csum = csum ^ (csum >> 4U); // xor nibbles
+
+    if ((csum & 0xfU) != 0xfU) {
+        return INVALID_ERPM;
+    }
+    decodedValue >>= 4;
+
+    return decodedValue;
+}
+
 // decode a telemetry packet from a GCR encoded stride buffer, take from betaflight decodeTelemetryPacket
 // see https://github.com/betaflight/betaflight/pull/8554#issuecomment-512507625 for a description of the protocol
 uint32_t RCOutput::bdshot_decode_telemetry_packet(dmar_uint_t* buffer, uint32_t count)
@@ -738,34 +769,7 @@ uint32_t RCOutput::bdshot_decode_telemetry_packet(dmar_uint_t* buffer, uint32_t 
         return INVALID_ERPM;
     }
 
-    // 0xff marks the sixteen quintets GCR never emits. Using 0 for those made a
-    // corrupt quintet decode to nibble 0, indistinguishable from the legitimate
-    // 0 at index 25, leaving only the four bit checksum to catch it
-    static const uint32_t decode[32] = {
-        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 9, 10, 11, 0xff, 13, 14, 15,
-        0xff, 0xff, 2, 3, 0xff, 5, 6, 7, 0xff, 0, 8, 1, 0xff, 4, 12, 0xff };
-
-    const uint32_t n0 = decode[value & 0x1fU];
-    const uint32_t n1 = decode[(value >> 5U) & 0x1fU];
-    const uint32_t n2 = decode[(value >> 10U) & 0x1fU];
-    const uint32_t n3 = decode[(value >> 15U) & 0x1fU];
-
-    if ((n0 | n1 | n2 | n3) > 0x0fU) {
-        return INVALID_ERPM;
-    }
-
-    uint32_t decodedValue = n0 | (n1 << 4U) | (n2 << 8U) | (n3 << 12U);
-
-    uint32_t csum = decodedValue;
-    csum = csum ^ (csum >> 8U); // xor bytes
-    csum = csum ^ (csum >> 4U); // xor nibbles
-
-    if ((csum & 0xfU) != 0xfU) {
-        return INVALID_ERPM;
-    }
-    decodedValue >>= 4;
-
-    return decodedValue;
+    return bdshot_decode_gcr_erpm(value);
 }
 #pragma GCC pop_options
 

--- a/libraries/AP_HAL_ChibiOS/RCOutput_iofirmware.cpp
+++ b/libraries/AP_HAL_ChibiOS/RCOutput_iofirmware.cpp
@@ -409,25 +409,7 @@ uint32_t RCOutput::bdshot_decode_telemetry_packet_f1(dmar_uint_t* buffer, uint32
         return INVALID_ERPM;
     }
 
-    static const uint32_t decode[32] = {
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 9, 10, 11, 0, 13, 14, 15,
-        0, 0, 2, 3, 0, 5, 6, 7, 0, 0, 8, 1, 0, 4, 12, 0 };
-
-    uint32_t decodedValue = decode[value & 0x1fU];
-    decodedValue |= decode[(value >> 5U) & 0x1fU] << 4U;
-    decodedValue |= decode[(value >> 10U) & 0x1fU] << 8U;
-    decodedValue |= decode[(value >> 15U) & 0x1fU] << 12U;
-
-    uint32_t csum = decodedValue;
-    csum = csum ^ (csum >> 8U); // xor bytes
-    csum = csum ^ (csum >> 4U); // xor nibbles
-
-    if ((csum & 0xfU) != 0xfU) {
-        return INVALID_ERPM;
-    }
-    decodedValue >>= 4;
-
-    return decodedValue;
+    return bdshot_decode_gcr_erpm(value);
 }
 
 #endif // HAL_WITH_BIDIR_DSHOT && STM32F1


### PR DESCRIPTION
### Summary

The GCR decode table mapped the sixteen quintets the encoding never emits to nibble 0, which is indistinguishable from the legitimate 0 at index 25. A corrupt quintet therefore decoded silently, leaving the four bit checksum as the only guard against a bad eRPM reaching the harmonic notch.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Tested on hardware

Table verified by inverting the encoder's own `nibble_map` in `hwdef/scripts/bdshot_encoder.py` and comparing entry by entry: the sixteen entries now marked `0xff` are exactly the codes the encoder cannot produce, and the sixteen valid entries are unchanged and cover all sixteen nibbles. Swept all 2^20 words - the old table accepted 61440, the new one accepts 4096, and every word the new code accepts decodes to the value the old code produced. So 57344 false accepts go away and no legitimate frame is lost or decoded differently.

Builds for SkySakuraH743 and iomcu-f103-dshot. Bluejay hardware testing still to come.

### Description

Betaflight measures 5-8% of bidirectional DShot frames failing to decode with motors running, so this path takes corrupt input constantly and by design - it is not an error case. What it did with that input was to map any impossible quintet onto nibble 0 rather than rejecting it, because 0 was also the table's "no such code" filler. The checksum was then the only thing standing between a corrupted frame and an accepted eRPM, and four bits lets roughly one in sixteen through.

The value matters beyond a telemetry display: it drives RPM-referenced harmonic notch tracking, so a wrong eRPM moves the notch off the real motor frequency.

Impossible quintets are now marked `0xff` and the word is rejected if any of its four nibbles came from one. The test is a single OR and compare, on a path that already computes a checksum.

The four lookups had to be pulled out into named values rather than left as the running `|=` accumulation: a valid result uses all sixteen bits, so there is no spare bit for a sentinel to survive the shifts - only the top quintet's would land clear of the result.

`RCOutput_iofirmware.cpp` carried a second copy of the table for the reversed-channel decoder on STM32F1, which the first version of this PR left alone. It is live code - PB8 and PA1 are BIDIR on iomcu-f103-dshot - so those channels kept the old false accept rate. The table, the quintet check and the checksum now live in one helper that both paths call, so the two cannot drift apart again. Dropping the duplicate and narrowing the table to `uint8_t` gives back 268 bytes on the F103, which has 8k of flash left.
