### PR TITLE
Ensure Copter always starts at startup location for each test

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -94,6 +94,16 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
     def sitl_start_location(self):
         return SITL_START_LOCATION
 
+    def max_distance_from_startup_location_at_end_of_test(self):
+        # Copter's tests start from the point the simulation puts the
+        # vehicle, so each of them has to leave it there.  Two metres
+        # sits in the gap the measurements show: a copter which takes
+        # off and lands comes back to within about 1.3m of where it
+        # started - Landing measured 1.24m and 1.10m on consecutive
+        # runs - while the tests which genuinely fly away and stay away
+        # start at 2.38m and run to 400m.
+        return 2
+
     def mavproxy_options(self):
         ret = super(AutoTestCopter, self).mavproxy_options()
         if self.frame != 'heli':
@@ -680,6 +690,9 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.wait_waypoint(0, num_wp-1, timeout=500)
         self.progress("test: MISSION COMPLETE: passed!")
         self.land_and_disarm()
+
+        # we are not at the home location - reboot so the next test starts there
+        self.reboot_sitl()
 
     def WPArcs(self):
         '''Test WP Arc functionality'''
@@ -1668,6 +1681,9 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.set_parameter('FS_OPTIONS', 0)
         self.progress("All GCS failsafe tests complete")
 
+        # we are not at the home location - reboot so the next test starts there
+        self.reboot_sitl()
+
     def TerrainFailsafe(self):
         '''test that auto mode triggers terrain failsafe if waypoint alt frame is terrain and terrain database is disabled'''
         # allow arming and takeoff in Auto mode
@@ -1852,6 +1868,9 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.wait_landed_and_disarmed()
         self.set_parameter('SIM_BATT_VOLTAGE', 12.5)
         self.clear_battery_failsafe()
+
+        # we are not at the home location - reboot so the next test starts there
+        self.reboot_sitl()
 
     def BatteryFailsafeCriticalLanding(self):
         '''Battery failsafe critical landing not interrupted by RC failure'''
@@ -10140,6 +10159,9 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.wait_disarmed()
 
+        # we are not at the home location - reboot so the next test starts there
+        self.reboot_sitl()
+
     def PrecisionLoiterCompanion(self):
         """Use Companion PrecLand backend precision messages to loiter."""
 
@@ -13405,6 +13427,10 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         # ship will have moved on, so we land on the water which isn't moving
         self.wait_groundspeed(0, 2)
 
+        # we are not at the home location - reboot so the next test starts there
+        self.set_parameter("SIM_SHIP_ENABLE", 0)
+        self.reboot_sitl()
+
     def ParameterValidation(self):
         '''Test parameters are checked for validity'''
         # wait 10 seconds for initialisation
@@ -13505,6 +13531,9 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         if self.mode_is("ALT_HOLD"):
             raise NotAchievedException("Changed to ALT_HOLD with no altitude estimate")
         self.disarm_vehicle(force=True)
+
+        # we are not at the home location - reboot so the next test starts there
+        self.reboot_sitl()
 
     def DeadReckoningInWind(self):
         '''ensure copter dead-reckoning on drag does not destabilise the EKF in wind'''
@@ -14575,6 +14604,9 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.wait_statustext("height achieved - controlling position", check_context=True)
         self.wait_mode('AUTO')
         self.wait_disarmed(timeout=240)
+
+        # we are not at the home location - reboot so the next test starts there
+        self.reboot_sitl()
 
     def GroundEffectCompensation_takeOffExpected(self):
         '''Test EKF's handling of takeoff-expected'''
@@ -16572,6 +16604,9 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.land_and_disarm()
 
+        # we are not at the home location - reboot so the next test starts there
+        self.reboot_sitl()
+
     def start_flying_simple_relhome_mission(self, items):
         '''uploads items, changes mode to auto, waits ready to arm and arms
         vehicle.  If the first item it a takeoff you can expect the
@@ -18376,6 +18411,9 @@ RTL_ALT_M 111
         self.wait_statustext('AutoTrim cancelled', check_context=True)
         self.do_land()
         self.set_rc(9, 1000)
+
+        # we are not at the home location - reboot so the next test starts there
+        self.reboot_sitl()
 
     def RTLStoppingDistanceSpeed(self):
         '''test stopping distance unaffected by RTL speed'''

--- a/Tools/autotest/helicopter.py
+++ b/Tools/autotest/helicopter.py
@@ -22,6 +22,15 @@ class AutoTestHelicopter(AutoTestCopter):
 
     sitl_start_loc = mavutil.location(40.072842, -105.230575, 1586, 0)     # Sparkfun AVC Location
 
+    def max_distance_from_startup_location_at_end_of_test(self):
+        # this class inherits ArduCopter's tests but not its
+        # discipline of leaving the vehicle where it started: a heli
+        # which takes off and lands drifts further than a multirotor
+        # (CI measured 2.5m and 3.1m for the takeoff tests), and the
+        # autorotation tests deliberately end well away from the
+        # startup location (110m).
+        return None
+
     def vehicleinfo_key(self):
         return 'Helicopter'
 

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -1828,6 +1828,10 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         if distance > max_distance:
             raise NotAchievedException(f"Did not land within {max_distance}m of ship {distance=}")
 
+        # we are not at the home location - reboot so the next test starts there
+        self.set_parameter("SIM_SHIP_ENABLE", 0)
+        self.reboot_sitl()
+
     def RCDisableAirspeedUse(self):
         '''check disabling airspeed using RC switch'''
         self.set_parameter("RC9_OPTION", 106)

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -7701,6 +7701,14 @@ class TestSuite(abc.ABC):
             raise NotAchievedException("Far from startup location: %s" % data)
         self.progress("Close to startup location: %s" % data)
 
+    def max_distance_from_startup_location_at_end_of_test(self):
+        '''how far a test may leave the vehicle from where the simulation
+        started it, or None not to care.  Only ArduCopter requires its
+        tests to start at the startup location; the others legitimately
+        finish wherever they got to - a rover which fails safe part-way
+        through a mission stops there, 215m out.'''
+        return None
+
     def assert_simstate_location_is_at_startup_location(self, dist_max=1):
         simstate_loc = self.sim_location()
         start_loc = self.sitl_start_location()
@@ -9814,6 +9822,30 @@ Also, ignores heartbeats not from our target system'''
             else:
                 self.progress("Test failed but ArduPilot process alive; rebooting")
                 self.reboot_sitl() # that'll learn it
+
+        # a test which wanders off and stops somewhere else hands the
+        # next test a displaced vehicle.  ArduCopter's tests require the
+        # vehicle to start where the simulation puts it, and nothing
+        # enforced that between them: the assertion in reboot_sitl()
+        # fires only if a test happens to reboot, and it checks the
+        # position rather than restoring it.  Ask the simulator where
+        # the vehicle really is rather than believing the vehicle.
+        startup_location_dist_max = self.max_distance_from_startup_location_at_end_of_test()
+        if (passed and
+                ardupilot_alive and
+                not reset_needed and
+                startup_location_dist_max is not None):
+            try:
+                self.assert_simstate_location_is_at_startup_location(
+                    dist_max=startup_location_dist_max)
+            except Exception as e:  # noqa: BLE001
+                self.print_exception_caught(e, send_statustext=False)
+                if ex is None:
+                    ex = e
+                passed = False
+                # whatever happens, do not pass the displacement on:
+                self.progress("Resetting SITL to recover the startup location")
+                self.reset_SITL_commandline()
 
         if self._mavproxy is not None:
             self.progress("Stopping auto-started mavproxy")


### PR DESCRIPTION
### Summary

We've had a rule that of all the vehicles, Copter is the only one where you can guarantee a starting location for.  Enforce that, fix problems.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

This change eliminates problems brought about by changes in test ordering, such as parallelising the test suite.
