### PR TITLE
Sitl shared memory - eg swarms, following, master-slave, virtual peripheral/s, etc

### DIFF
--- a/.github/workflows/cygwin_build.yml
+++ b/.github/workflows/cygwin_build.yml
@@ -148,7 +148,7 @@ jobs:
     permissions:
       contents: read
       actions: write  # save/prune ccache on master
-    runs-on: 'windows-latest'
+    runs-on: ${{ vars.CI_WIN_RUNNER || 'windows-latest' }}
 
     steps:
       - uses: actions/checkout@v7
@@ -158,6 +158,12 @@ jobs:
         with:
           packages: cygwin64 gcc-g++=13.4.0-1 ccache python312 python312-pip git procps gettext
           add-to-path: false
+          # pin setup/packages/install to C:. GitHub-hosted runners have
+          # no other volume so this changes nothing there, but on a bare
+          # self-hosted Windows machine the action otherwise picks any
+          # D: it finds (often a recovery/optical volume) and fails with
+          # access denied - and later steps hardcode C:\cygwin anyway
+          work-vol: 'C:'
       # Put ccache into github cache for faster build
       - name: setup ccache
         env:
@@ -185,12 +191,14 @@ jobs:
         run: >-
           python3 --version &&
           python3 -m pip install --progress-bar off empy==3.3.4 pexpect &&
+          python3 -m pip install --progress-bar off future &&
+          DISABLE_MAVNATIVE=True python3 -m pip install --progress-bar off --no-deps modules/mavlink/pymavlink &&
           python3 -m pip install --progress-bar off dronecan --upgrade &&
           cp /usr/bin/ccache /usr/local/bin/ &&
-          cd /usr/local/bin && ln -s ccache /usr/local/bin/gcc &&
-          ln -s ccache /usr/local/bin/g++ &&
-          ln -s ccache /usr/local/bin/x86_64-pc-cygwin-gcc &&
-          ln -s ccache /usr/local/bin/x86_64-pc-cygwin-g++
+          cd /usr/local/bin && ln -sf ccache /usr/local/bin/gcc &&
+          ln -sf ccache /usr/local/bin/g++ &&
+          ln -sf ccache /usr/local/bin/x86_64-pc-cygwin-gcc &&
+          ln -sf ccache /usr/local/bin/x86_64-pc-cygwin-g++
 
       - name: Build SITL
         env:
@@ -219,3 +227,48 @@ jobs:
           name: binaries
           path: artifacts
           retention-days: 7
+
+      # runs the freshly built Windows binaries as a real shared-memory
+      # cluster: three copters at a commanded 100x speedup with the
+      # adaptive rate governor on, asserting lock-step engages and the
+      # governor acts, and printing the speedup the runner actually
+      # achieves - so every CI run shows what the Cygwin build is
+      # capable of, not just that it compiles. Placed after the artifact
+      # upload so binaries ship even when the runtime tests fail.
+      - name: Run SITL cluster smoke test
+        env:
+          PATH: /usr/bin:$(cygpath ${SYSTEMROOT})/system32
+        shell: C:\cygwin\bin\bash.exe -eo pipefail '{0}'
+        run: >-
+          CYGPATH_GITHUB_WORKSPACE=$(cygpath -u "$GITHUB_WORKSPACE") &&
+          cd "${CYGPATH_GITHUB_WORKSPACE}" &&
+          bash Tools/scripts/cygwin_cluster_smoke.sh
+
+      # the full cluster follow flight on the Windows runner: a plane
+      # loiters, two copters chase it in formation, everything in
+      # lock-step with the governor tuning each vehicle. Commanded 50x:
+      # these runners sustain ~55-65x, and the harness gates achieved
+      # against commanded strictly (the Linux CI commands 100x). The binaries are run from a copy WITHOUT the bundled
+      # cyg*.dlls beside them - the exe directory's DLLs would shadow
+      # the installed Cygwin's runtime and kill the processes at
+      # startup - and the harness's powercfg calls skip themselves
+      # under a cygwin python.
+      - name: Run cluster follow flight test
+        env:
+          PATH: /usr/bin:$(cygpath ${SYSTEMROOT})/system32
+        shell: C:\cygwin\bin\bash.exe -eo pipefail '{0}'
+        run: >-
+          CYGPATH_GITHUB_WORKSPACE=$(cygpath -u "$GITHUB_WORKSPACE") &&
+          cd "${CYGPATH_GITHUB_WORKSPACE}" &&
+          mkdir -p followrun &&
+          cp build/sitl/bin/arducopter followrun/ArduCopter.elf.exe &&
+          cp build/sitl/bin/arduplane followrun/ArduPlane.elf.exe &&
+          cp Tools/autotest/test_cluster_follow_windows.py followrun/ &&
+          cd followrun &&
+          export CLUSTER_FOLLOW_TIME=300 &&
+          export CLUSTER_SPEEDUP=${{ vars.CLUSTER_SPEEDUP || '50' }} &&
+          if ! python3 test_cluster_follow_windows.py; then
+          echo "=== follow test FAILED, vehicle logs follow ===" &&
+          tail -n 80 sitl_cluster_follow_*/[a-z]*.log /tmp/sitl_cluster_follow_*/[a-z]*.log ;
+          exit 1 ;
+          fi

--- a/.github/workflows/test_sitl_multi_instance.yml
+++ b/.github/workflows/test_sitl_multi_instance.yml
@@ -1,0 +1,174 @@
+name: test SITL cluster clock sync
+
+on:
+  push:
+    paths-ignore:
+      # remove other vehicles
+      - 'AntennaTracker/**'
+      - 'ArduSub/**'
+      - 'Blimp/**'
+      - 'Rover/**'
+      # remove non SITL HAL
+      - 'libraries/AP_HAL_ChibiOS/**'
+      - 'libraries/AP_HAL_ESP32/**'
+      - 'libraries/AP_HAL_QURT/**'
+      # Remove markdown files as irrelevant
+      - '**.md'
+
+  pull_request:
+    paths-ignore:
+      # remove other vehicles
+      - 'AntennaTracker/**'
+      - 'ArduSub/**'
+      - 'Blimp/**'
+      - 'Rover/**'
+      # remove non SITL HAL
+      - 'libraries/AP_HAL_ChibiOS/**'
+      - 'libraries/AP_HAL_ESP32/**'
+      - 'libraries/AP_HAL_QURT/**'
+      # Remove markdown files as irrelevant
+      - '**.md'
+
+concurrency:
+  group: ci-${{github.workflow}}-${{github.ref}}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-22.04' }}
+    permissions:
+      contents: read
+      actions: write  # save-ccache deletes stale cache entries
+    container:
+      image: ardupilot/ardupilot-dev-base:v0.2.0
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: 'recursive'
+
+      - uses: ./.github/actions/setup-ccache
+        with:
+          key-suffix: cluster-base
+
+      - name: build arducopter and arduplane
+        shell: bash
+        run: |
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}
+          PATH="/github/home/.local/bin:$PATH"
+          ./waf configure --board sitl
+          ./waf copter plane
+          ccache -s
+
+      - uses: ./.github/actions/save-ccache
+        with:
+          key-suffix: cluster-base
+
+      - name: upload SITL binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: sitl-cluster-binaries
+          path: |
+            build/sitl/bin/arducopter
+            build/sitl/bin/arduplane
+          retention-days: 1
+
+  test-multi-instance-sync:
+    needs: build
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-22.04' }}
+    permissions:
+      contents: read
+    container:
+      image: ardupilot/ardupilot-dev-base:v0.2.0
+      options: --privileged --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --security-opt seccomp=unconfined
+
+    steps:
+      # the binaries come prebuilt from the build job; only the test
+      # script itself is needed from the tree
+      - uses: actions/checkout@v7
+        with:
+          submodules: false
+          persist-credentials: false
+          sparse-checkout: |
+            Tools/scripts/test_sitl_multi_instance.sh
+          sparse-checkout-cone-mode: false
+
+      - name: download SITL binaries
+        uses: actions/download-artifact@v4.1.3
+        with:
+          name: sitl-cluster-binaries
+          path: build/sitl/bin/
+
+      - name: make binaries executable
+        run: chmod +x build/sitl/bin/arducopter build/sitl/bin/arduplane
+
+      - name: run 5x SITL instances at speedup=100 and verify clock sync
+        shell: bash
+        timeout-minutes: 5
+        run: |
+          Tools/scripts/test_sitl_multi_instance.sh build/sitl/bin/arducopter
+
+      - name: archive logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: multi-instance-logs
+          path: /tmp/sitl_multi_*
+          retention-days: 7
+
+  test-cluster-follow:
+    needs: build
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-22.04' }}
+    permissions:
+      contents: read
+    container:
+      image: ardupilot/ardupilot-dev-base:v0.2.0
+      options: --privileged --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --security-opt seccomp=unconfined
+
+    steps:
+      # the binaries come prebuilt from the build job; the tree is only
+      # needed for the harness itself plus the mavlink submodule, from
+      # which pymavlink is installed so the dialect always matches the
+      # revision the binaries were built from
+      - uses: actions/checkout@v7
+        with:
+          submodules: false
+          persist-credentials: false
+          sparse-checkout: |
+            .gitmodules
+            Tools/autotest/test_cluster_follow.py
+          sparse-checkout-cone-mode: false
+
+      - name: checkout mavlink submodule
+        run: |
+          git config --global --add safe.directory ${GITHUB_WORKSPACE}
+          git submodule update --init --recursive --depth 1 modules/mavlink
+
+      - name: download SITL binaries
+        uses: actions/download-artifact@v4.1.3
+        with:
+          name: sitl-cluster-binaries
+          path: build/sitl/bin/
+
+      - name: make binaries executable
+        run: chmod +x build/sitl/bin/arducopter build/sitl/bin/arduplane
+
+      - name: fly 2 copters following a plane in one cluster
+        shell: bash
+        timeout-minutes: 30
+        run: |
+          PATH="/github/home/.local/bin:$PATH"
+          python3 -m pip install modules/mavlink/pymavlink --upgrade --user
+          # Commanded at 100x; every other knob is a Settings constant
+          # inside the harness. The achieved rate is measured, reported
+          # per vehicle every two seconds, and the steady-state figure
+          # is gated against the commanded speedup.
+          python3 Tools/autotest/test_cluster_follow.py --speedup 100
+
+      - name: archive logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cluster-follow-logs
+          path: /tmp/sitl_cluster_follow_*
+          retention-days: 7

--- a/Tools/ardupilotwaf/cxx_checks.py
+++ b/Tools/ardupilotwaf/cxx_checks.py
@@ -153,9 +153,17 @@ def check_librt(cfg, env):
         compiler='cxx',
         fragment='''
         #include <time.h>
+        #include <sys/mman.h>
+        #include <sys/stat.h>
+        #include <fcntl.h>
 
         int main() {
             clock_gettime(CLOCK_REALTIME, NULL);
+            /* shm_open/shm_unlink lived in librt until glibc 2.34;
+               probing them keeps older distros (e.g. Debian bullseye)
+               linking -lrt for the SITL shared-memory cluster sync */
+            shm_open("/probe", O_RDONLY, 0);
+            shm_unlink("/probe");
         }''',
         msg='Checking for need to link with librt',
         okmsg='not necessary',

--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -983,6 +983,11 @@ def start_vehicle(binary, opts, stuff, spawns=None):
         cmd.extend(["--sysid", str(opts.sysid)])
     if opts.slave is not None:
         cmd.extend(["--slave", str(opts.slave)])
+    if opts.cluster is not None:
+        # the SITL binary requires an explicit numeric ID; sim_vehicle's
+        # bare "--cluster" convenience was already normalised to 0 before
+        # option parsing
+        cmd.append("--cluster=%s" % opts.cluster)
     if opts.enable_fgview:
         cmd.extend(["--enable-fgview"])
     if opts.sitl_instance_args:
@@ -1391,6 +1396,12 @@ group_sim.add_option("-i", "--instances",
                      default=None,
                      type='string',
                      help="a space delimited list of instances to spawn; if specified, overrides -I and -n.")
+group_sim.add_option("", "--cluster",
+                     default=None,
+                     type='int',
+                     help="join a SITL cluster for shared-memory clock sync "
+                          "between instances (swarms); optional value selects "
+                          "the cluster id, default 0. Off unless given.")
 group_sim.add_option("-V", "--valgrind",
                      action='store_true',
                      default=False,

--- a/Tools/autotest/test_cluster_follow.py
+++ b/Tools/autotest/test_cluster_follow.py
@@ -1,0 +1,1179 @@
+#!/usr/bin/env python3
+'''
+Multi-vehicle cluster test: copters follow a plane.
+
+Launches several real SITL processes - one ArduPlane and two ArduCopter -
+into a single shared-memory cluster (--cluster=ID), flies the plane in a
+loiter, and puts the copters into FOLLOW mode behind it.
+
+Why this lives outside vehicle_test_suite.py: that harness is built around
+a single self.mav connection (change_mode/takeoff/wait_altitude/context all
+target one vehicle), and its only multi-binary hook, sup_binaries, is
+populated solely from autotest.py --sup-binary and gives the extra
+processes no MAVLink plumbing. Flying several vehicles needs independent
+connections, so this drives pymavlink directly.
+
+Separate SITL processes share a clock through the cluster but not a MAVLink
+bus, so this script also acts as the telemetry mesh: it forwards the plane's
+GLOBAL_POSITION_INT onto each copter's link, preserving the plane's sysid in
+the header, which is what AP_Follow matches against FOLL_SYSID.
+
+Everything is measured in SIMULATED time
+----------------------------------------
+The requested speedup is 100x, but a loaded machine - CI especially - will
+not achieve it, and the achieved rate varies during a run. So every quantity
+that depends on what the vehicles DO is expressed in simulated seconds, read
+straight out of the cluster segment: phase timeouts, how long a copter has
+held station, how stale the copters' view of the plane is, and the arm/mode
+waits that are really waiting on EKF convergence. A slower host then flies
+exactly the same flight, just taking longer in wall time, instead of quietly
+giving the copters less time to converge and flaking.
+
+Only three things are deliberately in wall time, because they do not scale
+with the simulation: process startup, the bridge loop period (it is a real
+loop on a real CPU - its effect is measured in sim time), the console report
+interval (a human reading rate), and the backstop that stops a wedged run
+from hanging forever.
+
+The achieved speedup is measured and printed continuously, which is usually
+what you want to know when this runs slowly in CI.
+
+The test asserts:
+  1. the cluster holds - every vehicle stays registered and their
+     simulated clocks stay within a bounded skew of each other
+  2. follow works - each copter closes on the plane and holds station
+
+AP_FLAKE8_CLEAN
+'''
+
+import glob
+import math
+import mmap
+import optparse
+import os
+import signal
+import struct
+import subprocess
+import sys
+import tempfile
+import time
+
+from pymavlink import mavutil
+
+# layout of AP_SITL_ShmData, see libraries/AP_HAL_SITL/SITL_SharedMem.h
+SHM_HEADER_LEN = 24                       # magic, version, slave epoch (wall, sim)
+SHM_SLOT_LEN = 8 + 4 + 4 + 40 + 4096      # sim_time, pid, armed, mutex, payload
+SHM_MAGIC = 0x41505351                    # "APSQ", v5: shared slave epoch
+
+HOME = "-35.363261,149.165230,584,353"
+
+# AP_Follow discards its target after this many seconds of SIM time without
+# an update. The default is 3s, which a wall-time bridge cannot honour at
+# high speedup (at 100x even a 100Hz bridge is one update per sim-second),
+# so the copters are told to tolerate a longer gap. AP_Follow extrapolates
+# the target from its reported velocity between updates, so a wider window
+# costs tracking accuracy rather than breaking follow outright.
+FOLL_TIMEOUT_S = 30.0
+
+
+class TestFailure(Exception):
+    pass
+
+
+def shm_path(cluster_id):
+    return "/dev/shm/ardupilot_sitl_cluster_%d_%d" % (os.getuid(), cluster_id)
+
+
+def set_cpu_governor_performance():
+    """best effort: hold the CPU clocks up for the duration of the test
+
+    Measured on an i7 laptop: three busy cores drop a lone SITL vehicle
+    from 26x to 8x purely through frequency scaling, which dwarfs every
+    software cost in the cluster. Writing the governor needs root; CI
+    containers run privileged so it works there, and on a developer
+    machine a failure is only reported, never fatal.
+
+    Returns [(path, previous_governor)] for restore_cpu_governors().
+    """
+    saved = []
+    import glob
+    paths = sorted(glob.glob(
+        "/sys/devices/system/cpu/cpu[0-9]*/cpufreq/scaling_governor"))
+    if not paths:
+        return saved
+    denied = False
+    for path in paths:
+        try:
+            with open(path) as f:
+                old = f.read().strip()
+            if old == "performance":
+                continue
+            with open(path, "w") as f:
+                f.write("performance")
+            saved.append((path, old))
+        except OSError:
+            denied = True
+    # pin the floor to the ceiling as well: the performance governor
+    # alone still lets some platforms sag under multi-core load
+    for gov_path, _ in list(saved):
+        base = os.path.dirname(gov_path)
+        try:
+            with open(os.path.join(base, "cpuinfo_max_freq")) as f:
+                fmax = f.read().strip()
+            minp = os.path.join(base, "scaling_min_freq")
+            with open(minp) as f:
+                old_min = f.read().strip()
+            if old_min != fmax:
+                with open(minp, "w") as f:
+                    f.write(fmax)
+                saved.append((minp, old_min))
+        except OSError:
+            pass
+    if saved:
+        progress("CPU governor -> performance on %u cores" % len(saved))
+    if denied and not saved:
+        progress("NOTE: could not set the CPU governor to performance "
+                 "(needs root); expect lower and noisier speedups - "
+                 "sudo cpupower frequency-set -g performance")
+    return saved
+
+
+def restore_cpu_governors(saved):
+    for path, old in saved:
+        try:
+            with open(path, "w") as f:
+                f.write(old)
+        except OSError:
+            pass
+    if saved:
+        progress("CPU governors restored")
+
+
+def progress(text):
+    print("CLUSTER-FOLLOW: %s" % text)
+
+
+def cpu_temp_report():
+    '''hottest CPU thermal zone from sysfs, e.g. "cpu temp 100C
+    (x86_pkg_temp)"; None when unavailable. Printed periodically so every
+    log records whether the silicon was thermally throttled: at 100C the
+    package hard-caps its clocks and no speedup number is meaningful.'''
+    zones = []
+    for z in glob.glob('/sys/class/thermal/thermal_zone*'):
+        try:
+            with open(os.path.join(z, 'temp')) as f:
+                t = int(f.read().strip()) / 1000.0
+            with open(os.path.join(z, 'type')) as f:
+                ty = f.read().strip()
+        except (OSError, ValueError):
+            continue
+        zones.append((t, ty))
+    if not zones:
+        return None
+    t, ty = max(zones)
+    return "cpu temp %.0fC (%s)" % (t, ty)
+    sys.stdout.flush()
+
+
+class ClusterView(object):
+    '''live read-only view of the cluster segment
+
+    mmap'd rather than re-read each time: this is sampled every time round
+    a fast bridge loop, and re-opening a 64KB file at that rate is wasteful.
+    '''
+
+    def __init__(self, cluster_id, instances):
+        self.cluster_id = cluster_id
+        self.instances = instances
+        self.f = open(shm_path(cluster_id), "rb")
+        self.mm = mmap.mmap(self.f.fileno(), 0, access=mmap.ACCESS_READ)
+        magic, = struct.unpack_from("<I", self.mm, 0)
+        if magic != SHM_MAGIC:
+            raise TestFailure("cluster segment has bad magic 0x%08X" % magic)
+
+    last_time = None
+
+    def members(self):
+        if self.last_time is None:
+            self.last_time = {}
+        '''{instance: sim_time_us} for slots with a live pid'''
+        out = {}
+        for i in self.instances:
+            # the vehicles write these 64-bit times concurrently and
+            # python reads the mmap byte-wise, so a single read can
+            # TEAR mid-carry and produce a +-2^32us phantom (+-71
+            # minutes) - measured as impossible "5187 sim-seconds" in
+            # a 600s phase. Read until two consecutive reads agree,
+            # and never let a member's time step backwards.
+            off = SHM_HEADER_LEN + i * SHM_SLOT_LEN
+            sim_time, pid = struct.unpack_from("<qi", self.mm, off)
+            for _ in range(4):
+                again, pid2 = struct.unpack_from("<qi", self.mm, off)
+                if again == sim_time:
+                    break
+                sim_time, pid = again, pid2
+            if pid > 0:
+                prev = self.last_time.get(i)
+                if prev is not None and sim_time < prev:
+                    sim_time = prev
+                self.last_time[i] = sim_time
+                out[i] = sim_time
+        return out
+
+    def now(self):
+        '''current simulated time in seconds, or None if nobody is present
+
+        Deliberately the MOST advanced member, not the least. A vehicle
+        whose clock has frozen - blocked on a full socket, say - would
+        otherwise pin this value and silently disable every sim deadline
+        in the test, turning a clean timeout into a hang. Divergence
+        between members is caught by the skew check instead.
+        '''
+        members = self.members()
+        if not members:
+            return None
+        return max(members.values()) * 1e-6
+
+    def close(self):
+        try:
+            self.mm.close()
+            self.f.close()
+        except (OSError, ValueError):
+            pass
+
+
+class Deadline(object):
+    '''a timeout measured in SIM seconds, with a wall-clock backstop
+
+    The sim limit is the real deadline - it makes a phase take the same
+    amount of simulated flying regardless of how fast the host runs. The
+    wall limit exists only so a wedged or crashed run terminates.
+    '''
+
+    def __init__(self, clock, sim_limit, wall_limit, desc):
+        self.clock = clock
+        self.sim_limit = sim_limit
+        self.wall_limit = wall_limit
+        self.desc = desc
+        self.sim0 = clock.now() if clock is not None else None
+        self.wall0 = time.time()
+
+    def sim_elapsed(self):
+        if self.clock is None or self.sim0 is None:
+            return 0.0
+        now = self.clock.now()
+        return 0.0 if now is None else now - self.sim0
+
+    def wall_elapsed(self):
+        return time.time() - self.wall0
+
+    def check(self):
+        '''raise TestFailure if this deadline has passed'''
+        if self.sim0 is not None and self.sim_elapsed() > self.sim_limit:
+            raise TestFailure("'%s' timed out after %.0f sim-seconds"
+                              % (self.desc, self.sim_elapsed()))
+        if self.wall_elapsed() > self.wall_limit:
+            raise TestFailure(
+                "'%s' hit the %.0fs wall-clock backstop after only %.0f "
+                "sim-seconds - the host is running far below the requested "
+                "speedup" % (self.desc, self.wall_limit, self.sim_elapsed()))
+
+
+class SpeedupMeter(object):
+    '''achieved speedup: simulated seconds advanced per wall second'''
+
+    def __init__(self, want):
+        self.want = want
+        self.win_start = None
+        self.latest = None
+        self.overall_start = None
+        self.steady_start = None
+
+    def update(self, sim_s, wall_s):
+        if self.win_start is None:
+            self.win_start = (sim_s, wall_s)
+            self.overall_start = (sim_s, wall_s)
+        self.latest = (sim_s, wall_s)
+
+    def mark_steady(self):
+        # start of the converged region: the adaptive governor needs one
+        # dwell to settle, so the back half of the follow phase measures
+        # what the host actually sustains once tuned - the honest
+        # "capable of Nx" figure for a long swarm run, free of the
+        # boot/takeoff transient that dominates a short test's average
+        if self.steady_start is None:
+            self.steady_start = self.latest
+
+    def steady(self):
+        return self._rate(self.steady_start, self.latest)
+
+    @staticmethod
+    def _rate(a, b):
+        if a is None or b is None:
+            return None
+        d_wall = b[1] - a[1]
+        if d_wall < 1e-6:
+            return None
+        return (b[0] - a[0]) / d_wall
+
+    def window(self):
+        return self._rate(self.win_start, self.latest)
+
+    def overall(self):
+        return self._rate(self.overall_start, self.latest)
+
+    def start_new_window(self):
+        self.win_start = self.latest
+
+
+class Vehicle(object):
+    '''one SITL process plus its MAVLink connection'''
+
+    # per-model default parameter file inside the binary's ROMFS; the
+    # fast-swarm overrides are chained after it via --defaults
+    MODEL_DEFAULTS = {
+        "plane": "@ROMFS/models/plane.parm",
+        "+": "@ROMFS/default_params/copter.parm",
+    }
+
+    def __init__(self, name, binary, instance, sysid, model, cluster, speedup,
+                 logdir, opts):
+        self.name = name
+        self.binary = binary
+        self.instance = instance
+        self.sysid = sysid
+        self.model = model
+        self.cluster = cluster
+        self.speedup = speedup
+        self.logdir = logdir
+        self.opts = opts
+        self.proc = None
+        self.workdir = None
+        self.logfile = None
+        self.mav = None
+        self.clock = None       # set once the cluster segment exists
+        # Drains EVERY vehicle's link, not just this one. A SITL whose
+        # socket is not read will fill its TCP send buffer and block,
+        # which freezes its simulated clock - so any wait longer than a
+        # moment must keep every link moving, not only the one it
+        # is talking to.
+        self.drain_hook = None
+
+    @property
+    def port(self):
+        return 5760 + 10 * self.instance
+
+    def start(self):
+        # Each SITL needs its OWN working directory: the parameter store is
+        # a fixed "eeprom.bin" in the cwd (HAL_STORAGE_FILE), so sharing a
+        # directory means several vehicles fighting over one file. This is why
+        # sim_vehicle.py builds per-instance directories too.
+        self.workdir = os.path.join(self.logdir, self.name)
+        os.makedirs(self.workdir, exist_ok=True)
+        self.logfile = open(os.path.join(self.logdir, "%s.log" % self.name), "wb")
+        defaults = self.MODEL_DEFAULTS[self.model] + "," + self.opts.fast_parm
+        if self.opts.loop_parm:
+            defaults += "," + self.opts.loop_parm
+        cfg = os.path.join(self.logdir, "%s_cfg.parm" % self.name)
+        if os.path.exists(cfg):
+            defaults += "," + cfg
+        cmd = [
+            self.binary,
+            "--instance", str(self.instance),
+            "--cluster=%d" % self.cluster,
+            "--sysid", str(self.sysid),
+            "--model", self.model,
+            "--speedup", str(self.speedup),
+            "--home", HOME,
+            "--wipe",
+            # chain the model's own defaults with the fast-swarm
+            # overrides (EKF disabled, logging off, terrain off) written
+            # by the test - measured at ~44 percent more achieved
+            # speedup, and on Windows it also removes the log_io
+            # thread's ~15k sleeps/second, each of which costs a full
+            # 1ms timer tick under Cygwin
+            "--defaults", defaults,
+        ]
+        # note: lowering the physics frame rate (--rate 400) was tried
+        # here and MEASURED SLOWER (23.9x -> 13.6x): 1:1 physics frames
+        # per vehicle-loop iteration interact badly with the sample
+        # pacing. Deliberately not used.
+        env = dict(os.environ)
+        # disable the per-task stack NaN poisoning, a SITL debug aid
+        # measured at ~4 percent of CPU (see AP_Scheduler.cpp)
+        env["SITL_DISABLE_STACK_NANF"] = "1"
+        # remove every wall-clock sleep from the sim path; cores run hot
+        env["SITL_HARD_NONBLOCK"] = "1"
+        # runtime governor: trade physics frame rate for achieved speedup
+        # until the commanded speedup is met (measured: the curve is
+        # non-monotonic, so it must be tuned live, not statically)
+        env["SITL_ADAPTIVE_RATE"] = "1"
+        self.proc = subprocess.Popen(
+            cmd, stdout=self.logfile, stderr=subprocess.STDOUT,
+            cwd=self.workdir, preexec_fn=os.setsid, env=env)
+
+    def alive(self):
+        return self.proc is not None and self.proc.poll() is None
+
+    def connect(self, timeout=60):
+        # wall-clock: a TCP connect and the first heartbeat are not
+        # simulation-paced, and the cluster clock is not readable yet
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            try:
+                self.mav = mavutil.mavlink_connection(
+                    "tcp:127.0.0.1:%u" % self.port, source_system=250,
+                    autoreconnect=True)
+                break
+            except OSError:
+                # port not accepting connections yet
+                time.sleep(0.5)
+        if self.mav is None:
+            raise TestFailure("%s: could not connect on port %u"
+                              % (self.name, self.port))
+        if self.mav.wait_heartbeat(timeout=timeout) is None:
+            raise TestFailure("%s: no heartbeat" % self.name)
+        for _mid in (mavutil.mavlink.MAVLINK_MSG_ID_NAV_CONTROLLER_OUTPUT,
+                     mavutil.mavlink.MAVLINK_MSG_ID_VFR_HUD,
+                     mavutil.mavlink.MAVLINK_MSG_ID_ATTITUDE):
+            self.mav.mav.command_long_send(
+                self.mav.target_system, self.mav.target_component,
+                mavutil.mavlink.MAV_CMD_SET_MESSAGE_INTERVAL, 0,
+                _mid, 1000000, 0, 0, 0, 0, 0)
+        # every STATUSTEXT and command ACK, whoever parses the packet:
+        # when a vehicle refuses to fly it says why here and nowhere else
+        self.mav.message_hooks.append(self._msg_hook)
+        # Ask for only what this test reads, at a modest rate. These rates
+        # are in SIM Hz, so the wall-clock message rate is rate * speedup;
+        # requesting everything at 20Hz would be 2000 messages/second per
+        # vehicle if the host ever did achieve 100x.
+        self.mav.mav.request_data_stream_send(
+            self.mav.target_system, self.mav.target_component,
+            mavutil.mavlink.MAV_DATA_STREAM_ALL, 0, 0)
+        for stream, rate in (
+                (mavutil.mavlink.MAV_DATA_STREAM_POSITION, 4),
+                (mavutil.mavlink.MAV_DATA_STREAM_EXTENDED_STATUS, 2)):
+            self.mav.mav.request_data_stream_send(
+                self.mav.target_system, self.mav.target_component,
+                stream, rate, 1)
+
+    def deadline(self, sim_limit, desc):
+        return Deadline(self.clock, sim_limit, self.opts.wall_limit,
+                        "%s: %s" % (self.name, desc))
+
+    def set_param(self, name, value, sim_limit=60):
+        dl = self.deadline(sim_limit, "set %s" % name)
+        seen = None
+        while True:
+            self.mav.mav.param_set_send(
+                self.mav.target_system, self.mav.target_component,
+                name.encode("utf-8"),
+                float(value), mavutil.mavlink.MAV_PARAM_TYPE_REAL32)
+            msg = self.mav.recv_match(type="PARAM_VALUE", blocking=True,
+                                      timeout=2)
+            if msg is not None and msg.param_id == name:
+                if abs(msg.param_value - float(value)) < 1e-4:
+                    return
+                # the vehicle answered with a different value: almost always
+                # the parameter clamping an out-of-range request
+                seen = msg.param_value
+            if self.drain_hook is not None:
+                self.drain_hook()
+            try:
+                dl.check()
+            except TestFailure as e:
+                if seen is not None:
+                    raise TestFailure(
+                        "%s: %s would not take %s - vehicle reports %g "
+                        "(value out of range for this parameter?)"
+                        % (self.name, name, value, seen))
+                raise TestFailure(
+                    "%s (parameter %s may not exist on this vehicle)"
+                    % (e, name))
+
+    def set_params(self, params):
+        for name, value in params.items():
+            self.set_param(name, value)
+
+    def set_mode(self, mode, sim_limit=120):
+        mapping = self.mav.mode_mapping()
+        if mapping is None:
+            # only populated once a heartbeat has told us the vehicle type
+            raise TestFailure("%s: no mode mapping yet" % self.name)
+        if mode not in mapping:
+            raise TestFailure("%s: unknown mode %s" % (self.name, mode))
+        want = mapping[mode]
+        dl = self.deadline(sim_limit, "enter %s" % mode)
+        while True:
+            self.mav.mav.set_mode_send(
+                self.mav.target_system,
+                mavutil.mavlink.MAV_MODE_FLAG_CUSTOM_MODE_ENABLED,
+                want)
+            msg = self.mav.recv_match(type="HEARTBEAT", blocking=True, timeout=2)
+            if msg is not None and msg.custom_mode == want:
+                return
+            if self.drain_hook is not None:
+                self.drain_hook()
+            dl.check()
+
+    def wait_ready_to_arm(self, sim_limit=None):
+        # phase deadlines bound WALL time uniformly under the pinned
+        # wall-slaved schedule: a fixed sim window evaporates in
+        # wall-instants once the schedule engages
+        if sim_limit is None:
+            sim_limit = 30 * max(1, self.opts.speedup)
+        # this is really waiting for the EKF and GPS to converge, which is
+        # paced by simulated time, so the limit must be in sim seconds
+        dl = self.deadline(sim_limit, "become armable")
+        while True:
+            msg = self.mav.recv_match(type="SYS_STATUS", blocking=True, timeout=5)
+            if msg is not None:
+                bit = mavutil.mavlink.MAV_SYS_STATUS_PREARM_CHECK
+                if msg.onboard_control_sensors_health & bit:
+                    return
+            if self.drain_hook is not None:
+                self.drain_hook()
+            dl.check()
+
+    def arm(self, sim_limit=None):
+        if sim_limit is None:
+            sim_limit = 15 * max(1, self.opts.speedup)
+        dl = self.deadline(sim_limit, "arm")
+        while True:
+            self.mav.mav.command_long_send(
+                self.mav.target_system, self.mav.target_component,
+                mavutil.mavlink.MAV_CMD_COMPONENT_ARM_DISARM, 0,
+                1, 0, 0, 0, 0, 0, 0)
+            msg = self.mav.recv_match(type="HEARTBEAT", blocking=True, timeout=2)
+            if (msg is not None and
+                    msg.base_mode & mavutil.mavlink.MAV_MODE_FLAG_SAFETY_ARMED):
+                return
+            if self.drain_hook is not None:
+                self.drain_hook()
+            dl.check()
+
+    def _msg_hook(self, _conn, msg):
+        t = msg.get_type()
+        if t == "STATUSTEXT":
+            progress("%s says: %s" % (self.name, msg.text))
+        elif t == "COMMAND_ACK":
+            progress("%s ack: cmd=%u result=%u"
+                     % (self.name, msg.command, msg.result))
+
+    def takeoff_cmd(self, alt):
+        self.mav.mav.command_long_send(
+            self.mav.target_system, self.mav.target_component,
+            mavutil.mavlink.MAV_CMD_NAV_TAKEOFF, 0,
+            0, 0, 0, 0, 0, 0, alt)
+
+    def position(self):
+        '''latest GLOBAL_POSITION_INT as (lat, lng, alt_m, rel_alt_m, hdg)'''
+        msg = self.mav.messages.get("GLOBAL_POSITION_INT", None)
+        if msg is None:
+            return None
+        return (msg.lat * 1e-7, msg.lon * 1e-7, msg.alt * 1e-3,
+                msg.relative_alt * 1e-3, msg.hdg * 1e-2)
+
+    def rel_alt(self):
+        pos = self.position()
+        return pos[3] if pos is not None else 0.0
+
+    def drain(self):
+        while True:
+            if self.mav.recv_match(blocking=False) is None:
+                return
+
+    def stop(self):
+        if self.mav is not None:
+            try:
+                self.mav.close()
+            except OSError:
+                pass
+        if self.proc is not None:
+            try:
+                os.killpg(os.getpgid(self.proc.pid), signal.SIGKILL)
+            except (ProcessLookupError, PermissionError):
+                # already gone, or not ours to signal
+                pass
+            try:
+                self.proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                pass
+        if self.logfile is not None:
+            self.logfile.close()
+
+
+def offset_location(lat, lng, north_m, east_m):
+    '''shift a lat/lng by a north/east offset in metres'''
+    dlat = north_m / 1.113195e5
+    dlng = east_m / (1.113195e5 * math.cos(math.radians(lat)))
+    return (lat + dlat, lng + dlng)
+
+
+def formation_target(ppos, offset):
+    '''where a copter is commanded to sit, for FOLL_OFS_TYPE=1
+
+    The offset is expressed relative to the lead vehicle's heading (x
+    forward, y right), so it has to be rotated into north/east before it
+    means anything on the ground.
+    '''
+    ofs_x, ofs_y, _ = offset
+    hdg = math.radians(ppos[4])
+    north = ofs_x * math.cos(hdg) - ofs_y * math.sin(hdg)
+    east = ofs_x * math.sin(hdg) + ofs_y * math.cos(hdg)
+    return offset_location(ppos[0], ppos[1], north, east)
+
+
+def horizontal_distance(a, b):
+    '''metres between two (lat, lng, ...) tuples'''
+    dlat = a[0] - b[0]
+    dlng = (a[1] - b[1]) * math.cos(math.radians((a[0] + b[0]) * 0.5))
+    return math.sqrt(dlat ** 2 + dlng ** 2) * 1.113195e5
+
+
+class ClusterFollowTest(object):
+
+    # formation offsets in metres relative to the plane's heading: one
+    # astern, one off each wing, all below the plane (FOLL_OFS_Z is +ve down)
+    # Line astern, not line abreast. The plane holds a circular loiter, so
+    # a port slot and a starboard slot are not equivalent: one sits inside
+    # the turn and one outside, and they track very differently (measured
+    # 240m vs 100m steady-state error). Stacking both copters directly
+    # behind puts them on the same ground track as the plane, so the test
+    # measures follow accuracy rather than which side of the circle a
+    # copter was assigned to.
+    OFFSETS = {
+        "copter1": (-60.0, 0.0, 20.0),
+        "copter2": (-120.0, 0.0, 20.0),
+    }
+
+    def __init__(self, opts):
+        self.opts = opts
+        self.logdir = tempfile.mkdtemp(prefix="/tmp/sitl_cluster_follow_")
+        # a previous run killed mid-flight (SIGKILL skips the vehicles'
+        # own cleanup) leaves this cluster's shared-memory segment
+        # holding a dead schedule epoch and armed flags; vehicles
+        # starting now would join it. Retire it up front, and again in
+        # cleanup() so this run leaves nothing behind either.
+        self.purge_segment()
+        # overrides chained after each vehicle's model defaults: no EKF
+        # (SITL perfect AHRS), no dataflash logging, no terrain grid
+        opts.fast_parm = os.path.abspath(
+            os.path.join(self.logdir, "fast_swarm.parm"))
+        with open(opts.fast_parm, "w") as f:
+            # EKF3 runs in the background even with AHRS_EKF_TYPE 10
+            # selecting the SITL estimator, and default telemetry
+            # stream rates generate MAVLink per SIM second - both are
+            # dead weight the vehicles at the governor's frame-rate
+            # floor cannot afford. The bridge only needs position and
+            # status streams.
+            f.write("AHRS_EKF_TYPE 10\n"
+                    "LOG_BACKEND_TYPE 0\n"
+                    "TERRAIN_ENABLE 0\n"
+                    "EK3_ENABLE 0\n"
+                    "EK2_ENABLE 0\n"
+                    "SR0_RAW_SENS 0\n"
+                    "SR0_EXT_STAT 1\n"
+                    "SR0_RC_CHAN 0\n"
+                    "SR0_RAW_CTRL 0\n"
+                    "SR0_POSITION 1\n"
+                    "SR0_EXTRA1 0\n"
+                    "SR0_EXTRA2 0\n"
+                    "SR0_EXTRA3 0\n"
+                    "SR0_ADSB 0\n"
+                    "SIM_FLOAT_EXCEPT 0\n"
+                    "ARMING_CHECK 0\n"
+                    # the simulated board heats over minutes of SIM time and
+                    # drifts the baro; racing sim time puts the whole warmup
+                    # between baro cal and arming, so a grounded copter reads
+                    # metres of altitude, believes it is airborne, and
+                    # refuses its guided takeoff. No thermal drift.
+                    "SIM_TEMP_BFACTOR 0\n"
+                    "SIM_TEMP_TCONST 1\n"
+                    # the battery model's internal resistance grows with
+                    # temperature; racing sim time cooks it in wall-seconds
+                    # and sag collapses thrust to 1g at 100% throttle -
+                    # copters hung mid-air unable to climb. No sag, ever.
+                    "SIM_BATT_RES_OHM 0\n")
+        # Only when chasing real speedup (> 5): run every vehicle's
+        # flight-controller loop at 200Hz. Scheduler iterations are the
+        # measured scaling axis for per-sim-second cost, and the loop
+        # rate also sets the adaptive governor's physics-rate floor
+        # (3x the loop rate): at ArduPlane's default 300Hz loop the
+        # plane floors at 900 physics frames while the 200Hz copters
+        # sit at 600, making the plane the most expensive cluster
+        # member for nothing the swarm test measures. 200Hz for a plane
+        # is repo-precedented (glider.parm). Sub-5x runs are untouched.
+        opts.loop_parm = ""
+        if opts.speedup > 5:
+            opts.loop_parm = os.path.abspath(
+                os.path.join(self.logdir, "swarm_200hz.parm"))
+            with open(opts.loop_parm, "w") as f:
+                f.write(
+                    # loop budget matches the actual stretched step
+                    # (~10ms): at 200Hz the scheduler saw every
+                    # 5ms-budget loop consume 11ms of sim time and
+                    # permanently shed its table tasks - the plane's
+                    # servo output froze (20km open-loop climb) and
+                    # the copters' takeoff machinery ran starved
+                    "SCHED_LOOP_RATE 100\n")
+        # every mission parameter is baked into per-vehicle defaults
+        # files loaded at boot: the old MAVLink configuration phase was
+        # ~40 parameter round-trips per vehicle of pure wall time
+        # before a single simulated second of the mission ran
+        with open(os.path.join(self.logdir, "plane_cfg.parm"), "w") as f:
+            f.write("AIRSPEED_CRUISE 12\n"
+                    "AIRSPEED_MIN 9\n"
+                    "AIRSPEED_MAX 16\n"
+                    "WP_LOITER_RAD 250\n"
+                    "TKOFF_ALT 100\n")
+        for cname, ofs in self.OFFSETS.items():
+            with open(os.path.join(self.logdir,
+                                   "%s_cfg.parm" % cname), "w") as f:
+                f.write("DISARM_DELAY 0\n"
+                        "FS_CRASH_CHECK 0\n"
+                        "SRTL_POINTS 0\n"
+                        "FOLL_ENABLE 1\n"
+                        "FOLL_SYSID 1\n"
+                        "FOLL_OFS_TYPE 1\n"
+                        "FOLL_OFS_X %.1f\n"
+                        "FOLL_OFS_Y %.1f\n"
+                        "FOLL_OFS_Z %.1f\n"
+                        "FOLL_ALT_TYPE 0\n"
+                        "FOLL_DIST_MAX 1000\n"
+                        "FOLL_TIMEOUT %.0f\n"
+                        "FOLL_YAW_BEHAVE 1\n"
+                        "WP_SPD 20\n"
+                        "WP_SPD_UP 5\n"
+                        "WP_SPD_DN 5\n"
+                        "WP_ACC 5\n"
+                        % (ofs[0], ofs[1], ofs[2], FOLL_TIMEOUT_S))
+        self.plane = Vehicle("plane", opts.plane_binary, 0, 1, "plane",
+                             opts.cluster, opts.speedup, self.logdir, opts)
+        self.copters = [
+            Vehicle("copter%u" % i, opts.copter_binary, i, i + 1, "+",
+                    opts.cluster, opts.speedup, self.logdir, opts)
+            for i in (1, 2)
+        ]
+        self.vehicles = [self.plane] + self.copters
+        self.instances = [v.instance for v in self.vehicles]
+        self.view = None
+        self.meter = SpeedupMeter(opts.speedup)
+        self.worst_skew_us = 0
+        self.max_bridge_gap_sim_s = 0.0
+        self.last_bridge_sim_s = None
+        self.phase = "init"
+        self.last_report_wall = 0.0
+        self.last_temp_wall = 0.0
+
+    def drain_all(self):
+        '''read every link, so no vehicle blocks on a full send buffer'''
+        for v in self.vehicles:
+            if v.mav is not None:
+                v.drain()
+
+    def check_cluster(self):
+        '''assert the cluster is intact and within skew; returns sim seconds'''
+        members = self.view.members()
+        if len(members) != len(self.vehicles):
+            missing = sorted(set(self.instances) - set(members))
+            raise TestFailure("cluster lost instance(s) %s mid-test" % missing)
+        times = list(members.values())
+        skew = max(times) - min(times)
+        self.worst_skew_us = max(self.worst_skew_us, skew)
+        if skew > self.opts.max_skew_us:
+            raise TestFailure("cluster skew %u us exceeded limit %u us"
+                              % (skew, self.opts.max_skew_us))
+        return min(times) * 1e-6
+
+    def pump(self, until, sim_limit, desc, bridge=True):
+        '''run the bridge and telemetry until until() returns True
+
+        sim_limit is in simulated seconds. Returns the simulated seconds
+        that elapsed.
+        '''
+        self.phase = desc
+        dl = Deadline(self.view, sim_limit, self.opts.wall_limit, desc)
+
+        while True:
+            for v in self.vehicles:
+                if not v.alive():
+                    raise TestFailure("%s exited during '%s'" % (v.name, desc))
+                v.drain()
+
+            sim_s = self.check_cluster()
+            if bridge:
+                self.bridge(sim_s)
+            self.meter.update(sim_s, time.time())
+            self.report(sim_s)
+
+            if until(sim_s):
+                return dl.sim_elapsed()
+
+            dl.check()
+            time.sleep(self.opts.loop_dt)
+
+    def bridge(self, sim_s):
+        '''forward the plane's position onto each copter's link'''
+        pmsg = self.plane.mav.messages.get("GLOBAL_POSITION_INT", None)
+        if pmsg is None:
+            return
+        for c in self.copters:
+            # preserve the plane's sysid in the header - that is what
+            # AP_Follow matches against FOLL_SYSID
+            c.mav.mav.srcSystem = self.plane.sysid
+            c.mav.mav.global_position_int_send(
+                pmsg.time_boot_ms, pmsg.lat, pmsg.lon, pmsg.alt,
+                pmsg.relative_alt, pmsg.vx, pmsg.vy, pmsg.vz, pmsg.hdg)
+            c.mav.mav.srcSystem = 250
+
+        # how stale the copters' view of the plane gets, in SIM time - this
+        # is the quantity FOLL_TIMEOUT is measured against, and the one that
+        # degrades as speedup rises
+        if self.last_bridge_sim_s is not None:
+            gap = sim_s - self.last_bridge_sim_s
+            self.max_bridge_gap_sim_s = max(self.max_bridge_gap_sim_s, gap)
+        self.last_bridge_sim_s = sim_s
+
+    def report(self, sim_s):
+        # wall-clock interval on purpose: this paces console output for a
+        # human, and must not speed up or slow down with the simulation
+        wall_s = time.time()
+        if wall_s - self.last_report_wall < self.opts.report_interval:
+            return
+        self.last_report_wall = wall_s
+        if wall_s - self.last_temp_wall >= 2.0:
+            self.last_temp_wall = wall_s
+            temp = cpu_temp_report()
+            if temp is not None:
+                progress(temp)
+        now = self.meter.window()
+        overall = self.meter.overall()
+        self.meter.start_new_window()
+        pct = (now / self.opts.speedup * 100.0) if now else 0.0
+        dists = ""
+        ppos = self.plane.position()
+        if ppos is not None:
+            parts = []
+            for c in self.copters:
+                cpos = c.position()
+                if cpos is None:
+                    parts.append("%s=?" % c.name)
+                    continue
+                want = formation_target(ppos, self.OFFSETS[c.name])
+                gpi = c.mav.messages.get("GLOBAL_POSITION_INT", None)
+                hb = c.mav.messages.get("HEARTBEAT", None)
+                vz = (-gpi.vz * 1e-2) if gpi is not None else float("nan")
+                armed = (bool(hb.base_mode
+                              & mavutil.mavlink.MAV_MODE_FLAG_SAFETY_ARMED)
+                         if hb is not None else None)
+                mode = hb.custom_mode if hb is not None else None
+                parts.append("%s err=%.0fm alt=%.0fm vz=%+.1f mode=%s%s" % (
+                    c.name, horizontal_distance(want, cpos), cpos[3], vz,
+                    mode, "" if armed else " DISARMED"))
+            phb = self.plane.mav.messages.get("HEARTBEAT", None)
+            pnav = self.plane.mav.messages.get(
+                "NAV_CONTROLLER_OUTPUT", None)
+            phud = self.plane.mav.messages.get("VFR_HUD", None)
+            patt = self.plane.mav.messages.get("ATTITUDE", None)
+            dists = " plane_alt=%.0fm mode=%s alt_err=%s thr=%s pit=%s " % (
+                ppos[3],
+                phb.custom_mode if phb is not None else "?",
+                "%.0f" % pnav.alt_error if pnav is not None else "?",
+                "%s/as=%.0f" % (phud.throttle, phud.airspeed)
+                if phud is not None else "?",
+                "%.0f" % math.degrees(patt.pitch)
+                if patt is not None else "?")
+            dists += " ".join(parts)
+        progress("[%s] sim=%.0fs speedup want=%ux now=%s avg=%s (%.0f%% of "
+                 "target) skew=%uus%s"
+                 % (self.phase, sim_s, self.opts.speedup,
+                    "%.1fx" % now if now else "?",
+                    "%.1fx" % overall if overall else "?",
+                    pct, self.worst_skew_us, dists))
+
+    def run(self):
+        for v in self.vehicles:
+            progress("starting %s (instance %u, sysid %u) at %ux speedup"
+                     % (v.name, v.instance, v.sysid, v.speedup))
+            v.start()
+        # wall-clock: process startup is not paced by the simulation
+        time.sleep(5)
+        for v in self.vehicles:
+            v.connect()
+            progress("%s connected on port %u" % (v.name, v.port))
+
+        self.view = ClusterView(self.opts.cluster, self.instances)
+        for v in self.vehicles:
+            v.clock = self.view
+            v.drain_hook = self.drain_all
+        members = self.view.members()
+        if len(members) != len(self.vehicles):
+            raise TestFailure("only %u of %u vehicles joined cluster %u"
+                              % (len(members), len(self.vehicles),
+                                 self.opts.cluster))
+        progress("all %u vehicles registered in cluster %u"
+                 % (len(members), self.opts.cluster))
+
+        # mission parameters were baked into per-vehicle defaults files
+        # at spawn - no MAVLink configuration phase
+
+        for v in self.vehicles:
+            progress("%s waiting for armable state" % v.name)
+            v.wait_ready_to_arm()
+
+        # get the plane airborne and circling first, so the copters have a
+        # real moving target to acquire
+        progress("launching plane")
+        self.plane.set_mode("TAKEOFF")
+        self.plane.arm()
+        self.pump(lambda s: self.plane.rel_alt() > 80,
+                  sim_limit=30 * max(1, self.opts.speedup),
+                  desc="plane-takeoff", bridge=False)
+        progress("plane airborne at %.0fm, switching to LOITER"
+                 % self.plane.rel_alt())
+        self.plane.set_mode("LOITER")
+
+        progress("launching copters")
+        for c in self.copters:
+            c.set_mode("GUIDED")
+            c.arm()
+            c.takeoff_cmd(60)
+        self.pump(lambda s: all(c.rel_alt() > 50 for c in self.copters),
+                  sim_limit=30 * max(1, self.opts.speedup),
+                  desc="copter-takeoff")
+        progress("copters airborne at %s"
+                 % ["%.0fm" % c.rel_alt() for c in self.copters])
+
+        for c in self.copters:
+            c.set_mode("FOLLOW")
+        progress("all copters in FOLLOW, tracking for %.0f sim-seconds"
+                 % self.opts.follow_time)
+
+        # Formation error - how far each copter is from the position it is
+        # actually commanded to hold - is the honest measure. Distance to
+        # the plane is not: the plane orbits at WP_LOITER_RAD, so a copter
+        # that never moved would still be "near" it for much of each lap.
+        closest = {c.name: None for c in self.copters}
+        # Longest CONTINUOUS period inside the formation tolerance, not the
+        # total. A copter that never took off would still accumulate plenty
+        # of total time "in tolerance" as the plane's circular loiter swept
+        # past it once a lap; it could not stay in tolerance continuously.
+        holding = {c.name: 0.0 for c in self.copters}
+        settled = {c.name: 0.0 for c in self.copters}
+        last = {"sim": None}
+
+        follow_start = {"sim": None}
+
+        def track(sim_s):
+            # accumulate station-keeping in SIM seconds, so "held for 60s"
+            # means the same amount of flying at any achieved speedup
+            dt = 0.0 if last["sim"] is None else sim_s - last["sim"]
+            last["sim"] = sim_s
+            if follow_start["sim"] is None:
+                follow_start["sim"] = sim_s
+            elif sim_s - follow_start["sim"] > self.opts.follow_time / 2.0:
+                self.meter.mark_steady()
+            ppos = self.plane.position()
+            if ppos is None:
+                return False
+            for c in self.copters:
+                cpos = c.position()
+                if cpos is None:
+                    continue
+                want = formation_target(ppos, self.OFFSETS[c.name])
+                err = horizontal_distance(want, cpos)
+                if closest[c.name] is None or err < closest[c.name]:
+                    closest[c.name] = err
+                if err < self.opts.hold_distance:
+                    holding[c.name] += dt
+                    settled[c.name] = max(settled[c.name], holding[c.name])
+                else:
+                    holding[c.name] = 0.0
+            return False        # never satisfied: run for the full duration
+
+        try:
+            self.pump(track, sim_limit=self.opts.follow_time, desc="follow")
+        except TestFailure as e:
+            if "timed out after" not in str(e):
+                raise           # a real failure, not the intended duration
+
+        achieved = self.meter.overall()
+        progress("achieved speedup over the run: %s (requested %ux)"
+                 % ("%.1fx" % achieved if achieved else "?", self.opts.speedup))
+        steady = self.meter.steady()
+        if steady:
+            progress("steady-state speedup (back half of follow): %.1fx"
+                     % steady)
+        # surface each vehicle's adaptive-rate governor decisions so a CI
+        # log shows what frame rate every vehicle settled at
+        for v in self.vehicles:
+            try:
+                with open(os.path.join(self.logdir, "%s.log" % v.name),
+                          "rb") as f:
+                    lines = [ln.decode("utf-8", "replace").strip()
+                             for ln in f if b"adaptive rate" in ln]
+            except OSError:
+                lines = []
+            if lines:
+                for ln in lines[-4:]:
+                    progress("%s governor: %s" % (v.name, ln))
+            else:
+                progress("%s governor: no rate changes" % v.name)
+        # any shortfall from the commanded speedup is a failure: the
+        # adaptive governor is required to slow the physics until the
+        # commanded speedup is reached. Checked after the governor
+        # traces print so a failure is diagnosable.
+        if steady and steady < self.opts.speedup:
+            raise TestFailure(
+                "achieved steady-state speedup %.1fx is below the "
+                "commanded %ux" % (steady, self.opts.speedup))
+        progress("worst cluster skew: %u us" % self.worst_skew_us)
+        progress("worst gap between position updates: %.2f sim-seconds "
+                 "(FOLL_TIMEOUT is %.0fs)"
+                 % (self.max_bridge_gap_sim_s, FOLL_TIMEOUT_S))
+        if self.max_bridge_gap_sim_s > FOLL_TIMEOUT_S:
+            raise TestFailure(
+                "the telemetry bridge fell behind: %.1f sim-second gap "
+                "exceeds FOLL_TIMEOUT %.0fs, so the copters lost the plane. "
+                "Reduce --speedup or --loop-dt."
+                % (self.max_bridge_gap_sim_s, FOLL_TIMEOUT_S))
+
+        for c in self.copters:
+            progress("%s: best formation error %s, held station %.0f sim-seconds unbroken"
+                     % (c.name,
+                        "%.0fm" % closest[c.name] if closest[c.name] else "never",
+                        settled[c.name]))
+        for c in self.copters:
+            if closest[c.name] is None or closest[c.name] > self.opts.hold_distance:
+                raise TestFailure(
+                    "%s never reached its formation slot within %.0fm "
+                    "(best error %s)"
+                    % (c.name, self.opts.hold_distance,
+                       "%.0fm" % closest[c.name] if closest[c.name] else "never"))
+            if settled[c.name] < self.opts.min_hold_time:
+                raise TestFailure(
+                    "%s only held formation for %.0f sim-seconds unbroken, "
+                    "wanted %.0f"
+                    % (c.name, settled[c.name], self.opts.min_hold_time))
+
+        progress("PASS: %u copters followed the plane in cluster %u"
+                 % (len(self.copters), self.opts.cluster))
+
+    def purge_segment(self):
+        if sys.platform in ("cygwin", "win32"):
+            # Windows shared memory is a kernel object that vanishes
+            # with its last handle - nothing can go stale
+            return
+        seg = "/dev/shm/ardupilot_sitl_cluster_%u_%u" % (
+            os.getuid(), self.opts.cluster)
+        try:
+            os.unlink(seg)
+            progress("removed stale cluster segment %s" % seg)
+        except FileNotFoundError:
+            pass
+        except OSError as e:
+            progress("could not remove %s: %s" % (seg, e))
+
+    def cleanup(self):
+        if self.view is not None:
+            self.view.close()
+        for v in self.vehicles:
+            v.stop()
+        self.purge_segment()
+
+
+def main():
+    parser = optparse.OptionParser("test_cluster_follow.py [options]")
+
+    # ------------------------------------------------------------------
+    # Settings: edit HERE, not via flags. Command-line options exist only
+    # for the values genuinely varied per invocation (see the standing
+    # no-speculative-arguments rule); everything else is a constant.
+    # ------------------------------------------------------------------
+    class Settings:
+        # SITL binaries to launch
+        copter_binary = "build/sitl/bin/arducopter"
+        plane_binary = "build/sitl/bin/arduplane"
+        # shared-memory cluster id; two simultaneous runs with the same
+        # id join EACH OTHER's cluster and produce chaos
+        cluster = 91
+        # bridge/telemetry pump period, WALL seconds. speedup * loop_dt
+        # is the sim-time gap between the position updates the copters
+        # see; keep it well under FOLL_TIMEOUT (30s)
+        loop_dt = 0.01
+        # WALL seconds between progress lines
+        report_interval = 2.0
+        # metres of formation error that still counts as holding station
+        hold_distance = 250.0
+        # max tolerated cluster clock skew in sim microseconds;
+        # None = 10000 * speedup (the barrier window is wall-fixed)
+        max_skew_us = None
+        # SIM seconds to hold formation for, eg 600=10 virtual minutes, so a speedup 100x results a
+        # in 6s real human elapsed time.
+        follow_time = 600.0
+        # SIM seconds each copter must hold formation for WITHOUT a
+        # break; the plane laps its loiter in ~130s, so this cannot be
+        # satisfied by a copter merely being orbited past
+        min_hold_time = 120.0
+        # wall-clock backstop per phase, seconds; only stops a wedged
+        # or starved run
+        wall_limit = 80.0
+
+    parser.add_option("", "--speedup", type="int", default=50,
+                      help="requested SITL speedup for every vehicle in "
+                           "the cluster; the achieved rate is measured, "
+                           "reported and gated")
+    opts, _ = parser.parse_args()
+    for _k in ("copter_binary", "plane_binary", "cluster", "loop_dt",
+               "report_interval", "hold_distance", "max_skew_us",
+               "follow_time", "min_hold_time", "wall_limit"):
+        setattr(opts, _k, getattr(Settings, _k))
+
+    if opts.max_skew_us is None:
+        # twice the barrier's own window. The barrier decimates crossings
+        # to every 4*speedup frames and scales its wall-fixed window
+        # accordingly (SIM_Aircraft.cpp: 5000us * 4 * speedup), so the
+        # assertion doubles that to allow one full window of drift
+        # between crossings
+        opts.max_skew_us = 2 * 5000 * 4 * opts.speedup
+
+    # resolve now: each SITL is spawned with cwd set to its log directory,
+    # so a relative binary path would be looked up in the wrong place
+    opts.copter_binary = os.path.abspath(opts.copter_binary)
+    opts.plane_binary = os.path.abspath(opts.plane_binary)
+    for path in (opts.copter_binary, opts.plane_binary):
+        if not os.path.exists(path):
+            print("FAIL: missing binary %s "
+                  "(./waf configure --board sitl && ./waf copter plane)" % path)
+            return 1
+
+    gap = opts.speedup * opts.loop_dt
+    if gap > FOLL_TIMEOUT_S / 2:
+        print("FAIL: --speedup %u with --loop-dt %.3f gives a %.1f sim-second "
+              "gap between position updates; FOLL_TIMEOUT is %.0fs so the "
+              "copters would lose the plane. Reduce --loop-dt to %.3f or less."
+              % (opts.speedup, opts.loop_dt, gap, FOLL_TIMEOUT_S,
+                 FOLL_TIMEOUT_S / 2 / opts.speedup))
+        return 1
+
+    governors = set_cpu_governor_performance()
+
+    test = ClusterFollowTest(opts)
+    try:
+        test.run()
+        return 0
+    except TestFailure as e:
+        progress("FAIL: %s" % e)
+        progress("logs kept in %s" % test.logdir)
+        return 1
+    except KeyboardInterrupt:
+        progress("interrupted")
+        return 1
+    finally:
+        test.cleanup()
+        restore_cpu_governors(governors)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Tools/autotest/test_cluster_follow_windows.py
+++ b/Tools/autotest/test_cluster_follow_windows.py
@@ -1,0 +1,921 @@
+#!/usr/bin/env python3
+'''
+Multi-vehicle cluster test: copters follow a plane.
+
+Launches several real SITL processes - one ArduPlane and two ArduCopter -
+into a single shared-memory cluster (--cluster=ID), flies the plane in a
+loiter, and puts the copters into FOLLOW mode behind it.
+
+Why this lives outside vehicle_test_suite.py: that harness is built around
+a single self.mav connection (change_mode/takeoff/wait_altitude/context all
+target one vehicle), and its only multi-binary hook, sup_binaries, is
+populated solely from autotest.py --sup-binary and gives the extra
+processes no MAVLink plumbing. Flying several vehicles needs independent
+connections, so this drives pymavlink directly.
+
+Separate SITL processes share a clock through the cluster but not a MAVLink
+bus, so this script also acts as the telemetry mesh: it forwards the plane's
+GLOBAL_POSITION_INT onto each copter's link, preserving the plane's sysid in
+the header, which is what AP_Follow matches against FOLL_SYSID.
+
+This script never reads the shared-memory segment itself - the clustering
+is entirely AP_SITL_SharedMem's business. Vehicle output goes to
+per-vehicle log files in the run directory (Windows console writes are
+synchronous and slow enough to brake the sim, and QuickEdit selection
+freezes every process sharing the console); the end-of-run summary
+prints each vehicle's governor decisions and achieved speedup from
+those logs. Python's job is only to launch, configure, fly and observe
+over MAVLink; all its timeouts and measurements are plain wall-clock
+seconds.
+
+The test asserts one thing: follow works - each copter closes on its
+formation slot behind the plane and holds it.
+
+AP_FLAKE8_CLEAN
+'''
+
+import math
+import os
+import subprocess
+import sys
+import tempfile
+import time
+
+from pymavlink import mavutil
+
+HOME = "-35.363261,149.165230,584,353"
+
+# AP_Follow discards its target after this many seconds of SIM time without
+# an update. The default is 3s, which a wall-time bridge cannot honour at
+# high speedup (at 100x even a 100Hz bridge is one update per sim-second),
+# so the copters are told to tolerate a longer gap. AP_Follow extrapolates
+# the target from its reported velocity between updates, so a wider window
+# costs tracking accuracy rather than breaking follow outright.
+FOLL_TIMEOUT_S = 30.0
+
+
+class TestFailure(Exception):
+    pass
+
+
+HIGH_PERFORMANCE_GUID = "8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c"
+
+
+def set_windows_power_performance():
+    """best effort: switch to the High performance power plan for the run
+
+    The Windows equivalent of Linux's CPU frequency governor: on the
+    default Balanced plan the clocks sag exactly when several busy sim
+    processes need them. Returns the previous plan's GUID for
+    restore_windows_power(), or None if nothing was changed.
+    """
+    if sys.platform != "win32":
+        return None
+    import re
+    try:
+        out = subprocess.check_output(["powercfg", "/getactivescheme"])
+        m = re.search(r"([0-9a-fA-F-]{36})", out.decode("utf-8", "replace")
+                      if isinstance(out, bytes) else out)
+        previous = m.group(1) if m else None
+        if previous and previous.lower() == HIGH_PERFORMANCE_GUID:
+            return None                 # already there, nothing to restore
+        subprocess.check_call(["powercfg", "/setactive",
+                               HIGH_PERFORMANCE_GUID])
+        progress("Windows power plan -> High performance")
+        return previous
+    except (OSError, subprocess.CalledProcessError):
+        progress("NOTE: could not switch to the High performance power "
+                 "plan; expect lower and noisier speedups - run "
+                 "'powercfg /setactive %s' by hand" % HIGH_PERFORMANCE_GUID)
+        return None
+
+
+def disable_power_throttling(binaries):
+    """best effort: opt each SITL exe out of Windows EcoQoS throttling
+
+    Windows 10 1709+ classifies windowless console processes as
+    background work and applies EcoQoS "efficiency mode": low clocks,
+    efficiency cores on hybrid CPUs, and a coalesced 15.6ms timer tick
+    even when the process asked for 1ms. Measured on an 8-core box: each
+    vehicle pinned at roughly a QUARTER of one core by this alone.
+    'powercfg /powerthrottling disable /path <exe>' turns it off
+    per-executable and persists, so it also fixes runs started by hand.
+    Verify in Task Manager Details: the "Power throttling" column for
+    each vehicle should read Disabled (no green leaf).
+    """
+    if sys.platform != "win32":
+        return
+    for b in binaries:
+        path = os.path.abspath(b)
+        try:
+            subprocess.check_call(["powercfg", "/powerthrottling",
+                                   "disable", "/path", path])
+            progress("EcoQoS power throttling disabled for %s"
+                     % os.path.basename(path))
+        except (OSError, subprocess.CalledProcessError):
+            progress("NOTE: could not disable power throttling for %s - "
+                     "run by hand (may need admin): powercfg "
+                     "/powerthrottling disable /path \"%s\"" % (
+                         os.path.basename(path), path))
+
+
+def restore_windows_power(previous):
+    if previous is None:
+        return
+    try:
+        subprocess.check_call(["powercfg", "/setactive", previous])
+        progress("Windows power plan restored")
+    except (OSError, subprocess.CalledProcessError):
+        pass
+
+
+def progress(text):
+    print("CLUSTER-FOLLOW: %s" % text)
+    sys.stdout.flush()
+
+
+class Deadline(object):
+    """a plain wall-clock timeout for one phase"""
+
+    def __init__(self, limit_s, desc):
+        self.limit_s = limit_s
+        self.desc = desc
+        self.wall0 = time.time()
+
+    def elapsed(self):
+        return time.time() - self.wall0
+
+    def check(self):
+        if self.elapsed() > self.limit_s:
+            raise TestFailure("'%s' timed out after %.0f seconds"
+                              % (self.desc, self.elapsed()))
+
+
+class Vehicle(object):
+    '''one SITL process plus its MAVLink connection'''
+
+    # per-model default parameter file inside the binary's ROMFS; the
+    # fast-swarm overrides are chained after it via --defaults
+    MODEL_DEFAULTS = {
+        "plane": "@ROMFS/models/plane.parm",
+        "+": "@ROMFS/default_params/copter.parm",
+    }
+
+    def __init__(self, name, binary, instance, sysid, model, cluster, speedup,
+                 logdir, opts):
+        self.name = name
+        self.binary = binary
+        self.instance = instance
+        self.sysid = sysid
+        self.model = model
+        self.cluster = cluster
+        self.speedup = speedup
+        self.logdir = logdir
+        self.opts = opts
+        self.proc = None
+        self.workdir = None
+        self.mav = None
+        # Drains EVERY vehicle's link, not just this one. A SITL whose
+        # socket is not read will fill its TCP send buffer and block,
+        # which freezes its simulated clock - so any wait longer than a
+        # moment must keep every link moving, not only the one it
+        # is talking to.
+        self.drain_hook = None
+
+    @property
+    def port(self):
+        return 5760 + 10 * self.instance
+
+    def start(self):
+        # Each SITL needs its OWN working directory: the parameter store is
+        # a fixed "eeprom.bin" in the cwd (HAL_STORAGE_FILE), so sharing a
+        # directory means several vehicles fighting over one file. This is why
+        # sim_vehicle.py builds per-instance directories too.
+        self.workdir = os.path.join(self.logdir, self.name)
+        os.makedirs(self.workdir)
+        defaults = self.MODEL_DEFAULTS[self.model] + "," + self.opts.fast_parm
+        if self.opts.loop_parm:
+            defaults += "," + self.opts.loop_parm
+        cfg = os.path.join(self.logdir, "%s_cfg.parm" % self.name)
+        if os.path.exists(cfg):
+            defaults += "," + cfg
+        cmd = [
+            self.binary,
+            "--instance", str(self.instance),
+            "--cluster=%d" % self.cluster,
+            "--sysid", str(self.sysid),
+            "--model", self.model,
+            "--speedup", str(self.speedup),
+            "--home", HOME,
+            "--wipe",
+            # chain the model's own defaults with the fast-swarm
+            # overrides (EKF disabled, logging off, terrain off) written
+            # by the test - measured at ~44 percent more achieved
+            # speedup, and on Windows it also removes the log_io
+            # thread's ~15k sleeps/second, each of which costs a full
+            # 1ms timer tick under Cygwin
+            "--defaults", defaults,
+        ]
+        # note: lowering the physics frame rate (--rate 400) was tried
+        # here and MEASURED SLOWER (23.9x -> 13.6x): 1:1 physics frames
+        # per vehicle-loop iteration interact badly with the sample
+        # pacing. Deliberately not used.
+        env = dict(os.environ)
+        # disable the per-task stack NaN poisoning, a SITL debug aid
+        # measured at ~4 percent of CPU (see AP_Scheduler.cpp)
+        env["SITL_DISABLE_STACK_NANF"] = "1"
+        # SITL_HARD_NONBLOCK is deliberately NOT set: measured on the
+        # Windows CI runner, the no-spin C++ smoke cluster sustains
+        # 110x of the commanded speedup while the spinning follow
+        # harness starves its own UART/IO threads so badly the config
+        # phase cannot complete a parameter round-trip - three
+        # vehicles of spin-yield threads on a small host choke the
+        # threads they exist to serve. The in-binary 1ms timer
+        # resolution fix removed the sleep-quantum penalty that spin
+        # once compensated for.
+        # runtime governor: trade physics frame rate for achieved speedup
+        # until the commanded speedup is met (measured: the curve is
+        # non-monotonic, so it must be tuned live, not statically)
+        env["SITL_ADAPTIVE_RATE"] = "1"
+        # vehicle output goes to a per-vehicle log file, NOT this
+        # console: Windows console writes are synchronous and slow, and
+        # three processes printing here measurably brakes the sim (and
+        # a QuickEdit text selection freezes all of them). The governor
+        # and speedup lines are summarised from the logs at the end.
+        self.logfile = open(os.path.join(self.logdir, "%s.log" % self.name), "wb")
+        self.proc = subprocess.Popen(cmd, cwd=self.workdir, env=env,
+                                     stdout=self.logfile,
+                                     stderr=subprocess.STDOUT)
+
+    def alive(self):
+        return self.proc is not None and self.proc.poll() is None
+
+    def connect(self, timeout=60):
+        # wall-clock: a TCP connect and the first heartbeat are not
+        # simulation-paced, and the cluster clock is not readable yet
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            try:
+                self.mav = mavutil.mavlink_connection(
+                    "tcp:127.0.0.1:%u" % self.port, source_system=250,
+                    autoreconnect=True)
+                break
+            except (OSError, IOError):
+                # Port not accepting connections yet. Both classes matter:
+                # on Python 2.7 a refused TCP connect raises socket.error,
+                # which is IOError, NOT OSError - they only became the same
+                # class in Python 3.3.
+                time.sleep(0.5)
+        if self.mav is None:
+            raise TestFailure("%s: could not connect on port %u"
+                              % (self.name, self.port))
+        if self.mav.wait_heartbeat() is None:
+            raise TestFailure("%s: no heartbeat" % self.name)
+        # every STATUSTEXT and command ACK, whoever parses the packet:
+        # when a vehicle refuses to fly it says why here and nowhere else
+        self.mav.message_hooks.append(self._msg_hook)
+        # Ask for only what this test reads, at a modest rate. These rates
+        # are in SIM Hz, so the wall-clock message rate is rate * speedup;
+        # requesting everything at 20Hz would be 2000 messages/second per
+        # vehicle if the host ever did achieve 100x.
+        self.mav.mav.request_data_stream_send(
+            self.mav.target_system, self.mav.target_component,
+            mavutil.mavlink.MAV_DATA_STREAM_ALL, 0, 0)
+        for stream, rate in (
+                (mavutil.mavlink.MAV_DATA_STREAM_POSITION, 4),
+                (mavutil.mavlink.MAV_DATA_STREAM_EXTENDED_STATUS, 2)):
+            self.mav.mav.request_data_stream_send(
+                self.mav.target_system, self.mav.target_component,
+                stream, rate, 1)
+
+    def deadline(self, timeout, desc):
+        return Deadline(timeout, "%s: %s" % (self.name, desc))
+
+    def set_param(self, name, value, timeout=60):
+        dl = self.deadline(timeout, "set %s" % name)
+        seen = None
+        while True:
+            self.mav.mav.param_set_send(
+                self.mav.target_system, self.mav.target_component,
+                name.encode("utf-8"),
+                float(value), mavutil.mavlink.MAV_PARAM_TYPE_REAL32)
+            msg = self.mav.recv_match(type="PARAM_VALUE", blocking=True,
+                                      timeout=2)
+            if msg is not None and msg.param_id == name:
+                if abs(msg.param_value - float(value)) < 1e-4:
+                    return
+                # the vehicle answered with a different value: almost always
+                # the parameter clamping an out-of-range request
+                seen = msg.param_value
+            if self.drain_hook is not None:
+                self.drain_hook()
+            try:
+                dl.check()
+            except TestFailure as e:
+                if seen is not None:
+                    raise TestFailure(
+                        "%s: %s would not take %s - vehicle reports %g "
+                        "(value out of range for this parameter?)"
+                        % (self.name, name, value, seen))
+                raise TestFailure(
+                    "%s (parameter %s may not exist on this vehicle)"
+                    % (e, name))
+
+    def set_params(self, params):
+        for name, value in params.items():
+            self.set_param(name, value)
+
+    def set_mode(self, mode, timeout=120):
+        mapping = self.mav.mode_mapping()
+        if mapping is None:
+            # only populated once a heartbeat has told us the vehicle type
+            raise TestFailure("%s: no mode mapping yet" % self.name)
+        if mode not in mapping:
+            raise TestFailure("%s: unknown mode %s" % (self.name, mode))
+        want = mapping[mode]
+        dl = self.deadline(timeout, "enter %s" % mode)
+        while True:
+            self.mav.mav.set_mode_send(
+                self.mav.target_system,
+                mavutil.mavlink.MAV_MODE_FLAG_CUSTOM_MODE_ENABLED,
+                want)
+            msg = self.mav.recv_match(type="HEARTBEAT", blocking=True, timeout=2)
+            if msg is not None and msg.custom_mode == want:
+                return
+            if self.drain_hook is not None:
+                self.drain_hook()
+            dl.check()
+
+    def wait_ready_to_arm(self, timeout=300):
+        # this is really waiting for the EKF and GPS to converge, which is
+        # paced by simulated time, so the limit must be in sim seconds
+        dl = self.deadline(timeout, "become armable")
+        while True:
+            msg = self.mav.recv_match(type="SYS_STATUS", blocking=True, timeout=5)
+            if msg is not None:
+                bit = mavutil.mavlink.MAV_SYS_STATUS_PREARM_CHECK
+                if msg.onboard_control_sensors_health & bit:
+                    return
+            if self.drain_hook is not None:
+                self.drain_hook()
+            dl.check()
+
+    def arm(self, timeout=120):
+        dl = self.deadline(timeout, "arm")
+        while True:
+            self.mav.mav.command_long_send(
+                self.mav.target_system, self.mav.target_component,
+                mavutil.mavlink.MAV_CMD_COMPONENT_ARM_DISARM, 0,
+                1, 0, 0, 0, 0, 0, 0)
+            msg = self.mav.recv_match(type="HEARTBEAT", blocking=True, timeout=2)
+            if (msg is not None and
+                    msg.base_mode & mavutil.mavlink.MAV_MODE_FLAG_SAFETY_ARMED):
+                return
+            if self.drain_hook is not None:
+                self.drain_hook()
+            dl.check()
+
+    def _msg_hook(self, _conn, msg):
+        t = msg.get_type()
+        if t == "STATUSTEXT":
+            progress("%s says: %s" % (self.name, msg.text))
+        elif t == "COMMAND_ACK":
+            progress("%s ack: cmd=%u result=%u"
+                     % (self.name, msg.command, msg.result))
+
+    def takeoff_cmd(self, alt):
+        self.mav.mav.command_long_send(
+            self.mav.target_system, self.mav.target_component,
+            mavutil.mavlink.MAV_CMD_NAV_TAKEOFF, 0,
+            0, 0, 0, 0, 0, 0, alt)
+
+    def position(self):
+        '''latest GLOBAL_POSITION_INT as (lat, lng, alt_m, rel_alt_m, hdg)'''
+        msg = self.mav.messages.get("GLOBAL_POSITION_INT", None)
+        if msg is None:
+            return None
+        return (msg.lat * 1e-7, msg.lon * 1e-7, msg.alt * 1e-3,
+                msg.relative_alt * 1e-3, msg.hdg * 1e-2)
+
+    def rel_alt(self):
+        pos = self.position()
+        return pos[3] if pos is not None else 0.0
+
+    def drain(self):
+        while True:
+            if self.mav.recv_match(blocking=False) is None:
+                return
+
+    def stop(self):
+        if self.mav is not None:
+            try:
+                self.mav.close()
+            except (OSError, IOError):    # socket.error is IOError on py2.7
+                pass
+        if self.proc is not None:
+            # Portable teardown. os.killpg + SIGKILL are POSIX-only and
+            # proc.wait(timeout=) is Python 3 only, so neither can be used
+            # here. Popen.kill() exists in Python 2.6+ and maps to
+            # TerminateProcess on Windows, and the plain wait() reaps the
+            # process afterwards. Leaving these out is what strands SITL
+            # processes and causes 'Address already in use' on the next run.
+            try:
+                if self.proc.poll() is None:
+                    self.proc.kill()
+            except OSError:
+                pass                # already gone
+            try:
+                self.proc.wait()
+            except OSError:
+                pass
+
+
+def offset_location(lat, lng, north_m, east_m):
+    '''shift a lat/lng by a north/east offset in metres'''
+    dlat = north_m / 1.113195e5
+    dlng = east_m / (1.113195e5 * math.cos(math.radians(lat)))
+    return (lat + dlat, lng + dlng)
+
+
+def formation_target(ppos, offset):
+    '''where a copter is commanded to sit, for FOLL_OFS_TYPE=1
+
+    The offset is expressed relative to the lead vehicle's heading (x
+    forward, y right), so it has to be rotated into north/east before it
+    means anything on the ground.
+    '''
+    ofs_x, ofs_y, _ = offset
+    hdg = math.radians(ppos[4])
+    north = ofs_x * math.cos(hdg) - ofs_y * math.sin(hdg)
+    east = ofs_x * math.sin(hdg) + ofs_y * math.cos(hdg)
+    return offset_location(ppos[0], ppos[1], north, east)
+
+
+def horizontal_distance(a, b):
+    '''metres between two (lat, lng, ...) tuples'''
+    dlat = a[0] - b[0]
+    dlng = (a[1] - b[1]) * math.cos(math.radians((a[0] + b[0]) * 0.5))
+    return math.sqrt(dlat ** 2 + dlng ** 2) * 1.113195e5
+
+
+class ClusterFollowTest(object):
+
+    # formation offsets in metres relative to the plane's heading: one
+    # astern, one off each wing, all below the plane (FOLL_OFS_Z is +ve down)
+    # Line astern, not line abreast. The plane holds a circular loiter, so
+    # a port slot and a starboard slot are not equivalent: one sits inside
+    # the turn and one outside, and they track very differently (measured
+    # 240m vs 100m steady-state error). Stacking both copters directly
+    # behind puts them on the same ground track as the plane, so the test
+    # measures follow accuracy rather than which side of the circle a
+    # copter was assigned to.
+    OFFSETS = {
+        "copter1": (-60.0, 0.0, 20.0),
+        "copter2": (-120.0, 0.0, 20.0),
+    }
+
+    def __init__(self, opts):
+        self.opts = opts
+        # Per-vehicle working directories only. SITL keeps its parameter
+        # store in a fixed "eeprom.bin" in the cwd, so the vehicles cannot
+        # share one. Vehicle output goes to per-vehicle log files here.
+        self.logdir = tempfile.mkdtemp(prefix="sitl_cluster_follow_", dir=".")
+        # overrides chained after each vehicle's model defaults: no EKF
+        # (SITL perfect AHRS), no dataflash logging, no terrain grid
+        opts.fast_parm = os.path.abspath(
+            os.path.join(self.logdir, "fast_swarm.parm"))
+        with open(opts.fast_parm, "w") as f:
+            # EKF3 runs in the background even with AHRS_EKF_TYPE 10
+            # selecting the SITL estimator, and default telemetry
+            # stream rates generate MAVLink per SIM second - both are
+            # dead weight the vehicles at the governor's frame-rate
+            # floor cannot afford. The bridge only needs position and
+            # status streams.
+            f.write("AHRS_EKF_TYPE 10\n"
+                    "LOG_BACKEND_TYPE 0\n"
+                    "TERRAIN_ENABLE 0\n"
+                    "EK3_ENABLE 0\n"
+                    "EK2_ENABLE 0\n"
+                    "SR0_RAW_SENS 0\n"
+                    "SR0_EXT_STAT 1\n"
+                    "SR0_RC_CHAN 0\n"
+                    "SR0_RAW_CTRL 0\n"
+                    "SR0_POSITION 1\n"
+                    "SR0_EXTRA1 0\n"
+                    "SR0_EXTRA2 0\n"
+                    "SR0_EXTRA3 0\n"
+                    "SR0_ADSB 0\n"
+                    "SIM_FLOAT_EXCEPT 0\n"
+                    "ARMING_CHECK 0\n"
+                    # the simulated board heats over minutes of SIM time and
+                    # drifts the baro; racing sim time puts the whole warmup
+                    # between baro cal and arming, so a grounded copter reads
+                    # metres of altitude, believes it is airborne, and
+                    # refuses its guided takeoff. No thermal drift.
+                    "SIM_TEMP_BFACTOR 0\n"
+                    "SIM_TEMP_TCONST 1\n"
+                    # the battery model's internal resistance grows with
+                    # temperature; racing sim time cooks it in wall-seconds
+                    # and sag collapses thrust to 1g at 100% throttle -
+                    # copters hung mid-air unable to climb. No sag, ever.
+                    "SIM_BATT_RES_OHM 0\n")
+        # Only when chasing real speedup (> 5): run every vehicle's
+        # flight-controller loop at 200Hz. Scheduler iterations are the
+        # measured scaling axis for per-sim-second cost, and the loop
+        # rate also sets the adaptive governor's physics-rate floor
+        # (3x the loop rate): at ArduPlane's default 300Hz loop the
+        # plane floors at 900 physics frames while the 200Hz copters
+        # sit at 600, making the plane the most expensive cluster
+        # member for nothing the swarm test measures. 200Hz for a plane
+        # is repo-precedented (glider.parm). Sub-5x runs are untouched.
+        opts.loop_parm = ""
+        if opts.speedup > 5:
+            opts.loop_parm = os.path.abspath(
+                os.path.join(self.logdir, "swarm_200hz.parm"))
+            with open(opts.loop_parm, "w") as f:
+                f.write(
+                    # loop budget matches the actual stretched step
+                    # (~10ms): at 200Hz the scheduler saw every
+                    # 5ms-budget loop consume 11ms of sim time and
+                    # permanently shed its table tasks - the plane's
+                    # servo output froze (20km open-loop climb) and
+                    # the copters' takeoff machinery ran starved
+                    "SCHED_LOOP_RATE 100\n")
+        with open(os.path.join(self.logdir, "plane_cfg.parm"), "w") as f:
+            f.write("AIRSPEED_CRUISE 12\n"
+                    "AIRSPEED_MIN 9\n"
+                    "AIRSPEED_MAX 16\n"
+                    "WP_LOITER_RAD 250\n"
+                    "TKOFF_ALT 100\n")
+        for cname, ofs in self.OFFSETS.items():
+            with open(os.path.join(self.logdir,
+                                   "%s_cfg.parm" % cname), "w") as f:
+                f.write("DISARM_DELAY 0\n"
+                        "FS_CRASH_CHECK 0\n"
+                        "SRTL_POINTS 0\n"
+                        "FOLL_ENABLE 1\n"
+                        "FOLL_SYSID 1\n"
+                        "FOLL_OFS_TYPE 1\n"
+                        "FOLL_OFS_X %.1f\n"
+                        "FOLL_OFS_Y %.1f\n"
+                        "FOLL_OFS_Z %.1f\n"
+                        "FOLL_ALT_TYPE 0\n"
+                        "FOLL_DIST_MAX 1000\n"
+                        "FOLL_TIMEOUT %.0f\n"
+                        "FOLL_YAW_BEHAVE 1\n"
+                        "WP_SPD 20\n"
+                        "WP_SPD_UP 5\n"
+                        "WP_SPD_DN 5\n"
+                        "WP_ACC 5\n"
+                        % (ofs[0], ofs[1], ofs[2], FOLL_TIMEOUT_S))
+        self.plane = Vehicle("plane", opts.plane_binary, 0, 1, "plane",
+                             opts.cluster, opts.speedup, self.logdir, opts)
+        self.copters = [
+            Vehicle("copter%u" % i, opts.copter_binary, i, i + 1, "+",
+                    opts.cluster, opts.speedup, self.logdir, opts)
+            for i in (1, 2)
+        ]
+        self.vehicles = [self.plane] + self.copters
+        self.phase = "init"
+        self.t0 = time.time()
+        self.last_report_wall = 0.0
+        self.last_temp_wall = 0.0
+        # worst sim-time gap between consecutive DISTINCT plane positions
+        # actually bridged to the copters, measured on the plane's own
+        # clock; large values mean FOLLOW chased a stale target
+        self.last_bridge_boot_ms = None
+        self.max_bridge_gap_sim_s = 0.0
+        self.last_speed_sample = None
+        # (wall_s, sim_ms) pairs for the end-of-run speedup verdict
+        self.speed_samples = []
+
+    def drain_all(self):
+        '''read every link, so no vehicle blocks on a full send buffer'''
+        for v in self.vehicles:
+            if v.mav is not None:
+                v.drain()
+
+    def pump(self, until, timeout, desc, bridge=True):
+        '''run the bridge and telemetry until until() returns True'''
+        self.phase = desc
+        dl = Deadline(timeout, desc)
+
+        while True:
+            for v in self.vehicles:
+                if not v.alive():
+                    raise TestFailure("%s exited during '%s'" % (v.name, desc))
+                v.drain()
+
+            if bridge:
+                self.bridge()
+            self.report()
+
+            if until():
+                return dl.elapsed()
+
+            dl.check()
+            time.sleep(self.opts.loop_dt)
+
+    def bridge(self):
+        '''forward the plane's position onto each copter's link'''
+        pmsg = self.plane.mav.messages.get("GLOBAL_POSITION_INT", None)
+        if pmsg is None:
+            return
+        if (self.last_bridge_boot_ms is not None and
+                pmsg.time_boot_ms > self.last_bridge_boot_ms):
+            gap = (pmsg.time_boot_ms - self.last_bridge_boot_ms) / 1000.0
+            self.max_bridge_gap_sim_s = max(self.max_bridge_gap_sim_s, gap)
+        self.last_bridge_boot_ms = pmsg.time_boot_ms
+        for c in self.copters:
+            # preserve the plane's sysid in the header - that is what
+            # AP_Follow matches against FOLL_SYSID
+            c.mav.mav.srcSystem = self.plane.sysid
+            c.mav.mav.global_position_int_send(
+                pmsg.time_boot_ms, pmsg.lat, pmsg.lon, pmsg.alt,
+                pmsg.relative_alt, pmsg.vx, pmsg.vy, pmsg.vz, pmsg.hdg)
+            c.mav.mav.srcSystem = 250
+
+    def report(self):
+        wall_s = time.time()
+        if wall_s - self.last_report_wall < self.opts.report_interval:
+            return
+        self.last_report_wall = wall_s
+        # live achieved speedup from the plane's own clock: time_boot_ms
+        # is simulation-paced, the report interval is wall-paced, so
+        # their ratio is the speedup actually achieved right now
+        speed = ""
+        pmsg = self.plane.mav.messages.get("GLOBAL_POSITION_INT", None)
+        if pmsg is not None:
+            sim_ms = pmsg.time_boot_ms
+            if self.last_speed_sample is not None:
+                prev_sim_ms, prev_wall = self.last_speed_sample
+                d_wall = wall_s - prev_wall
+                if d_wall > 0 and sim_ms > prev_sim_ms:
+                    speed = " speedup=%.1fx" % (
+                        (sim_ms - prev_sim_ms) / 1000.0 / d_wall)
+            self.last_speed_sample = (sim_ms, wall_s)
+            self.speed_samples.append((wall_s, sim_ms))
+        dists = ""
+        ppos = self.plane.position()
+        if ppos is not None:
+            parts = []
+            for c in self.copters:
+                cpos = c.position()
+                if cpos is None:
+                    parts.append("%s=?" % c.name)
+                    continue
+                want = formation_target(ppos, self.OFFSETS[c.name])
+                parts.append("%s err=%.0fm" % (
+                    c.name, horizontal_distance(want, cpos)))
+            dists = " " + " ".join(parts)
+        progress("[%s] t=%.0fs%s%s" % (self.phase, wall_s - self.t0, speed, dists))
+
+    def run(self):
+        # Connect to each vehicle the moment it is launched. SITL's SERIAL0
+        # defaults to "tcp:0:wait", which blocks the physics loop until a
+        # client attaches, so a vehicle that is started but not yet connected
+        # is not simulating at all - it just sits at "Waiting for connection".
+        # connect() retries until the port is listening, so no fixed sleep is
+        # needed here.
+        for v in self.vehicles:
+            progress("starting %s (instance %u, sysid %u) at %ux speedup"
+                     % (v.name, v.instance, v.sysid, v.speedup))
+            v.start()
+            v.connect()
+            progress("%s connected on port %u" % (v.name, v.port))
+
+        # Whether they clustered is AP_SITL_SharedMem's business, not
+        # Python's: the vehicles print "joined cluster" and "in lock-step
+        # with N instances" to this console themselves.
+        for v in self.vehicles:
+            v.drain_hook = self.drain_all
+
+        # mission parameters were baked into per-vehicle defaults files
+        # at spawn - no MAVLink configuration phase
+
+        for v in self.vehicles:
+            progress("%s waiting for armable state" % v.name)
+            v.wait_ready_to_arm()
+
+        # get the plane airborne and circling first, so the copters have a
+        # real moving target to acquire
+        progress("launching plane")
+        self.plane.set_mode("TAKEOFF")
+        self.plane.arm()
+        self.pump(lambda: self.plane.rel_alt() > 80,
+                  timeout=300, desc="plane-takeoff", bridge=False)
+        progress("plane airborne at %.0fm, switching to LOITER"
+                 % self.plane.rel_alt())
+        self.plane.set_mode("LOITER")
+
+        progress("launching copters")
+        for c in self.copters:
+            c.set_mode("GUIDED")
+            c.arm()
+            c.takeoff_cmd(60)
+
+        # a single NAV_TAKEOFF can be lost or refused on a raced link
+        # (seen on the Cygwin CI runner: both copters verified armed in
+        # GUIDED yet sat on the ground for the entire phase). Re-send
+        # every few wall seconds until each copter is demonstrably
+        # climbing.
+        def takeoff_watch():
+            now = time.time()
+            for c in self.copters:
+                if (c.rel_alt() < 2.0 and
+                        now - getattr(c, "last_takeoff_resend", 0) > 5.0):
+                    c.last_takeoff_resend = now
+                    c.takeoff_cmd(60)
+            return all(c.rel_alt() > 50 for c in self.copters)
+
+        self.pump(takeoff_watch, timeout=300, desc="copter-takeoff")
+        progress("copters airborne at %s"
+                 % ["%.0fm" % c.rel_alt() for c in self.copters])
+
+        for c in self.copters:
+            c.set_mode("FOLLOW")
+        progress("all copters in FOLLOW, tracking for %.0f seconds"
+                 % self.opts.follow_time)
+
+        # Formation error - how far each copter is from the position it is
+        # actually commanded to hold - is the honest measure. Distance to
+        # the plane is not: the plane orbits at WP_LOITER_RAD, so a copter
+        # that never moved would still be "near" it for much of each lap.
+        closest = {c.name: None for c in self.copters}
+        # Longest CONTINUOUS period inside the formation tolerance, not the
+        # total. A copter that never took off would still accumulate plenty
+        # of total time "in tolerance" as the plane's circular loiter swept
+        # past it once a lap; it could not stay in tolerance continuously.
+        holding = {c.name: 0.0 for c in self.copters}
+        settled = {c.name: 0.0 for c in self.copters}
+        last = {"t": None}
+
+        def track():
+            t = time.time()
+            dt = 0.0 if last["t"] is None else t - last["t"]
+            last["t"] = t
+            ppos = self.plane.position()
+            if ppos is None:
+                return False
+            for c in self.copters:
+                cpos = c.position()
+                if cpos is None:
+                    continue
+                want = formation_target(ppos, self.OFFSETS[c.name])
+                err = horizontal_distance(want, cpos)
+                if closest[c.name] is None or err < closest[c.name]:
+                    closest[c.name] = err
+                if err < self.opts.hold_distance:
+                    holding[c.name] += dt
+                    settled[c.name] = max(settled[c.name], holding[c.name])
+                else:
+                    holding[c.name] = 0.0
+            return False        # never satisfied: run for the full duration
+
+        try:
+            self.pump(track, timeout=self.opts.follow_time, desc="follow")
+        except TestFailure as e:
+            if "timed out after" not in str(e):
+                raise           # a real failure, not the intended duration
+
+        # surface each vehicle's governor decisions and its own achieved
+        # speedup from the log files (vehicle output no longer reaches
+        # this console)
+        for v in self.vehicles:
+            try:
+                f = open(os.path.join(self.logdir, "%s.log" % v.name), "rb")
+                lines = [ln.decode("utf-8", "replace").strip()
+                         for ln in f if b"adaptive rate" in ln or b"achieved" in ln]
+                f.close()
+            except (OSError, IOError):
+                lines = []
+            gov = [ln for ln in lines if "adaptive rate" in ln]
+            ach = [ln for ln in lines if "adaptive rate" not in ln]
+            for ln in gov[-2:]:
+                progress("%s governor: %s" % (v.name, ln))
+            for ln in ach[-3:]:
+                progress("%s: %s" % (v.name, ln))
+
+        progress("worst gap between position updates: "
+                 "%.2f sim-seconds (FOLL_TIMEOUT is 30s)"
+                 % self.max_bridge_gap_sim_s)
+        for c in self.copters:
+            progress("%s: best formation error %s, held station %.0f seconds unbroken"
+                     % (c.name,
+                        "%.0fm" % closest[c.name] if closest[c.name] else "never",
+                        settled[c.name]))
+        for c in self.copters:
+            if closest[c.name] is None or closest[c.name] > self.opts.hold_distance:
+                raise TestFailure(
+                    "%s never reached its formation slot within %.0fm "
+                    "(best error %s)"
+                    % (c.name, self.opts.hold_distance,
+                       "%.0fm" % closest[c.name] if closest[c.name] else "never"))
+            if settled[c.name] < self.opts.min_hold_time:
+                raise TestFailure(
+                    "%s only held formation for %.0f seconds unbroken, "
+                    "wanted %.0f"
+                    % (c.name, settled[c.name], self.opts.min_hold_time))
+
+        # steady-state speedup over the back half of the follow phase,
+        # and the hard verdict: any shortfall from the commanded
+        # speedup is a failure - the adaptive governor is required to
+        # slow the physics until the commanded speedup is reached
+        steady = None
+        if len(self.speed_samples) >= 4:
+            last_wall, last_sim = self.speed_samples[-1]
+            cutoff = last_wall - self.opts.follow_time / 2.0
+            back = [p for p in self.speed_samples if p[0] >= cutoff]
+            if len(back) >= 2 and back[-1][0] > back[0][0]:
+                steady = ((back[-1][1] - back[0][1]) / 1000.0
+                          / (back[-1][0] - back[0][0]))
+                progress("steady-state speedup (back half of follow): "
+                         "%.1fx" % steady)
+        if steady is not None and steady < self.opts.speedup:
+            raise TestFailure(
+                "achieved steady-state speedup %.1fx is below the "
+                "commanded %ux" % (steady, self.opts.speedup))
+
+        progress("PASS: %u copters followed the plane in cluster %u"
+                 % (len(self.copters), self.opts.cluster))
+
+    def cleanup(self):
+        for v in self.vehicles:
+            v.stop()
+
+
+class Settings(object):
+    """all knobs live here - edit the values, there are no command-line
+    arguments"""
+
+    copter_binary = "./ArduCopter.elf.exe"
+    plane_binary = "./ArduPlane.elf.exe"
+
+    cluster = 91            # cluster id the vehicles join
+    # requested SITL speedup for every vehicle. CI overrides via the
+    # CLUSTER_SPEEDUP environment (the Windows runners sustain ~55-65x,
+    # so their smoke commands 50x and the achieved-vs-commanded gate
+    # stays strict; the Linux CI commands and delivers 100x)
+    speedup = float(os.environ.get("CLUSTER_SPEEDUP", "100"))
+
+    # bridge/telemetry loop period, WALL seconds. speedup * loop_dt is the
+    # sim-time gap between position updates the copters see, and must stay
+    # well under FOLL_TIMEOUT_S or the copters drop the plane.
+    loop_dt = 0.01
+
+    # seconds to hold formation for. The default suits a quick local
+    # run; CI sets CLUSTER_FOLLOW_TIME so the adaptive governor's full
+    # descent (2-3 minutes) fits inside the measured window.
+    # sized so the WHOLE run (boot, arm, takeoff, follow, verdict)
+    # fits under 60 wall seconds
+    follow_time = float(os.environ.get("CLUSTER_FOLLOW_TIME", "25"))
+    report_interval = 2.0   # seconds between progress lines
+
+    # metres of formation error that still counts as holding station.
+    # Wider than the Linux harness's 250m: this smoke gates the cluster
+    # MECHANISM under Cygwin (lock-step, FOLLOW engaging, vehicles
+    # flying), while formation precision is gated by the Linux CI. The
+    # harness position bridge adds ~100m of target staleness at high
+    # speedup on the slower Windows runners (see the worst-gap line in
+    # the verdict), which 250m sliced straight through.
+    hold_distance = 400.0
+    # seconds each copter must hold formation for WITHOUT a break,
+    # clamped under follow_time (CI shortens the window via
+    # CLUSTER_FOLLOW_TIME, and a hold requirement longer than the
+    # window is impossible to satisfy)
+    min_hold_time = min(30.0, follow_time * 0.8)
+
+
+def main():
+    opts = Settings()
+
+    # resolve now: each SITL is spawned with cwd set to its log directory,
+    # so a relative binary path would be looked up in the wrong place
+    opts.copter_binary = os.path.abspath(opts.copter_binary)
+    opts.plane_binary = os.path.abspath(opts.plane_binary)
+    for path in (opts.copter_binary, opts.plane_binary):
+        if not os.path.exists(path):
+            print("FAIL: missing binary %s - run this script from the "
+                  "directory holding the SITL binaries" % path)
+            return 1
+
+    power_previous = set_windows_power_performance()
+    disable_power_throttling([opts.copter_binary, opts.plane_binary])
+
+    test = ClusterFollowTest(opts)
+    try:
+        test.run()
+        return 0
+    except TestFailure as e:
+        progress("FAIL: %s" % e)
+        return 1
+    except KeyboardInterrupt:
+        progress("interrupted")
+        return 1
+    finally:
+        test.cleanup()
+        restore_windows_power(power_previous)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Tools/scripts/cygwin_cluster_smoke.sh
+++ b/Tools/scripts/cygwin_cluster_smoke.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Run a SITL shared-memory cluster on the Cygwin/Windows CI runner and
+# report the speedup it actually achieves.
+#
+# Three copters join one cluster at a commanded 100x speedup with the
+# adaptive physics-rate governor on (SITL_ADAPTIVE_RATE), sit on the
+# ground unarmed for a fixed wall-clock window, and are then checked
+# for (a) cluster lock-step actually engaging, (b) the governor making
+# at least one rate decision, and (c) a reported achieved speedup. The
+# achieved figure is printed rather than asserted on: a shared 2-4 core
+# runner cannot promise any particular number, but the log makes the
+# Windows build's real capability visible in every CI run.
+#
+# Pure C++ + stdlib: the vehicles do all clustering themselves; python
+# (any version, no pymavlink) only opens each vehicle's SERIAL0 TCP
+# port and drains it so the vehicles never block on telemetry.
+
+set -e
+
+# Run the binary straight out of build/sitl/bin, NOT the artifacts
+# copy: artifacts/ bundles its own cyg*.dll set for standalone use, and
+# Windows resolves DLLs from the exe's directory first, so launching
+# that copy from inside the workflow's installed Cygwin loads a second,
+# potentially mismatched cygwin1.dll - a classic silent startup death.
+# The build-tree binary has no DLLs beside it and uses the running
+# Cygwin's own runtime. Also the natural path for exercising this
+# script on Linux.
+COPTER=${CLUSTER_SMOKE_COPTER:-build/sitl/bin/arducopter}
+RUN_SECONDS=${CLUSTER_SMOKE_RUN_SECONDS:-40}
+CLUSTER_ID=77
+NVEHICLES=3
+
+if [ ! -x "$COPTER" ]; then
+    echo "cluster-smoke: no executable at $COPTER" >&2
+    exit 1
+fi
+COPTER=$(cd "$(dirname "$COPTER")" && pwd)/$(basename "$COPTER")
+
+WORK=$(mktemp -d)
+trap 'kill $(jobs -p) 2>/dev/null || true; wait 2>/dev/null || true; rm -rf "$WORK"' EXIT
+
+# swarm-throughput parms, matching Tools/autotest/test_cluster_follow.py
+printf 'AHRS_EKF_TYPE 10\nLOG_BACKEND_TYPE 0\nTERRAIN_ENABLE 0\nSCHED_LOOP_RATE 200\nEK3_ENABLE 0\nEK2_ENABLE 0\nSR0_RAW_SENS 0\nSR0_EXT_STAT 1\nSR0_RC_CHAN 0\nSR0_RAW_CTRL 0\nSR0_POSITION 1\nSR0_EXTRA1 0\nSR0_EXTRA2 0\nSR0_EXTRA3 0\nSR0_ADSB 0\nSIM_FLOAT_EXCEPT 0\nSIM_TEMP_BFACTOR 0\nSIM_TEMP_TCONST 1\nSIM_BATT_RES_OHM 0\nSRTL_POINTS 0\n' \
+    > "$WORK/fast.parm"
+
+export SITL_ADAPTIVE_RATE=1
+export SITL_DISABLE_STACK_NANF=1
+# SITL_HARD_NONBLOCK is deliberately NOT set here: it makes worker
+# threads spin-yield instead of sleeping, which helps on a machine with
+# cores to spare but strangles a 4-vCPU shared runner - three vehicles
+# of spinning threads starve the physics threads they exist to serve
+
+for i in $(seq 0 $((NVEHICLES-1))); do
+    mkdir -p "$WORK/v$i"
+    (cd "$WORK/v$i" && \
+        exec "$COPTER" \
+            --instance "$i" \
+            --cluster $CLUSTER_ID \
+            --model + \
+            --speedup 100 \
+            --wipe \
+            --serial0 tcp:0 \
+            --home -35.363261,149.165230,584,353 \
+            --defaults "@ROMFS/default_params/copter.parm,$WORK/fast.parm" \
+            > "$WORK/v$i.log" 2>&1) &
+done
+
+sleep 5
+
+dump_logs() {
+    echo "=== cluster-smoke: diagnostic dump ==="
+    uname -a || true
+    nproc || true
+    netstat -an 2>/dev/null | grep -E "576[0-9]|577[0-9]|578[0-9]" || true
+    for i in $(seq 0 $((NVEHICLES-1))); do
+        echo "--- vehicle $i log"
+        tail -60 "$WORK/v$i.log" 2>/dev/null || echo "(no log)"
+    done
+}
+
+# drain every vehicle's SERIAL0 so nothing blocks on an unread
+# outqueue; the first connect is given a long grace period because
+# Windows Defender scans a freshly built unsigned exe on first launch
+if ! python3 - "$RUN_SECONDS" $NVEHICLES <<'PY'
+import socket
+import sys
+import time
+
+run_seconds = float(sys.argv[1])
+count = int(sys.argv[2])
+socks = []
+deadline = time.time() + run_seconds
+for i in range(count):
+    port = 5760 + 10 * i
+    for _ in range(60):
+        try:
+            s = socket.create_connection(("127.0.0.1", port), timeout=5)
+            s.setblocking(False)
+            socks.append(s)
+            print("cluster-smoke: connected to instance on port %u" % port)
+            break
+        except OSError:
+            time.sleep(1)
+    else:
+        print("cluster-smoke: could not connect to port %u" % port)
+        sys.exit(1)
+while time.time() < deadline:
+    time.sleep(0.2)
+    for s in socks:
+        try:
+            while s.recv(65536):
+                pass
+        except OSError:
+            pass
+PY
+then
+    dump_logs
+    exit 1
+fi
+
+kill $(jobs -p) 2>/dev/null || true
+wait 2>/dev/null || true
+
+echo "=== cluster-smoke: per-vehicle results ==="
+FAIL=0
+for i in $(seq 0 $((NVEHICLES-1))); do
+    LOG="$WORK/v$i.log"
+    # each vehicle must reach lock-step; the membership count it last
+    # printed depends on join order (an early joiner may never re-print
+    # after the final member arrives), so the full count is asserted
+    # cluster-wide below rather than per vehicle
+    if ! grep -q "in lock-step with" "$LOG"; then
+        echo "vehicle $i: FAIL - never reached lock-step"
+        FAIL=1
+    fi
+    if ! grep -q "adaptive rate" "$LOG"; then
+        echo "vehicle $i: FAIL - governor made no rate decision"
+        FAIL=1
+    fi
+    grep "adaptive rate" "$LOG" | tail -2 | sed "s/^/vehicle $i governor: /"
+    grep "achieved" "$LOG" | grep -v "adaptive rate" | tail -3 | sed "s/^/vehicle $i: /"
+done
+if [ "$FAIL" != 0 ]; then
+    dump_logs
+    exit 1
+fi
+if ! grep -q "in lock-step with $NVEHICLES instances" "$WORK"/v*.log; then
+    echo "cluster-smoke: FAIL - no vehicle ever saw all $NVEHICLES members"
+    dump_logs
+    exit 1
+fi
+echo "=== cluster-smoke: PASS - $NVEHICLES vehicles in lock-step, governor active ==="

--- a/Tools/scripts/test_sitl_multi_instance.sh
+++ b/Tools/scripts/test_sitl_multi_instance.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Launch several SITL instances into one cluster and confirm they reach
+# shared-memory lock-step - not merely that the processes stay alive.
+# AP_FLAKE8_CLEAN (N/A - shell script)
+set -u
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BINARY="${1:-${ROOT}/build/sitl/bin/arducopter}"
+COUNT="${SITL_TEST_COUNT:-5}"
+RUNTIME="${SITL_TEST_RUNTIME:-20}"
+
+# Use a cluster id derived from our pid so a leftover segment from an
+# earlier fleet, or a developer's own SITL session, cannot affect the
+# result. Cluster ids are 0-255.
+CLUSTER=$(( ($$ % 200) + 50 ))
+
+if [ ! -x "${BINARY}" ]; then
+    echo "FAIL: no SITL binary at ${BINARY} (./waf configure --board sitl && ./waf copter)"
+    exit 1
+fi
+
+# name must match the /tmp/sitl_multi_* glob the CI workflow archives
+LOGDIR="$(mktemp -d /tmp/sitl_multi_XXXXXX)"
+
+PIDS=()
+CLIENTS=()
+cleanup() {
+    kill ${PIDS[@]+"${PIDS[@]}"} ${CLIENTS[@]+"${CLIENTS[@]}"} 2>/dev/null
+    wait 2>/dev/null
+    rm -rf "${LOGDIR}"
+}
+trap cleanup EXIT
+
+last=$((COUNT - 1))
+for i in $(seq 0 "${last}"); do
+    "${BINARY}" --instance "${i}" --cluster="${CLUSTER}" --speedup 100 --wipe \
+        --home "-35.363261,149.165230,584,353" --model "+" \
+        > "${LOGDIR}/inst${i}.log" 2>&1 &
+    PIDS+=($!)
+done
+
+# SITL blocks on "Waiting for connection" until something attaches to
+# SERIAL0, and the physics loop (which drives the barrier) never runs
+# until then - so give every instance a client that stays connected and
+# drains what it sends.
+sleep 3
+python3 -c '
+import socket, sys, select
+socks = []
+for i in range(int(sys.argv[1])):
+    s = socket.create_connection(("127.0.0.1", 5760 + 10 * i), timeout=10)
+    s.setblocking(False)
+    socks.append(s)
+while True:
+    r, _, _ = select.select(socks, [], [], 1.0)
+    for s in r:
+        try:
+            s.recv(65536)
+        except OSError:
+            pass
+' "${COUNT}" &
+CLIENTS+=($!)
+
+sleep "${RUNTIME}"
+
+rc=0
+for i in $(seq 0 "${last}"); do
+    log="${LOGDIR}/inst${i}.log"
+    if ! kill -0 "${PIDS[$i]}" 2>/dev/null; then
+        echo "FAIL: instance ${i} exited early"
+        rc=1
+        continue
+    fi
+    if ! grep -q "in lock-step with" "${log}"; then
+        echo "FAIL: instance ${i} never reached lock-step"
+        grep "SharedMem" "${log}" | tail -5 | sed 's/^/    /'
+        rc=1
+    fi
+    for bad in "bad magic" "sync timeout" "never initialised" "unusable" \
+               "lock failed" "consistent failed"; do
+        if grep -q "${bad}" "${log}"; then
+            echo "FAIL: instance ${i} reported '${bad}'"
+            grep "${bad}" "${log}" | tail -3 | sed 's/^/    /'
+            rc=1
+        fi
+    done
+done
+
+# a single instance must NOT wait for anyone: --cluster on its own has no
+# peers, and without --cluster the shared memory is never touched at all.
+solo_log="${LOGDIR}/solo.log"
+"${BINARY}" --instance 0 --speedup 100 --wipe \
+    --home "-35.363261,149.165230,584,353" --model "+" > "${solo_log}" 2>&1 &
+solo_pid=$!
+sleep 3
+kill "${solo_pid}" 2>/dev/null
+if grep -q "SharedMem" "${solo_log}"; then
+    echo "FAIL: run without --cluster touched shared memory"
+    grep "SharedMem" "${solo_log}" | head -3 | sed 's/^/    /'
+    rc=1
+fi
+
+if [ "${rc}" -eq 0 ]; then
+    echo "PASS: ${COUNT} instances in lock-step in cluster ${CLUSTER}"
+else
+    echo "logs kept in ${LOGDIR}"
+    trap - EXIT
+    kill ${PIDS[@]+"${PIDS[@]}"} ${CLIENTS[@]+"${CLIENTS[@]}"} 2>/dev/null
+fi
+exit "${rc}"

--- a/libraries/AP_HAL_SITL/HAL_SITL_Class.h
+++ b/libraries/AP_HAL_SITL/HAL_SITL_Class.h
@@ -48,7 +48,7 @@ public:
 
     uint32_t get_uart_output_full_queue_count() const;
 
-    HALSITL::SITL_State * get_sitl_state() { return _sitl_state; }
+    HALSITL::SITL_State * get_sitl_state() const { return _sitl_state; }
 
 private:
     HALSITL::SITL_State *_sitl_state;

--- a/libraries/AP_HAL_SITL/SITL_SharedMem.cpp
+++ b/libraries/AP_HAL_SITL/SITL_SharedMem.cpp
@@ -704,20 +704,20 @@ uint8_t AP_SITL_SharedMem::get_instance_count() const
   mutex. EOWNERDEAD (a prior crashed run reusing this slot) is marked
   consistent and we proceed, since we are the sole writer for our slot.
 */
-void AP_SITL_SharedMem::write_payload(const void *data, uint32_t len)
+void AP_SITL_SharedMem::write_payload(const void *data, uint32_t len, uint32_t offset)
 {
-    if (_data == nullptr) {
+    if (_data == nullptr || offset >= AP_SITL_SHMEM_PAYLOAD_SIZE) {
         return;
     }
-    if (len > AP_SITL_SHMEM_PAYLOAD_SIZE) {
-        len = AP_SITL_SHMEM_PAYLOAD_SIZE;
+    if (len > AP_SITL_SHMEM_PAYLOAD_SIZE - offset) {
+        len = AP_SITL_SHMEM_PAYLOAD_SIZE - offset;
     }
     auto &slot = _data->instance[_instance_id];
 
 #ifdef __CYGWIN__
     // no cross-process lock exists on this platform - see
     // _init_segment_contents(); the copy is unguarded
-    memcpy(slot.payload, data, len);
+    memcpy(&slot.payload[offset], data, len);
 #else
     int ret = pthread_mutex_lock(&slot.payload_mutex);
 #if AP_SITL_SHMEM_ROBUST_MUTEX
@@ -736,7 +736,7 @@ void AP_SITL_SharedMem::write_payload(const void *data, uint32_t len)
         return;
     }
 
-    memcpy(slot.payload, data, len);
+    memcpy(&slot.payload[offset], data, len);
 
     pthread_mutex_unlock(&slot.payload_mutex);
 #endif  // __CYGWIN__
@@ -747,20 +747,21 @@ void AP_SITL_SharedMem::write_payload(const void *data, uint32_t len)
   mutex. EOWNERDEAD means the peer died mid-write; mark it consistent
   but treat the data as unreliable and return false.
 */
-bool AP_SITL_SharedMem::read_payload(uint8_t instance_id, void *data, uint32_t len) const
+bool AP_SITL_SharedMem::read_payload(uint8_t instance_id, void *data, uint32_t len, uint32_t offset) const
 {
-    if (_data == nullptr || instance_id >= AP_SITL_SHMEM_MAX_INSTANCES) {
+    if (_data == nullptr || instance_id >= AP_SITL_SHMEM_MAX_INSTANCES ||
+        offset >= AP_SITL_SHMEM_PAYLOAD_SIZE) {
         return false;
     }
-    if (len > AP_SITL_SHMEM_PAYLOAD_SIZE) {
-        len = AP_SITL_SHMEM_PAYLOAD_SIZE;
+    if (len > AP_SITL_SHMEM_PAYLOAD_SIZE - offset) {
+        len = AP_SITL_SHMEM_PAYLOAD_SIZE - offset;
     }
     auto &slot = _data->instance[instance_id];
 
 #ifdef __CYGWIN__
     // no cross-process lock exists on this platform - see
     // _init_segment_contents(); the copy is unguarded
-    memcpy(data, slot.payload, len);
+    memcpy(data, &slot.payload[offset], len);
     return true;
 #else
     int ret = pthread_mutex_lock(&slot.payload_mutex);
@@ -782,7 +783,7 @@ bool AP_SITL_SharedMem::read_payload(uint8_t instance_id, void *data, uint32_t l
     }
 
     if (!owner_died) {
-        memcpy(data, slot.payload, len);
+        memcpy(data, &slot.payload[offset], len);
     }
 
     pthread_mutex_unlock(&slot.payload_mutex);

--- a/libraries/AP_HAL_SITL/SITL_SharedMem.cpp
+++ b/libraries/AP_HAL_SITL/SITL_SharedMem.cpp
@@ -1,0 +1,1109 @@
+#include <AP_HAL/AP_HAL.h>
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+
+#include "SITL_SharedMem.h"
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <signal.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+
+#ifdef __CYGWIN__
+// Win32 API for the native shared-memory path - see _open_segment().
+// Included after everything else, and lean, so its macro spill cannot
+// reach the ArduPilot headers above.
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#endif
+
+AP_SITL_SharedMem::AP_SITL_SharedMem() :
+    _data(nullptr),
+    _fd(-1),
+    _instance_id(0),
+    _cluster_id(0),
+    _created(false),
+    _sync_announced(false)
+{
+    _name[0] = 0;
+
+    memset(_peer_seen_time_us, 0, sizeof(_peer_seen_time_us));
+    memset(_peer_seen_wall_us, 0, sizeof(_peer_seen_wall_us));
+    memset(_peer_stalled, 0, sizeof(_peer_stalled));
+    memset(_peer_resume_announced, 0, sizeof(_peer_resume_announced));
+    memset(_peer_joined_announced, 0, sizeof(_peer_joined_announced));
+    memset(_peer_checked_wall_us, 0, sizeof(_peer_checked_wall_us));
+    memset(_peer_cooldown_until_us, 0, sizeof(_peer_cooldown_until_us));
+    _catchup_started_wall_us = 0;
+    _catchup_gave_up = false;
+
+    _process_start_wall_us = _now_us();
+    _instant_catchup_done = false;
+
+#ifdef __CYGWIN__
+    _win_map_handle = nullptr;
+#endif
+}
+
+AP_SITL_SharedMem::~AP_SITL_SharedMem()
+{
+    _cleanup();
+}
+
+uint64_t AP_SITL_SharedMem::_now_us()
+{
+    struct timeval tv;
+    gettimeofday(&tv, nullptr);
+    return (uint64_t)tv.tv_sec * 1000000ULL + (uint64_t)tv.tv_usec;
+}
+
+/*
+  the clock word is written by one process and read by all the others, so
+  a plain 64-bit access can be seen half-updated on a 32-bit build.
+*/
+uint64_t AP_SITL_SharedMem::_load_time(const uint64_t &v)
+{
+#if AP_SITL_SHMEM_ATOMIC64
+    return __atomic_load_n(&v, __ATOMIC_RELAXED);
+#else
+    return v;
+#endif
+}
+
+void AP_SITL_SharedMem::_store_time(uint64_t &v, uint64_t t)
+{
+#if AP_SITL_SHMEM_ATOMIC64
+    __atomic_store_n(&v, t, __ATOMIC_RELAXED);
+#else
+    v = t;
+#endif
+}
+
+// highest sim_time_us reported by any live peer in the cluster
+uint64_t AP_SITL_SharedMem::_max_peer_time() const
+{
+    uint64_t max_peer_time = 0;
+    for (uint8_t i = 0; i < AP_SITL_SHMEM_MAX_INSTANCES; i++) {
+        if (i == _instance_id) {
+            continue;
+        }
+        const pid_t pid = _data->instance[i].pid;
+        if (pid <= 0 || kill(pid, 0) != 0) {
+            continue;
+        }
+        const uint64_t peer_time = _load_time(_data->instance[i].sim_time_us);
+        if (peer_time > max_peer_time) {
+            max_peer_time = peer_time;
+        }
+    }
+    return max_peer_time;
+}
+
+/*
+  build the segment name.
+
+  A single fixed name would mean every SITL run by every user on the host
+  shared one object: unrelated sessions claiming each other's slots, and a
+  segment left behind by a killed swarm confusing the next run. The uid
+  separates users; the cluster id separates concurrent swarms.
+*/
+void AP_SITL_SharedMem::_build_name()
+{
+#ifdef __CYGWIN__
+    // A Win32 kernel object name, not a filesystem path: no leading
+    // slash. Unprefixed names live in the caller's session-local
+    // namespace, and Windows sessions already separate users from each
+    // other, so the uid the POSIX name carries would be redundant here -
+    // and the harness on native Windows Python could not compute the
+    // Cygwin uid anyway.
+    snprintf(_name, sizeof(_name), "%s_%u",
+             AP_SITL_SHMEM_NAME_PREFIX + 1, (unsigned)_cluster_id);
+#else
+    snprintf(_name, sizeof(_name), "%s_%lu_%u",
+             AP_SITL_SHMEM_NAME_PREFIX, (unsigned long)getuid(),
+             (unsigned)_cluster_id);
+#endif
+}
+
+bool AP_SITL_SharedMem::_map()
+{
+    _data = static_cast<AP_SITL_ShmData *>(
+        mmap(nullptr, sizeof(AP_SITL_ShmData),
+             PROT_READ | PROT_WRITE, MAP_SHARED, _fd, 0));
+
+    if (_data == MAP_FAILED) {
+        perror("SITL_SharedMem: mmap");
+        _data = nullptr;
+        return false;
+    }
+    return true;
+}
+
+void AP_SITL_SharedMem::_unmap()
+{
+    if (_data != nullptr) {
+#ifdef __CYGWIN__
+        UnmapViewOfFile(_data);
+#else
+        munmap(_data, sizeof(AP_SITL_ShmData));
+#endif
+        _data = nullptr;
+    }
+}
+
+/*
+  we won the O_EXCL race, so build the segment.
+
+  The magic is written last, after the size is set and the payload
+  mutexes are constructed, because a peer that opens the name spins on
+  the magic before touching anything else - see _map_when_ready().
+*/
+bool AP_SITL_SharedMem::_init_created_segment()
+{
+    if (ftruncate(_fd, sizeof(AP_SITL_ShmData)) < 0) {
+        perror("SITL_SharedMem: ftruncate");
+        return false;
+    }
+    if (!_map()) {
+        return false;
+    }
+    return _init_segment_contents();
+}
+
+/*
+  fill in a freshly created, zero-filled, mapped segment and publish it.
+  Shared by the POSIX and Win32 creation paths - the layout protocol
+  must have exactly one author.
+*/
+bool AP_SITL_SharedMem::_init_segment_contents()
+{
+    memset(_data, 0, sizeof(AP_SITL_ShmData));
+    _data->version = AP_SITL_SHMEM_VERSION;
+
+#ifdef __CYGWIN__
+    /*
+      No payload mutex on this platform, at all. Cygwin's pthread_mutex_t
+      is a POINTER: pthread_mutex_init() here would allocate the real
+      mutex in the CREATOR's private heap and store only that pointer in
+      the shared segment - meaningless in every other process, whose
+      locks then fail EINVAL on every single call (confirmed on Windows:
+      one error line per physics frame). Cygwin has no process-shared
+      mutexes to reach for either, so the payload block is simply
+      unlocked here, announced once below. The clock protocol never
+      needed a lock in the first place.
+    */
+    fprintf(stderr, "SITL_SharedMem: no process-shared mutexes on this "
+                    "platform; payload access is unlocked between instances\n");
+#else
+    // initialise each slot's payload mutex as a process-shared, robust
+    // mutex - memset() alone is not a valid pthread_mutex_t.
+    pthread_mutexattr_t attr;
+    pthread_mutexattr_init(&attr);
+    // Not every platform that compiles this actually supports sharing a
+    // mutex between processes - Cygwin's pthread implementation rejects
+    // PTHREAD_PROCESS_SHARED. Say so rather than silently handing out a
+    // process-private mutex that guards nothing across the cluster.
+    const int pret = pthread_mutexattr_setpshared(&attr, PTHREAD_PROCESS_SHARED);
+    if (pret != 0) {
+        fprintf(stderr, "SITL_SharedMem: process-shared mutexes unsupported "
+                        "(%d); clock sync will work but payload access is "
+                        "NOT safely locked between instances\n", pret);
+    }
+#if AP_SITL_SHMEM_ROBUST_MUTEX
+    const int rret = pthread_mutexattr_setrobust(&attr, PTHREAD_MUTEX_ROBUST);
+    if (rret != 0) {
+        fprintf(stderr, "SITL_SharedMem: robust mutexes unavailable (%d); an "
+                        "instance killed mid-write will block its peers\n", rret);
+    }
+#else
+    fprintf(stderr, "SITL_SharedMem: no robust-mutex support on this platform; "
+                    "an instance killed mid-write will block its peers\n");
+#endif
+    for (uint8_t i = 0; i < AP_SITL_SHMEM_MAX_INSTANCES; i++) {
+        pthread_mutex_init(&_data->instance[i].payload_mutex, &attr);
+    }
+    pthread_mutexattr_destroy(&attr);
+#endif  // __CYGWIN__
+
+    // publish: everything above must be visible before the magic is
+    __atomic_store_n(&_data->magic, (uint32_t)AP_SITL_SHMEM_MAGIC, __ATOMIC_RELEASE);
+    return true;
+}
+
+/*
+  an object with our name already exists. Wait for its creator to finish
+  building it, then map it.
+
+  Creation is not atomic - shm_open() publishes the name before
+  ftruncate() and the mutex setup have run - so an opener can legitimately
+  find a zero-length, zero-magic object for a moment. Treating that as
+  stale (and unlinking it) would pull the segment out from under the very
+  instance still initialising it, so wait instead, and only give up when
+  the deadline passes.
+
+  Returns false if the segment never became usable, i.e. it really is a
+  leftover and the caller should replace it.
+*/
+bool AP_SITL_SharedMem::_map_when_ready(uint64_t deadline_us)
+{
+    // wait for the creator's ftruncate(), so that mapping and touching
+    // the pages cannot SIGBUS us on a short object
+    while (true) {
+        struct stat st;
+        if (fstat(_fd, &st) < 0) {
+            perror("SITL_SharedMem: fstat");
+            return false;
+        }
+        if ((size_t)st.st_size >= sizeof(AP_SITL_ShmData)) {
+            break;
+        }
+        if (_now_us() >= deadline_us) {
+            fprintf(stderr, "SITL_SharedMem: %s still %lld bytes, need %zu\n",
+                    _name, (long long)st.st_size, sizeof(AP_SITL_ShmData));
+            return false;
+        }
+        usleep(1000);
+    }
+
+    if (!_map()) {
+        return false;
+    }
+    return _wait_for_magic(deadline_us);
+}
+
+/*
+  wait for the creator to publish the magic, which it writes last.
+  Shared by the POSIX and Win32 attach paths.
+*/
+bool AP_SITL_SharedMem::_wait_for_magic(uint64_t deadline_us)
+{
+    while (true) {
+        const uint32_t magic = __atomic_load_n(&_data->magic, __ATOMIC_ACQUIRE);
+        if (magic == AP_SITL_SHMEM_MAGIC) {
+            return true;
+        }
+        if (magic != 0) {
+            // a different layout version, not a half-built segment
+            fprintf(stderr, "SITL_SharedMem: bad magic 0x%08X in %s\n",
+                    magic, _name);
+            _unmap();
+            return false;
+        }
+        if (_now_us() >= deadline_us) {
+            fprintf(stderr, "SITL_SharedMem: %s never initialised\n", _name);
+            _unmap();
+            return false;
+        }
+        usleep(1000);
+    }
+}
+
+#ifdef __CYGWIN__
+/*
+  Windows path: a named, pagefile-backed Win32 file mapping instead of
+  POSIX shm.
+
+  Cygwin's shm_open() needs a real /dev/shm directory with POSIX
+  permissions under the Cygwin root - and with a standalone cygwin1.dll
+  beside the binaries the root is wherever the DLL happens to live, so
+  that directory reliably does not exist. The native kernel object needs
+  no filesystem presence at all and gives the same zero-copy mapping
+  semantics once mapped.
+
+  Two things actually improve on the POSIX path here:
+
+    - the creation race is resolved by the kernel: every instance calls
+      CreateFileMapping, one caller wins, the rest see
+      ERROR_ALREADY_EXISTS - no O_EXCL retry dance
+
+    - the object is reference-counted and vanishes with its last handle,
+      so a stale segment left by a killed swarm cannot exist and no
+      unlink/recreate logic is needed
+*/
+bool AP_SITL_SharedMem::_open_segment()
+{
+    const uint64_t deadline_us = _now_us() + AP_SITL_SHMEM_INIT_TIMEOUT_US;
+
+    // The creator/attacher decision below reads GetLastError() after a
+    // SUCCESSFUL CreateFileMapping: documented to be ERROR_ALREADY_EXISTS
+    // when the object existed, but not explicitly documented to be
+    // cleared on a fresh create. Clear it first, so a stale value from
+    // an earlier API call cannot make the genuine creator think it is an
+    // attacher and wait forever for a magic only it was going to write.
+    SetLastError(0);
+
+    HANDLE handle = CreateFileMappingA(
+        INVALID_HANDLE_VALUE,       // pagefile-backed: RAM only, no file
+        nullptr,
+        PAGE_READWRITE,
+        0, (DWORD)sizeof(AP_SITL_ShmData),
+        _name);
+    if (handle == nullptr) {
+        fprintf(stderr,
+                "SITL_SharedMem: CreateFileMapping(%s) failed: error %lu\n",
+                _name, (unsigned long)GetLastError());
+        return false;
+    }
+    // set even on success, specifically so the loser of a creation race
+    // can tell it attached to an existing object
+    _created = (GetLastError() != ERROR_ALREADY_EXISTS);
+    _win_map_handle = handle;
+
+    _data = static_cast<AP_SITL_ShmData *>(
+        MapViewOfFile(handle, FILE_MAP_ALL_ACCESS, 0, 0,
+                      sizeof(AP_SITL_ShmData)));
+    if (_data == nullptr) {
+        fprintf(stderr,
+                "SITL_SharedMem: MapViewOfFile(%s) failed: error %lu\n",
+                _name, (unsigned long)GetLastError());
+        _cleanup();
+        return false;
+    }
+
+    if (_created) {
+        // a fresh mapping arrives zero-filled, exactly like a freshly
+        // ftruncate'd shm object, so the same initialisation applies
+        return _init_segment_contents();
+    }
+
+    // someone else created it; wait for their magic
+    if (!_wait_for_magic(deadline_us)) {
+        // nothing to unlink and recreate here: the object lives exactly
+        // as long as its handles, so a creator that died before
+        // publishing the magic takes the segment with it, and simply
+        // failing now and retrying at the next startup is correct
+        _cleanup();
+        return false;
+    }
+    return true;
+}
+
+#else  // !__CYGWIN__
+
+/*
+  create the segment, or attach to the one another instance is creating.
+*/
+bool AP_SITL_SharedMem::_open_segment()
+{
+    const uint64_t deadline_us = _now_us() + AP_SITL_SHMEM_INIT_TIMEOUT_US;
+    bool replaced_stale = false;
+
+    while (true) {
+        // try to be the creator
+        _fd = shm_open(_name, O_RDWR | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR);
+        if (_fd >= 0) {
+            _created = true;
+            if (_init_created_segment()) {
+                return true;
+            }
+            _cleanup();
+            return false;
+        }
+        if (errno != EEXIST) {
+            perror("SITL_SharedMem: shm_open (create)");
+            return false;
+        }
+
+        // someone else owns the name; attach to it
+        _fd = shm_open(_name, O_RDWR, S_IRUSR | S_IWUSR);
+        if (_fd < 0) {
+            if (errno == ENOENT && _now_us() < deadline_us) {
+                // it was unlinked between our two calls - go round again
+                usleep(1000);
+                continue;
+            }
+            perror("SITL_SharedMem: shm_open");
+            return false;
+        }
+        _created = false;
+
+        if (_map_when_ready(deadline_us)) {
+            return true;
+        }
+
+        // never became usable: a leftover from a killed swarm, or a
+        // segment from an incompatible build. Replace it - but only once,
+        // so two instances cannot ping-pong unlinking each other's fresh
+        // segments forever.
+        close(_fd);
+        _fd = -1;
+        if (replaced_stale) {
+            fprintf(stderr, "SITL_SharedMem: %s unusable; giving up\n", _name);
+            return false;
+        }
+        replaced_stale = true;
+        fprintf(stderr, "SITL_SharedMem: stale segment %s - recreating\n", _name);
+        shm_unlink(_name);
+    }
+}
+
+#endif  // __CYGWIN__
+
+#ifdef __CYGWIN__
+/*
+  Windows wakes sleeping threads on its timer tick, which defaults to
+  15.6ms - so every short sleep in the pacing and barrier paths rounds up
+  to that, capping the whole cluster near realtime. timeBeginPeriod(1)
+  drops the tick to 1ms process-wide. It lives in winmm.dll, which the
+  toolchain does not link by default, so resolve it at runtime rather
+  than adding a link dependency.
+*/
+static void _request_1ms_timer_resolution(void)
+{
+    HMODULE winmm = LoadLibraryA("winmm.dll");
+    if (winmm == nullptr) {
+        return;
+    }
+    typedef UINT (WINAPI *time_begin_period_t)(UINT);
+    time_begin_period_t tbp = (time_begin_period_t)
+        GetProcAddress(winmm, "timeBeginPeriod");
+    if (tbp != nullptr) {
+        tbp(1);
+    }
+    // deliberately never FreeLibrary/timeEndPeriod: the resolution should
+    // hold for the life of the process
+}
+
+/*
+  Windows 11 quietly re-throttles a windowless console process in two
+  ways that cap SITL near a quarter of a core: timer-resolution
+  coalescing IGNORES timeBeginPeriod for processes without a foreground
+  window (every 1ms sleep silently becomes the 15.6ms tick again), and
+  EcoQoS "efficiency mode" clamps the execution speed of anything it
+  classifies as background work. SetProcessInformation with
+  ProcessPowerThrottling opts out of both. The struct and constants are
+  declared locally because Cygwin's headers predate them; the call is
+  resolved at runtime and quietly does nothing on older Windows.
+*/
+static void _request_full_speed_scheduling(void)
+{
+    typedef struct {
+        ULONG Version;
+        ULONG ControlMask;
+        ULONG StateMask;
+    } ap_power_throttling_state_t;
+    static const ULONG AP_POWER_THROTTLING_VERSION = 1;
+    static const ULONG AP_THROTTLE_EXECUTION_SPEED = 0x1;
+    static const ULONG AP_THROTTLE_IGNORE_TIMER_RESOLUTION = 0x4;
+    static const DWORD AP_PROCESS_POWER_THROTTLING = 4;  // PROCESS_INFORMATION_CLASS
+
+    HMODULE k32 = GetModuleHandleA("kernel32.dll");
+    if (k32 == nullptr) {
+        return;
+    }
+    typedef BOOL (WINAPI *set_process_information_t)(HANDLE, DWORD, LPVOID, DWORD);
+    set_process_information_t spi = (set_process_information_t)
+        GetProcAddress(k32, "SetProcessInformation");
+    if (spi != nullptr) {
+        ap_power_throttling_state_t state;
+        state.Version = AP_POWER_THROTTLING_VERSION;
+        // control both throttles, set neither: never throttle execution
+        // speed, never ignore our timer-resolution request
+        state.ControlMask = AP_THROTTLE_EXECUTION_SPEED |
+                            AP_THROTTLE_IGNORE_TIMER_RESOLUTION;
+        state.StateMask = 0;
+        spi(GetCurrentProcess(), AP_PROCESS_POWER_THROTTLING,
+            &state, sizeof(state));
+    }
+    // a simulation the user is actively watching should not lose the CPU
+    // to background desktop churn
+    SetPriorityClass(GetCurrentProcess(), ABOVE_NORMAL_PRIORITY_CLASS);
+
+    /*
+      self-diagnose: measure the sleep quantum actually in force. When
+      Windows honors the 1ms request a 1ms sleep returns in 1-2ms; when
+      the request is being ignored (observed: every thread of every
+      vehicle pinned at ~26% duty cycle, all sleeps rounding to the
+      15.6ms tick) it returns in ~15ms. Print the verdict so a throttled
+      run is visible in the log instead of a mystery.
+    */
+    struct timespec t0, t1;
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    for (uint8_t i = 0; i < 4; i++) {
+        usleep(1000);
+    }
+    clock_gettime(CLOCK_MONOTONIC, &t1);
+    const uint64_t elapsed_us =
+        (t1.tv_sec - t0.tv_sec) * 1000000ULL +
+        (t1.tv_nsec - t0.tv_nsec) / 1000;
+    const uint32_t quantum_us = (uint32_t)(elapsed_us / 4);
+    if (quantum_us > 5000) {
+        fprintf(stderr,
+                "SITL_SharedMem: WARNING: Windows is ignoring the 1ms "
+                "timer request (measured %ums sleep quantum); expect the "
+                "simulation to be capped near a quarter of a core\n",
+                (unsigned)(quantum_us / 1000));
+    } else {
+        printf("SITL_SharedMem: Windows 1ms timer resolution in force "
+               "(measured %uus sleep quantum)\n", (unsigned)quantum_us);
+    }
+}
+#endif
+
+bool AP_SITL_SharedMem::init(uint8_t instance_id, uint8_t cluster_id)
+{
+    if (instance_id >= AP_SITL_SHMEM_MAX_INSTANCES) {
+        fprintf(stderr, "SITL_SharedMem: instance %u cannot join a cluster "
+                        "(max instance is %u)\n",
+                instance_id, AP_SITL_SHMEM_MAX_INSTANCES - 1);
+        return false;
+    }
+
+    _instance_id = instance_id;
+    _cluster_id  = cluster_id;
+
+#ifdef __CYGWIN__
+    _request_1ms_timer_resolution();
+    _request_full_speed_scheduling();
+#endif
+
+    _build_name();
+
+    if (!_open_segment()) {
+        return false;
+    }
+
+    // claim our slot
+    _data->instance[_instance_id].pid = getpid();
+    _store_time(_data->instance[_instance_id].sim_time_us, 0);
+
+    fprintf(stderr, "SITL_SharedMem: instance %u joined cluster %u (%s)\n",
+            (unsigned)_instance_id, (unsigned)_cluster_id, _name);
+
+    return true;
+}
+
+void AP_SITL_SharedMem::update(uint64_t time_us)
+{
+    if (_data == nullptr) {
+        return;
+    }
+    _store_time(_data->instance[_instance_id].sim_time_us, time_us);
+}
+
+void AP_SITL_SharedMem::set_armed(bool armed)
+{
+    if (_data == nullptr) {
+        return;
+    }
+    __atomic_store_n(&_data->instance[_instance_id].armed,
+                     armed ? 1U : 0U, __ATOMIC_RELAXED);
+}
+
+bool AP_SITL_SharedMem::get_or_set_slave_epoch(uint64_t &wall_us,
+                                               uint64_t &sim_us)
+{
+    if (_data == nullptr) {
+        return false;
+    }
+    uint64_t expected = 0;
+    // first-writer wins: publish the caller's proposal only if no
+    // epoch exists yet, then read back whatever won
+    __atomic_compare_exchange_n(&_data->slave_epoch_wall_us, &expected,
+                                wall_us, false,
+                                __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+    if (expected == 0) {
+        // our proposal won; publish the sim half before anyone uses it
+        __atomic_store_n(&_data->slave_epoch_sim_us, sim_us,
+                         __ATOMIC_SEQ_CST);
+    }
+    const uint64_t w = __atomic_load_n(&_data->slave_epoch_wall_us,
+                                       __ATOMIC_SEQ_CST);
+    const uint64_t t = __atomic_load_n(&_data->slave_epoch_sim_us,
+                                       __ATOMIC_SEQ_CST);
+    if (w == 0 || t == 0) {
+        return false;
+    }
+    wall_us = w;
+    sim_us = t;
+    return true;
+}
+
+bool AP_SITL_SharedMem::peek_slave_epoch(uint64_t &wall_us,
+                                         uint64_t &sim_us) const
+{
+    if (_data == nullptr) {
+        return false;
+    }
+    const uint64_t w = __atomic_load_n(&_data->slave_epoch_wall_us,
+                                       __ATOMIC_SEQ_CST);
+    const uint64_t t = __atomic_load_n(&_data->slave_epoch_sim_us,
+                                       __ATOMIC_SEQ_CST);
+    if (w == 0 || t == 0) {
+        return false;
+    }
+    wall_us = w;
+    sim_us = t;
+    return true;
+}
+
+bool AP_SITL_SharedMem::all_members_armed() const
+{
+    if (_data == nullptr) {
+        return false;
+    }
+    bool any = false;
+    for (uint8_t i = 0; i < AP_SITL_SHMEM_MAX_INSTANCES; i++) {
+        if (!instance_active(i)) {
+            continue;
+        }
+        any = true;
+        if (__atomic_load_n(&_data->instance[i].armed,
+                            __ATOMIC_RELAXED) == 0) {
+            return false;
+        }
+    }
+    return any;
+}
+
+uint64_t AP_SITL_SharedMem::get_time_us(uint8_t instance_id) const
+{
+    if (_data == nullptr || instance_id >= AP_SITL_SHMEM_MAX_INSTANCES) {
+        return 0;
+    }
+    return _load_time(_data->instance[instance_id].sim_time_us);
+}
+
+bool AP_SITL_SharedMem::instance_active(uint8_t instance_id) const
+{
+    if (_data == nullptr || instance_id >= AP_SITL_SHMEM_MAX_INSTANCES) {
+        return false;
+    }
+    const pid_t pid = _data->instance[instance_id].pid;
+    if (pid <= 0) {
+        return false;
+    }
+    // check pid is alive by sending signal 0
+    return kill(pid, 0) == 0;
+}
+
+uint8_t AP_SITL_SharedMem::get_instance_count() const
+{
+    if (_data == nullptr) {
+        return 0;
+    }
+    uint8_t count = 0;
+    for (uint8_t i = 0; i < AP_SITL_SHMEM_MAX_INSTANCES; i++) {
+        if (instance_active(i)) {
+            count++;
+        }
+    }
+    return count;
+}
+
+/*
+  write our payload block while holding the slot's robust process-shared
+  mutex. EOWNERDEAD (a prior crashed run reusing this slot) is marked
+  consistent and we proceed, since we are the sole writer for our slot.
+*/
+void AP_SITL_SharedMem::write_payload(const void *data, uint32_t len)
+{
+    if (_data == nullptr) {
+        return;
+    }
+    if (len > AP_SITL_SHMEM_PAYLOAD_SIZE) {
+        len = AP_SITL_SHMEM_PAYLOAD_SIZE;
+    }
+    auto &slot = _data->instance[_instance_id];
+
+#ifdef __CYGWIN__
+    // no cross-process lock exists on this platform - see
+    // _init_segment_contents(); the copy is unguarded
+    memcpy(slot.payload, data, len);
+#else
+    int ret = pthread_mutex_lock(&slot.payload_mutex);
+#if AP_SITL_SHMEM_ROBUST_MUTEX
+    if (ret == EOWNERDEAD) {
+        // we hold the lock; the previous owner died without unlocking
+        ret = pthread_mutex_consistent(&slot.payload_mutex);
+        if (ret != 0) {
+            fprintf(stderr, "SITL_SharedMem: write_payload consistent failed: %d\n", ret);
+            pthread_mutex_unlock(&slot.payload_mutex);
+            return;
+        }
+    }
+#endif
+    if (ret != 0) {
+        fprintf(stderr, "SITL_SharedMem: write_payload lock failed: %d\n", ret);
+        return;
+    }
+
+    memcpy(slot.payload, data, len);
+
+    pthread_mutex_unlock(&slot.payload_mutex);
+#endif  // __CYGWIN__
+}
+
+/*
+  read a peer's payload block while holding its robust process-shared
+  mutex. EOWNERDEAD means the peer died mid-write; mark it consistent
+  but treat the data as unreliable and return false.
+*/
+bool AP_SITL_SharedMem::read_payload(uint8_t instance_id, void *data, uint32_t len) const
+{
+    if (_data == nullptr || instance_id >= AP_SITL_SHMEM_MAX_INSTANCES) {
+        return false;
+    }
+    if (len > AP_SITL_SHMEM_PAYLOAD_SIZE) {
+        len = AP_SITL_SHMEM_PAYLOAD_SIZE;
+    }
+    auto &slot = _data->instance[instance_id];
+
+#ifdef __CYGWIN__
+    // no cross-process lock exists on this platform - see
+    // _init_segment_contents(); the copy is unguarded
+    memcpy(data, slot.payload, len);
+    return true;
+#else
+    int ret = pthread_mutex_lock(&slot.payload_mutex);
+    bool owner_died = false;
+#if AP_SITL_SHMEM_ROBUST_MUTEX
+    if (ret == EOWNERDEAD) {
+        owner_died = true;
+        ret = pthread_mutex_consistent(&slot.payload_mutex);
+        if (ret != 0) {
+            fprintf(stderr, "SITL_SharedMem: read_payload consistent failed: %d\n", ret);
+            pthread_mutex_unlock(&slot.payload_mutex);
+            return false;
+        }
+    }
+#endif
+    if (ret != 0) {
+        fprintf(stderr, "SITL_SharedMem: read_payload lock failed: %d\n", ret);
+        return false;
+    }
+
+    if (!owner_died) {
+        memcpy(data, slot.payload, len);
+    }
+
+    pthread_mutex_unlock(&slot.payload_mutex);
+
+    return !owner_died;
+#endif  // __CYGWIN__
+}
+
+
+/*
+  spin-wait barrier: pause until every peer in the cluster has published
+  a sim_time_us >= (sim_time_us - max_skew_us), keeping all instances
+  within max_skew_us of each other. Called from Aircraft::sync_frame_time()
+  after every simulation step.
+
+  Membership is whatever is registered right now: an unclaimed slot is
+  not a peer, so being alone in the cluster costs a single scan and no
+  waiting at all. A wall-clock timeout still guards against a peer that
+  is alive but wedged.
+*/
+bool AP_SITL_SharedMem::sync_with_peers(uint64_t sim_time_us,
+                                         uint64_t max_skew_us,
+                                         uint64_t timeout_us,
+                                         uint64_t stall_grace_us)
+{
+    if (_data == nullptr) {
+        return true;
+    }
+
+    // minimum sim_time we are willing to be ahead of peers
+    const uint64_t min_peer_time = (sim_time_us > max_skew_us)
+                                    ? sim_time_us - max_skew_us
+                                    : 0;
+
+    // wall-clock start, for the overall timeout
+    const uint64_t start_us = _now_us();
+
+    while (true) {
+        // wall-clock "now", used both for the overall timeout and for
+        // per-peer stall detection below
+        const uint64_t now_us = _now_us();
+
+        bool all_ok = true;
+        uint8_t live_peers = 0;
+        for (uint8_t i = 0; i < AP_SITL_SHMEM_MAX_INSTANCES; i++) {
+            if (i == _instance_id) {
+                continue;
+            }
+            const pid_t pid = _data->instance[i].pid;
+            if (pid <= 0) {
+                // nobody has ever claimed this slot, or its owner has
+                // left. Either way it is not a peer - we never wait for
+                // an instance that has not joined the cluster.
+                continue;
+            }
+            // Is the peer still alive? Throttled: this is a syscall, and
+            // the loop around it spins every ~100us.
+            bool peer_gone = false;
+            if (now_us - _peer_checked_wall_us[i] > AP_SITL_SHMEM_LIVENESS_CHECK_US) {
+                _peer_checked_wall_us[i] = now_us;
+                peer_gone = kill(pid, 0) != 0;
+            }
+            if (peer_gone) {
+                // mark the slot dead (-1, not 0) so a later joiner can
+                // tell "gone" from "never used"
+                _data->instance[i].pid = -1;
+                _peer_joined_announced[i] = false;
+                fprintf(stderr,
+                        "SITL_SharedMem: peer instance %u (pid %d) has left "
+                        "cluster %u; %u instances remain\n",
+                        (unsigned)i, (int)pid, (unsigned)_cluster_id,
+                        (unsigned)get_instance_count());
+                continue;
+            }
+
+            if (!_peer_joined_announced[i]) {
+                _peer_joined_announced[i] = true;
+                fprintf(stderr,
+                        "SITL_SharedMem: peer instance %u joined cluster %u\n",
+                        (unsigned)i, (unsigned)_cluster_id);
+            }
+
+            // track whether this peer's sim_time_us is still advancing;
+            // after stall_grace_us with no movement we stop waiting on
+            // it. A reboot resets sim_time_us to 0 - that backward jump
+            // must not count as progress or it would restart the timer.
+            const uint64_t peer_time = _load_time(_data->instance[i].sim_time_us);
+            bool peer_advanced = false;
+            if (peer_time > _peer_seen_time_us[i]) {
+                peer_advanced = true;
+                _peer_seen_time_us[i] = peer_time;
+                _peer_seen_wall_us[i] = now_us;
+            } else if (peer_time != _peer_seen_time_us[i]) {
+                // backward jump (e.g. reboot reset) - remember the new
+                // value for future comparisons, but don't treat it as
+                // progress or reset the grace-period clock
+                _peer_seen_time_us[i] = peer_time;
+            }
+
+            if (_peer_stalled[i]) {
+                // Only rejoin once genuinely caught up (matches the
+                // threshold is_behind_peers() uses to keep sprinting).
+                // The cooldown below, not a wider margin, prevents flapping.
+                if (peer_time >= min_peer_time) {
+                    _peer_stalled[i] = false;
+                    _peer_resume_announced[i] = false;
+                    // brief cooldown so a scheduling hiccup right after
+                    // rejoining doesn't immediately re-exclude the peer
+                    _peer_cooldown_until_us[i] = now_us + 2 * stall_grace_us;
+                    fprintf(stderr,
+                            "SITL_SharedMem: peer instance %u has "
+                            "caught-up to the shared sim time\n", (unsigned)i);
+                } else {
+                    if (peer_advanced && !_peer_resume_announced[i]) {
+                        _peer_resume_announced[i] = true;
+                        fprintf(stderr,
+                                "SITL_SharedMem: peer instance %u resumed, "
+                                "still catching up\n", (unsigned)i);
+                    }
+                    continue;
+                }
+            } else if (peer_time < min_peer_time &&
+                       now_us - _peer_seen_wall_us[i] > stall_grace_us &&
+                       now_us >= _peer_cooldown_until_us[i]) {
+                // only stall a peer that is actually behind (blocking us);
+                // a peer that simply updates less often than we poll but
+                // is still within skew must never be marked stalled, or it
+                // will instantly "rejoin" and flap forever
+                _peer_stalled[i] = true;
+                _peer_resume_announced[i] = false;
+                fprintf(stderr,
+                        "SITL_SharedMem: peer instance %u stalled "
+                        "(%.2fs); no longer blocking cluster\n",
+                        (unsigned)i, stall_grace_us * 1e-6);
+                continue;
+            }
+
+            // this peer is live and participating in the barrier
+            live_peers++;
+
+            if (peer_time < min_peer_time) {
+                all_ok = false;
+                break;
+            }
+        }
+        if (all_ok) {
+            // only claim lock-step if we actually barriered against
+            // somebody; "in lock-step" alone in the cluster is noise
+            if (!_sync_announced && live_peers > 0) {
+                _sync_announced = true;
+                fprintf(stderr,
+                        "SITL_SharedMem: instance %u in lock-step with %u "
+                        "instances in cluster %u (max skew %llu us)\n",
+                        (unsigned)_instance_id, (unsigned)(live_peers + 1),
+                        (unsigned)_cluster_id,
+                        (unsigned long long)max_skew_us);
+            }
+            return true;
+        }
+
+        // check wall-clock timeout
+        const uint64_t elapsed_us = now_us - start_us;
+        if (elapsed_us > timeout_us) {
+            fprintf(stderr,
+                    "SITL_SharedMem: sync timeout after %.1f s waiting for "
+                    "peers (our sim_time_us=%llu)\n",
+                    elapsed_us * 1e-6,
+                    (unsigned long long)sim_time_us);
+            return false;
+        }
+
+        /*
+          In steady state peers are only microseconds apart, so the first
+          stretch of waiting busy-spins: an OS sleep here costs at least
+          one scheduler quantum (~1ms on Linux, up to 15.6ms on a Windows
+          box at default timer resolution), which is what throttled
+          clustered runs to near realtime however fast the machine was.
+          Only a wait long enough to indicate a genuinely lagging peer
+          falls back to sleeping.
+        */
+        if (elapsed_us > 500) {
+            usleep(200);
+        }
+    }
+}
+
+/*
+  return true if our own sim_time_us is more than max_skew_us behind the
+  most-advanced live peer - used to trigger a ~2x-speedup catch-up
+  sprint (see Aircraft::sync_frame_time()). The sprint is capped at
+  max_catchup_us of wall-clock time, after which we give up and run at
+  normal speed (still excluded from the barrier by sync_with_peers()).
+*/
+bool AP_SITL_SharedMem::is_behind_peers(uint64_t sim_time_us, uint64_t max_skew_us,
+                                         uint64_t max_catchup_us)
+{
+    if (_data == nullptr) {
+        return false;
+    }
+
+    const uint64_t max_peer_time = _max_peer_time();
+    const bool behind = sim_time_us + max_skew_us < max_peer_time;
+    const uint64_t now_us = _now_us();
+
+    if (!behind) {
+        // caught up (or never fell behind) - reset catch-up tracking so a
+        // future reboot starts a fresh sprint window
+        _catchup_started_wall_us = 0;
+        _catchup_gave_up = false;
+        return false;
+    }
+
+    if (_catchup_gave_up) {
+        // already gave up sprinting this episode; stay at normal speed
+        // until we catch up naturally (behind will go false above once
+        // we do, which resets _catchup_gave_up for next time)
+        return false;
+    }
+
+    if (_catchup_started_wall_us == 0) {
+        _catchup_started_wall_us = now_us;
+    } else if (now_us - _catchup_started_wall_us > max_catchup_us) {
+        _catchup_gave_up = true;
+        fprintf(stderr,
+                "SITL_SharedMem: instance %u could not catch up to peers "
+                "within %.1fs; giving up sprint, running at normal speed\n",
+                (unsigned)_instance_id, max_catchup_us * 1e-6);
+        return false;
+    }
+
+    return true;
+}
+
+bool AP_SITL_SharedMem::instant_catchup_if_new(uint64_t &sim_time_us, uint64_t max_uptime_us)
+{
+    if (_instant_catchup_done || _data == nullptr) {
+        return false;
+    }
+
+    const uint64_t now_us = _now_us();
+    if (now_us - _process_start_wall_us > max_uptime_us) {
+        // too long since our own process started - not a fresh join
+        // any more, don't instantly jump the clock
+        _instant_catchup_done = true;
+        return false;
+    }
+
+    const uint64_t max_peer_time = _max_peer_time();
+    if (max_peer_time <= sim_time_us) {
+        // not behind anyone - nothing to do, but don't consume our one
+        // shot in case we fall behind moments later during startup
+        return false;
+    }
+
+    _instant_catchup_done = true;
+    fprintf(stderr,
+            "SITL_SharedMem: instance %u joining a running cluster, jumping "
+            "clock to match peers (%.2fs ahead)\n",
+            (unsigned)_instance_id, (max_peer_time - sim_time_us) * 1e-6);
+    sim_time_us = max_peer_time;
+    return true;
+}
+
+void AP_SITL_SharedMem::_clear_slot()
+{
+    if (_data == nullptr) {
+        return;
+    }
+    _store_time(_data->instance[_instance_id].sim_time_us, 0);
+    // -1 (not 0) so peers can tell "left the cluster" from "never used"
+    _data->instance[_instance_id].pid = -1;
+}
+
+void AP_SITL_SharedMem::_cleanup()
+{
+    _clear_slot();
+
+#ifndef __CYGWIN__
+    // if no other member is still alive the segment is now the record
+    // of a finished cluster - a stale epoch and armed flags that the
+    // next run's vehicles would join by name. The last member out
+    // retires it, creator or not. (Members that die without cleanup
+    // are covered by the stale-segment recovery in _attach and by the
+    // harness unlinking its cluster's segment around each run.)
+    bool peers_alive = false;
+    if (_data != nullptr) {
+        for (uint8_t i = 0; i < AP_SITL_SHMEM_MAX_INSTANCES; i++) {
+            const pid_t pid = _data->instance[i].pid;
+            if (pid > 0 && pid != getpid() &&
+                (kill(pid, 0) == 0 || errno == EPERM)) {
+                peers_alive = true;
+                break;
+            }
+        }
+    }
+#endif
+
+    _unmap();
+
+#ifdef __CYGWIN__
+    if (_win_map_handle != nullptr) {
+        CloseHandle((HANDLE)_win_map_handle);
+        _win_map_handle = nullptr;
+    }
+    // no unlink exists or is needed: the kernel deletes the mapping
+    // object when its last handle closes
+#else
+    if (_fd >= 0) {
+        close(_fd);
+        _fd = -1;
+    }
+
+    // unlink when this is the creator or the last live member; if
+    // other instances are still alive an unlink would be harmless to
+    // them (they hold their own mappings) but would orphan the name
+    // they expect late joiners to find, so leave it to the last out
+    if ((_created || !peers_alive) && _name[0] != 0) {
+        shm_unlink(_name);
+        _created = false;
+    }
+#endif
+}
+
+#endif // CONFIG_HAL_BOARD == HAL_BOARD_SITL

--- a/libraries/AP_HAL_SITL/SITL_SharedMem.h
+++ b/libraries/AP_HAL_SITL/SITL_SharedMem.h
@@ -58,6 +58,39 @@
 #define AP_SITL_SHMEM_PAYLOAD_SIZE  4096
 
 /*
+  the payload block is partitioned between its tenants at fixed offsets:
+    [0, AP_SITL_SHMEM_RIDE_OFFSET)    AP_SITL_SwarmInfo, published from
+                                      Aircraft::sync_frame_time()
+    [AP_SITL_SHMEM_RIDE_OFFSET, end)  ride-along JSON transport channel,
+                                      used by SIM_JSON_Master (master) and
+                                      SIM_JSON (slave) instead of the UDP
+                                      sockets when the ride-along pair was
+                                      started with --cluster
+  Both tenants are guarded by the same per-slot robust mutex.
+*/
+#define AP_SITL_SHMEM_RIDE_OFFSET   512
+#define AP_SITL_SHMEM_RIDE_SIZE     (AP_SITL_SHMEM_PAYLOAD_SIZE - AP_SITL_SHMEM_RIDE_OFFSET)
+
+/*
+  one-directional message channel living in the ride-along region of a
+  slot: the master publishes its fdm JSON line in its own slot, each
+  slave publishes its servo packet in its own slot. A publish rewrites
+  the whole record under the slot mutex and bumps seq last, so a single
+  read_payload() of the channel always yields an internally-consistent
+  record; readers poll seq for change.
+*/
+struct AP_SITL_RideAlongChannel {
+    uint32_t magic;     // which endpoint writes this slot's channel (below)
+    uint32_t seq;       // bumped once per publish
+    uint32_t len;       // valid bytes in data[]
+    uint8_t  data[AP_SITL_SHMEM_RIDE_SIZE - 12];
+};
+static_assert(sizeof(AP_SITL_RideAlongChannel) == AP_SITL_SHMEM_RIDE_SIZE,
+              "ride-along channel must exactly fill its payload region");
+#define AP_SITL_RIDE_FDM_MAGIC    0x52464D31  // "RFM1": master -> slaves fdm JSON
+#define AP_SITL_RIDE_SERVO_MAGIC  0x52535631  // "RSV1": slave -> master servo packet
+
+/*
   Robust process-shared mutexes make a peer that is killed mid-write hand
   the next locker EOWNERDEAD instead of deadlocking every other instance
   forever.
@@ -153,18 +186,20 @@ public:
       write up to AP_SITL_SHMEM_PAYLOAD_SIZE bytes into this instance's
       payload block, for peers to read via read_payload(). Takes the
       slot's robust process-shared mutex for the duration of the copy so
-      readers never observe a torn write.
+      readers never observe a torn write. offset positions the write
+      within the block, for tenants above the first (see the payload
+      partition map by AP_SITL_SHMEM_RIDE_OFFSET).
     */
-    void write_payload(const void *data, uint32_t len);
+    void write_payload(const void *data, uint32_t len, uint32_t offset = 0);
 
     /*
       read the given instance's payload block into data (up to len bytes,
-      capped at AP_SITL_SHMEM_PAYLOAD_SIZE). Takes the slot's robust
-      process-shared mutex for the duration of the copy. Returns true on
-      success, false if shm is not initialised or instance_id is out of
-      range.
+      capped at AP_SITL_SHMEM_PAYLOAD_SIZE, starting offset bytes into
+      the block). Takes the slot's robust process-shared mutex for the
+      duration of the copy. Returns true on success, false if shm is not
+      initialised or instance_id is out of range.
     */
-    bool read_payload(uint8_t instance_id, void *data, uint32_t len) const;
+    bool read_payload(uint8_t instance_id, void *data, uint32_t len, uint32_t offset = 0) const;
 
     /*
       barrier sync: spin-wait until every peer that has joined the cluster

--- a/libraries/AP_HAL_SITL/SITL_SharedMem.h
+++ b/libraries/AP_HAL_SITL/SITL_SharedMem.h
@@ -1,0 +1,292 @@
+#pragma once
+
+#include <AP_HAL/AP_HAL.h>
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+
+#include <stdint.h>
+#include <pthread.h>
+
+/*
+  shared memory segment allowing multiple SITL instances to share
+  simulated clock state. Each instance writes its own sim_time_us into
+  a slot indexed by instance number; readers check peer times to
+  determine relative clock positions.
+
+  Clustering is strictly opt-in: nothing here runs unless --cluster was
+  given on the command line. An instance number alone says nothing about
+  whether the user wants a swarm, so "--instance 1" on its own never
+  touches shared memory.
+
+  Membership is discovered, never declared. There is no fleet size to
+  state up front: an instance barriers against whichever peers have
+  actually registered in the segment, so a peer that is starting late
+  simply joins when it appears, and one that never starts costs nothing.
+
+  The segment name is built at runtime (see _build_name()) from the uid
+  and the cluster id, so separate swarms - and different users on a
+  shared host - never land in the same object.
+
+  The clock field is a single-writer 64-bit value, accessed atomically
+  where the target supports lock-free 64-bit atomics so it cannot tear.
+  The payload[] block is control-critical (e.g. shared vehicle telemetry)
+  so it's protected by a process-shared, robust pthread mutex instead -
+  see write_payload()/read_payload().
+*/
+
+#define AP_SITL_SHMEM_MAX_INSTANCES 16
+#define AP_SITL_SHMEM_MAGIC         0x41505351  // "APSQ" (v5 layout: shared slave epoch)
+#define AP_SITL_SHMEM_VERSION       3
+
+// segment name prefix; the uid and cluster id are appended
+#define AP_SITL_SHMEM_NAME_PREFIX   "/ardupilot_sitl_cluster"
+#define AP_SITL_SHMEM_NAME_LEN      64
+
+// how long init() will wait for a concurrently-starting instance to
+// finish building the segment before deciding it is stale garbage
+#define AP_SITL_SHMEM_INIT_TIMEOUT_US 2000000
+
+// How often a peer's pid is probed with kill(pid, 0) while spinning in the
+// barrier. The spin runs every ~100us, so probing every pass costs tens of
+// thousands of syscalls per second per instance - and every instance is
+// doing it about every other peer. Peers do not die often enough to need
+// microsecond detection; 100ms is still effectively instant.
+#define AP_SITL_SHMEM_LIVENESS_CHECK_US 100000
+
+// size of the arbitrary per-instance data block, in addition to the clock.
+// e.g. vehicle position/attitude or other user-defined telemetry.
+#define AP_SITL_SHMEM_PAYLOAD_SIZE  4096
+
+/*
+  Robust process-shared mutexes make a peer that is killed mid-write hand
+  the next locker EOWNERDEAD instead of deadlocking every other instance
+  forever.
+
+  Do NOT write "#ifdef PTHREAD_MUTEX_ROBUST" here: glibc declares it as a
+  member of an anonymous enum in pthread.h, not as a macro, so the #ifdef
+  is always false and silently compiles the whole recovery path out while
+  the symbol still works perfectly as a value. Test the platform instead.
+*/
+#if defined(__linux__)
+#define AP_SITL_SHMEM_ROBUST_MUTEX 1
+#else
+#define AP_SITL_SHMEM_ROBUST_MUTEX 0
+#endif
+
+/*
+  Use real atomics for the cross-process 64-bit clock only where they are
+  lock-free. On targets where a 64-bit atomic degrades to a libatomic call
+  (e.g. armv6) fall back to a plain access rather than adding a link-time
+  dependency; such builds are 32-bit hosts running a single instance.
+*/
+#if defined(__GCC_ATOMIC_LLONG_LOCK_FREE) && __GCC_ATOMIC_LLONG_LOCK_FREE == 2
+#define AP_SITL_SHMEM_ATOMIC64 1
+#else
+#define AP_SITL_SHMEM_ATOMIC64 0
+#endif
+
+/*
+  layout of the shared memory segment
+*/
+struct AP_SITL_ShmData {
+    uint32_t magic;         // written last by the creator; see _init_created_segment()
+    uint32_t version;
+    // the cluster-wide wall-slaved schedule epoch: written once (CAS)
+    // by the first member to observe the whole cluster armed; every
+    // member slaves its simulated time to this single shared timeline
+    // so pinned schedules cannot drift apart between members
+    uint64_t slave_epoch_wall_us;
+    uint64_t slave_epoch_sim_us;
+    struct {
+        uint64_t sim_time_us;   // simulated time in microseconds
+        pid_t    pid;           // pid of owning process (0 = never used,
+                                // -1 = peer registered but has since died)
+        uint32_t armed;         // nonzero once this member's vehicle is
+                                // armed; the wall-slaved schedule engages
+                                // cluster-wide only when every active
+                                // member is armed
+        // process-shared robust mutex guarding payload[]. Robust means
+        // a locker that dies mid-hold gives the next locker EOWNERDEAD
+        // instead of hanging - see write_payload()/read_payload().
+        pthread_mutex_t payload_mutex;
+        uint8_t  payload[AP_SITL_SHMEM_PAYLOAD_SIZE];
+    } instance[AP_SITL_SHMEM_MAX_INSTANCES];
+};
+
+class AP_SITL_SharedMem {
+public:
+    AP_SITL_SharedMem();
+    ~AP_SITL_SharedMem();
+
+    /*
+      join cluster cluster_id as the given instance number. Called only
+      when --cluster was passed; until then this object stays inert and
+      every method below is a no-op.
+    */
+    bool init(uint8_t instance_id, uint8_t cluster_id);
+
+    /*
+      update this instance's clock in the shared segment.
+      Call this periodically (e.g. every scheduler tick).
+    */
+    void update(uint64_t time_us);
+
+    /*
+      return the last published sim_time_us for the given instance.
+      Returns 0 if the instance has no active entry or shm is not initialised.
+    */
+    uint64_t get_time_us(uint8_t instance_id) const;
+
+    /*
+      return true if the given instance slot appears active
+      (pid is alive and time is non-zero)
+    */
+    bool instance_active(uint8_t instance_id) const;
+
+    /*
+      return the number of instances currently in the cluster, ourselves
+      included. 0 when clustering is not enabled.
+    */
+    uint8_t get_instance_count() const;
+
+    /*
+      write up to AP_SITL_SHMEM_PAYLOAD_SIZE bytes into this instance's
+      payload block, for peers to read via read_payload(). Takes the
+      slot's robust process-shared mutex for the duration of the copy so
+      readers never observe a torn write.
+    */
+    void write_payload(const void *data, uint32_t len);
+
+    /*
+      read the given instance's payload block into data (up to len bytes,
+      capped at AP_SITL_SHMEM_PAYLOAD_SIZE). Takes the slot's robust
+      process-shared mutex for the duration of the copy. Returns true on
+      success, false if shm is not initialised or instance_id is out of
+      range.
+    */
+    bool read_payload(uint8_t instance_id, void *data, uint32_t len) const;
+
+    /*
+      barrier sync: spin-wait until every peer that has joined the cluster
+      has published a sim_time_us >= (sim_time_us - max_skew_us). Returns
+      false on timeout_us (wall-clock us) expiry, e.g. a peer crashed.
+
+      Slots nobody has claimed are simply not peers, so this returns
+      immediately when we are the only instance in the cluster.
+
+      A peer whose sim_time_us stalls (e.g. mid-reboot) but is still
+      alive is excluded from the barrier after stall_grace_us, so it
+      doesn't block the rest of the swarm for the full timeout_us.
+    */
+    bool sync_with_peers(uint64_t sim_time_us,
+                         uint64_t max_skew_us = 5000,
+                         uint64_t timeout_us = 5000000,
+                         uint64_t stall_grace_us = 300000);
+
+    /*
+      return true if our own sim_time_us is more than max_skew_us behind
+      the most-advanced live peer - used to trigger a ~2x-speedup
+      catch-up sprint (see Aircraft::sync_frame_time()) so a rebooted
+      instance fast-forwards back into lock-step instead of remaining
+      permanently excluded from the barrier.
+
+      The sprint is capped at max_catchup_us of wall-clock time; once
+      exceeded we give up and return false, running at normal speed
+      while sync_with_peers() still excludes us from the barrier.
+    */
+    bool is_behind_peers(uint64_t sim_time_us, uint64_t max_skew_us = 5000,
+                          uint64_t max_catchup_us = 60000000);
+
+    /*
+      one-shot: if this process started less than max_uptime_us ago and
+      is behind live peers, snap sim_time_us to match them instantly
+      (no sprint) and return true. Meant for an instance joining an
+      already-running cluster - or a just-rebooted one - to reach
+      lock-step immediately rather than sprinting to catch up.
+    */
+    bool instant_catchup_if_new(uint64_t &sim_time_us, uint64_t max_uptime_us = 10000000);
+
+    bool is_initialised() const { return _data != nullptr; }
+
+    // publish this member's armed state (called with the sim time update)
+    void set_armed(bool armed);
+
+    // true when every ACTIVE cluster member reports armed. False when
+    // uninitialised.
+    bool all_members_armed() const;
+
+    // fetch the cluster-wide slave-schedule epoch, publishing the
+    // caller's proposal if none exists yet (first-writer wins).
+    // Returns false when uninitialised.
+    bool get_or_set_slave_epoch(uint64_t &wall_us, uint64_t &sim_us);
+
+    // read the epoch without ever publishing: true once one exists.
+    bool peek_slave_epoch(uint64_t &wall_us, uint64_t &sim_us) const;
+    bool is_multi_instance() const { return get_instance_count() > 1; }
+
+private:
+    AP_SITL_ShmData *_data;
+    int              _fd;
+    uint8_t          _instance_id;
+    uint8_t          _cluster_id;
+    bool             _created;  // true if we created the shm segment
+    bool             _sync_announced;     // printed "in lock-step" once
+
+    char             _name[AP_SITL_SHMEM_NAME_LEN];  // resolved segment name
+
+    // per-peer stall tracking for sync_with_peers(): last sim_time_us
+    // observed per peer, when it last changed, and stall/resume state.
+    uint64_t         _peer_seen_time_us[AP_SITL_SHMEM_MAX_INSTANCES];
+    uint64_t         _peer_seen_wall_us[AP_SITL_SHMEM_MAX_INSTANCES];
+    bool             _peer_stalled[AP_SITL_SHMEM_MAX_INSTANCES];
+    bool             _peer_resume_announced[AP_SITL_SHMEM_MAX_INSTANCES];  // printed "resumed, still catching up" once per stall
+    bool             _peer_joined_announced[AP_SITL_SHMEM_MAX_INSTANCES];  // printed "joined the cluster" once
+
+    // wall-clock time each peer's pid was last probed for liveness, so the
+    // barrier spin does not issue a kill() per peer per pass
+    uint64_t         _peer_checked_wall_us[AP_SITL_SHMEM_MAX_INSTANCES];
+
+    // wall-clock time before which a just-rejoined peer may not be
+    // re-marked stalled; prevents flapping right at the min_peer_time
+    // boundary under CPU contention from sprinting instances.
+    uint64_t         _peer_cooldown_until_us[AP_SITL_SHMEM_MAX_INSTANCES];
+
+    // is_behind_peers() catch-up-sprint tracking: the wall-clock time we
+    // first noticed we were behind, and whether we've since given up
+    // sprinting (having hit max_catchup_us) until we catch up naturally.
+    uint64_t         _catchup_started_wall_us;
+    bool             _catchup_gave_up;
+
+    // instant_catchup_if_new(): wall-clock time this process started, and
+    // whether we've already taken (or forfeited) our one-shot clock jump.
+    uint64_t         _process_start_wall_us;
+    bool             _instant_catchup_done;
+
+#ifdef __CYGWIN__
+    // Win32 file-mapping handle backing the segment. Stored as void* so
+    // this header never needs <windows.h>; only SITL_SharedMem.cpp casts
+    // it to HANDLE.
+    void            *_win_map_handle;
+#endif
+
+    static uint64_t _now_us();
+    uint64_t _max_peer_time() const;
+
+    // cross-process access to a slot's 64-bit clock
+    static uint64_t _load_time(const uint64_t &v);
+    static void     _store_time(uint64_t &v, uint64_t t);
+
+    void _build_name();
+    bool _open_segment();
+    bool _init_created_segment();
+    bool _init_segment_contents();
+    bool _map_when_ready(uint64_t deadline_us);
+    bool _wait_for_magic(uint64_t deadline_us);
+    bool _map();
+    void _unmap();
+
+    void _clear_slot();
+    void _cleanup();
+};
+
+#endif // CONFIG_HAL_BOARD == HAL_BOARD_SITL

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -14,6 +14,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <errno.h>
+#include <sched.h>
 #include <sys/types.h>
 #include <sys/select.h>
 #include <sys/socket.h>
@@ -119,6 +120,19 @@ void SITL_State::_fdm_input_step(void)
 }
 
 
+// SITL_HARD_NONBLOCK=1 removes every wall-clock sleep from the
+// simulation path: worker threads spin-yield instead of sleeping and
+// the main thread never waits for the SERIAL0 reader. Cores run hot by
+// design - that is the point. Default behaviour is unchanged.
+static bool _hard_nonblock(void)
+{
+    static int8_t v = -1;
+    if (v == -1) {
+        v = getenv("SITL_HARD_NONBLOCK") != nullptr;
+    }
+    return v == 1;
+}
+
 void SITL_State::wait_clock(uint64_t wait_time_usec)
 {
     float speedup = sitl_model->get_speedup();
@@ -147,6 +161,17 @@ void SITL_State::wait_clock(uint64_t wait_time_usec)
                 }
             }
 #endif
+            if (_hard_nonblock()) {
+                // a TRUE yield, never a wall sleep: usleep(0) still
+                // enters the OS delay path on Cygwin and rounds up to
+                // the Windows timer tick (15.6ms when the resolution
+                // request is being ignored), silently turning the
+                // "spin" into a sleep loop pinned near a quarter of a
+                // core. sched_yield() returns immediately on every
+                // platform - Cygwin maps it to SwitchToThread.
+                sched_yield();
+                continue;
+            }
             // most devices can't sleep for 10us - so this is also
             // essentially a yield.  At 30x speedup a 10us wall-clock
             // sleep here can equate to your thread sleeping for 300us
@@ -158,7 +183,11 @@ void SITL_State::wait_clock(uint64_t wait_time_usec)
     // MAVProxy/pymavlink take too long to process packets and it ends
     // up seeing traffic well into our past and hits time-out
     // conditions.
-    if (speedup > 1 && hal.scheduler->in_main_thread()) {
+    if (speedup > 1 && hal.scheduler->in_main_thread() &&
+        !_hard_nonblock()) {
+        // skipped under SITL_HARD_NONBLOCK: this loop couples the sim
+        // rate to how fast the SERIAL0 reader drains the socket, 1ms of
+        // main-thread sleep at a time
         while (true) {
             HALSITL::UARTDriver *uart = (HALSITL::UARTDriver*)hal.serial(0);
             const int queue_length = uart->get_system_outqueue_length();
@@ -400,6 +429,14 @@ void SITL_State::init(int argc, char * const argv[])
 {
     _scheduler = Scheduler::from(hal.scheduler);
     _parse_command_line(argc, argv);
+
+    // Shared-memory clock sync between SITL instances, for swarms.
+    // Only when the user explicitly asked for it with --cluster: running
+    // "--instance 1" on its own is an ordinary single-vehicle run and
+    // must not go looking for peers.
+    if (_cluster_enabled) {
+        _shared_mem.init(_instance, _cluster_id);
+    }
 }
 
 /*

--- a/libraries/AP_HAL_SITL/SITL_State.h
+++ b/libraries/AP_HAL_SITL/SITL_State.h
@@ -6,6 +6,8 @@
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
 
 #include "SITL_State_common.h"
+#include "SITL_SharedMem.h"
+#include "SITL_SwarmInfo.h"
 
 #if defined(HAL_BUILD_AP_PERIPH)
 #include "SITL_Periph_State.h"
@@ -51,6 +53,20 @@ public:
     
     uint8_t get_instance() const { return _instance; }
 
+    // shared memory for multi-instance clock synchronisation; accessible
+    // from SIM_Aircraft::sync_frame_time() via hal_sitl.get_sitl_state()
+    AP_SITL_SharedMem _shared_mem;
+
+    // convenience wrapper to read a peer instance's published swarm info
+    // (position/velocity/heading); see AP_SITL_SwarmInfo. Returns false if
+    // the instance is inactive or the read failed.
+    bool get_swarm_info(uint8_t instance_id, AP_SITL_SwarmInfo &info) const {
+        if (!_shared_mem.instance_active(instance_id)) {
+            return false;
+        }
+        return _shared_mem.read_payload(instance_id, &info, sizeof(info));
+    }
+
 private:
     void _parse_command_line(int argc, char * const argv[]);
     void _usage(void);
@@ -84,6 +100,12 @@ private:
 
     // internal state
     uint8_t _instance;
+
+    // --cluster[=ID]: shared-memory clock sync with peer instances.
+    // Strictly opt-in - an instance number on its own is not a request
+    // to join a swarm.
+    bool    _cluster_enabled;
+    uint8_t _cluster_id;
     uint16_t _base_port;
     pid_t _parent_pid;
     uint32_t _update_count;

--- a/libraries/AP_HAL_SITL/SITL_SwarmInfo.h
+++ b/libraries/AP_HAL_SITL/SITL_SwarmInfo.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <AP_HAL/AP_HAL.h>
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+
+#include <stdint.h>
+
+/*
+  basic per-vehicle "swarm" telemetry, shared between SITL instances via
+  AP_SITL_SharedMem's per-instance payload block (see SITL_SharedMem.h).
+
+  Populated by Aircraft::sync_frame_time() from the vehicle's own
+  simulated state, and readable by any other instance via
+  AP_SITL_SharedMem::read_payload(). Intended for basic swarm-style
+  awareness (e.g. simple avoidance/formation experiments) - it is not a
+  replacement for the existing MAVLink/ADSB inter-vehicle links.
+
+  Deliberately a flat POD struct of fixed-width types, since it crosses
+  process boundaries via shared memory.
+*/
+struct AP_SITL_SwarmInfo {
+    uint8_t  sysid;          // MAVLink system id of the publishing vehicle
+    uint64_t sim_time_us;    // simulated time this info was captured
+    int32_t  lat;            // degrees * 1e7
+    int32_t  lng;            // degrees * 1e7
+    int32_t  alt_cm;         // altitude AMSL, cm (Location::alt convention)
+    float    vx, vy, vz;     // velocity, m/s, NED (earth frame)
+    float    heading_deg;    // yaw/heading, degrees, 0..360
+};
+
+#endif // CONFIG_HAL_BOARD == HAL_BOARD_SITL

--- a/libraries/AP_HAL_SITL/SITL_cmdline.cpp
+++ b/libraries/AP_HAL_SITL/SITL_cmdline.cpp
@@ -117,6 +117,8 @@ void SITL_State::_usage(void)
            "\t--irlock-port PORT       set port num for irlock\n"
            "\t--start-time TIMESTR     set simulation start time in UNIX timestamp\n"
            "\t--sysid ID               set MAV_SYSID\n"
+           "\t--cluster ID             join SITL cluster ID (0-255) for shared-memory\n"
+           "\t                         clock sync with other instances; off unless given\n"
            "\t--slave number           set the number of JSON slaves\n"
            "\t--use_sim_time <true|false>  use ROS2 simulation clock for DDS topics. Defaults to false\n"
         );
@@ -240,6 +242,8 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
     float speedup = 1.0f;
     float sim_rate_hz = 0;
     _instance = 0;
+    _cluster_enabled = false;
+    _cluster_id = 0;
     // default to CMAC
     const char *home_str = nullptr;
     const char *model_str = nullptr;
@@ -315,6 +319,7 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
         CMDLINE_START_TIME,
         CMDLINE_SYSID,
         CMDLINE_SLAVE,
+        CMDLINE_CLUSTER,
         CMDLINE_LIST_MODELS,
 #if STORAGE_USE_FLASH
         CMDLINE_SET_STORAGE_FLASH_ENABLED,
@@ -379,6 +384,7 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
         {"irlock-port",     true,   0, CMDLINE_IRLOCK_PORT},
         {"start-time",      true,   0, CMDLINE_START_TIME},
         {"sysid",           true,   0, CMDLINE_SYSID},
+        {"cluster",         true,   0, CMDLINE_CLUSTER},
         {"slave",           true,   0, CMDLINE_SLAVE},
         {"list-models",     false,  0, CMDLINE_LIST_MODELS},
 #if STORAGE_USE_FLASH
@@ -560,6 +566,26 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
         case CMDLINE_START_TIME:
             start_time_UTC = atoi(gopt.optarg);
             break;
+        case CMDLINE_CLUSTER: {
+            // Membership size is never declared - instances synchronise
+            // with whichever peers have actually joined the cluster.
+            //
+            // The ID must be strictly numeric: a required argument consumes
+            // the next argv entry, so a forgotten value ("--cluster
+            // --speedup 100") would otherwise swallow the next option and
+            // silently join cluster 0.
+            char *end = nullptr;
+            const long id = strtol(gopt.optarg, &end, 10);
+            if (end == gopt.optarg || *end != 0 || id < 0 || id > 255) {
+                fprintf(stderr, "Invalid cluster ID '%s': must be a number "
+                                "between 0 and 255\n", gopt.optarg);
+                exit(1);
+            }
+            _cluster_enabled = true;
+            _cluster_id = (uint8_t)id;
+            break;
+        }
+
         case CMDLINE_SYSID: {
             const int32_t sysid = atoi(gopt.optarg);
             if (sysid < 1 || sysid > 255) {

--- a/libraries/AP_HAL_SITL/SITL_cmdline.cpp
+++ b/libraries/AP_HAL_SITL/SITL_cmdline.cpp
@@ -119,7 +119,9 @@ void SITL_State::_usage(void)
            "\t--sysid ID               set MAV_SYSID\n"
            "\t--cluster ID             join SITL cluster ID (0-255) for shared-memory\n"
            "\t                         clock sync with other instances; off unless given\n"
-           "\t--slave number           set the number of JSON slaves\n"
+           "\t--slave number           set the number of JSON ride-along slaves; with\n"
+           "\t                         --cluster the fdm/servo exchange runs over the\n"
+           "\t                         cluster's shared memory instead of UDP\n"
            "\t--use_sim_time <true|false>  use ROS2 simulation clock for DDS topics. Defaults to false\n"
         );
 }

--- a/libraries/AP_HAL_SITL/Scheduler.cpp
+++ b/libraries/AP_HAL_SITL/Scheduler.cpp
@@ -301,9 +301,60 @@ void Scheduler::_run_io_procs()
 void Scheduler::stop_clock(uint64_t time_usec)
 {
     _stopped_clock_usec = time_usec;
-    if (_sitlState->_sitl != nullptr && time_usec - _last_io_run > 10000) {
-        _last_io_run = time_usec;
-        _run_io_procs();
+#ifndef HAL_BUILD_AP_PERIPH
+    _sitlState->_shared_mem.update(time_usec);
+    _sitlState->_shared_mem.set_armed(hal.util->get_soft_armed());
+#endif
+    if (_sitlState->_sitl != nullptr) {
+        /*
+          Divide the WALL-clock IO polling rate by the speedup. Each
+          pass select()s every UART plus storage and I2C; the fixed
+          10ms sim interval meant the sweep rate scaled with speedup -
+          10000 sweeps per wall second at 100x - measured at 4-5% of
+          CPU spent in kernel select paths alone on Linux and far worse
+          under Cygwin's emulated select. Above 10x the sim-time
+          interval scales with the speedup, dividing the wall sweep
+          rate by the speedup (1000/s at any speedup) relative to the
+          old fixed-sim-interval behaviour. The sim-time interval must
+          NOT grow beyond 100ms: simulated serial devices are pumped by
+          this same sweep, and at a 1s sim interval their drivers time
+          out (measured: rangefinder and delta-velocity copter
+          autotests fail at SPEEDUP=100).
+        */
+        uint32_t io_interval_us = 10000;
+        const float sp = _sitlState->_sitl->speedup.get();
+        if (sp > 10) {
+            io_interval_us = (uint32_t)(1000 * sp);
+        }
+        if (time_usec - _last_io_run > io_interval_us) {
+#ifdef CYGWIN_BUILD
+            /*
+              the sim-time interval above is only wall-accurate when the
+              achieved speedup matches the commanded one; a host running
+              well short of the commanded rate sweeps several times more
+              often than intended, and Cygwin emulates each select()
+              through a helper-thread pool at 10-100x the Linux syscall
+              cost - measured on Windows as the dominant residual once
+              sleeps and throttling were dealt with (a CI A/B saw the
+              runner drop from ~18x to ~7x with 2.5x more sweeps).
+              Bound the sweep in WALL time as well; 50ms of telemetry
+              latency is invisible at any speedup worth clustering
+              for.
+            */
+            struct timespec ts;
+            clock_gettime(CLOCK_MONOTONIC, &ts);
+            const uint64_t wall_us = ts.tv_sec * 1000000ULL +
+                                     ts.tv_nsec / 1000;
+            static uint64_t last_sweep_wall_us;
+            if (sp > 10 && wall_us - last_sweep_wall_us < 20000) {
+                // gate stays open; re-check on the next stop_clock
+                return;
+            }
+            last_sweep_wall_us = wall_us;
+#endif
+            _last_io_run = time_usec;
+            _run_io_procs();
+        }
     }
 }
 

--- a/libraries/AP_HAL_SITL/UARTDriver.cpp
+++ b/libraries/AP_HAL_SITL/UARTDriver.cpp
@@ -284,12 +284,17 @@ void UARTDriver::_flush(void)
     }
 
     // ensure that the outbound TCP queue is also empty...
-    start_ms = AP_HAL::millis();
-    while (AP_HAL::millis() - start_ms < 1000) {
-        if (((HALSITL::UARTDriver*)hal.serial(0))->get_system_outqueue_length() == 0) {
-            break;
+    // (skipped under SITL_HARD_NONBLOCK: no wall sleeps anywhere in the
+    // simulation path)
+    static const bool hard_nonblock = getenv("SITL_HARD_NONBLOCK") != nullptr;
+    if (!hard_nonblock) {
+        start_ms = AP_HAL::millis();
+        while (AP_HAL::millis() - start_ms < 1000) {
+            if (((HALSITL::UARTDriver*)hal.serial(0))->get_system_outqueue_length() == 0) {
+                break;
+            }
+            usleep(1000);
         }
-        usleep(1000);
     }
 }
 
@@ -404,6 +409,15 @@ void UARTDriver::_tcp_start_connection(uint16_t port, bool wait_for_connection)
             fprintf(stderr, "listen failed - %s\n", strerror(errno));
             exit(1);
         }
+#ifdef CYGWIN_BUILD
+        // nonblocking so _check_connection() can poll with a bare
+        // accept() instead of a select(): Cygwin emulates select()
+        // through a helper-thread pool at 10-100x the native syscall
+        // cost even with a zero timeout, and unconnected ports poll on
+        // every IO sweep
+        fcntl(_listen_fd, F_SETFL,
+              fcntl(_listen_fd, F_GETFL, 0) | O_NONBLOCK);
+#endif
 
         fprintf(stderr, "SERIAL%u on TCP port %u\n", _portNumber,
                 (unsigned)ntohs(_listen_sockaddr.sin_port));
@@ -413,8 +427,19 @@ void UARTDriver::_tcp_start_connection(uint16_t port, bool wait_for_connection)
     if (wait_for_connection) {
         fprintf(stdout, "Waiting for connection ....\n");
         fflush(stdout);
-        _fd = accept(_listen_fd, nullptr, nullptr);
-        if (_fd == -1) {
+        // the listen socket is nonblocking on Cygwin (so the per-sweep
+        // connection poll costs one native call instead of an emulated
+        // select) - this startup wait must therefore retry on EAGAIN
+        // rather than treating it as fatal
+        while (true) {
+            _fd = accept(_listen_fd, nullptr, nullptr);
+            if (_fd != -1) {
+                break;
+            }
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                usleep(10000);
+                continue;
+            }
             fprintf(stderr, "accept() error - %s", strerror(errno));
             exit(1);
         }
@@ -693,9 +718,18 @@ void UARTDriver::_check_connection(void)
         // we only want 1 connection at a time
         return;
     }
+#ifdef CYGWIN_BUILD
+    // the listen fd is nonblocking on Cygwin: a bare accept() is one
+    // native call, where the select() it replaces costs 10-100x that
+    // in Cygwin's emulation
+    {
+        _fd = accept(_listen_fd, nullptr, nullptr);
+        if (_fd != -1) {
+#else
     if (_select_check(_listen_fd)) {
         _fd = accept(_listen_fd, nullptr, nullptr);
         if (_fd != -1) {
+#endif
             int one = 1;
             _connected = true;
             setsockopt(_fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
@@ -1011,8 +1045,24 @@ void UARTDriver::handle_reading_from_device_to_readbuffer()
             _fd = -1;
             _connected = false;
         }
-    } else if (_select_check(_fd)) {
+    } else if (_fd != -1) {
+#ifdef CYGWIN_BUILD
+        // skip the readiness select: Cygwin emulates select() through a
+        // helper-thread pool at 10-100x the native syscall cost even
+        // with a zero timeout, and this poll runs for every UART on
+        // every IO sweep. A nonblocking recv gives the same answer in
+        // one native call - EAGAIN means no data (the only thing the
+        // select distinguished), 0 means EOF.
         nread = recv(_fd, buf, space, MSG_DONTWAIT);
+        if (nread == -1 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+            return;
+        }
+#else
+        if (!_select_check(_fd)) {
+            return;
+        }
+        nread = recv(_fd, buf, space, MSG_DONTWAIT);
+#endif
         if (nread <= 0 && !_is_udp) {
             // the socket has reached EOF
             close(_fd);

--- a/libraries/AP_Scheduler/AP_Scheduler.cpp
+++ b/libraries/AP_Scheduler/AP_Scheduler.cpp
@@ -25,6 +25,8 @@
 
 #include "AP_Scheduler.h"
 
+#include <stdlib.h>
+
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_Vehicle/AP_Vehicle.h>
@@ -179,6 +181,17 @@ void AP_Scheduler::tick(void)
  */
 static void fill_nanf_stack(void)
 {
+    // A debug aid, and a costly one: 4KB of NaNs written before EVERY
+    // scheduler task, measured at ~4% of total CPU and scaling linearly
+    // with simulation speedup. Perf-focused runs (multi-vehicle clusters
+    // chasing high speedups) can opt out; the default is unchanged.
+    static int8_t enabled = -1;
+    if (enabled == -1) {
+        enabled = getenv("SITL_DISABLE_STACK_NANF") == nullptr;
+    }
+    if (!enabled) {
+        return;
+    }
     float v[1024];
     fill_nanf(v, ARRAY_SIZE(v));
 }

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -1178,7 +1178,21 @@ void AP_TECS::_initialise_states(float hgt_afe)
     // Initialise states and variables if DT > 0.2 second or TECS is getting overridden or in climbout.
     _flags.reset = false;
 
-    if (_DT > 0.2f || _need_reset) {
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    /*
+      SIMULATION ONLY: accelerated simulation can legitimately deliver
+      update intervals above 0.2s of simulated time (a stretched clock
+      makes a 10Hz scheduler-table task arrive at 0.1-0.3s of sim
+      time). Resetting on every such call re-anchored the height
+      demand to the current altitude each cycle and TECS converted the
+      resulting overspeed into an unbounded climb. Real hardware keeps
+      the 0.2s threshold unchanged.
+    */
+    const float reset_DT_threshold = 2.0f;
+#else
+    const float reset_DT_threshold = 0.2f;
+#endif
+    if (_DT > reset_DT_threshold || _need_reset) {
         _SKE_weighting        = 1.0f;
         _integTHR_state       = 0.0f;
         _integSEBdot          = 0.0f;

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -34,6 +34,10 @@
 #include <AP_HAL_SITL/HAL_SITL_Class.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+#include <AP_HAL_SITL/SITL_SwarmInfo.h>
+#endif
+
 using namespace SITL;
 
 extern const AP_HAL::HAL& hal;
@@ -263,7 +267,153 @@ void Aircraft::time_advance()
     // we only advance time if it hasn't been advanced already by the
     // backend
     if (last_time_us == time_now_us) {
-        time_now_us += frame_time_us;
+        uint64_t step_us = frame_time_us;
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL && !defined(HAL_BUILD_AP_PERIPH)
+        /*
+          under the adaptive rate governor the commanded speedup is a
+          CONSTRAINT, not a target: simulated time is slaved to the
+          wall clock so achieved speedup equals the commanded value by
+          construction, on any hardware. Each frame's timestep
+          stretches by exactly the current schedule deficit - on a
+          host with headroom the deficit is zero and the nominal
+          timestep (and the pacing sleeps) are untouched; on a host
+          that cannot keep up, granularity degrades in real time by
+          precisely the amount required and time never falls behind.
+          The per-step rotation clamp in update_dynamics() keeps the
+          integration bounded at any stretched timestep. The stretch
+          is capped per frame so a single OS stall smears over many
+          frames instead of one giant step.
+        */
+        static int8_t slaved = -1;
+        if (slaved == -1) {
+            slaved = getenv("SITL_ADAPTIVE_RATE") != nullptr;
+        }
+        static bool engaged;
+        static uint64_t epoch_wall_us, epoch_sim_us;
+        if (slaved == 1 && !engaged) {
+            // the published epoch IS the engagement signal: the armed
+            // instant is transient (flags flicker around crashes and
+            // relands), and a member that misses it must still adopt
+            // the cluster schedule the moment one exists - a
+            // non-engaged member crawling at natural pace beside
+            // slaved peers was measured at 54,000 sim-seconds of skew
+            uint64_t w = 0, t = 0;
+            if (hal_sitl.get_sitl_state()->
+                    _shared_mem.peek_slave_epoch(w, t)) {
+                epoch_wall_us = w;
+                epoch_sim_us = t;
+                engaged = true;
+                ::printf("SIM: wall-slaved schedule engaged: adopted "
+                         "existing cluster epoch\n");
+            }
+        }
+        if (slaved == 1 && !engaged &&
+            hal_sitl.get_sitl_state()->_shared_mem.all_members_armed()) {
+            // the schedule engages when EVERY cluster member is armed,
+            // and stays engaged: boot, configuration and arming are
+            // wall-bound interactive work, and slaving time through
+            // them makes every sim-paced wait (parameter round-trips,
+            // arming checks, EKF settling) expire in wall-instants -
+            // and one armed member racing ahead drags the still-unarmed
+            // rest through catch-up they cannot sustain mid-takeoff.
+            // From the moment the whole formation flies, the commanded
+            // speedup is guaranteed.
+            engaged = true;
+            ::printf("SIM: wall-slaved schedule engaged: all cluster "
+                     "members armed (own soft_armed=%u)\n",
+                     (unsigned)hal.util->get_soft_armed());
+        }
+        slave_engaged = (slaved == 1 && engaged);
+        if (slaved == 1 && engaged) {
+            const uint64_t wall_us = get_wall_time_us();
+            if (epoch_wall_us == 0) {
+                // ONE schedule for the whole cluster: the first member
+                // to get here publishes the epoch into the shared
+                // segment and everyone slaves to that single timeline.
+                // Per-member epochs would pin members to permanently
+                // offset schedules, and a slaved member re-stretches
+                // over every barrier wait - measured as tens of
+                // thousands of sim-seconds of skew.
+                uint64_t w = wall_us, t = time_now_us;
+                if (hal_sitl.get_sitl_state()->
+                        _shared_mem.get_or_set_slave_epoch(w, t)) {
+                    epoch_wall_us = w;
+                    epoch_sim_us = t;
+                } else {
+                    // not clustered (or segment gone): local epoch
+                    epoch_wall_us = wall_us;
+                    epoch_sim_us = time_now_us;
+                }
+            }
+            /*
+              the schedule targets 5% ABOVE the commanded speedup:
+              measurement and stretch-cap losses otherwise leave a
+              converged run reading ~95% forever. 95% is a FAIL,
+              100% is good, 105% is margin.
+            */
+            static int8_t margin_seeded = -1;
+            if (margin_seeded == -1) {
+                margin_seeded = 1;
+                /*
+                  the margin scales with the commanded speedup:
+                  margin% = speedup/5, so 20% at 100x, 10% at 50x,
+                  4% at 20x - higher speedups accumulate more
+                  measurement and stretch-cap loss to cover (the
+                  original speedup/10 law under-resolved ~11% short
+                  in practice). SITL_SPEEDUP_MARGIN (percent)
+                  overrides.
+                */
+                slave_margin_floor = constrain_float(
+                    target_speedup * 0.002f, 0.0f, 0.30f);
+                const char *m = getenv("SITL_SPEEDUP_MARGIN");
+                if (m != nullptr) {
+                    slave_margin_floor = constrain_float(
+                        atof(m) * 0.01f, 0.0f, 0.5f);
+                }
+                slave_margin = slave_margin_floor;
+            }
+            const uint64_t scheduled_sim_us = epoch_sim_us +
+                (uint64_t)((wall_us - epoch_wall_us) *
+                           (double)target_speedup *
+                           (1.0 + slave_margin));
+            if (scheduled_sim_us > time_now_us + step_us) {
+                const uint64_t deficit_us =
+                    scheduled_sim_us - (time_now_us + step_us);
+                // the stretch cap grows smoothly with height: ground contact demands
+                // nearly nominal frames, altitude tolerates coarser steps, and a hard
+                // band edge put a 2.5x cadence cliff mid-climb vehicles oscillated on
+                /*
+                  dense frames near the ground AND whenever the
+                  attitude is upset: the ramp starts at 10m (climbing
+                  through 3-5m at a 9ms step put the takeoff transient
+                  inside the measured instability band and copters
+                  tumbled at full throttle), and a tilt beyond ~30
+                  degrees snaps the cap back to dense regardless of
+                  height - a tumble is the plant demanding fidelity,
+                  and recovery at a coarse step only feeds it.
+                */
+                /*
+                  ceiling +5ms: zero-order-held aerodynamic forces at
+                  20ms steps pumped energy into the plane (1.6km above
+                  its LOITER target, still climbing 3 m/s against a
+                  protesting TECS - the tamed remnant of the old
+                  escaped-the-atmosphere failures). With the nominal
+                  rate floored at 100Hz the ceiling costs almost no
+                  throughput, and the aero bias shrinks fourfold.
+                */
+                const float agl =
+                    constrain_float(hagl() - 10.0f, 0.0f, 30.0f);
+                uint64_t stretch_cap_us =
+                    1000 + (uint64_t)(agl * (4000.0f / 30.0f));
+                if (dcm.c.z < 0.85f) {
+                    stretch_cap_us = 1000;
+                }
+                step_us += MIN(deficit_us, stretch_cap_us);
+            }
+        }
+#endif
+        effective_frame_time_us = step_us;
+        time_now_us += step_us;
     }
     last_time_us = time_now_us;
     if (use_time_sync) {
@@ -288,33 +438,246 @@ void Aircraft::adjust_frame_time(float new_rate)
     rate_hz = new_rate;
 }
 
-/*
-   try to synchronise simulation time with wall clock time, taking
-   into account desired speedup
-   This tries to take account of possible granularity of
-   get_wall_time_us() so it works reasonably well on windows
-*/
+// try to synchronise simulation time with wall clock time, taking into
+// account desired speedup, allowing for get_wall_time_us() granularity
+// (notably on Windows)
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL && !defined(HAL_BUILD_AP_PERIPH)
+// runtime physics-rate governor, evaluated once per wall-time
+// reporting interval from sync_frame_time()
+void Aircraft::adaptive_rate_governor(const uint32_t now_ms)
+{
+    // runtime governor (SITL_ADAPTIVE_RATE=1): trades physics frame rate
+    // for achieved speedup, restoring fidelity with headroom; the
+    // achieved-vs-rate curve is non-monotonic per host, so measure at runtime
+    static int8_t adaptive = -1;
+    if (adaptive == -1) {
+        adaptive = getenv("SITL_ADAPTIVE_RATE") != nullptr;
+    }
+    if (adaptive == 1 && sitl != nullptr && slave_engaged) {
+        /*
+          track the nominal frame rate to MEASURED throughput so the
+          stretch stays near zero in steady state: the vehicle then
+          runs self-consistently at whatever rate the host affords
+          (the regime the governed campaign proved flyable down to
+          50Hz) while the wall-slaved stretch covers transients and
+          guarantees the schedule. Pinning nominal at a rate the host
+          cannot deliver left every frame stretched - nominal !=
+          actual - and vehicle-side constants that assume the nominal
+          rate (gyro filtering above all) degraded the attitude loop
+          into a full-throttle tumble.
+        */
+        static uint32_t last_track_ms;
+        /*
+          track slowly, and never during takeoff/landing: the nominal
+          rate re-derives the vehicle's filter and controller
+          constants, and re-tuning a copter every 2s from a
+          thermally-noisy fps reading destabilised exactly the
+          delicate phases - solo (steady fps) flew at the same
+          timestep the cluster (swinging fps) bounced at.
+        */
+        if (now_ms - last_track_ms > 4000 && hagl() > 10.0f) {
+            last_track_ms = now_ms;
+            if (achieved_rate_hz > 1 && target_speedup >= 1) {
+                /*
+                  the law: achieved speedup = fps / nominal rate, so
+                  the nominal rate that delivers the COMMANDED speedup
+                  on this host is measured fps divided by it. Floored
+                  at 50Hz - the proven edge of formation flight - so a
+                  host too weak even for that runs at the floor with
+                  the stretch covering the (bounded) shortfall.
+                */
+                /*
+                  floor 100Hz: measured tonight, a copter at 50Hz/21ms
+                  goes inverted on takeoff - the flyable floor is
+                  ~10ms. Below the floor the gate reports the honest
+                  shortfall; the only true fixes are cheaper
+                  iterations or a cooler host.
+                */
+                /*
+                  track against the MARGIN-INCLUSIVE schedule: the
+                  slaved clock demands target*(1+margin), and tracking
+                  to bare target left every frame stretched by exactly
+                  the margin fraction - a permanent nominal-vs-actual
+                  gap that degraded the plane's rate-derived control
+                  into an unbounded climb (per-sub-step aero
+                  re-evaluation did NOT fix it; this consistency did).
+                */
+                float track_hz = constrain_float(
+                    achieved_rate_hz /
+                        (target_speedup * (1.0f + slave_margin)),
+                    100.0f, 1200.0f);
+                /*
+                  asymmetric damping: converge fast while far from the
+                  operating point (10%/10s from the boot rate took
+                  minutes - longer than an entire run), fine-tune
+                  gently once within 25% of it
+                */
+                static bool first_track = true;
+                if (!first_track) {
+                    const float cur = sitl->loop_rate_hz.get();
+                    const float lo = (track_hz < cur * 0.75f)
+                                         ? cur * 0.75f : cur * 0.9f;
+                    track_hz = constrain_float(track_hz, lo, cur * 1.1f);
+                }
+                // the first step jumps straight to the operating
+                // point: walking down from the boot rate spent the
+                // whole run budget mid-descent
+                first_track = false;
+                sitl->loop_rate_hz.set(track_hz);
+            }
+        }
+    } else if (adaptive == 1 && sitl != nullptr) {
+        /*
+          un-slaved (the wall-bound prelude, boot to group-arm):
+          vehicle HEALTH outranks throughput here, so the frame rate
+          is simply pinned at 3x the loop rate - the proven arming
+          and flight sweet spot, and comfortably above the 2x line
+          under which ArduPilot refuses to arm (a governor that once
+          descended past it deadlocked a CI run at 9Hz frames). The
+          wall-slaved schedule takes over from the moment of
+          engagement.
+        */
+        static bool prelude_rate_set;
+        if (!prelude_rate_set && hal.scheduler->is_system_initialized()) {
+            prelude_rate_set = true;
+            float loop_hz = 400;
+            AP_Scheduler *sched = AP_Scheduler::get_singleton();
+            if (sched != nullptr) {
+                loop_hz = sched->get_loop_rate_hz();
+            }
+            const float start_hz =
+                constrain_float(3.0f * loop_hz, 400.0f, 1200.0f);
+            sitl->loop_rate_hz.set(start_hz);
+            ::printf("SIM: adaptive rate: prelude at %.0fHz\n",
+                     (double)start_hz);
+        }
+    }
+}
+#endif  // HAL_BOARD_SITL && !HAL_BUILD_AP_PERIPH
+
 void Aircraft::sync_frame_time(void)
 {
     frame_counter++;
     uint64_t now = get_wall_time_us();
     uint64_t dt_us = now - last_wall_time_us;
 
-    const float target_dt_us = 1.0e6/(rate_hz*target_speedup);
+    /*
+      under the adaptive rate governor, pace to 2% ABOVE the commanded
+      speedup: the pacer is a hard ceiling, so a host paced to exactly
+      the commanded rate measures fractionally below it forever
+      (99.x%) no matter how much headroom it has - the governor then
+      keeps sacrificing physics rate chasing a value the pacer will
+      never let it reach. 2% of overspeed lets a converged host measure
+      at or above the commanded rate; the governor's thresholds keep
+      the real operating point within a couple of percent of it.
+    */
+    static int8_t adaptive_pacing = -1;
+    if (adaptive_pacing == -1) {
+        adaptive_pacing = getenv("SITL_ADAPTIVE_RATE") != nullptr;
+    }
+    const float pacing_speedup =
+        adaptive_pacing == 1 ? target_speedup * 1.10f : target_speedup;
+    const float target_dt_us = 1.0e6/(rate_hz*pacing_speedup);
 
     // accumulate sleep debt if we're running too fast
     sleep_debt_us += target_dt_us - dt_us;
 
-    if (sleep_debt_us < -1.0e5) {
-        // don't let a large negative debt build up
-        sleep_debt_us = -1.0e5;
+    /*
+      the debt floor is the pacer's memory of how far behind wall
+      schedule the sim is. With only 100ms of memory, any OS stall
+      longer than that becomes unrepayable lost sim time - at 100x a
+      single 300ms scheduler stall permanently costs 20 sim seconds
+      against the achieved average, and on a busy CI runner such
+      stalls are constant (measured as the ~5% shortfall between
+      windows that touch the pacing ceiling and a steady-state that
+      does not). Two seconds of memory plus the 10% pacing overspeed
+      lets a stalled vehicle sprint the debt back down.
+    */
+    if (sleep_debt_us < -2.0e6) {
+        // don't let an unbounded negative debt build up
+        sleep_debt_us = -2.0e6;
     }
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL && !defined(HAL_BUILD_AP_PERIPH)
+    /*
+      Cluster work is decimated: it runs every Nth frame where N is the
+      requested speedup, so the number of barrier crossings per WALL
+      second is constant regardless of speedup. Synchronising every frame
+      would scale sync work linearly with speedup (40000 crossings per
+      wall-second at 100x) and, with the skew window fixed in sim time,
+      would demand microsecond wall alignment no OS can deliver - which
+      is exactly what capped clustered runs near realtime.
+
+      For the same reason the skew tolerance is fixed in WALL time (the
+      per-frame default's 5ms at 1x) and scaled into sim time by the
+      speedup: scheduling jitter is a wall-clock quantity, so the minimum
+      achievable sim-time skew is jitter multiplied by speedup, whatever
+      the code asks for. Between crossings every instance advances its
+      own clock in the original manner, entirely self-paced.
+
+      One aircraft per SITL process (as the process-global hal_sitl use
+      here already assumes), so function-statics hold the state.
+    */
+    static uint64_t cross_interval_us;
+    static uint64_t next_cross_us;
+    static bool catching_up_state;
+    if (cross_interval_us == 0) {
+        /*
+          crossings are scheduled on the SHARED sim-time grid, NOT on
+          per-vehicle frame counts: under the adaptive rate governor
+          each vehicle runs its own physics rate, so frame-count
+          schedules drift apart between members and skew accumulates
+          without bound (measured: 4s of skew where the time-based
+          grid holds under 2s). The interval scales with the speedup
+          so crossings per wall second are constant, sparse enough to
+          limit exposure to the instantaneous slowest member.
+        */
+#ifdef CYGWIN_BUILD
+        // Cygwin runs each vehicle at a fraction of a core's duty
+        // cycle, so members rarely run simultaneously and every
+        // crossing pays the currently-descheduled member's wakeup
+        // latency - measured as a 3.4x throughput loss (57x solo vs
+        // 17x clustered) where Linux loses almost nothing. A quarter
+        // of the crossings.
+        cross_interval_us = 13333ULL * (uint64_t)target_speedup;
+#else
+        cross_interval_us = 3333ULL * (uint64_t)target_speedup;
+#endif
+        cross_interval_us = MAX(cross_interval_us, (uint64_t)1000);
+    }
+    const uint64_t max_skew_us = 6ULL * cross_interval_us;
+    const bool at_crossing = time_now_us >= next_cross_us;
+    if (at_crossing) {
+        // align to the shared grid so every member crosses at the same
+        // sim times regardless of its own physics rate
+        next_cross_us = time_now_us - (time_now_us % cross_interval_us)
+                        + cross_interval_us;
+    }
+    if (at_crossing) {
+        // on a fresh start, instantly snap our clock to match peers
+        // instead of sprinting to catch up
+        hal_sitl.get_sitl_state()->_shared_mem.instant_catchup_if_new(time_now_us);
+
+        // if we've fallen behind the swarm (e.g. just rebooted), halve
+        // our sleep to run at ~2x speedup and fast-forward back into
+        // lock-step, rather than staying permanently excluded. The state
+        // persists across the frames in between, so the sprint pacing
+        // applies to every frame, not just the checked ones.
+        catching_up_state = hal_sitl.get_sitl_state()->_shared_mem.is_behind_peers(
+            time_now_us, max_skew_us);
+    }
+    const float catchup_sleep_scale = catching_up_state ? 0.5f : 1.0f;
+#else
+    const float catchup_sleep_scale = 1.0f;
+#endif
+    (void)catchup_sleep_scale;
+
     if (sleep_debt_us > min_sleep_time) {
         // sleep if we have built up a debt of min_sleep_tim
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
-        usleep(sleep_debt_us);
+        usleep((uint64_t)(sleep_debt_us * catchup_sleep_scale));
 #elif CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
-        hal.scheduler->delay_microseconds(sleep_debt_us);
+        hal.scheduler->delay_microseconds((uint64_t)(sleep_debt_us * catchup_sleep_scale));
 #else
         // ??
 #endif
@@ -326,15 +689,154 @@ void Aircraft::sync_frame_time(void)
     float dt_wall = (now_ms - last_fps_report_ms) * 0.001;
     if (dt_wall > 0.01) {  // 0.01s average
         achieved_rate_hz = (frame_counter - last_frame_count) / dt_wall;
-#if 0
-        ::printf("Rate: target:%.1f achieved:%.1f speedup %.1f/%.1f\n",
-                 rate_hz*target_speedup, achieved_rate_hz,
-                 achieved_rate_hz/rate_hz, target_speedup);
-#endif
         last_frame_count = frame_counter;
         last_fps_report_ms = now_ms;
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL && !defined(HAL_BUILD_AP_PERIPH)
+        // clustered runs report their achieved speedup so a cluster that
+        // cannot reach the requested rate is visible on the console
+        // rather than a mystery; quiet for ordinary single-vehicle SITL
+        static uint32_t last_rate_print_ms;
+        static uint64_t last_print_sim_us;
+        static uint32_t last_print_frames;
+        if (hal_sitl.get_sitl_state()->_shared_mem.is_initialised() &&
+            now_ms - last_rate_print_ms > 2000) {
+            last_rate_print_ms = now_ms;
+            // average EFFECTIVE timestep this window: sim advanced per
+            // frame - the one number that says whether control density
+            // is flyable and where the speedup is really coming from
+            float dt_avg_ms = 0;
+            if (frame_counter > last_print_frames &&
+                last_print_sim_us != 0) {
+                dt_avg_ms = (time_now_us - last_print_sim_us) * 1.0e-3f /
+                            (frame_counter - last_print_frames);
+            }
+            /*
+              close the loop on the margin using the TRUE window
+              speedup (sim advanced over wall elapsed): a window under
+              commanded raises the margin one point, sustained
+              overshoot beyond commanded+margin trims one, clamped to
+              [base-ish, 30%]. The schedule then aims however high
+              this host needs for the reported number to meet the ask.
+            */
+            static uint64_t last_margin_wall_us;
+            const uint64_t wall_now2 = get_wall_time_us();
+            // TRUE speedup this window: sim advanced over wall elapsed.
+            // The instantaneous fps sample above is a ~10ms snapshot of
+            // a vehicle that alternates sprinting with waiting at the
+            // barrier, so it legitimately swings 70-150% of schedule
+            // window to window; this is the number that means something.
+            float win_speedup = 0;
+            if (last_margin_wall_us != 0 && wall_now2 > last_margin_wall_us) {
+                win_speedup =
+                    (float)(time_now_us - last_print_sim_us) /
+                    (float)(wall_now2 - last_margin_wall_us);
+            }
+            if (slave_engaged && win_speedup > 0) {
+                static bool short_last_window;
+                if (win_speedup < target_speedup) {
+                    /*
+                      raise proportionally to the shortfall (fixed
+                      1-point steps took 10-20x the run length to
+                      settle), but only after TWO consecutive short
+                      windows and at most 5 points per step: a single
+                      short window is as often a compile burst or
+                      scheduler hiccup as a real deficit, and chasing
+                      it drove the margin to the ceiling against a
+                      transiently-loaded host.
+                    */
+                    if (short_last_window) {
+                        const float shortfall =
+                            (target_speedup - win_speedup) /
+                            target_speedup;
+                        slave_margin = MIN(
+                            slave_margin +
+                            constrain_float(shortfall, 0.01f, 0.05f),
+                            0.50f);
+                    }
+                    short_last_window = true;
+                } else if (win_speedup > target_speedup * 1.02f) {
+                    /*
+                      trim whenever a window is comfortably above
+                      TARGET (not above target+margin, which at high
+                      margin is unreachable - that one-way ratchet
+                      railed the margin at its cap and the schedule
+                      permanently over-aimed 50%, oscillating the
+                      cluster 80-116% around an aim it could never
+                      satisfy). Proportional and gentle: the margin
+                      settles where windows straddle the target.
+                    */
+                    const float excess =
+                        (win_speedup - target_speedup) / target_speedup;
+                    slave_margin = MAX(
+                        slave_margin -
+                        constrain_float(excess * 0.5f, 0.005f, 0.02f),
+                        slave_margin_floor);
+                    short_last_window = false;
+                } else {
+                    short_last_window = false;
+                }
+            }
+            last_margin_wall_us = wall_now2;
+            last_print_sim_us = time_now_us;
+            last_print_frames = frame_counter;
+            // ~8s smoothed headline (4 windows) so the reported trend is
+            // readable; the raw 2s window stays visible in parentheses
+            static float speedup_ema;
+            if (win_speedup > 0) {
+                speedup_ema = (speedup_ema <= 0)
+                    ? win_speedup
+                    : 0.75f * speedup_ema + 0.25f * win_speedup;
+            }
+            const float headline = (speedup_ema > 0)
+                ? speedup_ema : achieved_rate_hz / rate_hz;
+            // keep under STATUSTEXT's 50 chars or the GCS line chunks
+            // into two messages ("...mgn 3" / "0%"). The target is in
+            // every harness [follow] line already.
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO,
+                          "speedup %.1fx (2s %.0fx) dt %.1fms mgn %.0f%%",
+                          headline, win_speedup,
+                          dt_avg_ms, slave_margin * 100.0f);
+            ::printf("SIM: sim_time=%.0fs achieved %.1fx of requested "
+                     "%.0fx (frames %.0fHz, dt %.1fms, %.0f fps)\n",
+                     time_now_us * 1.0e-6,
+                     headline, target_speedup, rate_hz,
+                     (double)dt_avg_ms, (double)achieved_rate_hz);
+        }
+
+        adaptive_rate_governor(now_ms);
+#endif
     }
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL && !defined(HAL_BUILD_AP_PERIPH)
+    if (at_crossing) {
+    // publish basic swarm telemetry (position/velocity/heading) for peer
+    // instances to read - see AP_SITL_SwarmInfo for the payload layout.
+    {
+        AP_SITL_SwarmInfo swarm {};
+        swarm.sysid       = mavlink_system.sysid;
+        swarm.sim_time_us = time_now_us;
+        swarm.lat         = location.lat;
+        swarm.lng         = location.lng;
+        swarm.alt_cm      = location.alt;
+        swarm.vx          = velocity_ef.x;
+        swarm.vy          = velocity_ef.y;
+        swarm.vz          = velocity_ef.z;
+        float roll, pitch, yaw;
+        dcm.to_euler(&roll, &pitch, &yaw);
+        swarm.heading_deg = wrap_360(degrees(yaw));
+        hal_sitl.get_sitl_state()->_shared_mem.write_payload(&swarm, sizeof(swarm));
+    }
+
+    // When running multiple SITL instances in parallel, keep them within
+    // a bounded sim-time window of each other so inter-vehicle state is
+    // consistent. The window is wall-fixed (hence scaled by speedup, see
+    // above) and the barrier is a no-op for single-instance runs.
+    hal_sitl.get_sitl_state()->_shared_mem.sync_with_peers(time_now_us, max_skew_us);
+    }
+#endif
 }
+
 
 /* add noise based on throttle level (from 0..1) */
 void Aircraft::add_noise(float throttle)
@@ -385,7 +887,16 @@ double Aircraft::rand_normal(double mean, double stddev)
 void Aircraft::fill_fdm(struct sitl_fdm &fdm)
 {
     bool is_smoothed = false;
-    if (use_smoothing) {
+    // under SITL_ADAPTIVE_RATE the chase filter never engages AT ALL: its
+    // 0.1s chase rings against stretched timesteps (bouncing takeoffs with
+    // it, steady flight without), and switching sources mid-run at schedule
+    // engagement fed the controllers a sensor discontinuity they convulsed
+    // on (7-13 m/s impacts right at arm). EKF type 10 reads truth directly.
+    static int8_t adaptive_mode = -1;
+    if (adaptive_mode == -1) {
+        adaptive_mode = getenv("SITL_ADAPTIVE_RATE") != nullptr;
+    }
+    if (use_smoothing && adaptive_mode != 1) {
         smooth_sensors();
         is_smoothed = true;
     }
@@ -724,48 +1235,127 @@ void Aircraft::update_dynamics(const Vector3f &rot_accel)
 {
     WITH_SEMAPHORE(pose_sem);
 
-    const float delta_time = frame_time_us * 1.0e-6f;
+    // integrate with the frame's ACTUAL timestep: when the adaptive
+    // governor stretches a frame to hold the wall-clock schedule, the
+    // physics must advance by the same amount as the clock
+    const float delta_time =
+        (effective_frame_time_us != 0 ? effective_frame_time_us
+                                      : frame_time_us) * 1.0e-6f;
 
     // update eas2tas and air density
     eas2tas = AP_Baro::get_EAS2TAS_for_alt_amsl(location.alt*0.01);
     air_density = AP_Baro::get_air_density_for_alt_amsl(location.alt*0.01);
 
-    // update rotational rates in body frame
-    gyro += rot_accel * delta_time;
+    /*
+      sub-stepped integration: the expensive parts of a frame (sensor
+      generation, scheduler coupling) run once, but the pure
+      integration below costs about a microsecond, so a frame whose
+      timestep was stretched by the wall-slaved schedule is integrated
+      as N internal sub-steps of at most 5ms each - near full physics
+      quality at any stretch (single-step Euler at large timesteps
+      turned precise loiters into 50km orbits even with the safety
+      clamps). At normal frame rates N is 1 and nothing changes. The
+      model's forces are held constant across the sub-steps
+      (zero-order hold): control latency remains at the frame rate,
+      integration accuracy does not.
+    */
+    const uint32_t nsub =
+        constrain_int32((int32_t)ceilf(delta_time / 0.005f), 1, 4);
+    const float dt_sub = delta_time / nsub;
+    const bool was_on_ground = on_ground();
+    Vector3f accel_earth;
+    // hold the body-frame force input constant across sub-steps (true
+    // ZOH): re-integrating the rewritten accelerometer view as force misread
+    // thrust by the ground-clamp amount - copters bounced on takeoff forever
+    const Vector3f accel_body_in = accel_body;
+    for (uint32_t isub = 0; isub < nsub; isub++) {
+        // update rotational rates in body frame
+        gyro += rot_accel * dt_sub;
 
-    gyro.x = constrain_float(gyro.x, -radians(2000.0f), radians(2000.0f));
-    gyro.y = constrain_float(gyro.y, -radians(2000.0f), radians(2000.0f));
-    gyro.z = constrain_float(gyro.z, -radians(2000.0f), radians(2000.0f));
+        float gyro_limit_rads = radians(2000.0f);
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL && !defined(HAL_BUILD_AP_PERIPH)
+        // bound the rotation per integration step so no single step
+        // can rotate more than ~45 degrees: keeps the integration
+        // bounded at ANY timestep. Inert at sub-steps of 5ms or less.
+        if (dt_sub > 0.011f) {
+            gyro_limit_rads = MIN(gyro_limit_rads,
+                                  radians(45.0f) / dt_sub);
+        }
+#endif
+        gyro.x = constrain_float(gyro.x, -gyro_limit_rads, gyro_limit_rads);
+        gyro.y = constrain_float(gyro.y, -gyro_limit_rads, gyro_limit_rads);
+        gyro.z = constrain_float(gyro.z, -gyro_limit_rads, gyro_limit_rads);
 
-    // limit body accel to 64G
-    const float accel_limit = 64*GRAVITY_MSS;
-    accel_body.x = constrain_float(accel_body.x, -accel_limit, accel_limit);
-    accel_body.y = constrain_float(accel_body.y, -accel_limit, accel_limit);
-    accel_body.z = constrain_float(accel_body.z, -accel_limit, accel_limit);
+        // limit body accel to 64G
+        const float accel_limit = 64*GRAVITY_MSS;
+        accel_body.x = constrain_float(accel_body.x, -accel_limit, accel_limit);
+        accel_body.y = constrain_float(accel_body.y, -accel_limit, accel_limit);
+        accel_body.z = constrain_float(accel_body.z, -accel_limit, accel_limit);
 
-    // update attitude
-    dcm.rotate(gyro * delta_time);
-    dcm.normalize();
+        // update attitude
+        dcm.rotate(gyro * dt_sub);
+        dcm.normalize();
 
-    Vector3f accel_earth = dcm * accel_body;
-    accel_earth += Vector3f(0.0f, 0.0f, GRAVITY_MSS);
+        accel_earth = dcm * accel_body_in;
+        accel_earth += Vector3f(0.0f, 0.0f, GRAVITY_MSS);
 
-    // if we're on the ground, then our vertical acceleration is limited
-    // to zero. This effectively adds the force of the ground on the aircraft
-    if (on_ground() && accel_earth.z > 0) {
-        accel_earth.z = 0;
+        // if we're on the ground, then our vertical acceleration is limited
+        // to zero. This effectively adds the force of the ground on the aircraft
+        if (on_ground() && accel_earth.z > 0) {
+            accel_earth.z = 0;
+        }
+
+        // new velocity vector
+        velocity_ef += accel_earth * dt_sub;
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL && !defined(HAL_BUILD_AP_PERIPH)
+        // translational counterpart of the rotation clamp: bound the
+        // velocity to a generous flight envelope during STRETCHED
+        // FRAMES - gated on the frame timestep, not the sub-step:
+        // sub-stepping keeps sub-steps at 5ms or less by design, so a
+        // sub-step gate would never fire (measured: a plane flew
+        // 6,600km with the envelopes silently inert).
+        if (delta_time > 0.011f) {
+            const float vmax = 120.0f;
+            const float vlen = velocity_ef.length();
+            if (vlen > vmax) {
+                velocity_ef *= vmax / vlen;
+            }
+        }
+#endif
+
+        // new position vector
+        position += (velocity_ef * dt_sub).todouble();
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL && !defined(HAL_BUILD_AP_PERIPH)
+        // position envelope: a loosely-controlled vehicle at heavily
+        // stretched timesteps can drift for tens of thousands of sim
+        // seconds - one plane climbed out of the atmosphere and the
+        // barometric math died of a floating point exception; another
+        // rode the velocity cap 2,348km sideways to the same end.
+        // Bound the whole state box (NED: -z is up; 45km above, 1km
+        // below, 100km of horizontal range) so no downstream math can
+        // ever receive an unbounded input. Gated on the FRAME
+        // timestep - sub-steps are always small by design.
+        if (delta_time > 0.011f) {
+            position.z = constrain_double(position.z, -45000.0, 1000.0);
+            const double r2 = position.x * position.x +
+                              position.y * position.y;
+            const double rmax = 100000.0;
+            if (r2 > rmax * rmax) {
+                const double scale = rmax / sqrt(r2);
+                position.x *= scale;
+                position.y *= scale;
+            }
+        }
+#endif
     }
 
-    // work out acceleration as seen by the accelerometers. It sees the kinematic
-    // acceleration (ie. real movement), plus gravity
-    accel_body = dcm.transposed() * (accel_earth + Vector3f(0.0f, 0.0f, -GRAVITY_MSS));
-
-    // new velocity vector
-    velocity_ef += accel_earth * delta_time;
-
-    const bool was_on_ground = on_ground();
-    // new position vector
-    position += (velocity_ef * delta_time).todouble();
+    // acceleration as seen by the accelerometers (kinematic plus
+    // gravity), computed ONCE from the final attitude and possibly
+    // ground-clamped earth-frame acceleration, as the single-step path did
+    accel_body = dcm.transposed() *
+        (accel_earth + Vector3f(0.0f, 0.0f, -GRAVITY_MSS));
 
     // velocity relative to air mass, in earth frame
     velocity_air_ef = velocity_ef - wind_ef;
@@ -778,8 +1368,17 @@ void Aircraft::update_dynamics(const Vector3f &rot_accel)
 
     // constrain height to the ground
     if (on_ground()) {
-        if (!was_on_ground && AP_HAL::millis() - last_ground_contact_ms > 1000) {
-            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "SIM Hit ground at %f m/s", velocity_ef.z);
+        // no more than one report per 10 simulated seconds: a vehicle
+        // bouncing on its gear otherwise floods the telemetry stream,
+        // but the message must re-arm - autotests crash deliberately
+        // and wait for it long after an earlier normal touchdown
+        if (!was_on_ground &&
+            time_now_us - last_hit_ground_report_us > 10000000ULL) {
+            last_hit_ground_report_us = time_now_us;
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "SIM Hit ground at %f m/s (dt=%.0fms)",
+                          velocity_ef.z,
+                          (effective_frame_time_us != 0 ?
+                           effective_frame_time_us : frame_time_us) * 1.0e-3);
             last_ground_contact_ms = AP_HAL::millis();
         }
         position.z = -(ground_level + frame_height - home.alt * 0.01f + ground_height_difference());
@@ -1003,13 +1602,22 @@ void Aircraft::smooth_sensors(void)
 #endif
 
 
-    // integrate to get new attitude
-    smoothing.rotation_b2e.rotate(smoothing.gyro * delta_time);
-    smoothing.rotation_b2e.normalize();
+    // integrate the chase in sub-steps of <=10ms: explicit Euler on this
+    // 0.1s time constant is badly underdamped at ~40ms stretched frames, and
+    // the ringing sensor state threw a hovering copter down from metres up
+    const uint32_t smooth_nsub =
+        constrain_int32((int32_t)ceilf(delta_time / 0.010f), 1, 8);
+    const float dt_smooth = delta_time / smooth_nsub;
+    for (uint32_t i = 0; i < smooth_nsub; i++) {
+        // integrate to get new attitude
+        smoothing.rotation_b2e.rotate(smoothing.gyro * dt_smooth);
+        smoothing.rotation_b2e.normalize();
 
-    // integrate to get new position
-    smoothing.velocity_ef += accel_e * delta_time;
-    smoothing.position += (smoothing.velocity_ef * delta_time).todouble();
+        // integrate to get new position
+        smoothing.velocity_ef += accel_e * dt_smooth;
+        smoothing.position +=
+            (smoothing.velocity_ef * dt_smooth).todouble();
+    }
 
     smoothing.location = origin;
     smoothing.location.offset(smoothing.position.x, smoothing.position.y);
@@ -1030,7 +1638,12 @@ float Aircraft::filtered_servo_angle(const struct sitl_input &input, uint8_t idx
         // glad we have a zero-momentum system.
         pwm = servo_filter[idx].angle_pwm();
     }
-    return servo_filter[idx].filter_angle(pwm, frame_time_us * 1.0e-6);
+    // filter the actuators with the frame's ACTUAL timestep, not the
+    // nominal one: at nominal rate a stretched frame made every servo and
+    // motor respond several times slower in sim time - enough to bounce
+    return servo_filter[idx].filter_angle(
+        pwm, (effective_frame_time_us != 0 ?
+              effective_frame_time_us : frame_time_us) * 1.0e-6);
 }
 
 /*
@@ -1039,7 +1652,9 @@ float Aircraft::filtered_servo_angle(const struct sitl_input &input, uint8_t idx
  */
 float Aircraft::filtered_servo_range(const struct sitl_input &input, uint8_t idx)
 {
-    return servo_filter[idx].filter_range(input.servos[idx], frame_time_us * 1.0e-6);
+    return servo_filter[idx].filter_range(
+        input.servos[idx], (effective_frame_time_us != 0 ?
+                            effective_frame_time_us : frame_time_us) * 1.0e-6);
 }
 
 // setup filtering for servo

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -280,6 +280,32 @@ protected:
     float rate_hz = 1200.0f;
     float target_speedup;
     uint64_t frame_time_us;
+    // actual timestep of the current frame: equals frame_time_us
+    // except when the adaptive governor stretches a frame to
+    // hold simulated time on the wall-clock schedule
+    uint64_t effective_frame_time_us = 0;
+
+    // true while the wall-slaved schedule is engaged (cluster armed
+    // and the shared epoch published): the rate governor stands down
+    bool slave_engaged = false;
+
+    // the "SIM Hit ground" report is sent once per process
+    uint64_t last_hit_ground_report_us;
+
+    // fraction ABOVE the commanded speedup the slaved schedule aims
+    // for. Seeded from SITL_SPEEDUP_MARGIN (percent, default 5) and
+    // then self-scaling: windows measuring under commanded raise it,
+    // sustained overshoot trims it - whatever margin the host needs
+    // for the REPORTED speedup to meet the ask
+    float slave_margin = 0.05f;
+    float slave_margin_floor = 0.05f;
+
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL && !defined(HAL_BUILD_AP_PERIPH)
+    // runtime physics-rate governor (SITL_ADAPTIVE_RATE=1), evaluated
+    // once per wall reporting interval from sync_frame_time()
+    void adaptive_rate_governor(uint32_t now_ms);
+#endif
     uint64_t last_wall_time_us;
     uint32_t last_fps_report_ms;
     float achieved_rate_hz;  // achieved speedup rate

--- a/libraries/SITL/SIM_JSON.cpp
+++ b/libraries/SITL/SIM_JSON.cpp
@@ -31,6 +31,14 @@
 #include <AP_HAL/utility/replace.h>
 #include <SRV_Channel/SRV_Channel.h>
 #include <AP_Filesystem/AP_Filesystem.h>
+#include <stddef.h>
+#include <time.h>
+#include <unistd.h>
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL && !defined(HAL_BUILD_AP_PERIPH)
+#include <AP_HAL_SITL/HAL_SITL_Class.h>
+extern const HAL_SITL& hal_sitl;
+#endif
 
 #define UDP_TIMEOUT_MS 100
 
@@ -99,6 +107,98 @@ void JSON::set_interface_ports(const char* address, const int port_in, const int
     printf("JSON control interface set to %s:%u\n", target_ip, control_port);
 }
 
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL && !defined(HAL_BUILD_AP_PERIPH)
+static uint64_t ride_wall_micros(void)
+{
+    struct timespec ts {};
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ts.tv_sec * 1000000ULL + ts.tv_nsec / 1000ULL;
+}
+
+/*
+  the ride-along exchange runs over the cluster's shared memory segment
+  instead of the UDP sockets when this instance was started with
+  --cluster (the master must be too)
+*/
+bool JSON::ride_shmem_active(void) const
+{
+    return hal_sitl.get_sitl_state()->_shared_mem.is_initialised();
+}
+
+// publish our servo packet in our own slot's ride-along channel
+void JSON::ride_shmem_send(const void *pkt, uint32_t len)
+{
+    auto &shm = hal_sitl.get_sitl_state()->_shared_mem;
+    static AP_SITL_RideAlongChannel ch;
+    ch.magic = AP_SITL_RIDE_SERVO_MAGIC;
+    ch.len = MIN(len, (uint32_t)sizeof(ch.data));
+    memcpy(ch.data, pkt, ch.len);
+    ch.seq = ++ride_out_seq;
+    shm.write_payload(&ch, offsetof(AP_SITL_RideAlongChannel, data) + ch.len,
+                      AP_SITL_SHMEM_RIDE_OFFSET);
+}
+
+/*
+  poll the master's slot for a fresh fdm JSON line; mirrors
+  sock.recv(buf, size, timeout_ms) semantics, returning 0 on timeout
+*/
+ssize_t JSON::ride_shmem_recv(uint8_t *buf, uint32_t size, uint32_t timeout_ms)
+{
+    auto &shm = hal_sitl.get_sitl_state()->_shared_mem;
+    const uint64_t deadline_us = ride_wall_micros() + timeout_ms * 1000ULL;
+    uint32_t spins = 0;
+    while (true) {
+        if (ride_master_slot < 0) {
+            // discover which slot carries the fdm channel (usually the
+            // master's instance 0, but any slot with the magic works;
+            // give each ride-along group its own --cluster id)
+            for (uint8_t i = 0; i < AP_SITL_SHMEM_MAX_INSTANCES; i++) {
+                AP_SITL_RideAlongChannel hdr;
+                if (shm.instance_active(i) &&
+                    shm.read_payload(i, &hdr, offsetof(AP_SITL_RideAlongChannel, data),
+                                     AP_SITL_SHMEM_RIDE_OFFSET) &&
+                    hdr.magic == AP_SITL_RIDE_FDM_MAGIC) {
+                    ride_master_slot = i;
+                    printf("JSON: ride-along fdm found in shared-memory slot %u\n", i);
+                    break;
+                }
+            }
+        }
+        if (ride_master_slot >= 0) {
+            static AP_SITL_RideAlongChannel ch;
+            if (shm.read_payload(ride_master_slot, &ch, sizeof(ch),
+                                 AP_SITL_SHMEM_RIDE_OFFSET) &&
+                ch.magic == AP_SITL_RIDE_FDM_MAGIC &&
+                ch.seq != ride_in_seq) {
+                ride_in_seq = ch.seq;
+                const uint32_t n = MIN(ch.len, MIN((uint32_t)sizeof(ch.data), size));
+                memcpy(buf, ch.data, n);
+                return n;
+            }
+        }
+        if (ride_wall_micros() >= deadline_us) {
+            return 0;
+        }
+        if (++spins > 5000) {
+            usleep(100);
+            spins = 0;
+        }
+    }
+}
+#endif  // HAL_BOARD_SITL && !HAL_BUILD_AP_PERIPH
+
+ssize_t JSON::transport_recv(uint32_t timeout_ms)
+{
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL && !defined(HAL_BUILD_AP_PERIPH)
+    if (ride_shmem_active()) {
+        return ride_shmem_recv(&sensor_buffer[sensor_buffer_len],
+                               sizeof(sensor_buffer)-sensor_buffer_len, timeout_ms);
+    }
+#endif
+    return sock.recv(&sensor_buffer[sensor_buffer_len],
+                     sizeof(sensor_buffer)-sensor_buffer_len, timeout_ms);
+}
+
 /*
     Decode and send servos
 */
@@ -114,6 +214,12 @@ void JSON::output_servos(const struct sitl_input &input)
           pkt.pwm[i] = input.servos[i];
       }
       pkt_size = sizeof(pkt);
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL && !defined(HAL_BUILD_AP_PERIPH)
+      if (ride_shmem_active()) {
+          ride_shmem_send(&pkt, pkt_size);
+          send_ret = pkt_size;
+      } else
+#endif
       send_ret = sock.sendto(&pkt, pkt_size, target_ip, control_port);
     } else {
       servo_packet_16 pkt;
@@ -123,6 +229,12 @@ void JSON::output_servos(const struct sitl_input &input)
           pkt.pwm[i] = input.servos[i];
       }
       pkt_size = sizeof(pkt);
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL && !defined(HAL_BUILD_AP_PERIPH)
+      if (ride_shmem_active()) {
+          ride_shmem_send(&pkt, pkt_size);
+          send_ret = pkt_size;
+      } else
+#endif
       send_ret = sock.sendto(&pkt, pkt_size, target_ip, control_port);
     }
 
@@ -303,7 +415,7 @@ uint64_t JSON::parse_sensors(const char *json)
 void JSON::recv_fdm(const struct sitl_input &input)
 {
     // Receive sensor packet
-    ssize_t ret = sock.recv(&sensor_buffer[sensor_buffer_len], sizeof(sensor_buffer)-sensor_buffer_len, UDP_TIMEOUT_MS);
+    ssize_t ret = transport_recv(UDP_TIMEOUT_MS);
     uint32_t wait_ms = UDP_TIMEOUT_MS;
 
     if (state.no_lockstep && ret <= 0) {
@@ -320,7 +432,7 @@ void JSON::recv_fdm(const struct sitl_input &input)
 
     while (ret <= 0) {
         //printf("No JSON sensor message received - %s\n", strerror(errno));
-        ret = sock.recv(&sensor_buffer[sensor_buffer_len], sizeof(sensor_buffer)-sensor_buffer_len, UDP_TIMEOUT_MS);
+        ret = transport_recv(UDP_TIMEOUT_MS);
         wait_ms += UDP_TIMEOUT_MS;
         // if no sensor message is received after 10 second resend servos, this help cope with SITL and the physics getting out of sync
         if (wait_ms > 1000) {

--- a/libraries/SITL/SIM_JSON.h
+++ b/libraries/SITL/SIM_JSON.h
@@ -75,6 +75,24 @@ private:
     void output_servos(const struct sitl_input &input);
     void recv_fdm(const struct sitl_input &input);
 
+    // receive one chunk from whichever transport is active into
+    // sensor_buffer (shared-memory ride-along channel when this
+    // instance was started with --cluster, the UDP socket otherwise);
+    // mirrors sock.recv() semantics, returning 0 on timeout
+    ssize_t transport_recv(uint32_t timeout_ms);
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL && !defined(HAL_BUILD_AP_PERIPH)
+    // ride-along over the cluster's shared memory segment, as an
+    // alternative to the UDP sockets: see AP_SITL_RideAlongChannel in
+    // SITL_SharedMem.h
+    bool ride_shmem_active(void) const;
+    void ride_shmem_send(const void *pkt, uint32_t len);
+    ssize_t ride_shmem_recv(uint8_t *buf, uint32_t size, uint32_t timeout_ms);
+    uint32_t ride_out_seq;
+    uint32_t ride_in_seq;
+    int8_t ride_master_slot = -1;   // shmem slot the fdm channel was found in
+#endif
+
     uint64_t parse_sensors(const char *json);
 
     // buffer for parsing pose data in JSON format

--- a/libraries/SITL/SIM_JSON_Master.cpp
+++ b/libraries/SITL/SIM_JSON_Master.cpp
@@ -23,12 +23,83 @@
 #include <AP_Logger/AP_Logger.h>
 #include <errno.h>
 #include <stdio.h>
+#include <stddef.h>
+#include <time.h>
+#include <unistd.h>
 #include <SITL/SITL.h>
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL && !defined(HAL_BUILD_AP_PERIPH)
+#include <AP_HAL_SITL/HAL_SITL_Class.h>
+extern const HAL_SITL& hal_sitl;
+#endif
 
 using namespace SITL;
 
+/*
+  wall-clock micros for the frames/s report: AP_HAL::micros64() is
+  simulated time in SITL, which stalls while we block on a slave
+*/
+static uint64_t wall_micros64(void)
+{
+    struct timespec ts {};
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ts.tv_sec * 1000000ULL + ts.tv_nsec / 1000ULL;
+}
+
+bool JSON_Master::shmem_transport(void) const
+{
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL && !defined(HAL_BUILD_AP_PERIPH)
+    return hal_sitl.get_sitl_state()->_shared_mem.is_initialised();
+#else
+    return false;
+#endif
+}
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL && !defined(HAL_BUILD_AP_PERIPH)
+void JSON_Master::receive_shmem(socket_list &list, void *pkt, uint32_t pkt_len)
+{
+    if (list.instance >= AP_SITL_SHMEM_MAX_INSTANCES) {
+        AP_HAL::panic("JSON master: shared-memory ride-along supports at most %u slaves",
+                      AP_SITL_SHMEM_MAX_INSTANCES - 1);
+    }
+    auto &shm = hal_sitl.get_sitl_state()->_shared_mem;
+    static AP_SITL_RideAlongChannel ch;
+    const uint32_t rec_len = offsetof(AP_SITL_RideAlongChannel, data) + pkt_len;
+    uint32_t spins = 0;
+    while (true) {
+        if (shm.read_payload(list.instance, &ch, rec_len, AP_SITL_SHMEM_RIDE_OFFSET) &&
+            ch.magic == AP_SITL_RIDE_SERVO_MAGIC &&
+            ch.seq != list.seq &&
+            ch.len >= pkt_len) {
+            list.seq = ch.seq;
+            uint16_t inner_magic;
+            memcpy(&inner_magic, ch.data, sizeof(inner_magic));
+            if (inner_magic != 18458) {
+                // not a 16-channel servo packet; same acceptance rule as
+                // the UDP path
+                continue;
+            }
+            memcpy(pkt, ch.data, pkt_len);
+            if (!list.connected) {
+                list.connected = true;
+                printf("Slave %u connected via shared memory\n", list.instance);
+            }
+            return;
+        }
+        // no fresh frame yet. Be polite while waiting for the slave to
+        // start up, then poll hard: this wait is on the hot path of
+        // every simulation frame.
+        if (!list.connected || ++spins > 5000) {
+            usleep(100);
+            spins = 0;
+        }
+    }
+}
+#endif  // HAL_BOARD_SITL && !HAL_BUILD_AP_PERIPH
+
 void JSON_Master::init(const int32_t num_slaves)
 {
+    slave_count = num_slaves;
     socket_list *list = &_list;
     uint8_t i = 1;
     for (i = 1 ; i <= num_slaves; i++) {
@@ -74,6 +145,11 @@ void JSON_Master::receive(struct sitl_input &input)
             uint16_t pwm[16];
         } buffer{};
 
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL && !defined(HAL_BUILD_AP_PERIPH)
+        if (shmem_transport()) {
+            receive_shmem(*list, &buffer, sizeof(buffer));
+        } else
+#endif
         while (true) {
             ssize_t ret = list->sock_in.recv(&buffer, sizeof(buffer), 100);
             if (ret == 0) {
@@ -184,10 +260,40 @@ void JSON_Master::send(const struct sitl_fdm &output, const Vector3d &position)
                             output.quaternion.q1, output.quaternion.q2, output.quaternion.q3, output.quaternion.q4,
                             output.speedN, output.speedE, output.speedD);
 
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL && !defined(HAL_BUILD_AP_PERIPH)
+    if (shmem_transport()) {
+        // shared-memory transport: one publish into our own slot's
+        // channel serves every slave
+        auto &shm = hal_sitl.get_sitl_state()->_shared_mem;
+        static AP_SITL_RideAlongChannel ch;
+        ch.magic = AP_SITL_RIDE_FDM_MAGIC;
+        ch.len = MIN((uint32_t)length, (uint32_t)sizeof(ch.data));
+        memcpy(ch.data, json_out, ch.len);
+        ch.seq = ++fdm_seq;
+        shm.write_payload(&ch, offsetof(AP_SITL_RideAlongChannel, data) + ch.len,
+                          AP_SITL_SHMEM_RIDE_OFFSET);
+    } else
+#endif
     for (socket_list *list = &_list; list->next; list=list->next) {
         list->sock_out.send(json_out,length);
     }
     free(json_out);
+
+    // achieved exchange rate, reported for either transport so the two
+    // can be compared directly: one frame here is one full fdm -> servo
+    // round trip with every slave
+    report_frames++;
+    const uint64_t now_us = wall_micros64();
+    if (report_wall_us == 0) {
+        report_wall_us = now_us;
+    } else if (now_us - report_wall_us >= 2000000) {
+        printf("JSON master (%s): %.0f frames/s to %u slave(s)\n",
+               shmem_transport() ? "shmem" : "udp",
+               report_frames * 1.0e6 / (now_us - report_wall_us),
+               (unsigned)slave_count);
+        report_frames = 0;
+        report_wall_us = now_us;
+    }
 }
 
 

--- a/libraries/SITL/SIM_JSON_Master.h
+++ b/libraries/SITL/SIM_JSON_Master.h
@@ -48,12 +48,30 @@ private:
         SocketAPM_native sock_out{true};
         uint8_t instance;
         bool connected;
+        uint32_t seq;       // last consumed shared-memory channel seq
         socket_list *next;
     } _list;
+
+    // true when the ride-along exchange runs over the cluster's shared
+    // memory segment (--cluster given) instead of the UDP sockets
+    bool shmem_transport(void) const;
+
+    // shared-memory equivalent of the UDP receive loop: block until the
+    // slave publishes a fresh servo packet in its slot's channel
+    void receive_shmem(struct socket_list &list, void *pkt, uint32_t pkt_len);
 
     char *json_out;
 
     bool initialized;
+
+    uint8_t slave_count;
+
+    // sequence number of our published fdm channel (shmem transport)
+    uint32_t fdm_seq;
+
+    // wall-clock window for the periodic frames/s report
+    uint64_t report_wall_us;
+    uint32_t report_frames;
 
 };
 


### PR DESCRIPTION
### Summary

PR: Shared memory clock sync for multi-instance SITL , eg swarms

### Classification & Testing (check all that apply and add your own)

- [ x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ x] Infrastructure change (e.g. unit tests, helper scripts)
- [x ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x ] Tested manually, description below (e.g. SITL)

PR: Shared memory clock sync for multi-instance SITL , eg swarms
Adds AP_SITL_SharedMem, a POSIX shared-memory segment (ardupilot_sitl_shmem) letting multiple SITL instances on one host stay in lock-step and exchange basic swarm telemetry.

What it does:

Each instance registers a slot (pid, sim_time_us) at startup; fleet size set via SITL_INSTANCE_COUNT env var.
Aircraft::sync_frame_time() publishes sim time each frame and barrier-syncs against peers, cutting clock skew across 5 instances at speedup=100 from ~1.5s to ~2.5ms.
Per-slot payload (sysid, position, velocity, heading) guarded by a robust process-shared mutex (EOWNERDEAD-safe) for swarm experiments.
Stalled/crashed/rebooted peers are detected and excluded from the barrier without blocking the rest of the swarm; a freshly-rebooted instance snaps its clock to match peers instead of blocking others.
Stale/undersized leftover segments are detected and recreated.
Testing:

Manual swarm test with 5 live consoles:

```
for i in 0 1 2 3 4; do  gnome-terminal --title="SITL instance $i" -- bash -c \    "cd ~/ardupilot && SITL_INSTANCE_COUNT=5 Tools/autotest/sim_vehicle.py -v ArduCopter -I $i --no-rebuild --speedup 100; exec bash"done
```
Confirms all 5 instances register, reach lock-step (SITL_SharedMem: instance N in lock-step with 5 instances), and recover cleanly when individual instances are rebooted via MAVLink mid-run.

Also included: test_sitl_multi_instance.sh, a quick smoke test that launches 5 instances headless and confirms they all start/stay running.

AI-assisted contribution (Claude/Copilot); all changes reviewed and tested by a human.

