### PR TITLE
AP_Param: terminate test_find_by_name var_info table

### DIFF
--- a/libraries/AP_Param/tests/test_find_by_name.cpp
+++ b/libraries/AP_Param/tests/test_find_by_name.cpp
@@ -73,11 +73,16 @@ const AP_Param::Info TestVehicle::var_info[] {
     GSCALAR(b,         "AA", 0),
     GSCALAR(b,         "CC", 0),
     GSCALAR(b,         "BB", 0),
+    AP_VAREND
 };
 
 TEST(FindByName, Bob)
 {
     for (const auto &x : TestVehicle::var_info) {
+        if (x.type == AP_PARAM_NONE) {
+            // end of the table
+            break;
+        }
         enum ap_var_type ptype = (ap_var_type)-1;
         AP_Param::ParamToken token = AP_Param::ParamToken {};
         AP_Param *p = AP_Param::find_by_name(x.name, &ptype, &token);


### PR DESCRIPTION
## Summary

`TestVehicle::var_info[]` in `libraries/AP_Param/tests/test_find_by_name.cpp` had no `AP_VAREND` terminator. The `AP_Param` constructor finds the table length by scanning for one:

https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Param/AP_Param.h#L251-L256

```cpp
    AP_Param(const struct Info *info)
    {
        _var_info = info;
        uint16_t i;
        for (i=0; info[i].type != AP_PARAM_NONE; i++) ;
        _num_vars = i;
```

With no terminator that loop reads past the end of the array. Apple clang proves the access is out of bounds and compiles it into a trap, so on macOS the test aborts during static initialisation, before running a single assertion:

```
$ ./build/sitl/tests/test_find_by_name
$ echo $?
133

(lldb) run
Process stopped, stop reason = EXC_BREAKPOINT (code=1, subcode=0x100001d3c)
    frame #0: test_find_by_name`_GLOBAL__sub_I_test_find_by_name.cpp + 120
->  0x100001d3c <+120>: brk    #0x1
```

Adding the terminator changes what the test iterates, since the `TEST` body walks the table with a range-`for` and `AP_VAREND` has `name = ""`. The loop now stops at the sentinel the same way `AP_Param` itself does.

The other two `AP_Param::Info` tables under `libraries/AP_Param/tests/` already terminate correctly, and a check of every `AP_Param::Info` table in the tree found no other missing terminator, so this is the only instance.

## Test

macOS 26 arm64, Apple clang 21.0.0, `./waf configure --board sitl`:

| | result |
|---|---|
| before | exit 133 (`SIGTRAP`), no output, 0 tests run |
| after | `[  PASSED  ] 1 test.` |
| control: `tests/test_param_conversion`, which already had `AP_VAREND` | `[  PASSED  ] 5 tests.` |

Linux is covered by CI rather than by me — I do not have a Linux machine to hand. Both Linux legs pass today without this change: on the current master commit `be40f5985`, run 31379386288 shows `build (base, unit-tests): success` and `build (clang, unit-tests): success`. So neither Linux toolchain traps here; they read a zero `type` byte immediately past the array and stop, which is why the test appears to pass. That is luck about adjacent memory, not defined behaviour — the over-read is UB either way, and Apple clang 21 on arm64 is what makes it visible.

## Checklist

- [x] One logical change, one subsystem
- [x] Verified red-to-green locally
- [ ] Hardware testing — not applicable, unit test only

---

This contribution was AI-assisted. I used Claude to investigate the crash and prepare the patch; I have reviewed and verified every line, ran the before and after builds myself, and I am responsible for the change.
