### PR TITLE
Stop state leaking out of various tests

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -7387,6 +7387,9 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
     def WPYawBehaviour1RTL(self):
         '''ensure behaviour 1 (face home) works in RTL'''
         self.start_subtest("moving off in guided mode and checking return yaw")
+        # the vehicle's heading is whatever the previous test left it
+        # at - reboot to get the known spawn heading
+        self.reboot_sitl()
         self.change_mode('GUIDED')
         self.wait_ready_to_arm()
         self.wait_heading(272, timeout=1)  # verify initial heading"

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -10000,10 +10000,15 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         })
         self.reboot_sitl()
 
+        # the FFT reports its finding during the hover below - before
+        # this wait begins - so collect from here rather than only
+        # seeing what arrives once we start looking
+        self.context_collect('STATUSTEXT')
+
         # do test flight:
         self.takeoff(10, mode="ALT_HOLD")
         tstart, tend, hover_throttle = self.hover_for_interval(10)
-        self.wait_statustext("Noise ", timeout=20)
+        self.wait_statustext("Noise ", timeout=20, check_context=True)
         self.set_parameter("SIM_GYR1_RND", 0) # stop noise so that we can get home
         self.do_RTL()
 
@@ -13592,11 +13597,16 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             "EK3_SRC1_VELZ": 0,    # None
             "AHRS_EKF_TYPE": 3,
         })
+        # this message is emitted as the vehicle comes up, so it can
+        # arrive before a wait started afterwards; collect across the
+        # reboot, which empties the collection as it goes
+        self.context_collect('STATUSTEXT')
+
         self.reboot_sitl()
 
         # allow EKF to initialise: validOrigin set from GPS, filter
         # reaches steady AID_NONE state
-        self.wait_statustext("EKF3 IMU0 initialised", timeout=30)
+        self.wait_statustext("EKF3 IMU0 initialised", timeout=30, check_context=True)
 
         # capture baseline reported position
         m = self.assert_receive_message('GLOBAL_POSITION_INT')
@@ -17775,9 +17785,14 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             'EK2_ENABLE': 1,
             'EK3_CHECK_SCALE': 1, # make EK3 slow to get origin
         })
-        self.reboot_sitl()
-
+        # collect before the reboot: the messages waited for below are
+        # emitted as the vehicle comes up, so a collection started
+        # afterwards is created too late to catch them.  reboot_sitl()
+        # empties collections as it goes, so the identical messages
+        # from before the reboot cannot satisfy those waits.
         self.context_collect('STATUSTEXT')
+
+        self.reboot_sitl()
 
         self.wait_statustext("EKF2 IMU0 origin set", timeout=60, check_context=True)
         self.wait_statustext("EKF2 IMU0 is using GPS", timeout=60, check_context=True)
@@ -17882,9 +17897,14 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             'AHRS_EKF_TYPE': 11,     # configured EXTERNAL: origin pre-arm check active
             'INS_GYR_CAL': 1,
         })
-        self.reboot_sitl()
-
+        # collect before the reboot: the messages waited for below are
+        # emitted as the vehicle comes up, so a collection started
+        # afterwards is created too late to catch them.  reboot_sitl()
+        # empties collections as it goes, so the identical messages
+        # from before the reboot cannot satisfy those waits.
         self.context_collect('STATUSTEXT')
+
+        self.reboot_sitl()
 
         # EKF3 obtains an origin from the SITL GPS:
         self.wait_statustext("EKF3 IMU0 origin set", timeout=60, check_context=True)

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -6445,15 +6445,8 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 self.set_analog_rangefinder_parameters()
                 self.set_parameter("SIM_SONAR_SCALE", 12)
 
-                start = self.mav.location()
-                target = start
-                (target.lat, target.lng) = mavextra.gps_offset(start.lat, start.lng, 4, -4)
-                self.progress("Setting target to %f %f" % (target.lat, target.lng))
-
                 self.set_parameters({
                     "SIM_PLD_ENABLE": 1,
-                    "SIM_PLD_LAT": target.lat,
-                    "SIM_PLD_LON": target.lng,
                     "SIM_PLD_HEIGHT": 0,
                     "SIM_PLD_ALT_LMT": 15,
                     "SIM_PLD_DIST_LMT": 10,
@@ -6462,6 +6455,21 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 self.reboot_sitl()
 
                 self.progress("Waiting for location")
+                self.wait_ready_to_arm()
+
+                # place the target relative to the vehicle's post-reboot
+                # position - which is the spawn position.  Sampling the
+                # position before the reboot places the target wherever
+                # the previous test happened to leave the vehicle:
+                start = self.mav.location()
+                target = start
+                (target.lat, target.lng) = mavextra.gps_offset(start.lat, start.lng, 4, -4)
+                self.progress("Setting target to %f %f" % (target.lat, target.lng))
+                self.set_parameters({
+                    "SIM_PLD_LAT": target.lat,
+                    "SIM_PLD_LON": target.lng,
+                })
+
                 self.zero_throttle()
                 self.takeoff(10, 1800, mode="LOITER")
                 self.change_mode("LAND")

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -17817,7 +17817,6 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         """Test common origin between EKF2 and EKF3"""
         # start on EKF2
         self.set_parameters({
-            'AHRS_EKF_TYPE': 2,
             'EK2_ENABLE': 1,
             'EK3_CHECK_SCALE': 1, # make EK3 slow to get origin
         })
@@ -17832,6 +17831,13 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.wait_statustext("EKF2 IMU0 origin set", timeout=60, check_context=True)
         self.wait_statustext("EKF2 IMU0 is using GPS", timeout=60, check_context=True)
+
+        # "AHRS: ... active" is emitted only when the active backend
+        # changes, so ask for EKF2 here rather than before the reboot:
+        # a vehicle which boots already configured for it comes up with
+        # it active and says nothing, and the wait would be left
+        # matching the message from before the reboot.
+        self.set_parameter('AHRS_EKF_TYPE', 2)
         self.wait_statustext("EKF2 active", timeout=60, check_context=True)
 
         # get EKF2 origin

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -18162,6 +18162,9 @@ RTL_ALT_M 111
 
     def RTLYaw(self):
         '''test that vehicle yaws to original heading on RTL'''
+        # the vehicle's heading is whatever the previous test left it
+        # at - reboot to get the known spawn heading
+        self.reboot_sitl()
         # 0 is WP_YAW_BEHAVIOR_NONE
         # 1 is WP_YAW_BEHAVIOR_LOOK_AT_NEXT_WP
         # 2 is WP_YAW_BEHAVIOR_LOOK_AT_NEXT_WP_EXCEPT_RTL

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -17996,6 +17996,13 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         """Test AHRS option to record and reuse origin"""
         self.context_push()
 
+        # The firmware writes these itself once the origin is known, so
+        # register them now, while they are still as the session started;
+        # otherwise the origin recorded here is left behind for every test
+        # which follows.
+        self.context_preserve_parameters([
+            'AHRS_ORIGIN_LAT', 'AHRS_ORIGIN_LON', 'AHRS_ORIGIN_ALT',
+        ])
         # Set AHRS_OPTIONS = 8 (UseRecordedOrigin)
         self.set_parameter('AHRS_OPTIONS', 8)
         self.set_parameter('LOG_DISARMED', 1)
@@ -18265,6 +18272,13 @@ RTL_ALT_M 111
 
     def CompassLearnCopyFromEKF(self):
         '''test compass learning whereby we copy learnt offsets from the EKF'''
+        # a successful learn makes the firmware save the offsets it found,
+        # which the suite has no record of and cannot put back
+        self.context_preserve_parameters([
+            "COMPASS_OFS_X", "COMPASS_OFS_Y", "COMPASS_OFS_Z",
+            "COMPASS_OFS2_X", "COMPASS_OFS2_Y", "COMPASS_OFS2_Z",
+            "COMPASS_OFS3_X", "COMPASS_OFS3_Y", "COMPASS_OFS3_Z",
+        ])
         self.reboot_sitl()
         self.context_push()
         self.set_parameters({

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -3628,6 +3628,25 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
     def CompassMot(self):
         '''test code that adjust mag field for motor interference'''
+        # simulate real motor interference for the calibration to
+        # learn: SIM_MAG_MOT is applied as mGauss per amp of battery
+        # current.  Without it the calibration fits noise and whatever
+        # attitude changes the (unanchored, throttled-up) vehicle's
+        # excursions produce - the historical strictly-positive
+        # compensation check passed or failed by accident.  Negative
+        # interference so the learned compensation is positive:
+        self.set_parameters({
+            "SIM_MAG_MOT_X": -10,
+            "SIM_MAG_MOT_Y": -10,
+            "SIM_MAG_MOT_Z": -10,
+            "SIM_CLAMP_CH": 11,
+        })
+        # hold the vehicle in the simulated clamp so the calibration
+        # is bench-static, as compassmot is in the real world - at
+        # full throttle an unclamped SITL vehicle takes off and
+        # crashes mid-calibration:
+        self.run_cmd(mavutil.mavlink.MAV_CMD_DO_SET_SERVO, p1=11, p2=2000)
+        self.wait_statustext("SITL: Clamp: grabbed vehicle")
         self.run_cmd(
             mavutil.mavlink.MAV_CMD_PREFLIGHT_CALIBRATION,
             0,  # p1
@@ -3677,10 +3696,16 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         m = self.wait_message_field_values("COMPASSMOT_STATUS", {
             "throttle": 0,
         }, verbose=True)
+        # the calibration should recover the injected interference:
+        # compensation is the negation of SIM_MAG_MOT (measured
+        # recovery error ~0.001%; tolerance is generous)
         for axis in "X", "Y", "Z":
             fieldname = "Compensation" + axis
-            if getattr(m, fieldname) <= 0:
-                raise NotAchievedException("Expected non-zero %s" % fieldname)
+            value = getattr(m, fieldname)
+            if abs(value - 10.0) > 0.5:
+                raise NotAchievedException(
+                    "%s %f does not match injected interference (want 10.0)" %
+                    (fieldname, value))
 
         # it's kind of crap - but any command-ack will stop the
         # calibration

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -9770,8 +9770,21 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         # when we pop the context
         self.set_parameter("FFT_ENABLE", 0)
 
+    # every parameter the harmonic notch has
+    # (libraries/Filter/HarmonicNotchFilter.cpp), which is what the FFT
+    # notch tune writes and saves for itself
+    harmonic_notch_params = [
+        "INS_HNTCH_%s" % suffix
+        for suffix in ("ENABLE", "FREQ", "BW", "ATT", "HMNCS", "REF",
+                       "MODE", "OPTS", "FM_RAT")
+    ]
+
     def GyroFFTAverage(self):
         """Use dynamic harmonic notch to control motor noise setup via FFT averaging."""
+        # the point of this test is that the vehicle works the notch out
+        # and saves it, which the suite has no record of and so cannot
+        # revert; register the values now so that it can
+        self.context_preserve_parameters(self.harmonic_notch_params)
         # basic gyro sample rate test
         self.progress("Flying with gyro FFT harmonic - Gyro sample rate")
         # Step 1

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -3641,6 +3641,17 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             "SIM_MAG_MOT_Z": -10,
             "SIM_CLAMP_CH": 11,
         })
+        # the calibration below makes the *firmware* write its results,
+        # so the suite has no record of them and they would survive into
+        # every test which follows in this session.  Register them for
+        # restoration on context_pop():
+        self.context_preserve_parameters([
+            "COMPASS_MOTCT",
+            "COMPASS_MOT_X", "COMPASS_MOT_Y", "COMPASS_MOT_Z",
+            "COMPASS_MOT2_X", "COMPASS_MOT2_Y", "COMPASS_MOT2_Z",
+            "COMPASS_MOT3_X", "COMPASS_MOT3_Y", "COMPASS_MOT3_Z",
+        ])
+
         # hold the vehicle in the simulated clamp so the calibration
         # is bench-static, as compassmot is in the real world - at
         # full throttle an unclamped SITL vehicle takes off and

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -18075,7 +18075,15 @@ RTL_ALT_M 111
         f2.write("RTL_ALT_M 750\n")
         f2.close()
 
-        self.customise_SITL_commandline([], defaults_filepath=[f1.name, f2.name])
+        # wipe: a defaults file only supplies parameters which are not
+        # already saved, so with the eeprom left alone anything an
+        # earlier test stored wins over the file we are testing -
+        # set_autodisarm_delay() saves DISARM_DELAY, and this test then
+        # reads back the stored value rather than the one from f1:
+        #     DefaultsCommaList (...) (parameter DISARM_DELAY want=20.000000 got=10.000000)
+        self.customise_SITL_commandline([],
+                                        defaults_filepath=[f1.name, f2.name],
+                                        wipe=True)
 
         # f2 overrides RTL_ALT_M; DISARM_DELAY comes only from f1
         self.assert_parameter_value("RTL_ALT_M", 750)

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -10436,6 +10436,10 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
     def check_avoidance_corners(self):
         self.takeoff(10, mode="LOITER")
         here = self.mav.location()
+        # the vehicle starts a test at home but with whatever heading
+        # the previous test left it; face west like the other corner
+        # legs explicitly face their travel direction:
+        self.reach_heading_manual(270)
         self.set_rc(2, 1400)
         west_loc = mavutil.location(-35.363007,
                                     149.164911,

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -18544,6 +18544,7 @@ RTL_ALT_M 111
         self.set_parameters({
             "MAV_GCS_SYSID": 250,
             "SIM_RC_FAIL": 1,  # no-pulses
+            "LOG_DISARMED": 1,  # we are timing sensitive, avoid stall on log open
         })
         self.reboot_sitl()
 

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -17657,6 +17657,14 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             "AUTO_OPTIONS": 3,
         })
 
+        # this checks yaw behaviour by watching the vehicle turn away
+        # from where it started, so it needs to start somewhere other
+        # than north - the SITL start heading is 270.  The vehicle is
+        # left wherever the previous test put it, which can be pointing
+        # very nearly north:
+        #     MissionRTLYawBehaviour (...) (Bad original heading 1)
+        self.reboot_sitl()
+
         self.start_subtest("behaviour with WP_YAW_BEHAVE set to next-waypoint-except-RTL")
         self.upload_simple_relhome_mission([
             #                                      N   E  U

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -18027,8 +18027,12 @@ RTL_ALT_M 123
 RTL_ALT_FINAL_M 129
 """)
         defaults_filepath.close()
+        # wipe: a defaults file only supplies parameters which are not
+        # already saved, so without this whatever an earlier test stored
+        # for DISARM_DELAY wins over the @READONLY value being tested:
+        #     ReadOnlyDefaults (...) (parameter DISARM_DELAY want=77.000000 got=10.000000)
         self.customise_SITL_commandline([
-        ], defaults_filepath=defaults_filepath.name)
+        ], defaults_filepath=defaults_filepath.name, wipe=True)
 
         self.context_collect('STATUSTEXT')
         self.send_set_parameter_direct("DISARM_DELAY", 88)

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -18020,6 +18020,13 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.set_parameter('AHRS_OPTIONS', 8)
         self.set_parameter('LOG_DISARMED', 1)
 
+        # AP_AHRS records the origin on the transition to having one
+        # ("if (origin_ok && !state.origin_ok)"), so if an earlier test in
+        # this session has already given the EKF an origin then the edge
+        # never comes again and nothing is written.  Reboot so that the
+        # transition happens with the option above already set.
+        self.reboot_sitl()
+
         # wait for vehicle to be ready to arm which means origin should have been written
         self.wait_ready_to_arm()
 

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -4939,6 +4939,15 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.run_auxfunc(64, 0, run_cmd=run_cmd)
         self.wait_statustext("RevThrottle: DISABLE", check_context=True)
         self.run_auxfunc(65, 2, run_cmd=run_cmd)  # 65 == GPS_DISABLE
+        # ... and put it back.  Aux function state is not a parameter, so
+        # context_pop() does not restore it, and the suite no longer
+        # restarts the SITL between tests - so without this every test
+        # which follows on this worker inherits a vehicle with no GPS,
+        # and an EKF which never starts:
+        #     AHRS2Logging (...) (Failed to get EKF.flags=831)      [EKF_UNINITIALIZED]
+        #     AHRS_ORIENTATION (...) (GPS status bits did not become good)
+        self.run_auxfunc(65, 0, run_cmd=run_cmd)
+        self.wait_gps_sys_status_not_present_or_enabled_and_healthy()
 
         self.start_subtest("Bad auxfunc")
         self.run_auxfunc(

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -6792,6 +6792,12 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.generic_mission_filepath_for_filename("flaps.txt"),
         ], checkfail=True)
         self.start_SITL()
+        # run_mission.py flew a SITL of its own in this directory, so the
+        # storage is not as we left it - notably the parameters the suite
+        # relies on, LOG_DISARMED and the two logging rate limits, are no
+        # longer set, and nothing here has put them back.  Ask for the
+        # standard reset at the end of the test.
+        self.context_get().sitl_commandline_customised = True
 
     def MAV_CMD_GUIDED_CHANGE_ALTITUDE(self):
         '''test handling of MAV_CMD_GUIDED_CHANGE_ALTITUDE'''

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -7529,6 +7529,12 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
     def CompassLearnInFlight(self):
         '''check we can learn compass offsets in flight'''
+        # learning completes only when the EKF's GSF yaw estimator is
+        # converged.  Flying done by earlier tests in the same boot can
+        # leave the EKF in a state where the GSF hovers above the
+        # convergence threshold for the length of this test - so reboot
+        # to run from a known state
+        self.reboot_sitl()
         self.context_push()
         self.set_parameters({
             "COMPASS_OFS_X": 1100,

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -5236,8 +5236,21 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         if ex is not None:
             raise ex
 
+    # The gains a completed autotune saves.  The firmware writes these,
+    # so the suite has no record of them and they would otherwise persist
+    # for the rest of the session.
+    autotune_saved_gains = [
+        "PTCH2SRV_RMAX_DN", "PTCH2SRV_RMAX_UP", "PTCH2SRV_TCONST",
+        "PTCH_RATE_D", "PTCH_RATE_FF", "PTCH_RATE_FLTD",
+        "PTCH_RATE_FLTT", "PTCH_RATE_I", "PTCH_RATE_P",
+        "RLL2SRV_RMAX", "RLL2SRV_TCONST",
+        "RLL_RATE_D", "RLL_RATE_FF", "RLL_RATE_FLTD",
+        "RLL_RATE_FLTT", "RLL_RATE_I", "RLL_RATE_P",
+    ]
+
     def AUTOTUNE(self):
         '''Test AutoTune mode'''
+        self.context_preserve_parameters(self.autotune_saved_gains)
 
         # Prior to 2026-07-15, the SITL airspeed sensor was reading about 5%
         # slower than actual during this test. We bump the scaling airspeed by
@@ -5343,6 +5356,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
     def AutotuneFiltering(self):
         '''Test AutoTune mode with filter updates disabled'''
+        self.context_preserve_parameters(self.autotune_saved_gains)
         self.set_parameters({
             "AUTOTUNE_OPTIONS": 3,
             # some filtering is required for autotune to complete
@@ -7557,6 +7571,13 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
     def CompassLearnInFlight(self):
         '''check we can learn compass offsets in flight'''
+        # a successful learn makes the firmware save the offsets it found,
+        # which the suite has no record of and cannot put back
+        self.context_preserve_parameters([
+            "COMPASS_OFS_X", "COMPASS_OFS_Y", "COMPASS_OFS_Z",
+            "COMPASS_OFS2_X", "COMPASS_OFS2_Y", "COMPASS_OFS2_Z",
+            "COMPASS_OFS3_X", "COMPASS_OFS3_Y", "COMPASS_OFS3_Z",
+        ])
         # learning completes only when the EKF's GSF yaw estimator is
         # converged.  Flying done by earlier tests in the same boot can
         # leave the EKF in a state where the GSF hovers above the

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -7068,6 +7068,15 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             "FS_LONG_ACTN": 3,
         })
         for command in self.run_cmd, self.run_cmd_int:
+            # We release the parachute sitting on the ground, which the
+            # vehicle permits only while it has never flown:
+            # parachute_manual_release() skips its "Too low" check on
+            # last_flying_ms being zero, and that is sticky for the life
+            # of the boot.  Any test which flew before us leaves it set
+            # and the release is refused with MAV_RESULT_FAILED - so
+            # start from a fresh boot rather than only leaving one
+            # behind for the iteration which follows.
+            self.reboot_sitl()
             self.wait_servo_channel_value(9, 1100)
             self.wait_ready_to_arm()
             self.arm_vehicle()
@@ -7077,7 +7086,6 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             )
             self.wait_servo_channel_value(9, 1300)
             self.disarm_vehicle()
-            self.reboot_sitl()
 
     def _MAV_CMD_DO_GO_AROUND(self, command):
         self.load_mission("mission.txt")

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -9063,6 +9063,13 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         # rule out.  Reboot so the SITL aircraft is reliably on the
         # ground at the start of the test.
         self.reboot_sitl()
+        # this test never arms, so its boot only produces an onboard
+        # log if disarmed logging is enabled.  LOG_DISARMED=1 is only a
+        # suite *default*, and predecessors which restart SITL with
+        # their own defaults can leave it 0 - in which case this boot
+        # has no log and the scan below silently reads the previous
+        # boot's log
+        self.set_parameter("LOG_DISARMED", 1)
         self.wait_ready_to_arm()
 
         # suspend periodic resets so baro drift can accumulate
@@ -9091,6 +9098,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         dfreader = self.dfreader_for_current_onboard_log()
         last_pd = None
         reset_us = None
+        seen_test_window = False
         peak_excursion = 0.0
         while True:
             m = dfreader.recv_match(type='XKF1', condition='XKF1.C==0')
@@ -9098,6 +9106,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
                 break
             if m.TimeUS < drift_start_us:
                 continue
+            seen_test_window = True
             if reset_us is None:
                 if last_pd is not None and abs(m.PD - last_pd) > 0.5:
                     reset_us = m.TimeUS
@@ -9108,6 +9117,11 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             if m.TimeUS - reset_us > 2.0e6:
                 break
             peak_excursion = max(peak_excursion, abs(m.PD))
+
+        if not seen_test_window:
+            raise NotAchievedException(
+                "Onboard log contains no data from this test's "
+                "timeframe - scanned a previous boot's log?")
 
         if reset_us is None:
             raise NotAchievedException(

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -5220,7 +5220,18 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.print_exception_caught(e)
             ex = e
 
-        self.reboot_sitl()
+        # The SIGALRM above makes SITL putenv("SITL_WATCHDOG_RESET=1")
+        # and exec itself, and reboot_sitl() execs too, so that variable
+        # - and the internal error every boot then raises because of it -
+        # follows this process for as long as it lives.  Whatever runs
+        # next on this SITL cannot become armable:
+        #     PreArm: Internal errors 0x800 l:243 watchdog_rst
+        # Rebooting does not shake it off; only a new process does.
+        # customise_SITL_commandline() starts one, and tells the
+        # framework it did, so the tidy-up afterwards knows the SITL has
+        # been replaced - doing the stop/start by hand here left the
+        # next test with no vehicle at all.
+        self.customise_SITL_commandline([])
 
         if ex is not None:
             raise ex

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -7686,6 +7686,11 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.install_example_script_context('simple_loop.lua')
         self.set_parameters({
             'SCR_ENABLE': 1,
+            # we never arm, so without this the vehicle is not logging
+            # at all: current_onboard_log_filepath() then hands back a
+            # log some earlier test left behind, which will never
+            # contain our record however long we wait for it.
+            'LOG_DISARMED': 1,
         })
         self.reboot_sitl()
         self.wait_ready_to_arm()
@@ -7705,6 +7710,11 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.install_example_script_context('simple_loop.lua')
         self.set_parameters({
             'SCR_ENABLE': 1,
+            # we never arm, so without this the vehicle is not logging
+            # at all: current_onboard_log_filepath() then hands back a
+            # log some earlier test left behind, which will never
+            # contain our record however long we wait for it.
+            'LOG_DISARMED': 1,
         })
         self.reboot_sitl()
         self.wait_ready_to_arm()
@@ -7724,6 +7734,8 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.install_example_script_context('simple_named_string.lua')
         self.set_parameters({
             'SCR_ENABLE': 1,
+            # we never arm; see LoggedNamedValueFloat
+            'LOG_DISARMED': 1,
         })
         self.reboot_sitl()
         self.wait_ready_to_arm()

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -7551,7 +7551,12 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.set_parameters({
             "COMPASS_OFS_X": 1100,
         })
-        self.send_set_parameter("COMPASS_LEARN", 3)  # 3 is in-flight learning
+        # the autopilot zeroes COMPASS_LEARN itself when learning
+        # completes, so a verified parameter-set could race with that
+        # and re-trigger learning; send it unverified, but tracked so
+        # a test failure reverts it - a leaked COMPASS_LEARN=3 stops
+        # the EKFs using the compass, breaking all subsequent tests
+        self.send_set_parameter("COMPASS_LEARN", 3, add_to_context=True)  # 3 is in-flight learning
         self.wait_parameter_value("COMPASS_LEARN", 0)
         self.assert_parameter_value("COMPASS_OFS_X", old_compass_ofs_x, epsilon=30)
         self.fly_home_land_and_disarm()

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -2496,6 +2496,18 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.test_adsb_send_threatening_adsb_message(here)
         m = self.assert_not_receive_message('COLLISION', timeout=4)
 
+        # AP_Avoidance::disable() writes AVD_ENABLE's live value.  Not
+        # saving it is correct - a switch position must not change what
+        # is stored - but writing the parameter at all is a firmware bug:
+        # the switch should drive a separate runtime flag, as
+        # AC_Avoid::proximity_avoidance_enable() does.  Until that is
+        # fixed, leaving the switch down means the live value reads 0
+        # while storage holds the 1 we set above, so the context restore
+        # asks for 0, sees 0, writes nothing, and the next boot in this
+        # session comes up with avoidance enabled.  Put the switch back.
+        self.set_rc(12, 2000)
+        self.delay_sim_time(1, reason="RC switch to be polled")
+
     def GuidedRequest(self, target_system=1, target_component=1):
         '''Test handling of MISSION_ITEM in guided mode'''
         self.progress("Takeoff")

--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -1277,6 +1277,14 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
 
     def SurfaceSensorless(self):
         """Test surface mode with sensorless thrust"""
+        # this drives the throttle down and waits to arrive at 9.5m, so
+        # it has to start above that.  The vehicle is wherever the
+        # previous test left it, which can be a long way below:
+        #     Failed to attain Altitude want -9.5, reached -52.093
+        # with the depth not moving at all - it was already far past the
+        # altitude it was descending towards.  Reboot back to the
+        # surface first, as several tests in this file already do.
+        self.reboot_sitl()
         # set GCS failsafe to SURFACE
         self.wait_ready_to_arm()
         self.arm_vehicle()

--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -532,6 +532,8 @@ def run_step(step):
     if opts.speedup is not None:
         fly_opts["speedup"] = opts.speedup
 
+    if opts.check_parameter_leaks:
+        fly_opts["check_parameter_leaks"] = True
     fly_opts["move_logs_on_test_failure"] = opts.move_logs_on_test_failure
 
     # handle "test.Copter" etc:
@@ -985,6 +987,13 @@ if __name__ == "__main__":
                          default=None,
                          type='int',
                          help='speedup to run the simulations at')
+    group_sim.add_option("--check-parameter-leaks",
+                         action='store_true',
+                         default=False,
+                         help='after each test, check no parameter the suite '
+                         'could not revert has been left changed; catches '
+                         'leaks into the tests which follow.  Slow: downloads '
+                         'the full parameter set twice per test')
     group_sim.add_option("--valgrind",
                          default=False,
                          action='store_true',

--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -532,8 +532,7 @@ def run_step(step):
     if opts.speedup is not None:
         fly_opts["speedup"] = opts.speedup
 
-    if opts.check_parameter_leaks:
-        fly_opts["check_parameter_leaks"] = True
+    fly_opts["check_parameter_leaks"] = opts.check_parameter_leaks
     fly_opts["move_logs_on_test_failure"] = opts.move_logs_on_test_failure
 
     # handle "test.Copter" etc:
@@ -989,11 +988,17 @@ if __name__ == "__main__":
                          help='speedup to run the simulations at')
     group_sim.add_option("--check-parameter-leaks",
                          action='store_true',
-                         default=False,
+                         dest='check_parameter_leaks',
+                         default=True,
                          help='after each test, check no parameter the suite '
                          'could not revert has been left changed; catches '
-                         'leaks into the tests which follow.  Slow: downloads '
-                         'the full parameter set twice per test')
+                         'leaks into the tests which follow.  On by default')
+    group_sim.add_option("--no-check-parameter-leaks",
+                         action='store_false',
+                         dest='check_parameter_leaks',
+                         help='do not check for parameter leaks after each '
+                         'test.  The check downloads the full parameter set '
+                         'once per test')
     group_sim.add_option("--valgrind",
                          default=False,
                          action='store_true',

--- a/Tools/autotest/helicopter.py
+++ b/Tools/autotest/helicopter.py
@@ -993,7 +993,10 @@ class AutoTestHelicopter(AutoTestCopter):
             "ARSPD_PIN": 1,      # Analog airspeed driver pin for SITL
         })
         # set the start location to CMAC to use same test script as other vehicles
-
+        # sitl_start_location() returns this for the rest of the session,
+        # so every later start_SITL() would come up at CMAC rather than
+        # at the heli's own start location; put it back afterwards.
+        self.context_preserve_attribute("sitl_start_loc")
         self.sitl_start_loc = mavutil.location(-35.362881, 149.165222, 582.000000, 90.0)   # CMAC
         self.customise_SITL_commandline(["--home", "%s,%s,%s,%s"
                                          % (-35.362881, 149.165222, 582.000000, 90.0)])

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -1581,8 +1581,19 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.set_current_waypoint(0, check_afterwards=False)
         self.fly_mission('mission.txt')
 
+    # The gains quicktune saves when it finishes.  Written by the applet
+    # or the C++ implementation rather than by us, so the suite cannot
+    # revert them and they would persist for the rest of the session.
+    quicktune_saved_gains = [
+        "Q_A_RAT_PIT_D", "Q_A_RAT_PIT_FLTT", "Q_A_RAT_PIT_I", "Q_A_RAT_PIT_P",
+        "Q_A_RAT_RLL_D", "Q_A_RAT_RLL_FLTT", "Q_A_RAT_RLL_I", "Q_A_RAT_RLL_P",
+        "Q_A_RAT_YAW_D", "Q_A_RAT_YAW_FLTD", "Q_A_RAT_YAW_FLTT",
+        "Q_A_RAT_YAW_I", "Q_A_RAT_YAW_P",
+    ]
+
     def VTOLQuicktune(self):
         '''VTOL Quicktune'''
+        self.context_preserve_parameters(self.quicktune_saved_gains)
         self.install_applet_script_context("VTOL-quicktune.lua")
 
         self.set_parameters({
@@ -1630,6 +1641,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
 
     def VTOLQuicktune_CPP(self):
         '''VTOL Quicktune in C++'''
+        self.context_preserve_parameters(self.quicktune_saved_gains)
         self.set_parameters({
             "RC7_OPTION": 181,
             "QWIK_ENABLE" : 1,

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -1621,6 +1621,9 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         # to test aux function method, use aux fn for save
         self.run_auxfunc(300, 2)
         self.wait_text("Tuning: saved", check_context=True)
+        # and put the switch back: aux function state survives
+        # context_pop(), and this test does not reboot afterwards
+        self.run_auxfunc(300, 0)
         self.change_mode("QLAND")
 
         self.wait_disarmed(timeout=120)
@@ -2694,6 +2697,12 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         alt_change = initial_altitude - recovery_altitude
 
         self.progress("Recovery AltChange %.1fm" % alt_change)
+
+        # stop asking for inverted flight.  Aux function state is not a
+        # parameter, so context_pop() does not clear it, and this test
+        # does not reboot - without this the next test on this worker
+        # starts with inverted flight still commanded.
+        self.run_auxfunc(43, 0)
 
         max_alt_change = 3
         if alt_change > max_alt_change:

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -3335,7 +3335,10 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         defaults_file.write("SERVO17_FUNCTION %d\n" % k_motor1)
         defaults_file.close()
 
-        self.customise_SITL_commandline([], defaults_filepath=defaults_file.name)
+        # wipe: a defaults file only supplies parameters which are not
+        # already saved, so anything an earlier test stored for
+        # SERVO17_FUNCTION would win over the default under test
+        self.customise_SITL_commandline([], defaults_filepath=defaults_file.name, wipe=True)
         self.assert_parameter_values({"SERVO17_FUNCTION": k_motor1})
 
         data, _ = self.ftp_burst_read("@PARAM/param.pck?withdefaults=1")

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -1584,11 +1584,12 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
     # The gains quicktune saves when it finishes.  Written by the applet
     # or the C++ implementation rather than by us, so the suite cannot
     # revert them and they would persist for the rest of the session.
+    # everything quicktune can save; the axes and suffixes here are
+    # AP_Quicktune::Param (libraries/AP_Quicktune/AP_Quicktune.h)
     quicktune_saved_gains = [
-        "Q_A_RAT_PIT_D", "Q_A_RAT_PIT_FLTT", "Q_A_RAT_PIT_I", "Q_A_RAT_PIT_P",
-        "Q_A_RAT_RLL_D", "Q_A_RAT_RLL_FLTT", "Q_A_RAT_RLL_I", "Q_A_RAT_RLL_P",
-        "Q_A_RAT_YAW_D", "Q_A_RAT_YAW_FLTD", "Q_A_RAT_YAW_FLTT",
-        "Q_A_RAT_YAW_I", "Q_A_RAT_YAW_P",
+        "Q_A_RAT_%s_%s" % (axis, suffix)
+        for axis in ("RLL", "PIT", "YAW")
+        for suffix in ("P", "I", "D", "SMAX", "FLTT", "FLTD", "FLTE", "FF")
     ]
 
     def VTOLQuicktune(self):

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -1708,16 +1708,11 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
 
         self.install_applet_script_context("plane_precland.lua")
 
-        here = self.mav.location()
-        target = self.offset_location_ne(here, 20, 0)
-
         self.set_parameters({
             "SCR_ENABLE": 1,
             "PLND_ENABLED": 1,
             "PLND_TYPE": 4,
             "SIM_PLD_ENABLE":   1,
-            "SIM_PLD_LAT" : target.lat,
-            "SIM_PLD_LON" : target.lng,
             "SIM_PLD_HEIGHT" : 0,
             "SIM_PLD_ALT_LMT" : 50,
             "SIM_PLD_DIST_LMT" : 30,
@@ -1741,6 +1736,19 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.wait_text("PLND: Loaded", check_context=True)
 
         self.wait_ready_to_arm()
+
+        # place the target near the vehicle's current position - which,
+        # having just rebooted, is the spawn position.  Sampling the
+        # position before the reboot places the target wherever the
+        # previous test happened to leave the vehicle, which can be
+        # hundreds of metres from where QRTL will descend:
+        here = self.mav.location()
+        target = self.offset_location_ne(here, 20, 0)
+        self.set_parameters({
+            "SIM_PLD_LAT": target.lat,
+            "SIM_PLD_LON": target.lng,
+        })
+
         self.change_mode("GUIDED")
         self.arm_vehicle()
         self.takeoff(60, 'GUIDED')

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -1828,6 +1828,10 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         if distance > max_distance:
             raise NotAchievedException(f"Did not land within {max_distance}m of ship {distance=}")
 
+        # we are not at the home location - reboot so the next test starts there
+        self.set_parameter("SIM_SHIP_ENABLE", 0)
+        self.reboot_sitl()
+
     def RCDisableAirspeedUse(self):
         '''check disabling airspeed using RC switch'''
         self.set_parameter("RC9_OPTION", 106)

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -1089,6 +1089,18 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.set_parameter("RC_OVERRIDE_TIME", 0)
         self.wait_rc_channel_value(ch, 1000)
         self.set_parameter("RC_OVERRIDE_TIME", old)
+        # an override is only live for RC_OVERRIDE_TIME seconds after it
+        # arrives, and the two parameter round-trips above can eat more
+        # than that in simulated time - one run came back to find the
+        # override long expired, and sat watching chan2 stay at 1000.
+        # Send a fresh one, which is what re-enabling overrides has to
+        # act upon anyway.
+        self.progress("Sending override message %u" % ch_override_value)
+        self.mav.mav.rc_channels_override_send(
+            1, # target system
+            1, # targe component
+            *channels
+        )
         self.wait_rc_channel_value(ch, ch_override_value)
 
         ch_override_value = 1720
@@ -6497,7 +6509,11 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         here = self.get_location()
         target_loc = self.offset_location_ne(here, 2000, 0)
         self.send_guided_mission_item(target_loc)
-        self.wait_distance_to_home(20, 100)
+        # the vehicle starts pointing away from the target, so it turns
+        # before it makes any ground: wait_distance_to_home()'s default
+        # ten seconds is enough only if that turn is quick, and one run
+        # spent them reaching 14.4m of the wanted 20m
+        self.wait_distance_to_home(20, 100, timeout=60)
 
         self.run_cmd(mavutil.mavlink.MAV_CMD_NAV_RETURN_TO_LAUNCH)
         self.wait_mode('RTL')

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -1517,6 +1517,19 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.load_rally_using_mavproxy("rover-test-rally.txt")
         self.assert_parameter_value('RALLY_TOTAL', 2)
 
+        # the file's rally points are fixed coordinates chosen relative
+        # to the SITL startup location, but RTL returns to whichever of
+        # home and the rally points is closest - and home is wherever
+        # the vehicle happened to be.  Re-place them relative to us so
+        # the rally point is the closer of the two once we have driven
+        # away, whatever a previous test did with the vehicle:
+        here = self.get_location()
+        rally_locs = [
+            self.offset_location_ne(here, 19.8, 33.0),
+            self.offset_location_ne(here, 99.1, -114.7),
+        ]
+        self.upload_rally_points_from_locations(rally_locs)
+
         self.wait_ready_to_arm()
         self.arm_vehicle()
 
@@ -1528,8 +1541,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
 
         self.change_mode("RTL")
 
-        # location copied in from rover-test-rally.txt:
-        loc = Location(40.071553, -105.229401, 1583, AltFrame.ABSOLUTE)
+        loc = rally_locs[0]
 
         self.wait_location(loc, accuracy=accuracy, minimum_duration=10, timeout=45)
         self.disarm_vehicle()
@@ -4882,8 +4894,11 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             "FENCE_ACTION": 0,
         })
         fence_middle = self.offset_location_ne(here, 0, 30)
-        # FIXME: this might be nowhere near "here"!
-        expected_stopping_point = Location.latlon_only(40.0713376, -105.2295738)
+        # the fences above are placed relative to "here", so the point we
+        # stop at is too: just short of the exclusion fence 20m to our
+        # east.  This used to be a fixed location, which only worked
+        # while "here" happened to be the startup location.
+        expected_stopping_point = self.offset_location_ne(here, -1.05, 15.05)
         self.drive_somewhere_stop_at_boundary(
             fence_middle,
             expected_stopping_point,
@@ -6284,6 +6299,11 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             "PLND_ORIENT": 0,
         })
 
+        # the loop below reboots, which returns the vehicle to the SITL
+        # startup location; take our reference from there rather than
+        # from wherever a previous test left us, or the target ends up
+        # that much further away than the drive to it allows for:
+        self.reboot_sitl()
         start = self.get_location()
         target = self.offset_location_ne(start, 50, 0)
         self.progress("Setting target to %f %f" % (start.lat, start.lng))

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -2468,6 +2468,15 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
     # FIXME: add a test that fences enclose an area (e.g. all the points aren't the same value!
     def Offboard(self, timeout=90):
         '''Test Offboard Control'''
+        # rover-guided-mission.txt is in absolute coordinates, anchored
+        # at the SITL startup location, and the run has to get all the
+        # way round it and back home inside the timeout.  Starting from
+        # wherever a previous test left the vehicle adds the drive out
+        # to the mission and the drive home again at the end, and the
+        # budget does not cover that:
+        #     Offboard (Test Offboard Control) (Didn't complete)
+        # with the mission on its last item, RTL, when time ran out.
+        self.reboot_sitl()
         self.load_mission("rover-guided-mission.txt")
         self.wait_ready_to_arm(require_absolute=True)
         self.arm_vehicle()

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -6768,6 +6768,13 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
 
         self.reboot_sitl()
 
+        # the applet creates its WEB_* parameters at runtime, and they
+        # only go away when the vehicle comes up without it; removing the
+        # script from disk at context_pop() does not unload the copy
+        # already running.  Nothing here has customised the SITL
+        # commandline, so ask for the standard reset explicitly.
+        self.context_get().sitl_commandline_customised = True
+
         self.progress("Starting PPP daemon")
         pppd = util.start_PPP_daemon("192.168.14.15:192.168.14.13", '127.0.0.1:5765')
 

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -6952,6 +6952,22 @@ class TestSuite(abc.ABC):
         """Get Saved parameters."""
         return self.contexts[-1]
 
+    def context_preserve_parameters(self, names):
+        """Arrange for these parameters to be restored on context_pop().
+
+        The context restores parameters the *suite* set.  It cannot know
+        about one the vehicle writes for itself - a calibration saving
+        its results, say - so those survive the test and leak into every
+        test which follows in the session.  Registering them here with
+        their current values puts them back with everything else, and
+        does so even if the test raises.
+        """
+        values = self.get_parameters(names)
+        already = [p[0] for p in self.context_get().parameters]
+        for name in names:
+            if name not in already:
+                self.context_get().parameters.append((name, values[name]))
+
     def context_push(self):
         """Save a copy of the parameters."""
         context = Context()
@@ -7040,6 +7056,11 @@ class TestSuite(abc.ABC):
         # A leaked *mission* is better caught by checking the item count
         # against what the test uploaded.
         "MIS_TOTAL",
+        # COMPASS_AUTODEC defaults on, so AP_Compass computes and writes
+        # the declination itself from the vehicle's position.  It reads
+        # back as zero until there is a position to compute it from, so
+        # any test which reboots appears to "change" it.
+        "COMPASS_DEC",
     ])
 
     def parameter_leak_exempt(self, name):
@@ -7051,6 +7072,12 @@ class TestSuite(abc.ABC):
         # which reboots therefore always "changes" these, and the value
         # reverts to the default until calibration completes.
         if re.match(r"^BARO\d*_GND_(PRESS|TEMP)$", name):
+            return True
+        # Airspeed zero offset and ratio: the offset is calibrated at
+        # every boot (AP_Airspeed.cpp set_and_save) and lands a hair
+        # different each time - measured drifting by 0.0007% - and the
+        # ratio is what AIRSPEED_AUTOCAL learns.
+        if re.match(r"^ARSPD\d*_(OFFSET|RATIO)$", name):
             return True
         # learned sensor calibration; the vehicle writes these itself
         for prefix in ("INS_GYROFFS", "INS_GYR2OFFS", "INS_GYR3OFFS",

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -2241,6 +2241,8 @@ class TestSuite(abc.ABC):
         self.statustext_id = 1
         self.message_hooks = []  # functions or MessageHook instances
         self.check_parameter_leaks_enabled = check_parameter_leaks
+        # the session's parameters as they were before the first test ran
+        self.pristine_parameters = None
 
     def __del__(self):
         if self.rc_thread is not None:
@@ -7050,12 +7052,15 @@ class TestSuite(abc.ABC):
         "STAT_RESET",
         "STAT_FLTCNT",
         "STAT_DISTFLWN",
-        "MOT_THST_HOVER",   # learned in flight
-        # the mission's home item appears once home is set, so this reads
-        # 0->1 for the first test in a session and is stable thereafter.
-        # A leaked *mission* is better caught by checking the item count
-        # against what the test uploaded.
+        # Item counts, not settings: the number of mission, fence and
+        # rally items currently loaded.  MIS_TOTAL additionally reads
+        # 0->1 for the first test in a session, as the mission's home
+        # item appears once home is set.  A leaked mission/fence/rally
+        # is better caught by checking the item count against what the
+        # test uploaded than by watching these.
         "MIS_TOTAL",
+        "FENCE_TOTAL",
+        "RALLY_TOTAL",
         # COMPASS_AUTODEC defaults on, so AP_Compass computes and writes
         # the declination itself from the vehicle's position.  It reads
         # back as zero until there is a position to compute it from, so
@@ -7079,6 +7084,25 @@ class TestSuite(abc.ABC):
         # ratio is what AIRSPEED_AUTOCAL learns.
         if re.match(r"^ARSPD\d*_(OFFSET|RATIO)$", name):
             return True
+        # MAVLink stream rates.  REQUEST_DATA_STREAM makes the firmware
+        # save these itself (GCS_Param.cpp, set_and_save_ifchanged under
+        # persist_streamrates()), and both MAVProxy on connect and the
+        # suite's own set_streamrate() send it - so a test can "change"
+        # them without touching them.  REVIEW: this is the shakiest
+        # entry in this list.  persist_streamrates() is true only for
+        # Plane, yet Rover and Copter tests changed these too, so
+        # something else writes them as well and is not understood yet;
+        # and unlike the other entries here these genuinely do affect
+        # what the next test sees.
+        if re.match(r"^MAV\d+_(RAW_SENS|EXT_STAT|RC_CHAN|RAW_CTRL|POSITION"
+                    r"|EXTRA[123]|PARAMS|ADSB)$", name):
+            return True
+        # Hover throttle / collective: filtered towards the observed hover
+        # value while flying (AP_MotorsMulticopter.cpp, AP_MotorsHeli.cpp),
+        # so any test which hovers moves them.  MOT_ is multicopter, Q_M_
+        # the quadplane equivalent, H_COL_HOVER the helicopter one.
+        if name in ("MOT_THST_HOVER", "Q_M_THST_HOVER", "H_COL_HOVER"):
+            return True
         # learned sensor calibration; the vehicle writes these itself
         for prefix in ("INS_GYROFFS", "INS_GYR2OFFS", "INS_GYR3OFFS",
                        "INS_ACCOFFS", "INS_ACC2OFFS", "INS_ACC3OFFS",
@@ -7100,32 +7124,49 @@ class TestSuite(abc.ABC):
             self.progress("Parameter snapshot failed: %s" % str(e))
             return None
 
-    def check_parameter_leaks(self, before):
-        '''compare the parameter set against a pre-test snapshot
+    def check_parameter_leaks(self):
+        """Report and repair parameters which have drifted from pristine.
 
-        Called after context_pop() has reverted everything the suite knows
-        about, so anything still changed was written by the vehicle itself
-        (a calibration writing its results, say) or set outside a context.
-        Either way it leaks into every test which follows in this session.
-        '''
+        Compared against the state before *any* test ran, not against the
+        start of this test, so a test which wipes the parameters cannot be
+        blamed for clearing drift an earlier test left behind - a wipe only
+        moves the session back towards pristine.
+
+        Anything found is put back.  That keeps the attribution exact, since
+        every test starts from the same known state, and it stops the leak
+        reaching the tests which follow - which is the whole reason to care
+        about it.  Restoring is done outside any context; the contexts for
+        this test are long gone by the time we run.
+        """
+        if self.pristine_parameters is None:
+            return None
         after = self.snapshot_parameters_for_leak_check()
-        if before is None or after is None:
+        if after is None:
             self.progress("Parameter leak check skipped; no usable snapshot")
             return None
-        leaked = []
-        for name in sorted(set(before) | set(after)):
+        described = []
+        restore = {}
+        for name in sorted(set(self.pristine_parameters) | set(after)):
             if self.parameter_leak_exempt(name):
                 continue
-            old = before.get(name)
-            new = after.get(name)
-            if old is None or new is None:
-                leaked.append("%s %s->%s" % (name, old, new))
-            elif abs(old - new) > max(abs(old), abs(new)) * 1e-6:
-                leaked.append("%s %f->%f" % (name, old, new))
-        if len(leaked) == 0:
+            was = self.pristine_parameters.get(name)
+            now = after.get(name)
+            if was is None or now is None:
+                # appeared or vanished; nothing sensible to restore
+                described.append("%s %s->%s" % (name, was, now))
+            elif abs(was - now) > max(abs(was), abs(now)) * 1e-6:
+                described.append("%s %f->%f" % (name, was, now))
+                restore[name] = was
+        if len(described) == 0:
             self.progress("Parameter leak check: clean")
             return None
-        return leaked
+        if len(restore):
+            self.progress("Restoring %u leaked parameters" % len(restore))
+            try:
+                self.set_parameters(restore, add_to_context=False, verbose=False)
+            except Exception as e:  # noqa: BLE001
+                self.progress("Could not restore leaked parameters: %s" % str(e))
+        return described
 
     def context_pop(self, process_interaction_allowed=True, hooks_already_removed=False):
         """Set parameters to origin values in reverse order."""
@@ -9851,11 +9892,11 @@ Also, ignores heartbeats not from our target system'''
         old_contexts_length = len(self.contexts)
         self.context_push()
 
-        # snapshot before the test runs, so the comparison after
-        # context_pop() shows what the suite could not put back
-        parameters_before = None
-        if self.check_parameter_leaks_enabled:
-            parameters_before = self.snapshot_parameters_for_leak_check()
+        # capture the session's pristine parameters once, before the
+        # first test has had a chance to change anything
+        if (self.check_parameter_leaks_enabled and
+                self.pristine_parameters is None):
+            self.pristine_parameters = self.snapshot_parameters_for_leak_check()
 
         start_time = time.time()
 
@@ -9914,18 +9955,6 @@ Also, ignores heartbeats not from our target system'''
         except Exception as e:  # noqa: BLE001
             self.print_exception_caught(e, send_statustext=False)
             passed = False
-
-        if self.check_parameter_leaks_enabled and ardupilot_alive:
-            leaked = self.check_parameter_leaks(parameters_before)
-            if leaked is not None:
-                self.progress("Test leaked %u parameters into the session:" % len(leaked))
-                for line in leaked:
-                    self.progress("  %s" % line)
-                if ex is None:
-                    ex = NotAchievedException(
-                        "Test leaked parameters the suite could not revert: %s" %
-                        ", ".join(leaked))
-                passed = False
 
         pre_reboot_bin_logs = self.bin_logs()
 
@@ -9994,6 +10023,43 @@ Also, ignores heartbeats not from our target system'''
                           (str(self.message_hooks), str(start_message_hooks)))
             passed = False
 
+        if self.reset_after_every_test:
+            reset_needed = True
+
+        if reset_needed:
+            self.reset_SITL_commandline()
+
+        # Check for leaked parameters *here*, after every reset and reboot
+        # the harness performs, because what matters is the state the next
+        # test inherits - not the state at the moment this one stopped
+        # running.  reset_SITL_commandline() restarts SITL with wipe=True,
+        # so a test which customised the commandline has had its whole
+        # parameter set replaced and leaks nothing; checking before that
+        # reported every frame default as a leak.  reboot_sitl() does not
+        # wipe, so a genuine leak still survives it and is still caught.
+        if self.check_parameter_leaks_enabled and ardupilot_alive:
+            leaked = self.check_parameter_leaks()
+            if leaked is not None:
+                self.progress("Test leaked %u parameters into the session:" % len(leaked))
+                for line in leaked:
+                    self.progress("  %s" % line)
+                if ex is None:
+                    ex = NotAchievedException(
+                        "Test leaked parameters the suite could not revert: %s" %
+                        ", ".join(leaked))
+                passed = False
+                result.exception = ex
+
+        if not self.is_tracker(): # FIXME - more to the point, fix Tracker's mission handling
+            self.clear_mission(mavutil.mavlink.MAV_MISSION_TYPE_ALL)
+            self.set_current_waypoint(0, check_afterwards=False)
+
+        # report the result only once everything which can still fail
+        # the test has run: the leak check above can flip a test to
+        # failed, and a banner printed before it would claim a success
+        # the result contradicts, skip check_logs() for exactly the
+        # failure the check exists to find, and leave debug_filename
+        # unset so the junit writer emits "see None".
         if passed:
 #            self.remove_bin_logs() # can't do this as one of the binlogs is probably open for writing by the SITL process.  If we force a rotate before running tests then we can do this.  # noqa
             pass
@@ -10016,16 +10082,6 @@ Also, ignores heartbeats not from our target system'''
             if interact:
                 self.progress("Starting MAVProxy interaction as directed")
                 self.mavproxy.interact()
-
-        if self.reset_after_every_test:
-            reset_needed = True
-
-        if reset_needed:
-            self.reset_SITL_commandline()
-
-        if not self.is_tracker(): # FIXME - more to the point, fix Tracker's mission handling
-            self.clear_mission(mavutil.mavlink.MAV_MISSION_TYPE_ALL)
-            self.set_current_waypoint(0, check_afterwards=False)
 
         tee.close()
 

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -2497,6 +2497,8 @@ class TestSuite(abc.ABC):
             else:
                 self.stop_SITL()
                 self.start_SITL(wipe=False)
+            # as below: the vehicle which sent these has gone
+            self.context_clear_collections()
         else:
             # receiving an ACK from the process turns out to be really
             # quite difficult.  So just send it and hope for the best.
@@ -2510,6 +2512,9 @@ class TestSuite(abc.ABC):
                 p2=1,
                 p6=p6,
             )
+            # anything collected up to here came from the vehicle we
+            # have just asked to go away:
+            self.context_clear_collections()
             do_context = True
         if do_context:
             self.context_push()
@@ -6977,6 +6982,17 @@ class TestSuite(abc.ABC):
         if msg_type in context.collections:
             return
         context.collections[msg_type] = []
+
+    def context_clear_collections(self):
+        '''empty every message collection, leaving them collecting.  Called
+        when the vehicle reboots: what the old vehicle said is not
+        evidence about the new one.  Without this a test cannot collect
+        across a reboot at all - and it has to, because the messages a
+        vehicle emits as it boots are sent before any collection
+        started after the reboot exists to catch them.'''
+        for context in self.contexts:
+            for msg_type in context.collections:
+                context.collections[msg_type] = []
 
     def context_collection(self, msg_type):
         '''return messages in collection'''

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -349,6 +349,10 @@ class Context(object):
         # first context_set_speedup() call in this context (None means
         # speedup was never changed in this context)
         self.original_speedup = None
+        # suite attributes to put back on context_pop(); list of
+        # (name, original value) tuples, filled in by
+        # context_preserve_attribute()
+        self.preserved_attributes = []
         # files snapshotted via context_backup_file() and restored on
         # context_pop(); list of (path, original_bytes) tuples
         self.backup_files = []
@@ -6977,6 +6981,17 @@ class TestSuite(abc.ABC):
             if name not in already:
                 self.context_get().parameters.append((name, values[name]))
 
+    def context_preserve_attribute(self, name):
+        """Arrange for one of our own attributes to be restored on context_pop().
+
+        For state a test changes on the suite rather than on the vehicle
+        - sitl_start_loc, say - which otherwise applies to every test
+        which follows in the session.
+        """
+        already = [p[0] for p in self.context_get().preserved_attributes]
+        if name not in already:
+            self.context_get().preserved_attributes.append((name, getattr(self, name)))
+
     def context_push(self):
         """Save a copy of the parameters."""
         context = Context()
@@ -7194,6 +7209,8 @@ class TestSuite(abc.ABC):
         dead = self.contexts.pop()
         if dead.original_speedup is not None:
             self.speedup = dead.original_speedup
+        for (name, value) in dead.preserved_attributes:
+            setattr(self, name, value)
         # remove hooks first; these hooks can raise exceptions which
         # we really don't want...
         if not hooks_already_removed:

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -7103,6 +7103,11 @@ class TestSuite(abc.ABC):
         # the quadplane equivalent, H_COL_HOVER the helicopter one.
         if name in ("MOT_THST_HOVER", "Q_M_THST_HOVER", "H_COL_HOVER"):
             return True
+        # Device IDs: the driver writes these when it detects (or stops
+        # detecting) a sensor, so they follow the simulated hardware
+        # rather than anything a test chose.
+        if re.match(r"^[A-Z0-9_]+_DEVID$", name):
+            return True
         # learned sensor calibration; the vehicle writes these itself
         for prefix in ("INS_GYROFFS", "INS_GYR2OFFS", "INS_GYR3OFFS",
                        "INS_ACCOFFS", "INS_ACC2OFFS", "INS_ACC3OFFS",

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -2137,7 +2137,7 @@ class TestSuite(abc.ABC):
                  enable_fgview=False,
                  move_logs_on_test_failure: bool = False,
                  asan=False,
-                 check_parameter_leaks=False,
+                 check_parameter_leaks=True,
                  ):
         if breakpoints is None:
             breakpoints = []

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -7079,10 +7079,14 @@ class TestSuite(abc.ABC):
         # 0->1 for the first test in a session, as the mission's home
         # item appears once home is set.  A leaked mission/fence/rally
         # is better caught by checking the item count against what the
-        # test uploaded than by watching these.
+        # test uploaded than by watching these.  CMD_TOTAL is Tracker's
+        # equivalent of MIS_TOTAL ("Number of loaded mission items"),
+        # and run_one_test_attempt deliberately does not clear Tracker's
+        # mission, so it goes the other way: 1->0.
         "MIS_TOTAL",
         "FENCE_TOTAL",
         "RALLY_TOTAL",
+        "CMD_TOTAL",
         # COMPASS_AUTODEC defaults on, so AP_Compass computes and writes
         # the declination itself from the vehicle's position.  It reads
         # back as zero until there is a position to compute it from, so

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -7164,6 +7164,19 @@ class TestSuite(abc.ABC):
                        "INS_ACC2_CALTEMP", "INS_ACC3_CALTEMP"):
             if name.startswith(prefix):
                 return True
+        # the same values for instances 4 and up, which are spelled
+        # INS<n>_ rather than folded into the INS_ prefixes above.  These
+        # additionally move when an accel calibration runs on a vehicle
+        # with fewer accels than INS_MAX_INSTANCES:
+        # _acal_save_calibrations() deliberately clears the unused slots
+        # ("clear any unused accels", AP_InertialSensor.cpp), taking
+        # ACCSCAL from its 1.0 default to 0.  Nothing downstream minds -
+        # accel_calibrated_ok_all() treats 0 and 1 alike for an accel
+        # which is not there.
+        if re.match(r"^INS\d+_(ACC|GYR)(OFFS|SCAL)_[XYZ]$", name):
+            return True
+        if re.match(r"^INS\d+_(ACC|GYR)_(CALTEMP|ID)$", name):
+            return True
         return False
 
     def snapshot_parameters_for_leak_check(self):

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -6664,9 +6664,13 @@ class TestSuite(abc.ABC):
     def send_set_parameter_mavproxy(self, name, value):
         self.mavproxy.send("param set %s %s\n" % (name, str(value)))
 
-    def send_set_parameter(self, name, value, verbose=False):
+    def send_set_parameter(self, name, value, verbose=False, add_to_context=False):
         if verbose:
             self.progress("Send set param for (%s) (%f)" % (name, value))
+        if add_to_context:
+            context_param_name_list = [p[0] for p in self.context_get().parameters]
+            if name.upper() not in context_param_name_list:
+                self.context_get().parameters.append((name, self.get_parameter(name)))
         return self.send_set_parameter_direct(name, value)
 
     def set_parameter(self, name, value, **kwargs):

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -2133,6 +2133,7 @@ class TestSuite(abc.ABC):
                  enable_fgview=False,
                  move_logs_on_test_failure: bool = False,
                  asan=False,
+                 check_parameter_leaks=False,
                  ):
         if breakpoints is None:
             breakpoints = []
@@ -2239,6 +2240,7 @@ class TestSuite(abc.ABC):
         self.dronecan_tests = dronecan_tests
         self.statustext_id = 1
         self.message_hooks = []  # functions or MessageHook instances
+        self.check_parameter_leaks_enabled = check_parameter_leaks
 
     def __del__(self):
         if self.rc_thread is not None:
@@ -7021,6 +7023,83 @@ class TestSuite(abc.ABC):
         del context.collections[msg_type]
         return ret
 
+    # Parameters which legitimately differ across a test through no fault
+    # of the test: cumulative statistics, and values the vehicle learns
+    # for itself in flight.  Anything else changing across a test which
+    # the suite could not revert is a leak into the tests which follow.
+    parameter_leak_exemptions = frozenset([
+        "STAT_BOOTCNT",
+        "STAT_FLTTIME",
+        "STAT_RUNTIME",
+        "STAT_RESET",
+        "STAT_FLTCNT",
+        "STAT_DISTFLWN",
+        "MOT_THST_HOVER",   # learned in flight
+        # the mission's home item appears once home is set, so this reads
+        # 0->1 for the first test in a session and is stable thereafter.
+        # A leaked *mission* is better caught by checking the item count
+        # against what the test uploaded.
+        "MIS_TOTAL",
+    ])
+
+    def parameter_leak_exempt(self, name):
+        '''True if name is allowed to differ across a test'''
+        if name in self.parameter_leak_exemptions:
+            return True
+        # Barometer ground pressure/temperature: written by the firmware
+        # every time it calibrates, which includes every reboot.  A test
+        # which reboots therefore always "changes" these, and the value
+        # reverts to the default until calibration completes.
+        if re.match(r"^BARO\d*_GND_(PRESS|TEMP)$", name):
+            return True
+        # learned sensor calibration; the vehicle writes these itself
+        for prefix in ("INS_GYROFFS", "INS_GYR2OFFS", "INS_GYR3OFFS",
+                       "INS_ACCOFFS", "INS_ACC2OFFS", "INS_ACC3OFFS",
+                       "INS_ACCSCAL", "INS_ACC2SCAL", "INS_ACC3SCAL",
+                       "INS_GYR_CALTEMP", "INS_GYR1_CALTEMP",
+                       "INS_GYR2_CALTEMP", "INS_GYR3_CALTEMP",
+                       "INS_ACC_CALTEMP", "INS_ACC1_CALTEMP",
+                       "INS_ACC2_CALTEMP", "INS_ACC3_CALTEMP"):
+            if name.startswith(prefix):
+                return True
+        return False
+
+    def snapshot_parameters_for_leak_check(self):
+        '''download the full parameter set, or None if that fails'''
+        try:
+            (parameters, _seq) = self.download_parameters(self.sysid_thismav(), 1)
+            return parameters
+        except Exception as e:  # noqa: BLE001
+            self.progress("Parameter snapshot failed: %s" % str(e))
+            return None
+
+    def check_parameter_leaks(self, before):
+        '''compare the parameter set against a pre-test snapshot
+
+        Called after context_pop() has reverted everything the suite knows
+        about, so anything still changed was written by the vehicle itself
+        (a calibration writing its results, say) or set outside a context.
+        Either way it leaks into every test which follows in this session.
+        '''
+        after = self.snapshot_parameters_for_leak_check()
+        if before is None or after is None:
+            self.progress("Parameter leak check skipped; no usable snapshot")
+            return None
+        leaked = []
+        for name in sorted(set(before) | set(after)):
+            if self.parameter_leak_exempt(name):
+                continue
+            old = before.get(name)
+            new = after.get(name)
+            if old is None or new is None:
+                leaked.append("%s %s->%s" % (name, old, new))
+            elif abs(old - new) > max(abs(old), abs(new)) * 1e-6:
+                leaked.append("%s %f->%f" % (name, old, new))
+        if len(leaked) == 0:
+            self.progress("Parameter leak check: clean")
+            return None
+        return leaked
+
     def context_pop(self, process_interaction_allowed=True, hooks_already_removed=False):
         """Set parameters to origin values in reverse order."""
         dead = self.contexts.pop()
@@ -9745,6 +9824,12 @@ Also, ignores heartbeats not from our target system'''
         old_contexts_length = len(self.contexts)
         self.context_push()
 
+        # snapshot before the test runs, so the comparison after
+        # context_pop() shows what the suite could not put back
+        parameters_before = None
+        if self.check_parameter_leaks_enabled:
+            parameters_before = self.snapshot_parameters_for_leak_check()
+
         start_time = time.time()
 
         hooks_removed = False
@@ -9802,6 +9887,18 @@ Also, ignores heartbeats not from our target system'''
         except Exception as e:  # noqa: BLE001
             self.print_exception_caught(e, send_statustext=False)
             passed = False
+
+        if self.check_parameter_leaks_enabled and ardupilot_alive:
+            leaked = self.check_parameter_leaks(parameters_before)
+            if leaked is not None:
+                self.progress("Test leaked %u parameters into the session:" % len(leaked))
+                for line in leaked:
+                    self.progress("  %s" % line)
+                if ex is None:
+                    ex = NotAchievedException(
+                        "Test leaked parameters the suite could not revert: %s" %
+                        ", ".join(leaked))
+                passed = False
 
         pre_reboot_bin_logs = self.bin_logs()
 

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -7143,6 +7143,17 @@ class TestSuite(abc.ABC):
         # rather than anything a test chose.
         if re.match(r"^[A-Z0-9_]+_DEVID$", name):
             return True
+        # the same thing under the compass's older spelling, and the
+        # DroneCAN node a GPS was found on, which the driver records when
+        # it detects one
+        if re.match(r"^COMPASS_DEV_ID\d*$", name):
+            return True
+        if re.match(r"^GPS\d*_CAN_NODEID$", name):
+            return True
+        # compass scale factors are learned in the same way as the
+        # offsets below, and are zeroed when a compass goes away
+        if re.match(r"^COMPASS_SCALE\d*$", name):
+            return True
         # learned sensor calibration; the vehicle writes these itself
         for prefix in ("INS_GYROFFS", "INS_GYR2OFFS", "INS_GYR3OFFS",
                        "INS_ACCOFFS", "INS_ACC2OFFS", "INS_ACC3OFFS",
@@ -7192,9 +7203,18 @@ class TestSuite(abc.ABC):
             was = self.pristine_parameters.get(name)
             now = after.get(name)
             if was is None or now is None:
-                # appeared or vanished; nothing sensible to restore
-                described.append("%s %s->%s" % (name, was, now))
-            elif abs(was - now) > max(abs(was), abs(now)) * 1e-6:
+                # Appeared or vanished rather than changed.  The shape of
+                # the parameter tree follows enable-style parameters -
+                # BATT_MONITOR decides which BATT_ parameters exist,
+                # CAN_P1_DRIVER whether there are any CAN_D1_UC_ ones -
+                # and only re-shapes on reboot.  A test which sets one of
+                # those and has it restored still leaves the old shape
+                # behind until the vehicle next boots, which is not a leak
+                # and is not something we can put back.  The parameter
+                # which decides the shape is itself compared here, so a
+                # genuine leak of one is still caught on its own account.
+                continue
+            if abs(was - now) > max(abs(was), abs(now)) * 1e-6:
                 described.append("%s %f->%f" % (name, was, now))
                 restore[name] = was
         if len(described) == 0:

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -3431,7 +3431,14 @@ class TestSuite(abc.ABC):
         return ret
 
     def apply_default_parameters(self):
-        self.set_parameters(self.default_parameter_list())
+        # deliberately not added to the context: these are the session's
+        # baseline, not something the running test asked for.  A test
+        # which resets the SITL commandline gets here part-way through,
+        # and if the context recorded the post-wipe values then popping
+        # it at the end of that test would revert the whole session to
+        # the firmware defaults.
+        self.set_parameters(self.default_parameter_list(),
+                            add_to_context=False)
         self.reboot_sitl()
 
     def reset_SITL_commandline(self):
@@ -7102,6 +7109,15 @@ class TestSuite(abc.ABC):
         # so any test which hovers moves them.  MOT_ is multicopter, Q_M_
         # the quadplane equivalent, H_COL_HOVER the helicopter one.
         if name in ("MOT_THST_HOVER", "Q_M_THST_HOVER", "H_COL_HOVER"):
+            return True
+        # AC_PosControl raises the vertical acceleration controller's
+        # integrator limit to the hover throttle if it is below it
+        # (AC_PosControl.cpp), so it moves the first time a vehicle runs
+        # that controller.  Sub is the one which shows this: it forces
+        # MOT_THST_HOVER to 0.5 (ArduSub/Parameters.cpp) but leaves the
+        # default limit at 0.1.  The write is to the live value only and
+        # never reaches storage, so a reboot puts it back.
+        if name in ("PSC_D_ACC_IMAX", "Q_P_D_ACC_IMAX"):
             return True
         # Device IDs: the driver writes these when it detects (or stops
         # detecting) a sensor, so they follow the simulated hardware

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -1266,7 +1266,13 @@ void Aircraft::add_shove_forces(Vector3f &rot_accel, Vector3f &body_accel)
         body_accel.z += sitl->shove.z;
     } else {
         sitl->shove.start_ms = 0;
-        sitl->shove.t.set(0);
+        // save as well as set: the parameter was written to storage to
+        // ask for the shove, so clearing only the live value leaves
+        // storage still asking for one.  A GCS - or the test suite
+        // putting parameters back after a test - then sees the live
+        // value already at zero and has no reason to write, and the
+        // next reboot loads the old duration and shoves again.
+        sitl->shove.t.set_and_save(0);
     }
 }
 


### PR DESCRIPTION
### Summary

Various fixes to stop tests leaking state.  Suggest reading this patch-wise.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

A collection of patches, all against the autotest library to fix various leaks.  Each is well-commented.

Some are really obvious - we're on a ship rather than at home!


This one is a bit of a concern:
```
    The test releases the parachute sitting on the ground, which the
    vehicle permits only while it has never flown:
    parachute_manual_release() skips its "Too low" altitude check on
    auto_state.last_flying_ms being zero, deliberately, to allow ground
    tests.  That is sticky for the life of the boot, so any test which flew
    earlier in the same SITL session leaves it set and the release comes
    back MAV_RESULT_FAILED, with "Parachute: Too low" in the log.
    
    The test already rebooted at the end of each iteration, which protected
```
