### PR TITLE
AP_DDS: Fix base_link cmd_vel coordinate conversion

### DIFF
--- a/libraries/AP_DDS/AP_DDS_ExternalControl.cpp
+++ b/libraries/AP_DDS/AP_DDS_ExternalControl.cpp
@@ -52,11 +52,11 @@ bool AP_DDS_External_Control::handle_velocity_control(geometry_msgs_msg_TwistSta
     }
 
     if (strcmp(cmd_vel.header.frame_id, BASE_LINK_FRAME_ID) == 0) {
-        // Convert commands from body frame (x-forward, y-left, z-up) to NED.
+        // Convert commands from ROS FLU to AP FRD.
         Vector3f linear_velocity;
         Vector3f linear_velocity_base_link {
             float(cmd_vel.twist.linear.x),
-            float(cmd_vel.twist.linear.y),
+            float(-cmd_vel.twist.linear.y),
             float(-cmd_vel.twist.linear.z) };
 
         if (isnan(linear_velocity_base_link.y) && isnan(linear_velocity_base_link.z)) {


### PR DESCRIPTION
### Summary

Correct frame conversion for base_link `cmd_vel` commands from ROS FLU to ArduPilot FRD.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Tested in SITL with Gazebo.

### Description

In `AP_DDS_External_Control::handle_velocity_control`, velocity commands sent in the `base_link` frame follow ROS FLU (Forward-Left-Up) conventions, as documented in the [ArduPilot ROS 2 Interfaces guide](https://ardupilot.org/dev/docs/ros2-interfaces.html) and indicated by inline code comments.

However, the frame conversion from ROS FLU to ArduPilot's body frame (FRD) was incorrect because `linear.y` was not inverted. As a result, positive Y linear velocity commands, which represent leftward motion in ROS FLU, were interpreted with the wrong sign, causing the vehicle to move right instead of left. This PR negates `linear.y` when handling `base_link` velocity commands to ensure the correct coordinate frame conversion.

#### Testing
Verified in SITL using Gazebo by publishing a positive Y linear velocity command:

```bash
ros2 topic pub /ap/cmd_vel geometry_msgs/msg/TwistStamped '{header: {frame_id: "base_link"}, twist: {linear: {x: 0.0, y: 1.0, z: 0.0}, angular: {x: 0.0, y: 0.0, z: 0.0}}}'
```

According to ROS FLU conventions, a positive Y linear velocity command (`linear.y = 1.0`) should move the vehicle to the left.

* **Before fix:** The vehicle moved to the right.
* **After fix:** The vehicle moved to the left as expected under ROS FLU body frame.