### PR TITLE
AP_GPS: fix conversion table dangling pointer warning

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -365,7 +365,7 @@ void AP_GPS::convert_parameters()
     }
 
     // table parameters to convert without scaling
-    static const AP_Param::ConversionInfo conversion_info[] {
+    const AP_Param::ConversionInfo conversion_info[] {
         // PARAMETER_CONVERSION - Added: Mar-2024 for 4.6
         { k_param_gps_key, 0, AP_PARAM_INT8, "GPS1_TYPE" },
         { k_param_gps_key, 1, AP_PARAM_INT8, "GPS2_TYPE" },


### PR DESCRIPTION
### Summary

Fixes a `-Wdangling-pointer` warning in `AP_GPS::convert_parameters()` by making the GPS parameter conversion table a normal local const array.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

Built Copter for `esp32s3m5stampfly` and confirmed the previous `dangling pointer` warning no longer appears.

### Description

`AP_GPS::convert_parameters()` builds a conversion table using the local `k_param_gps_key` value. The table was declared `static const`, which can trigger a GCC `-Wdangling-pointer` warning because the static object is initialized from a local variable.

This changes the table to a normal local const array. The table is used immediately by `AP_Param::convert_old_parameters()`, so behavior is unchanged while avoiding the warning.