### PR TITLE
AP_HAL_ESP32: suppress sign-compare warning in i2c_sw

### DIFF
--- a/libraries/AP_HAL_ESP32/i2c_sw.c
+++ b/libraries/AP_HAL_ESP32/i2c_sw.c
@@ -50,7 +50,10 @@
 #include "esp_intr_alloc.h"
 #include "esp_log.h"
 #include "malloc.h"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-compare"
 #include "freertos/FreeRTOS.h"
+#pragma GCC diagnostic pop
 #include "freertos/semphr.h"
 #include "xtensa_api.h"
 #include "freertos/task.h"


### PR DESCRIPTION
### Summary

Suppresses a `-Wsign-compare` warning from an ESP-IDF FreeRTOS include when compiling `AP_HAL_ESP32/i2c_sw.c`.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

Built Copter for `esp32s3m5stampfly` and confirmed the previous `spinlock.h` / `Wsign-compare` warning no longer appears.

### Description

`i2c_sw.c` includes ESP-IDF FreeRTOS headers which can emit a `-Wsign-compare` warning from `spinlock.h` with GCC 13.2.0. This change suppresses that warning only around the `FreeRTOS.h` include, keeping the scope local to this C file and avoiding a broader ESP32 CFLAGS change.
