### PR TITLE
AP_HAL_ESP32: enable flash scripting on StampFly

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem_ESP32.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_ESP32.cpp
@@ -25,13 +25,27 @@
 
 extern const AP_HAL::HAL& hal;
 
+#if defined(HAL_ESP32_FLASHFS)
+#define ESP32_FILESYSTEM_DISK_PATH "/APM/"
+#else
+#define ESP32_FILESYSTEM_DISK_PATH "/SDCARD/"
+#endif
+
+static const char *disk_path(const char *path)
+{
+    if (path != nullptr && path[0] == '/') {
+        return path;
+    }
+    return ESP32_FILESYSTEM_DISK_PATH;
+}
+
 int AP_Filesystem_ESP32::open(const char *fname, int flags, bool allow_absolute_paths)
 {
 #if FSDEBUG
     printf("DO open %s \n", fname);
 #endif
     // we automatically add O_CLOEXEC as we always want it for ArduPilot FS usage
-    return ::open(fname, flags | O_TRUNC | O_CLOEXEC, 0666);
+    return ::open(fname, flags | O_CLOEXEC, 0666);
 }
 
 int AP_Filesystem_ESP32::close(int fd)
@@ -162,7 +176,7 @@ int64_t AP_Filesystem_ESP32::disk_free(const char *path)
     DWORD fre_clust, fre_sect;
 
     /* Get volume information and free clusters of sdcard */
-    auto res = f_getfree("/SDCARD/", &fre_clust, &fs);
+    auto res = f_getfree(disk_path(path), &fre_clust, &fs);
     if (res) {
         return -1;
     }
@@ -183,7 +197,7 @@ int64_t AP_Filesystem_ESP32::disk_space(const char *path)
     DWORD fre_clust, tot_sect;
 
     /* Get volume information and free clusters of sdcard */
-    auto res = f_getfree("/SDCARD/", &fre_clust, &fs);
+    auto res = f_getfree(disk_path(path), &fre_clust, &fs);
     if (res) {
         return -1;
     }

--- a/libraries/AP_HAL_ESP32/Scheduler.cpp
+++ b/libraries/AP_HAL_ESP32/Scheduler.cpp
@@ -275,6 +275,7 @@ void Scheduler::reboot(bool hold_in_bootloader)
 {
     printf("Restarting now...\n");
     hal.rcout->force_safety_on();
+    unmount_flashfs();
     unmount_sdcard();
     esp_restart();
 }
@@ -420,6 +421,7 @@ void IRAM_ATTR Scheduler::_io_thread(void* arg)
 #ifdef SCHEDDEBUG
     printf("%s:%d start \n", __PRETTY_FUNCTION__, __LINE__);
 #endif
+    mount_flashfs();
     mount_sdcard();
     Scheduler *sched = (Scheduler *)arg;
     while (!sched->_initialized) {
@@ -440,6 +442,7 @@ void IRAM_ATTR Scheduler::_io_thread(void* arg)
             uint32_t now = AP_HAL::millis();
             if (now - last_sd_start_ms > 3000) {
                 last_sd_start_ms = now;
+                flashfs_retry();
                 sdcard_retry();
             }
         }
@@ -578,4 +581,3 @@ void IRAM_ATTR Scheduler::_main_thread(void *arg)
         };
     }
 }
-

--- a/libraries/AP_HAL_ESP32/SdCard.cpp
+++ b/libraries/AP_HAL_ESP32/SdCard.cpp
@@ -32,6 +32,89 @@
 #include <sys/types.h>
 #include "SPIDevice.h"
 
+#ifndef HAL_ESP32_FLASHFS_MOUNT_POINT
+#define HAL_ESP32_FLASHFS_MOUNT_POINT "/APM"
+#endif
+
+#ifndef HAL_ESP32_FLASHFS_PARTITION_LABEL
+#define HAL_ESP32_FLASHFS_PARTITION_LABEL "apm"
+#endif
+
+#ifndef HAL_ESP32_FLASHFS_SCRIPT_DIR
+#define HAL_ESP32_FLASHFS_SCRIPT_DIR HAL_ESP32_FLASHFS_MOUNT_POINT "/scripts"
+#endif
+
+#ifdef HAL_ESP32_FLASHFS
+static wl_handle_t flashfs_wl_handle = WL_INVALID_HANDLE;
+static bool flashfs_running;
+static HAL_Semaphore flashfs_sem;
+
+void mount_flashfs()
+{
+    WITH_SEMAPHORE(flashfs_sem);
+
+    if (flashfs_running) {
+        return;
+    }
+
+    esp_vfs_fat_mount_config_t mount_config = {
+        .format_if_mount_failed = true,
+        .max_files = 5,
+        .allocation_unit_size = 4096,
+        .disk_status_check_enable = false,
+        .use_one_fat = false,
+    };
+
+    esp_err_t ret = esp_vfs_fat_spiflash_mount_rw_wl(
+        HAL_ESP32_FLASHFS_MOUNT_POINT,
+        HAL_ESP32_FLASHFS_PARTITION_LABEL,
+        &mount_config,
+        &flashfs_wl_handle);
+
+    if (ret == ESP_OK) {
+        mkdir(HAL_ESP32_FLASHFS_SCRIPT_DIR, 0777);
+        printf("flash filesystem is mounted\n");
+        flashfs_running = true;
+    } else {
+        printf("flash filesystem is not mounted: %d\n", int(ret));
+        flashfs_wl_handle = WL_INVALID_HANDLE;
+        flashfs_running = false;
+    }
+}
+
+void unmount_flashfs()
+{
+    WITH_SEMAPHORE(flashfs_sem);
+
+    if (flashfs_running && flashfs_wl_handle != WL_INVALID_HANDLE) {
+        esp_vfs_fat_spiflash_unmount_rw_wl(HAL_ESP32_FLASHFS_MOUNT_POINT, flashfs_wl_handle);
+    }
+    flashfs_wl_handle = WL_INVALID_HANDLE;
+    flashfs_running = false;
+}
+
+bool flashfs_retry(void)
+{
+    if (!flashfs_running) {
+        mount_flashfs();
+    }
+    return flashfs_running;
+}
+#else
+void mount_flashfs()
+{
+}
+
+void unmount_flashfs()
+{
+}
+
+bool flashfs_retry(void)
+{
+    return true;
+}
+#endif
+
 #ifdef HAL_ESP32_SDCARD
 
 #if CONFIG_IDF_TARGET_ESP32S2 ||CONFIG_IDF_TARGET_ESP32C3
@@ -285,7 +368,5 @@ bool sdcard_retry(void)
     return true;
 }
 #endif
-
-
 
 

--- a/libraries/AP_HAL_ESP32/SdCard.h
+++ b/libraries/AP_HAL_ESP32/SdCard.h
@@ -18,3 +18,6 @@
 void mount_sdcard();
 void unmount_sdcard();
 bool sdcard_retry();
+void mount_flashfs();
+void unmount_flashfs();
+bool flashfs_retry();

--- a/libraries/AP_HAL_ESP32/hwdef/esp32s3m5stampfly/defaults.parm
+++ b/libraries/AP_HAL_ESP32/hwdef/esp32s3m5stampfly/defaults.parm
@@ -6,6 +6,7 @@ LOG_BACKEND_TYPE 2 # mavlink logging
 ARMING_SKIPCHK 1024 # disable logging check (in the event log rx is not up)
 LOG_DISARMED 1
 SCHED_LOOP_RATE 150 # flash won't go faster :(
+SCR_ENABLE 1 # enable Lua scripting
 
 # mavlink RC control
 FS_THR_ENABLE 0 # not wanted for mavlink control

--- a/libraries/AP_HAL_ESP32/hwdef/esp32s3m5stampfly/hwdef.dat
+++ b/libraries/AP_HAL_ESP32/hwdef/esp32s3m5stampfly/hwdef.dat
@@ -91,8 +91,11 @@ define HAL_LOGGING_BACKENDS_DEFAULT 2
 
 define AP_RCPROTOCOL_ENABLED 0
 
-define AP_FILESYSTEM_ESP32_ENABLED 0
-define AP_SCRIPTING_ENABLED 0
+define HAVE_FILESYSTEM_SUPPORT 1
+define AP_FILESYSTEM_ESP32_ENABLED 1
+define HAL_ESP32_FLASHFS 1
+define SCRIPTING_DIRECTORY "/APM/scripts"
+define AP_SCRIPTING_ENABLED 1
 
 # This is a board that's not really intended for anything other than copter
 AUTOBUILD_TARGETS Copter

--- a/libraries/AP_HAL_ESP32/targets/esp32s3/esp-idf/CMakeLists.txt
+++ b/libraries/AP_HAL_ESP32/targets/esp32s3/esp-idf/CMakeLists.txt
@@ -17,6 +17,7 @@ idf_build_process(esp32s3
     # targets and file generation
     COMPONENTS freertos
                fatfs
+               wear_levelling
                nvs_flash
                esptool_py
                app_update
@@ -104,6 +105,7 @@ add_custom_target(showinc ALL
 target_link_libraries(${elf_file}
                 idf::freertos
                 idf::fatfs
+                idf::wear_levelling
                 idf::nvs_flash
                 idf::spi_flash
                 idf::app_update

--- a/libraries/AP_HAL_ESP32/targets/esp32s3/partitions.csv
+++ b/libraries/AP_HAL_ESP32/targets/esp32s3/partitions.csv
@@ -3,3 +3,4 @@ nvs,      data, nvs,           ,  0x6000
 phy_init, data, phy,           ,  0x1000
 factory,   app, factory,       ,  3M
 storage,  0x45, 0x0,           ,  256K
+apm,      data, fat,           ,  1M

--- a/libraries/AP_Scripting/lua_scripts.cpp
+++ b/libraries/AP_Scripting/lua_scripts.cpp
@@ -265,7 +265,7 @@ void lua_scripts::load_all_scripts_in_dir(lua_State *L, const char *dirname) {
             continue;
         }
 
-        if ((de->d_name[0] == '.') || strncmp(&de->d_name[length-4], ".lua", 4)) {
+        if ((de->d_name[0] == '.') || strncasecmp(&de->d_name[length-4], ".lua", 4)) {
             // starts with . (hidden file) or doesn't end in .lua
             continue;
         }


### PR DESCRIPTION
### Summary

Enable ESP32 internal flash FAT filesystem support on M5StampFly and use it as the Lua scripting filesystem at `/APM/scripts`.

<img width="603" height="500" alt="スクリーンショット 2026-08-08 21 23 46" src="https://github.com/user-attachments/assets/58e53912-dd18-4e49-a16b-b339a584a835" />

<img width="561" height="562" alt="スクリーンショット 2026-08-09 15 57 39" src="https://github.com/user-attachments/assets/f17735f8-faf7-4528-91bd-356078043563" />

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

Built and tested on M5StampFly / `esp32s3m5stampfly`.

Build:
- `./waf copter -j1`
- `ardupilot.bin` size: `0x1de720`
- App partition free space: `0x1218e0` bytes, 38%

Hardware test:
- Flashed the generated firmware to M5StampFly.
- Verified the ESP32 flash filesystem mounted at `/APM`.
- Verified MAVFTP access to `/APM/scripts`.
- Uploaded `hello.lua`.
- Confirmed Lua execution through repeated GCS messages: `AP: StampFly Lua OK`.

### Description

This PR enables Lua scripting on the ESP32-S3 based M5StampFly board by adding an internal flash FAT filesystem partition and mounting it through the existing ESP32 filesystem backend.

Changes include:
- Add a 1MB FAT partition named `apm` to the ESP32-S3 partition table.
- Mount the internal flash FAT filesystem at `/APM`.
- Create `/APM/scripts` automatically during mount.
- Enable `AP_FILESYSTEM_ESP32_ENABLED` and `AP_SCRIPTING_ENABLED` for `esp32s3m5stampfly`.
- Set the StampFly scripting directory to `/APM/scripts`.
- Enable `SCR_ENABLE` by default for StampFly.
- Link the ESP-IDF `wear_levelling` component required by FAT-on-flash.
- Allow Lua script loading to accept uppercase `.LUA` filenames returned by FAT directory listings.