### PR TITLE
AP_RCProtocol: apply SITL RC failure modes to FDM input

### DIFF
--- a/libraries/AP_RCProtocol/AP_RCProtocol_FDM.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_FDM.cpp
@@ -24,6 +24,10 @@ void AP_RCProtocol_FDM::update()
         return;
     }
 
+    if (sitl->rc_fail == SITL::SIM::SITL_RCFail_NoPulses) {
+        return;
+    }
+
     // simulate RC input at 50Hz
     if (AP_HAL::millis() - last_input_ms < 20) {
         return;
@@ -31,17 +35,32 @@ void AP_RCProtocol_FDM::update()
 
     last_input_ms = AP_HAL::millis();
 
-    // scale from FDM 0-1 floats to PWM values
-    // these are the values that will be fed into the autopilot.
     uint16_t pwm_input[16];
     const uint8_t count = MIN(ARRAY_SIZE(pwm_input), fdm.rcin_chan_count);
-    for (uint8_t i=0; i<count; i++) {
-        pwm_input[i] = 1000 + fdm.rcin[i] * 1000;
+    bool failsafe = false;
+    if (sitl->rc_fail == SITL::SIM::SITL_RCFail_Throttle950) {
+        for (uint8_t i=0; i<count; i++) {
+            pwm_input[i] = 1500;
+        }
+        if (count > 2) {
+            pwm_input[2] = 950;
+        }
+    } else if (sitl->rc_fail == SITL::SIM::SITL_RCFail_Protocol_Fail_Bit_Set) {
+        for (uint8_t i=0; i<count; i++) {
+            pwm_input[i] = 1456;
+        }
+        failsafe = true;
+    } else {
+        // scale from FDM 0-1 floats to PWM values
+        // these are the values that will be fed into the autopilot.
+        for (uint8_t i=0; i<count; i++) {
+            pwm_input[i] = 1000 + fdm.rcin[i] * 1000;
+        }
     }
     add_input(
         count,
         pwm_input,
-        false,  // failsafe
+        failsafe,
         0, // check me
         0  // link quality
         );

--- a/libraries/AP_RCProtocol/tests/test_fdm.cpp
+++ b/libraries/AP_RCProtocol/tests/test_fdm.cpp
@@ -5,6 +5,9 @@
 #include <AP_gtest.h>
 
 #include <AP_RCProtocol/AP_RCProtocol_FDM.h>
+
+#if AP_RCPROTOCOL_FDM_ENABLED
+
 #include <RC_Channel/RC_Channel.h>
 #include <SITL/SITL.h>
 
@@ -97,5 +100,7 @@ TEST(AP_RCProtocolFDM, AppliesSITLRCFailureModes)
     EXPECT_EQ(backend.read(3), 2000);
     EXPECT_FALSE(frontend.failsafe_active());
 }
+
+#endif  // AP_RCPROTOCOL_FDM_ENABLED
 
 AP_GTEST_MAIN()

--- a/libraries/AP_RCProtocol/tests/test_fdm.cpp
+++ b/libraries/AP_RCProtocol/tests/test_fdm.cpp
@@ -1,0 +1,101 @@
+/*
+  Test RC input supplied by an external flight dynamics model.
+ */
+
+#include <AP_gtest.h>
+
+#include <AP_RCProtocol/AP_RCProtocol_FDM.h>
+#include <RC_Channel/RC_Channel.h>
+#include <SITL/SITL.h>
+
+const AP_HAL::HAL &hal = AP_HAL::get_HAL();
+
+class RC_Channel_FDMTest : public RC_Channel {};
+
+class RC_Channels_FDMTest : public RC_Channels {
+public:
+    RC_Channel_FDMTest obj_channels[NUM_RC_CHANNELS];
+
+    const RC_Channel_FDMTest *channel(const uint8_t chan) const override
+    {
+        return chan < NUM_RC_CHANNELS ? &obj_channels[chan] : nullptr;
+    }
+
+    RC_Channel_FDMTest *channel(const uint8_t chan) override
+    {
+        return chan < NUM_RC_CHANNELS ? &obj_channels[chan] : nullptr;
+    }
+
+protected:
+    int8_t flight_mode_channel_number() const override { return 5; }
+};
+
+#define RC_CHANNELS_SUBCLASS RC_Channels_FDMTest
+#define RC_CHANNEL_SUBCLASS RC_Channel_FDMTest
+
+#include <RC_Channel/RC_Channels_VarInfo.h>
+
+static RC_Channels_FDMTest rchannels;
+
+static void update_after_input_interval(AP_RCProtocol_FDM &backend)
+{
+    hal.scheduler->delay(21);
+    backend.update();
+}
+
+TEST(AP_RCProtocolFDM, AppliesSITLRCFailureModes)
+{
+    static SITL::SIM sitl;
+    static AP_RCProtocol frontend;
+    static AP_RCProtocol_FDM backend(frontend);
+
+    auto &fdm = sitl.state;
+    fdm.rcin_chan_count = 4;
+    fdm.rcin[0] = 0.25f;
+    fdm.rcin[1] = 0.50f;
+    fdm.rcin[2] = 0.75f;
+    fdm.rcin[3] = 1.00f;
+
+    sitl.rc_fail.set(SITL::SIM::SITL_RCFail_None);
+    frontend.set_failsafe_active(false);
+    update_after_input_interval(backend);
+    EXPECT_EQ(backend.read(0), 1250);
+    EXPECT_EQ(backend.read(1), 1500);
+    EXPECT_EQ(backend.read(2), 1750);
+    EXPECT_EQ(backend.read(3), 2000);
+    EXPECT_FALSE(frontend.failsafe_active());
+
+    const uint32_t frame_count = backend.get_rc_frame_count();
+    sitl.rc_fail.set(SITL::SIM::SITL_RCFail_NoPulses);
+    update_after_input_interval(backend);
+    EXPECT_EQ(backend.get_rc_frame_count(), frame_count);
+
+    sitl.rc_fail.set(SITL::SIM::SITL_RCFail_Throttle950);
+    update_after_input_interval(backend);
+    EXPECT_EQ(backend.get_rc_frame_count(), frame_count + 1);
+    EXPECT_EQ(backend.read(0), 1500);
+    EXPECT_EQ(backend.read(1), 1500);
+    EXPECT_EQ(backend.read(2), 950);
+    EXPECT_EQ(backend.read(3), 1500);
+    EXPECT_FALSE(frontend.failsafe_active());
+
+    sitl.rc_fail.set(SITL::SIM::SITL_RCFail_Protocol_Fail_Bit_Set);
+    update_after_input_interval(backend);
+    EXPECT_EQ(backend.get_rc_frame_count(), frame_count + 2);
+    EXPECT_EQ(backend.read(0), 1456);
+    EXPECT_EQ(backend.read(1), 1456);
+    EXPECT_EQ(backend.read(2), 1456);
+    EXPECT_EQ(backend.read(3), 1456);
+    EXPECT_TRUE(frontend.failsafe_active());
+
+    sitl.rc_fail.set(SITL::SIM::SITL_RCFail_None);
+    update_after_input_interval(backend);
+    EXPECT_EQ(backend.get_rc_frame_count(), frame_count + 3);
+    EXPECT_EQ(backend.read(0), 1250);
+    EXPECT_EQ(backend.read(1), 1500);
+    EXPECT_EQ(backend.read(2), 1750);
+    EXPECT_EQ(backend.read(3), 2000);
+    EXPECT_FALSE(frontend.failsafe_active());
+}
+
+AP_GTEST_MAIN()


### PR DESCRIPTION
### Summary

Apply the existing `SIM_RC_FAIL` modes to RC input received through the flight-dynamics-model backend, matching the virtual failure behavior already implemented by the UDP RC backend.

Fixes #33017.

### Classification & Testing (check all that apply and add your own)

- [ ] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Validation was performed from an ext4 checkout at upstream `master` commit `be40f5985f608ef8baa7c653384a3ab3d3834a82`:

```text
./waf configure --board sitl --debug
./waf --target tests/test_fdm -j4
./build/sitl/tests/test_fdm --gtest_color=no
```

On unchanged `master`, the regression produced 12 failed assertions: `NoPulses` still advanced the frame count, `Throttle950` retained the FDM channel values, and `ProtocolFail` neither wrote the flag values nor asserted failsafe. With this change, the same test passes 1/1.

```text
./waf plane -j4
```

The full SITL Plane build completed successfully (1,352 tasks; `arduplane` total flash used: 5,970,902 bytes).

```text
./waf check -j4
```

All 66 C++ test executables passed, including the new `test_fdm` regression.

### Description

`AP_RCProtocol_FDM` previously scaled every fresh FDM RC frame without consulting `SIM_RC_FAIL`. As a result, changing that parameter while an external flight-dynamics model was active did not simulate lost pulses, throttle failsafe, or a receiver protocol failure.

This change keeps normal FDM scaling intact and adds the same four behaviors used by the UDP backend:

- `None` scales the model's 0-1 channel values as before and clears protocol failsafe;
- `NoPulses` emits no new frame and does not advance the 50 Hz input timer;
- `Throttle950` centers the available channels and sets channel 3 to 950 when present;
- `ProtocolFail` reports 1456 on the available channels and sets the failsafe bit.

The regression exercises the actual path from `SITL::SIM::state` through `AP_RCProtocol_FDM::update()` and `add_input()`, including frame counts, PWM values, failsafe state, and recovery to normal input.

This change was developed with AI assistance; the submitter reviewed the implementation and test results and takes responsibility for the contribution.
