### PR TITLE
AP_Logger: mark LOG_BACKEND_TYPE as RebootRequired

### DIFF
--- a/libraries/AP_Logger/AP_Logger.cpp
+++ b/libraries/AP_Logger/AP_Logger.cpp
@@ -99,6 +99,7 @@ const AP_Param::GroupInfo AP_Logger::var_info[] = {
     // @Description: Bitmap of what Logger backend types to enable. Block-based logging is available on SITL and boards with dataflash chips. Multiple backends can be selected.
     // @Bitmask: 0:File,1:MAVLink,2:Block
     // @User: Standard
+    // @RebootRequired: True
     AP_GROUPINFO("_BACKEND_TYPE",  0, AP_Logger, _params.backend_types,       uint8_t(HAL_LOGGING_BACKENDS_DEFAULT)),
 
     // @Param: _FILE_BUFSIZE


### PR DESCRIPTION
### Summary

Adds the missing `@RebootRequired: True` metadata tag to `LOG_BACKEND_TYPE`.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Comment-only change to parameter metadata. Verified by source inspection; no
behavioural or binary change.

### Description

`LOG_BACKEND_TYPE` only takes effect at startup, but is not tagged
`@RebootRequired`, so GCS software gives no reboot prompt and a runtime
`PARAM_SET` returns a successful `PARAM_VALUE` while changing nothing. This is
a silent no-op that reports success, which is a difficult failure mode for
automated clients such as companion computers.

`AP_Logger::init()` reads `_params.backend_types` once, probes the enabled
backends and sets `_next_backend`. No other code path constructs or destroys a
backend. `AP_Logger::should_log()` gates on `_next_backend`, not on the live
parameter value, so a runtime change cannot enable or disable a backend.

The wiki already documents the parameter as reboot-required. The "Firmware
Limitations on AutoPilot Hardware" page suggests temporarily setting
`LOG_BACKEND_TYPE = 0` to free memory and notes that these workarounds all
require a reboot to take effect. This PR brings the metadata in line with the
documented behaviour.

Note that `_params.backend_types` does have one live read, in
`in_log_download()`, where the BLOCK bit selects how transfer activity
suppresses logging. I don't believe this makes the tag misleading, since that
branch is incidental rather than a supported runtime behaviour and no backend
is created or destroyed by it, but flagging it for reviewers.

`LOG_FILE_BUFSIZE` appears to be in the same position: consumed once at init,
documented on the same wiki page as requiring a reboot, and untagged. Happy to
add it here or in a separate PR if a maintainer confirms.

Related: #33952 reports the same class of defect (missing `@RebootRequired`
causing a silently ineffective `PARAM_SET`) against `WP_SPD`/`Q_WP_SPD` in
`AC_WPNav`. Different parameter and different root cause, but it may be worth
a broader audit of init-only parameters.