### PR TITLE
AP_DAL: guard wheel encoder access when disabled

### DIFF
--- a/libraries/AP_DAL/AP_DAL.cpp
+++ b/libraries/AP_DAL/AP_DAL.cpp
@@ -78,7 +78,11 @@ void AP_DAL::start_frame(AP_DAL::FrameType frametype)
 #if AP_OPTICALFLOW_ENABLED
     _RFRN.opticalflow_enabled = AP::opticalflow() && AP::opticalflow()->enabled();
 #endif
+#if AP_WHEELENCODER_ENABLED
     _RFRN.wheelencoder_enabled = AP::wheelencoder() && (AP::wheelencoder()->num_sensors() > 0);
+#else
+    _RFRN.wheelencoder_enabled = false;
+#endif
     _RFRN.ekf_type = int8_t(ahrs.configured_ekf_type());
     WRITE_REPLAY_BLOCK_IFCHANGED(RFRN, _RFRN, old);
 
@@ -592,4 +596,3 @@ void rprintf(const char *format, ...)
     va_end(ap);
 #endif
 }
-

--- a/libraries/AP_WheelEncoder/AP_WheelEncoder.h
+++ b/libraries/AP_WheelEncoder/AP_WheelEncoder.h
@@ -18,6 +18,10 @@
 #include <AP_Param/AP_Param.h>
 #include <AP_Math/AP_Math.h>
 
+#ifndef AP_WHEELENCODER_ENABLED
+#define AP_WHEELENCODER_ENABLED 1
+#endif
+
 // Maximum number of WheelEncoder measurement instances available on this platform
 #define WHEELENCODER_MAX_INSTANCES      2
 #define WHEELENCODER_CPR_DEFAULT        3200    // default encoder counts per full revolution of the wheel


### PR DESCRIPTION
### Summary

Avoids referencing `AP::wheelencoder()` from AP_DAL when `AP_WHEELENCODER_ENABLED` is disabled.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

Built Copter for `esp32s3m5stampfly` with `AP_WHEELENCODER_ENABLED=0` set through an extra hwdef.

```bash
./waf configure --board esp32s3m5stampfly --extra-hwdef /tmp/no-wheelencoder.hwdef
./waf copter -j1
```

Build completed successfully.

### Description

`AP_DAL::start_frame()` unconditionally accessed `AP::wheelencoder()` while updating replay frame navigation data. This caused link failures for builds that disable wheel encoder support and remove the AP_WheelEncoder library.

This change adds a default `AP_WHEELENCODER_ENABLED` definition and guards the AP_DAL wheel encoder access. When wheel encoder support is disabled, the replay flag is set false without referencing `AP::wheelencoder()`.
