### PR TITLE
AP_Vehicle: no takeoff-blocked warning once motors leave ground idle

### DIFF
--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -1185,6 +1185,21 @@ bool AP_Vehicle::motors_takeoff_check(float rpm_min, float rpm_max)
         return false;
     }
 
+    // once the motors have actually left ground idle the takeoff has
+    // been allowed; RPM is expected to leave the takeoff window, so
+    // the check is moot - and must not warn.  A blocked takeoff never
+    // advances the spool state, so this cannot mask a genuine block.
+    switch (motors->get_spool_state()) {
+    case AP_Motors::SpoolState::SHUT_DOWN:
+    case AP_Motors::SpoolState::GROUND_IDLE:
+        break;
+    case AP_Motors::SpoolState::SPOOLING_UP:
+    case AP_Motors::SpoolState::THROTTLE_UNLIMITED:
+    case AP_Motors::SpoolState::SPOOLING_DOWN:
+        takeoff_check_state.warning_ms = now_ms;
+        return true;
+    }
+
     // check ESCs are sending RPM at expected level
     uint32_t motor_mask = motors->get_motor_mask();
     const bool telem_active = AP::esc_telem().is_telemetry_active(motor_mask);


### PR DESCRIPTION
### Summary

Avoids spurious takeoff-blocked messages when flying - QuadPlanes

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

<img width="7778" height="3388" alt="image" src="https://github.com/user-attachments/assets/72c7d2c9-5521-4ec5-8691-ad6094604e17" />

(see note below on second box)

### Description

motors_takeoff_check() continues to be polled for the duration of a VTOL takeoff, and at takeoff power the RPM is legitimately outside the configured takeoff window - so whether its warning fires is a race between the takeoff phase completing and the 2-second warning timer expiring.  A quadplane taking off to a low altitude sits right on that edge, intermittently failing autotest under --parallel load with:

  TakeoffCheck (Test takeoff check - auto mode) (Spurious takeoff
  blocked message: Takeoff blocked: ESC RPM out of range)

A captured tlog shows the CRITICAL emitted with all four VTOL motors at ~8200 RPM, mid-climb, the takeoff long since allowed.

Treat the check as passed once the motors' actual spool state has left ground idle: the takeoff has been allowed at that point, so the check is moot - and must not warn.  The actual (not desired) spool state must be used: Copter gates its takeoff via the spool-up block while the desired state is already THROTTLE_UNLIMITED, so a blocked takeoff never advances the actual spool state and this cannot mask a genuine block.



While assembling the evidence here I noticed that we're *also* emitting this message at the end of the flight while disarmed.  I am now wondering whether we need to move QuadPlane to using the "set_spoolup_blocked" code rather than doing its own thing here (and whether that will fix things)

