### PR TITLE
AP_OSD: use vehicle method to get correct yaw

### DIFF
--- a/ArduPlane/Plane.cpp
+++ b/ArduPlane/Plane.cpp
@@ -1034,12 +1034,13 @@ bool Plane::start_takeoff(const float alt_m) {
 #endif
 
 // correct AHRS pitch for PTCH_TRIM_DEG in non-VTOL modes, and return VTOL view in VTOL
-void Plane::get_osd_roll_pitch_rad(float &roll, float &pitch) const
+void Plane::get_osd_attitude_rad(float &roll, float &pitch, float &yaw) const
 {
 #if HAL_QUADPLANE_ENABLED
     if (quadplane.show_vtol_view()) {
-        pitch = quadplane.ahrs_view->pitch;
-        roll = quadplane.ahrs_view->roll;
+        pitch = quadplane.ahrs_view->get_pitch_rad();
+        roll = quadplane.ahrs_view->get_roll_rad();
+        yaw = quadplane.ahrs_view->get_yaw_rad();
         return;
     }
 #endif
@@ -1048,6 +1049,7 @@ void Plane::get_osd_roll_pitch_rad(float &roll, float &pitch) const
     if (!(flight_option_enabled(FlightOptions::OSD_REMOVE_TRIM_PITCH))) {  // correct for PTCH_TRIM_DEG
         pitch -= g.pitch_trim * DEG_TO_RAD;
     }
+    yaw = ahrs.get_yaw_rad();
 }
 
 /*

--- a/ArduPlane/Plane.cpp
+++ b/ArduPlane/Plane.cpp
@@ -1034,8 +1034,11 @@ bool Plane::start_takeoff(const float alt_m) {
 #endif
 
 // correct AHRS pitch for PTCH_TRIM_DEG in non-VTOL modes, and return VTOL view in VTOL
-void Plane::get_osd_attitude_rad(float &roll, float &pitch, float &yaw) const
+void Plane::get_osd_attitude_rad(float &roll, float &pitch, float &yaw)
 {
+    // Take semaphore as this can be called from a thread
+    WITH_SEMAPHORE(ahrs.get_semaphore());
+
 #if HAL_QUADPLANE_ENABLED
     if (quadplane.show_vtol_view()) {
         pitch = quadplane.ahrs_view->get_pitch_rad();
@@ -1044,6 +1047,7 @@ void Plane::get_osd_attitude_rad(float &roll, float &pitch, float &yaw) const
         return;
     }
 #endif
+
     pitch = ahrs.get_pitch_rad();
     roll = ahrs.get_roll_rad();
     if (!(flight_option_enabled(FlightOptions::OSD_REMOVE_TRIM_PITCH))) {  // correct for PTCH_TRIM_DEG

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1081,7 +1081,7 @@ private:
     // Plane.cpp
     void disarm_if_autoland_complete();
     bool trigger_land_abort(const float climb_to_alt_m);
-    void get_osd_attitude_rad(float &roll, float &pitch, float &yaw) const override;
+    void get_osd_attitude_rad(float &roll, float &pitch, float &yaw) override;
     float tecs_hgt_afe(void);
     void get_scheduler_tasks(const AP_Scheduler::Task *&tasks,
                              uint8_t &task_count,

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -1081,7 +1081,7 @@ private:
     // Plane.cpp
     void disarm_if_autoland_complete();
     bool trigger_land_abort(const float climb_to_alt_m);
-    void get_osd_roll_pitch_rad(float &roll, float &pitch) const override;
+    void get_osd_attitude_rad(float &roll, float &pitch, float &yaw) const override;
     float tecs_hgt_afe(void);
     void get_scheduler_tasks(const AP_Scheduler::Task *&tasks,
                              uint8_t &task_count,

--- a/libraries/AP_Frsky_Telem/AP_Frsky_SPort_Passthrough.cpp
+++ b/libraries/AP_Frsky_Telem/AP_Frsky_SPort_Passthrough.cpp
@@ -691,7 +691,8 @@ uint32_t AP_Frsky_SPort_Passthrough::calc_attiandrng(void)
 
     float roll;
     float pitch;
-    AP::vehicle()->get_osd_roll_pitch_rad(roll,pitch);
+    float yaw;
+    AP::vehicle()->get_osd_attitude_rad(roll, pitch, yaw);
     // roll from [-18000;18000] centidegrees to unsigned 0.2 degree increments [0;1800] (just in case, limit to 2047 (0x7FF) since the value is stored on 11 bits)
     uint32_t attiandrng = ((uint16_t)roundf((roll * RAD_TO_DEG * 100 + 18000) * 0.05f) & ATTIANDRNG_ROLL_LIMIT);
     // pitch from [-9000;9000] centidegrees to unsigned 0.2 degree increments [0;900] (just in case, limit to 1023 (0x3FF) since the value is stored on 10 bits)

--- a/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
+++ b/libraries/AP_MSP/AP_MSP_Telem_Backend.cpp
@@ -29,6 +29,7 @@
 #include <AP_RTC/AP_RTC.h>
 #include <AP_VideoTX/AP_VideoTX.h>
 #include <GCS_MAVLink/GCS.h>
+#include <AP_Vehicle/AP_Vehicle.h>
 
 #include "AP_MSP.h"
 #include "AP_MSP_Telem_Backend.h"
@@ -340,7 +341,14 @@ void AP_MSP_Telem_Backend::update_flight_mode_str(char *flight_mode_str, uint8_t
         const char* unit = (units == OSD_UNIT_METRIC) ? "m/s" : "f/s";
 
         if (v_length > 1.0f) {
-            const int32_t angle = wrap_360_cd(rad_to_cd(atan2f(v.y, v.x)) - ahrs.yaw_sensor);
+#if AP_VEHICLE_ENABLED
+            float roll_rad, pitch_rad, yaw_rad;
+            AP::vehicle()->get_osd_attitude_rad(roll_rad, pitch_rad, yaw_rad);
+#else
+            float yaw_rad = ahrs.get_yaw_rad();
+#endif // AP_VEHICLE_ENABLED
+
+            const int32_t angle = wrap_360_cd(rad_to_cd(atan2f(v.y, v.x)) - rad_to_cd(yaw_rad));
             const int32_t interval = 36000 / ARRAY_SIZE(arrows);
             uint8_t arrow = arrows[((angle + interval / 2) / interval) % ARRAY_SIZE(arrows)];
             snprintf(flight_mode_str, size, "%s %d%s%c%c%c", notify->get_flight_mode_str(),  (uint8_t)roundf(v_length), unit, 0xE2, 0x86, arrow);
@@ -969,17 +977,25 @@ MSPCommandResult AP_MSP_Telem_Backend::msp_process_out_osd_config(sbuf_t *dst)
 
 MSPCommandResult AP_MSP_Telem_Backend::msp_process_out_attitude(sbuf_t *dst)
 {
+#if AP_VEHICLE_ENABLED
+    float roll_rad, pitch_rad, yaw_rad;
+    AP::vehicle()->get_osd_attitude_rad(roll_rad, pitch_rad, yaw_rad);
+#else
     AP_AHRS &ahrs = AP::ahrs();
     WITH_SEMAPHORE(ahrs.get_semaphore());
+    float roll_rad = ahrs.get_roll_rad();
+    float pitch_rad = ahrs.get_pitch_rad();
+    float yaw_rad = ahrs.get_yaw_rad();
+#endif // AP_VEHICLE_ENABLED
 
     const struct PACKED {
         int16_t roll;
         int16_t pitch;
         int16_t yaw;
     } attitude {
-        roll : int16_t(ahrs.get_roll_deg() * 10),     // degress to decidegrees
-        pitch : int16_t(ahrs.get_pitch_deg() * 10),   // degress to decidegrees
-        yaw : int16_t(ahrs.get_yaw_deg())
+        roll : int16_t(degrees(roll_rad) * 10),     // degress to decidegrees
+        pitch : int16_t(degrees(pitch_rad) * 10),   // degress to decidegrees
+        yaw : int16_t(wrap_360(degrees(yaw_rad)))
     };
 
     sbuf_write_data(dst, &attitude, sizeof(attitude));

--- a/libraries/AP_OSD/AP_OSD_Screen.cpp
+++ b/libraries/AP_OSD/AP_OSD_Screen.cpp
@@ -1692,7 +1692,9 @@ void AP_OSD_Screen::draw_gspeed(uint8_t x, uint8_t y)
     float angle = 0;
     const float length = v.length();
     if (length > 1.0f) {
-        angle = atan2f(v.y, v.x) - ahrs.get_yaw_rad();
+        float roll_rad, pitch_rad, yaw_rad;
+        AP::vehicle()->get_osd_attitude_rad(roll_rad, pitch_rad, yaw_rad);
+        angle = wrap_2PI(atan2f(v.y, v.x) - yaw_rad);
     }
     draw_speed(x + 1, y, angle, length);
 }
@@ -1704,8 +1706,9 @@ void AP_OSD_Screen::draw_horizon(uint8_t x, uint8_t y)
     WITH_SEMAPHORE(ahrs.get_semaphore());
     float roll;
     float pitch;
+    float yaw;
     bool inverted = false;
-    AP::vehicle()->get_osd_roll_pitch_rad(roll,pitch);
+    AP::vehicle()->get_osd_attitude_rad(roll, pitch, yaw);
     pitch *= -1;
     // Are we inverted? then flash horizon line
     if (abs(roll) >= radians(90)) {
@@ -1787,7 +1790,9 @@ void AP_OSD_Screen::draw_home(uint8_t x, uint8_t y)
     if (ahrs.get_location(loc) && ahrs.home_is_set()) {
         const Location &home_loc = ahrs.get_home();
         float distance = home_loc.get_distance(loc);
-        int32_t angle_cd = loc.get_bearing_to(home_loc) - ahrs.yaw_sensor;
+        float roll_rad, pitch_rad, yaw_rad;
+        AP::vehicle()->get_osd_attitude_rad(roll_rad, pitch_rad, yaw_rad);
+        int32_t angle_cd = loc.get_bearing_to(home_loc) - rad_to_cd(yaw_rad);
         if (distance < 2.0f) {
             //avoid fast rotating arrow at small distances
             angle_cd = 0;
@@ -1802,8 +1807,9 @@ void AP_OSD_Screen::draw_home(uint8_t x, uint8_t y)
 
 void AP_OSD_Screen::draw_heading(uint8_t x, uint8_t y)
 {
-    AP_AHRS &ahrs = AP::ahrs();
-    uint16_t yaw = ahrs.get_yaw_deg();
+    float roll_rad, pitch_rad, yaw_rad;
+    AP::vehicle()->get_osd_attitude_rad(roll_rad, pitch_rad, yaw_rad);
+    uint16_t yaw = degrees(wrap_2PI(yaw_rad));
     backend->write(x, y, false, "%3d%c", yaw, SYMBOL(SYM_DEGR));
 }
 
@@ -1924,8 +1930,9 @@ void AP_OSD_Screen::draw_compass(uint8_t x, uint8_t y)
         SYM_HEADING_DIVIDED_LINE,
         SYM_HEADING_LINE,
     };
-    AP_AHRS &ahrs = AP::ahrs();
-    int32_t yaw = ahrs.yaw_sensor;
+    float roll_rad, pitch_rad, yaw_rad;
+    AP::vehicle()->get_osd_attitude_rad(roll_rad, pitch_rad, yaw_rad);
+    int32_t yaw = rad_to_cd(wrap_2PI(yaw_rad));
     int32_t interval = 36000 / total_sectors;
     int8_t center_sector = ((yaw + interval / 2) / interval) % total_sectors;
     for (int8_t i = -4; i <= 4; i++) {
@@ -1950,7 +1957,9 @@ void AP_OSD_Screen::draw_wind(uint8_t x, uint8_t y)
         if (check_option(AP_OSD::OPTION_INVERTED_WIND)) {
             angle = M_PI;
         }
-        angle = angle + atan2f(v.y, v.x) - ahrs.get_yaw_rad();
+        float roll_rad, pitch_rad, yaw_rad;
+        AP::vehicle()->get_osd_attitude_rad(roll_rad, pitch_rad, yaw_rad);
+        angle = wrap_2PI(angle + atan2f(v.y, v.x) - yaw_rad);
     } 
     draw_speed(x + 1, y, angle, length);
 
@@ -2222,7 +2231,9 @@ void AP_OSD_Screen::draw_gps_longitude(uint8_t x, uint8_t y)
 
 void AP_OSD_Screen::draw_roll_angle(uint8_t x, uint8_t y)
 {
-    const float roll_deg = AP::ahrs().get_roll_deg();
+    float roll_rad, pitch_rad, yaw_rad;
+    AP::vehicle()->get_osd_attitude_rad(roll_rad, pitch_rad, yaw_rad);
+    const float roll_deg = degrees(roll_rad);
     char r;
     if (roll_deg > 0.5) {
         r = SYMBOL(SYM_ROLLR);
@@ -2236,7 +2247,9 @@ void AP_OSD_Screen::draw_roll_angle(uint8_t x, uint8_t y)
 
 void AP_OSD_Screen::draw_pitch_angle(uint8_t x, uint8_t y)
 {
-    const float pitch_deg = AP::ahrs().get_pitch_deg();
+    float roll_rad, pitch_rad, yaw_rad;
+    AP::vehicle()->get_osd_attitude_rad(roll_rad, pitch_rad, yaw_rad);
+    const float pitch_deg = degrees(pitch_rad);
     char p;
     if (pitch_deg > 0.5) {
         p = SYMBOL(SYM_PTCHUP);
@@ -2265,8 +2278,9 @@ void AP_OSD_Screen::draw_hdop(uint8_t x, uint8_t y)
 
 void AP_OSD_Screen::draw_waypoint(uint8_t x, uint8_t y)
 {
-    AP_AHRS &ahrs = AP::ahrs();
-    int32_t angle_cd = osd->nav_info.wp_bearing - ahrs.yaw_sensor;
+    float roll_rad, pitch_rad, yaw_rad;
+    AP::vehicle()->get_osd_attitude_rad(roll_rad, pitch_rad, yaw_rad);
+    int32_t angle_cd = osd->nav_info.wp_bearing - rad_to_cd(yaw_rad);
     if (osd->nav_info.wp_distance < 2.0f) {
         //avoid fast rotating arrow at small distances
         angle_cd = 0;

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -1020,9 +1020,12 @@ void AP_Vehicle::publish_osd_info()
 }
 #endif
 
-void AP_Vehicle::get_osd_attitude_rad(float &roll, float &pitch, float &yaw) const
+void AP_Vehicle::get_osd_attitude_rad(float &roll, float &pitch, float &yaw)
 {
 #if AP_AHRS_ENABLED
+    // Take semaphore as this can be called from a thread
+    WITH_SEMAPHORE(ahrs.get_semaphore());
+
     roll = ahrs.get_roll_rad();
     pitch = ahrs.get_pitch_rad();
     yaw = ahrs.get_yaw_rad();

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -1020,14 +1020,16 @@ void AP_Vehicle::publish_osd_info()
 }
 #endif
 
-void AP_Vehicle::get_osd_roll_pitch_rad(float &roll, float &pitch) const
+void AP_Vehicle::get_osd_attitude_rad(float &roll, float &pitch, float &yaw) const
 {
 #if AP_AHRS_ENABLED
     roll = ahrs.get_roll_rad();
     pitch = ahrs.get_pitch_rad();
+    yaw = ahrs.get_yaw_rad();
 #else
     roll = 0.0;
     pitch = 0.0;
+    yaw = 0.0;
 #endif
 }
 

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -312,8 +312,8 @@ public:
      */
     virtual bool get_pan_tilt_norm(float &pan_norm, float &tilt_norm) const { return false; }
 
-    // Returns roll and  pitch for OSD Horizon, Plane overrides to correct for VTOL view and fixed wing PTCH_TRIM_DEG
-    virtual void get_osd_roll_pitch_rad(float &roll, float &pitch) const;
+    // Returns roll, pitch, and yaw for OSD Horizon, Plane overrides to correct for VTOL view and fixed wing PTCH_TRIM_DEG
+    virtual void get_osd_attitude_rad(float &roll, float &pitch, float &yaw) const;
 
     /*
      get the target earth-frame angular velocities in rad/s (Z-axis component used by some gimbals)

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -313,7 +313,7 @@ public:
     virtual bool get_pan_tilt_norm(float &pan_norm, float &tilt_norm) const { return false; }
 
     // Returns roll, pitch, and yaw for OSD Horizon, Plane overrides to correct for VTOL view and fixed wing PTCH_TRIM_DEG
-    virtual void get_osd_attitude_rad(float &roll, float &pitch, float &yaw) const;
+    virtual void get_osd_attitude_rad(float &roll, float &pitch, float &yaw);
 
     /*
      get the target earth-frame angular velocities in rad/s (Z-axis component used by some gimbals)


### PR DESCRIPTION
### Summary

Currently the existing vehicle attitude getter is not used for all ahrs uses and its missing yaw. This updates OSD to use it in all cases and adds yaw. The difference only exists on plane for FW vs VTOL flight, tailsitter being the largest change in reported attitude.

<!-- Put a one or two line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
