### PR TITLE
AP_HAL_ESP32: suppress no sdcard setup message on M5StampFly

### DIFF
--- a/libraries/AP_HAL_ESP32/SdCard.cpp
+++ b/libraries/AP_HAL_ESP32/SdCard.cpp
@@ -275,7 +275,9 @@ void unmount_sdcard()
 // empty impl's
 void mount_sdcard()
 {
+#ifndef HAL_ESP32_SUPPRESS_NO_SDCARD_SETUP_MESSAGE
     printf("No sdcard setup.\n");
+#endif
 }
 void unmount_sdcard()
 {

--- a/libraries/AP_HAL_ESP32/hwdef/esp32s3m5stampfly/hwdef.dat
+++ b/libraries/AP_HAL_ESP32/hwdef/esp32s3m5stampfly/hwdef.dat
@@ -92,6 +92,10 @@ define HAL_LOGGING_BACKENDS_DEFAULT 2
 define AP_RCPROTOCOL_ENABLED 0
 
 define AP_FILESYSTEM_ESP32_ENABLED 0
+
+# M5StampFly has no SD card, so avoid a misleading startup message from
+# the ESP32 no-SD-card fallback.
+define HAL_ESP32_SUPPRESS_NO_SDCARD_SETUP_MESSAGE 1
 define AP_SCRIPTING_ENABLED 0
 
 # This is a board that's not really intended for anything other than copter


### PR DESCRIPTION
### Summary

Suppress the misleading `No sdcard setup.` startup message on M5StampFly, which does not have an SD card.

<img width="561" height="562" alt="スクリーンショット 2026-08-09 15 57 39" src="https://github.com/user-attachments/assets/097db431-a184-454e-858d-330faf0b2de5" />

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

Built ArduCopter for `esp32s3m5stampfly`:

```text
./waf configure --board esp32s3m5stampfly
./waf copter -j1
```

Build completed successfully:

```text
ardupilot.bin binary size 0x19fb80 bytes.
Smallest app partition is 0x300000 bytes.
0x160480 bytes (46%) free.
```

Also tested on M5StampFly hardware. After flashing and monitoring the serial boot log, the misleading `No sdcard setup.` message no longer appears.

After
<img width="1136" height="785" alt="スクリーンショット 2026-08-11 11 03 48" src="https://github.com/user-attachments/assets/5555977d-e09f-46af-8bc1-7bafe9e922ec" />

Before
<img width="1166" height="808" alt="スクリーンショット 2026-08-11 10 54 04" src="https://github.com/user-attachments/assets/75ddf44e-415f-4b45-9b14-58926fc61e27" />

### Description

M5StampFly does not have an SD card. The ESP32 HAL currently prints `No sdcard setup.` from the no-SD-card fallback path, which can look like a warning or missing board setup even though this is the correct hardware configuration for M5StampFly.

This change adds a board-specific define for M5StampFly and uses it to suppress that fallback message only for boards that explicitly opt in.

Other ESP32 boards keep the existing behavior.