### PR TITLE
Sitl plane inertia

### DIFF
--- a/Tools/autotest/models/skywalker_2013.json
+++ b/Tools/autotest/models/skywalker_2013.json
@@ -53,4 +53,11 @@
         0.0,
         -0.05
     ]
+
+    # "aero_moment_inertia" is the roll, pitch and yaw moment of inertia in
+    # kg.m^2 the aerodynamic moments are divided by. Defaults to [1, 1, 1],
+    # which is not physical: realistic values mean retuning the coefficients
+    # above and the default gains. Spelled differently from the multicopter
+    # model's "moment_inertia" because a quadplane hands one file to both.
+    # "aero_moment_inertia": [ 0.2, 0.14, 0.3 ]
 }

--- a/libraries/SITL/SIM_Plane.cpp
+++ b/libraries/SITL/SIM_Plane.cpp
@@ -193,6 +193,12 @@ void Plane::load_coeffs(const char *model_json)
         COFF_FLOAT(deltae_max),
         COFF_FLOAT(deltar_max),
         { "CGOffset", &coefficient.CGOffset, VarType::VECTOR3F },
+        // deliberately not called "moment_inertia": SIM_Frame reads that key,
+        // and for a quadplane both models are handed the same json file. A
+        // copter inertia is of order 0.02 to 0.05 kg.m^2, so sharing the key
+        // would divide the aerodynamic moments by it as well and multiply
+        // them by twenty to fifty, which is the symptom described in #26972
+        { "aero_moment_inertia", &coefficient.moment_of_inertia, VarType::VECTOR3F },
     };
 
     for (uint8_t i=0; i<ARRAY_SIZE(vars); i++) {
@@ -208,6 +214,12 @@ void Plane::load_coeffs(const char *model_json)
             parse_vector3(v, vars[i].label, *(Vector3f *)vars[i].ptr);
 
         }
+    }
+
+    if (!is_positive(coefficient.moment_of_inertia.x) ||
+        !is_positive(coefficient.moment_of_inertia.y) ||
+        !is_positive(coefficient.moment_of_inertia.z)) {
+        AP_HAL::panic("%s: aero_moment_inertia must be positive on all axes", model_json);
     }
 
     delete obj;
@@ -472,7 +484,14 @@ void Plane::calculate_forces(const struct sitl_input &input, Vector3f &rot_accel
     }
     
     Vector3f force = getForce(aileron, elevator, rudder);
-    rot_accel = getTorque(aileron, elevator, rudder, thrust, force);
+
+    // getTorque() returns aerodynamic moments in N.m, so they are divided by
+    // the moment of inertia to give angular acceleration, the same way
+    // SIM_Frame does it for the multicopter model. See issue #26972.
+    const Vector3f torque = getTorque(aileron, elevator, rudder, thrust, force);
+    rot_accel.x = torque.x / coefficient.moment_of_inertia.x;
+    rot_accel.y = torque.y / coefficient.moment_of_inertia.y;
+    rot_accel.z = torque.z / coefficient.moment_of_inertia.z;
 
     if (have_launcher) {
         /*

--- a/libraries/SITL/SIM_Plane.h
+++ b/libraries/SITL/SIM_Plane.h
@@ -90,6 +90,13 @@ protected:
         // the X CoG offset should be -0.02, but that makes the plane too tail heavy
         // in manual flight. Adjusted to -0.15 gives reasonable flight
         Vector3f CGOffset{-0.15, 0, -0.05};
+        // Moment of inertia in kg.m^2 that getTorque()'s aerodynamic moments
+        // are divided by. The {1,1,1} default is not physical: it reproduces,
+        // bit for bit, the behaviour from before this term was explicit, when
+        // the moments went straight into rot_accel. It cannot be derived from
+        // mass and geometry, because it depends on how the mass is
+        // distributed. See issue #26972.
+        Vector3f moment_of_inertia{1, 1, 1};
     } default_coefficients;
 
     struct Coefficients coefficient;

--- a/libraries/SITL/tests/test_sim_plane_inertia.cpp
+++ b/libraries/SITL/tests/test_sim_plane_inertia.cpp
@@ -1,0 +1,233 @@
+/*
+  Coverage for the moment of inertia term in SITL::Plane, see issue #26972.
+
+  getTorque() returns aerodynamic moments in N.m, and calculate_forces()
+  divides them by coefficient.moment_of_inertia to get angular acceleration.
+
+  Two things need protecting:
+
+  - the unit default must reproduce the previous behaviour exactly, since the
+    aerodynamic coefficients and the default gains are tuned around it;
+  - the division must actually happen, otherwise a later change could drop it
+    and nothing would notice.
+ */
+
+#include <AP_gtest.h>
+
+#include <SITL/SIM_Plane.h>
+#include <SITL/SITL.h>
+#include <AP_Baro/AP_Baro.h>
+
+const AP_HAL::HAL& hal = AP_HAL::get_HAL();
+
+using namespace SITL;
+
+// SITL::Plane construction reaches AP::sitl() and, through the battery
+// temperature setup, AP::baro().  Both singletons must exist.  They are
+// static because SITL::SIM is far too large for the stack.
+static SITL::SIM sitl_singleton;
+static AP_Baro baro_singleton;
+
+static const float test_airspeed = 20.0;
+static const uint16_t aileron_pwm = 1700;
+static const uint16_t centred_pwm = 1500;
+static const uint16_t throttle_off_pwm = 1000;
+
+// deflection the servo model produces for aileron_pwm over the default
+// 1000-2000 range, i.e. what calculate_forces() feeds to the physics
+static const float test_aileron = (aileron_pwm - 1500) / 500.0;
+
+// memcmp rather than ==, because gtest's float comparison trips
+// -Werror=float-equal and these checks are deliberately bit-exact
+#define EXPECT_BIT_IDENTICAL(a, b) \
+    EXPECT_EQ(0, memcmp(&(a), &(b), sizeof(Vector3f)))
+
+/*
+  exposes SITL::Plane's protected physics entry points and flight state, so
+  that models can be driven from an identical starting point.
+
+  final because SITL::Aircraft has no virtual destructor, the simulator never
+  deleting a model through a base pointer, and deleting a probe would
+  otherwise trip -Wdelete-non-virtual-dtor
+ */
+class PlaneProbe final : public SITL::Plane {
+public:
+    using SITL::Plane::Plane;
+
+    // level flight, well clear of the ground so the on_ground() friction
+    // term in calculate_forces() cannot apply.
+    // set_start_location() is what normally establishes these, and a unit
+    // test does not call it, so hagl() has to be pinned down here
+    void set_flight_state(void) {
+        dcm.identity();
+        gyro.zero();
+        velocity_ef = Vector3f(test_airspeed, 0, 0);
+        velocity_air_ef = velocity_ef;
+        velocity_air_bf = Vector3f(test_airspeed, 0, 0);
+        airspeed = test_airspeed;
+        airspeed_pitot = test_airspeed;
+        ground_level = 0;
+        local_ground_level = 0;
+        home.alt = 0;
+        position = Vector3d(0, 0, -100);
+    }
+
+    // the full model path, exactly as the simulator runs it
+    void run(const struct sitl_input &input, Vector3f &rot_accel_out, Vector3f &accel_body_out) {
+        set_flight_state();
+        calculate_forces(input, rot_accel_out);
+        accel_body_out = accel_body;
+    }
+
+    // the aerodynamic force and moment alone, for the same state and the
+    // same deflection that run() ends up using
+    void aero(float aileron, Vector3f &force_out, Vector3f &torque_out) {
+        set_flight_state();
+        angle_of_attack = atan2f(velocity_air_bf.z, velocity_air_bf.x);
+        beta = atan2f(velocity_air_bf.y, velocity_air_bf.x);
+        force_out = getForce(aileron, 0, 0);
+        torque_out = getTorque(aileron, 0, 0, 0, force_out);
+    }
+
+    void set_moment_of_inertia(const Vector3f &moi) { coefficient.moment_of_inertia = moi; }
+    float get_mass_kg(void) const { return mass; }
+    bool is_on_ground(void) const { return on_ground(); }
+};
+
+// no servo dynamics, so every model sees the commanded deflection at once
+// rather than an independently settling filter state
+static void disable_servo_model(void)
+{
+    sitl_singleton.servo.servo_speed.set(0);
+    sitl_singleton.servo.servo_delay.set(0);
+    sitl_singleton.servo.servo_filter.set(0);
+}
+
+static void roll_demand_input(struct sitl_input &input)
+{
+    for (uint8_t i = 0; i < ARRAY_SIZE(input.servos); i++) {
+        input.servos[i] = centred_pwm;
+    }
+    input.servos[0] = aileron_pwm;      // roll demand
+    input.servos[2] = throttle_off_pwm; // no thrust: keeps the linear channel clean
+}
+
+/*
+  With the unit default, rot_accel must still be the raw aerodynamic moment,
+  bit for bit, and must still not depend on mass.
+
+  "plane" (2kg, SIM_Plane.cpp) and "plane-heavy" (8kg) differ only in mass,
+  so they isolate it. accel_body is the control: calculate_forces() divides it
+  by mass explicitly, so it must show the 4x ratio, which proves the
+  measurement is sensitive to mass at all.
+ */
+TEST(SIM_Plane, unit_inertia_preserves_legacy_behaviour)
+{
+    disable_servo_model();
+
+    struct sitl_input input {};
+    roll_demand_input(input);
+
+    // allocated the way the simulator allocates its model, so that the
+    // calloc-backed operator new applies here too
+    PlaneProbe *light = NEW_NOTHROW PlaneProbe("plane");
+    PlaneProbe *heavy = NEW_NOTHROW PlaneProbe("plane-heavy");
+    ASSERT_NE(nullptr, light);
+    ASSERT_NE(nullptr, heavy);
+
+    Vector3f light_rot_accel, light_accel_body;
+    Vector3f heavy_rot_accel, heavy_accel_body;
+    light->run(input, light_rot_accel, light_accel_body);
+    heavy->run(input, heavy_rot_accel, heavy_accel_body);
+
+    Vector3f light_force, light_torque, heavy_force, heavy_torque;
+    light->aero(test_aileron, light_force, light_torque);
+    heavy->aero(test_aileron, heavy_force, heavy_torque);
+
+    const float mass_ratio = light->get_mass_kg() / heavy->get_mass_kg();
+
+    ::printf("mass                      : %.3f kg vs %.3f kg (ratio %.6f)\n",
+             light->get_mass_kg(), heavy->get_mass_kg(), mass_ratio);
+    ::printf("aero force  N     light   : %.9f %.9f %.9f\n", light_force.x, light_force.y, light_force.z);
+    ::printf("aero force  N     heavy   : %.9f %.9f %.9f\n", heavy_force.x, heavy_force.y, heavy_force.z);
+    ::printf("aero moment Nm    light   : %.9f %.9f %.9f\n", light_torque.x, light_torque.y, light_torque.z);
+    ::printf("aero moment Nm    heavy   : %.9f %.9f %.9f\n", heavy_torque.x, heavy_torque.y, heavy_torque.z);
+    ::printf("accel_body  m/s/s light   : %.9f %.9f %.9f\n", light_accel_body.x, light_accel_body.y, light_accel_body.z);
+    ::printf("accel_body  m/s/s heavy   : %.9f %.9f %.9f\n", heavy_accel_body.x, heavy_accel_body.y, heavy_accel_body.z);
+    ::printf("rot_accel   rad/s/s light : %.9f %.9f %.9f\n", light_rot_accel.x, light_rot_accel.y, light_rot_accel.z);
+    ::printf("rot_accel   rad/s/s heavy : %.9f %.9f %.9f\n", heavy_rot_accel.x, heavy_rot_accel.y, heavy_rot_accel.z);
+    ::printf("accel_body heavy/light    : %.9f\n", heavy_accel_body.z / light_accel_body.z);
+    ::printf("rot_accel  heavy/light    : %.9f\n", heavy_rot_accel.x / light_rot_accel.x);
+
+    // airborne, so the ground friction term cannot corrupt the linear channel
+    EXPECT_FALSE(light->is_on_ground());
+    EXPECT_FALSE(heavy->is_on_ground());
+
+    // the aileron actually produces a rolling moment
+    EXPECT_GT(fabsf(light_torque.x), 0.01);
+
+    // the aerodynamic moment is a property of airflow and geometry, so it
+    // does not depend on mass. Same for the aerodynamic force.
+    EXPECT_BIT_IDENTICAL(light_torque, heavy_torque);
+    EXPECT_BIT_IDENTICAL(light_force, heavy_force);
+
+    // control: the linear channel is divided by mass, so it scales
+    EXPECT_NEAR(heavy_accel_body.z / light_accel_body.z, mass_ratio, 1.0e-6);
+
+    // dividing by the unit default leaves the moment untouched
+    EXPECT_BIT_IDENTICAL(light_rot_accel, light_torque);
+    EXPECT_BIT_IDENTICAL(heavy_rot_accel, heavy_torque);
+    EXPECT_BIT_IDENTICAL(light_rot_accel, heavy_rot_accel);
+
+    delete light;
+    delete heavy;
+}
+
+/*
+  With a non-unit inertia, each axis of rot_accel must be the moment on that
+  axis divided by that axis' inertia. Distinct powers of two are used so the
+  division is exact in binary and a swapped axis cannot pass.
+ */
+TEST(SIM_Plane, explicit_inertia_scales_angular_acceleration)
+{
+    disable_servo_model();
+
+    struct sitl_input input {};
+    roll_demand_input(input);
+
+    const Vector3f moi{2, 4, 8};
+
+    // allocated the way the simulator allocates its model, so that the
+    // calloc-backed operator new applies here too
+    PlaneProbe *reference = NEW_NOTHROW PlaneProbe("plane");
+    PlaneProbe *scaled = NEW_NOTHROW PlaneProbe("plane");
+    ASSERT_NE(nullptr, reference);
+    ASSERT_NE(nullptr, scaled);
+    scaled->set_moment_of_inertia(moi);
+
+    Vector3f unused_force, torque;
+    reference->aero(test_aileron, unused_force, torque);
+
+    Vector3f scaled_rot_accel, scaled_accel_body;
+    scaled->run(input, scaled_rot_accel, scaled_accel_body);
+
+    const Vector3f expected{torque.x / moi.x, torque.y / moi.y, torque.z / moi.z};
+
+    ::printf("moment of inertia         : %.3f %.3f %.3f\n", moi.x, moi.y, moi.z);
+    ::printf("aero moment Nm            : %.9f %.9f %.9f\n", torque.x, torque.y, torque.z);
+    ::printf("rot_accel expected        : %.9f %.9f %.9f\n", expected.x, expected.y, expected.z);
+    ::printf("rot_accel measured        : %.9f %.9f %.9f\n",
+             scaled_rot_accel.x, scaled_rot_accel.y, scaled_rot_accel.z);
+
+    // the moment must be non-trivial on the axes being checked, otherwise
+    // dividing it would prove nothing
+    EXPECT_GT(fabsf(torque.x), 0.01);
+    EXPECT_GT(fabsf(torque.y), 0.01);
+
+    EXPECT_BIT_IDENTICAL(scaled_rot_accel, expected);
+
+    delete reference;
+    delete scaled;
+}
+
+AP_GTEST_MAIN()


### PR DESCRIPTION
### Summary
Divides the plane model's aerodynamic moments by an explicit moment of inertia
instead of assigning them straight to `rot_accel`. The default is unity, so
existing behaviour is reproduced bit for bit.

### Classification & Testing (check all that apply and add your own)
- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

`libraries/SITL/tests/test_sim_plane_inertia.cpp` covers two cases:

  - with the default `{1, 1, 1}`, `calculate_forces()` returns exactly the
    values it returned before this change -- the assertion is bit equality, not
    a tolerance
  - with a non-unity inertia, each axis of `rot_accel` scales as `tau_i / I_i`

Run with:

    ./waf configure --board sitl && ./waf tests
    ./build/sitl/tests/test_sim_plane_inertia

Also flown in SITL on the default plane frame and on
`plane:Tools/autotest/models/skywalker_2013.json`, which behave as before,
since the key is off by default.

### Description
`Plane::getTorque()` returns aerodynamic moments in N.m, but
`calculate_forces()` assigned them straight to `rot_accel`, which
`Aircraft::update_dynamics()` integrates as an angular acceleration in
rad/s^2. Full aileron on the default plane model yields a roll moment of about
20.7 N.m, and the simulator has been integrating that number as 20.7 rad/s^2.
In effect the model has always carried an implicit, unstated inertia of
1 kg.m^2 on every axis, and the shipped coefficients and default gains are
tuned around it.

This adds `Coefficients::moment_of_inertia`, settable from a model file as
`aero_moment_inertia`, and divides the moments by it component-wise. It
defaults to `{1, 1, 1}`, so nothing changes for any existing frame or model
file, bit for bit. Non-positive values are rejected at load time rather than
silently producing infinities.

The key is deliberately not spelled `moment_inertia` like SIM_Frame's: a
quadplane hands one model file to both models, and a multicopter inertia is far
smaller than the value the aerodynamic side is tuned around, so silently
sharing one key would change quadplane behaviour.

Two things are knowingly left out of scope:

  - `SIM_QuadPlane` sums the two models with `rot_accel += quad_rot_accel`.
    Once the plane side divides by its own inertia, that is
    `tau_aero/I_aero + tau_quad/I_copter` -- two inertias for one rigid body.
    The physically correct form sums the torques and divides once by a single
    airframe inertia, which is a larger change and needs retuning. I would
    welcome a steer on whether that is the intended destination.
  - the gyroscopic term, `tau - omega x (I*omega)`. At the `{1, 1, 1}` default
    it is identically zero, so it can be added later without affecting output
    compatibility.

Related to #26972 (the quadplane half of that issue is not addressed here).
Supersedes #33893, where I pushed the wrong branch.