### PR TITLE
AP_NavEKF3: add LOG_REPLAY=2 (replay logging from arming without LOG_DISARMED

### DIFF
--- a/Tools/Replay/LR_MsgHandler.cpp
+++ b/Tools/Replay/LR_MsgHandler.cpp
@@ -289,6 +289,84 @@ void LR_MsgHandler_RBOH::process_message(uint8_t *msgbytes)
     AP::dal().handle_message(msg, ekf2, ekf3);
 }
 
+#if EK3_FEATURE_REPLAY_SNAPSHOT
+/*
+  EKF snapshot assembly for LOG_REPLAY=2 logs. Each RSNH restarts
+  assembly for its core, so a partially written snapshot that the
+  firmware retried is discarded cleanly.
+ */
+static struct {
+    uint8_t *buf;
+    uint32_t total_len;
+    uint16_t num_chunks;
+    uint16_t chunks_seen;
+    uint8_t seen[(RSN_SNAPSHOT_MAX_CHUNKS+7)/8];
+    uint8_t version;
+    uint8_t ftype_size;
+} snapshot_assembly[MAX_EKF_CORES];
+
+void LR_MsgHandler_RSNH::process_message(uint8_t *msgbytes)
+{
+    MSG_CREATE(RSNH, msgbytes);
+    if (msg.core >= ARRAY_SIZE(snapshot_assembly)) {
+        return;
+    }
+    auto &assembly = snapshot_assembly[msg.core];
+    free(assembly.buf);
+    assembly.buf = nullptr;
+    if (msg.total_len == 0 || msg.total_len > RSN_SNAPSHOT_MAX_LEN_BYTES) {
+        ::printf("RSNH core %u: bad total_len %u, ignored\n",
+                 unsigned(msg.core), unsigned(msg.total_len));
+        return;
+    }
+    assembly.buf = (uint8_t *)calloc(1, msg.total_len);
+    if (assembly.buf == nullptr) {
+        ::printf("RSNH core %u: allocation failed\n", unsigned(msg.core));
+        return;
+    }
+    assembly.total_len = msg.total_len;
+    assembly.num_chunks = (msg.total_len + RSND_CHUNK_LEN_BYTES - 1) / RSND_CHUNK_LEN_BYTES;
+    assembly.chunks_seen = 0;
+    memset(assembly.seen, 0, sizeof(assembly.seen));
+    assembly.version = msg.version;
+    assembly.ftype_size = msg.ftype_size;
+}
+
+void LR_MsgHandler_RSND::process_message(uint8_t *msgbytes)
+{
+    MSG_CREATE(RSND, msgbytes);
+    if (msg.core >= ARRAY_SIZE(snapshot_assembly)) {
+        return;
+    }
+    auto &assembly = snapshot_assembly[msg.core];
+    const uint32_t ofs = msg.seq * RSND_CHUNK_LEN_BYTES;
+    if (assembly.buf == nullptr || msg.seq >= assembly.num_chunks) {
+        return;
+    }
+    // every chunk is full sized except the last
+    const uint32_t expected = MIN(assembly.total_len - ofs, uint32_t(RSND_CHUNK_LEN_BYTES));
+    if (msg.len != expected) {
+        return;
+    }
+    // a chunk can appear twice if one log backend dropped it and the
+    // firmware retried; only the first copy counts towards completion
+    if (assembly.seen[msg.seq/8] & (1U << (msg.seq%8))) {
+        return;
+    }
+    assembly.seen[msg.seq/8] |= 1U << (msg.seq%8);
+    assembly.chunks_seen++;
+    memcpy(&assembly.buf[ofs], msg.data, msg.len);
+    if (assembly.chunks_seen == assembly.num_chunks) {
+        if (!ekf3.loadCoreSnapshot(msg.core, assembly.version, assembly.ftype_size,
+                                   assembly.buf, assembly.total_len)) {
+            ::printf("EKF3 snapshot core %u load failed\n", unsigned(msg.core));
+        }
+        free(assembly.buf);
+        assembly.buf = nullptr;
+    }
+}
+#endif  // EK3_FEATURE_REPLAY_SNAPSHOT
+
 void LR_MsgHandler_REPH::process_message(uint8_t *msgbytes)
 {
     MSG_CREATE(REPH, msgbytes);

--- a/Tools/Replay/LR_MsgHandler.h
+++ b/Tools/Replay/LR_MsgHandler.h
@@ -81,6 +81,18 @@ class LR_MsgHandler_RBOH : public LR_MsgHandler_EKF
     void process_message(uint8_t *msg) override;
 };
 
+class LR_MsgHandler_RSNH : public LR_MsgHandler_EKF
+{
+    using LR_MsgHandler_EKF::LR_MsgHandler_EKF;
+    void process_message(uint8_t *msg) override;
+};
+
+class LR_MsgHandler_RSND : public LR_MsgHandler_EKF
+{
+    using LR_MsgHandler_EKF::LR_MsgHandler_EKF;
+    void process_message(uint8_t *msg) override;
+};
+
 class LR_MsgHandler_RFRN : public LR_MsgHandler
 {
 public:

--- a/Tools/Replay/LogReader.cpp
+++ b/Tools/Replay/LogReader.cpp
@@ -3,6 +3,8 @@
 #include "MsgHandler.h"
 #include "Replay.h"
 
+#include <AP_DAL/AP_DAL.h>
+
 #include <stdio.h>
 #include <unistd.h>
 #include <sys/types.h>
@@ -130,6 +132,12 @@ bool LogReader::handle_log_format_msg(const struct log_Format &f)
         msgparser[f.type] = NEW_NOTHROW LR_MsgHandler_RBOH(formats[f.type], ekf2, ekf3);
     } else if (streq(name, "RTER")) {
         msgparser[f.type] = NEW_NOTHROW LR_MsgHandler_RTER(formats[f.type], ekf2, ekf3);
+#if EK3_FEATURE_REPLAY_SNAPSHOT
+    } else if (streq(name, "RSNH")) {
+        msgparser[f.type] = NEW_NOTHROW LR_MsgHandler_RSNH(formats[f.type], ekf2, ekf3);
+    } else if (streq(name, "RSND")) {
+        msgparser[f.type] = NEW_NOTHROW LR_MsgHandler_RSND(formats[f.type], ekf2, ekf3);
+#endif
 	} else {
         // debug("  No parser for (%s)\n", name);
     }

--- a/Tools/Replay/MsgHandler.cpp
+++ b/Tools/Replay/MsgHandler.cpp
@@ -36,6 +36,7 @@ void MsgHandler::init_field_types()
     add_field_type('Z', sizeof(char[64]));
     add_field_type('q', sizeof(int64_t));
     add_field_type('Q', sizeof(uint64_t));
+    add_field_type('a', sizeof(int16_t[32]));
 }
 
 struct MsgHandler::format_field_info *MsgHandler::find_field_info(const char *label)

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -6,6 +6,7 @@ AP_FLAKE8_CLEAN
 
 from __future__ import annotations
 
+import bisect
 import copy
 import math
 import os
@@ -14282,6 +14283,142 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         if not ok:
             raise NotAchievedException("check_replay (%s) failed" % current_log_filepath)
 
+    def ReplaySnapshotLog(self):
+        '''check LOG_REPLAY=2 logs from arming and warm-starts Replay'''
+        util.build_SITL('tool/Replay', clean=False, configure=False)
+        self.set_parameters({
+            "LOG_REPLAY": 2,
+            "LOG_DISARMED": 0,
+            "LOG_FILE_BUFSIZE": 200,  # replay wants a large write buffer
+            "LOG_DARM_RATEMAX": 0,
+            "LOG_FILE_RATEMAX": 0,
+            # arming is slow in wall time (log open plus snapshot write);
+            # prevent auto-disarm before takeoff at high speedup
+            "DISARM_DELAY": 0,
+            # the replay stream saturates simulated logging IO at high
+            # speedup and blocks get dropped, corrupting the comparison
+            "SIM_SPEEDUP": 8,
+            # wind, so the wind states move and a state left out of the
+            # snapshot shows up in the replay comparison
+            "SIM_WIND_SPD": 5,
+            "SIM_WIND_DIR": 225,
+        })
+        self.reboot_sitl()
+
+        self.wait_ready_to_arm(require_absolute=True)
+        self.takeoffAndMoveAway()
+        self.do_RTL()
+        main_log = self.current_onboard_log_filepath()
+        self.reboot_sitl()  # close and flush the flight's log
+
+        # the log must carry the snapshot and the from-arm replay stream
+        if self.dfreader_for_path(main_log).recv_match(type='RSNH') is None:
+            raise NotAchievedException("Log missing EKF snapshot")
+        if self.dfreader_for_path(main_log).recv_match(type='RFRH') is None:
+            raise NotAchievedException("Log missing replay data")
+
+        # the warm start announcement lands in the replay output log as
+        # a MSG record
+        self.run_replay(main_log)
+        replay_log = self.current_onboard_log_filepath()
+        dfreader = self.dfreader_for_path(replay_log)
+        if not any('warm start from snapshot' in m.Message
+                   for m in iter(lambda: dfreader.recv_match(type='MSG'), None)):
+            raise NotAchievedException("Replay did not warm-start from snapshot")
+        # compare all replayed EKF output (C>=100) against the original
+        # run. Limits are absolute per field; 'rel' allows 50% (for
+        # covariances, which span orders of magnitude); 'disc' fields may
+        # differ on up to 2% of samples where a transition lands one
+        # sample apart
+        limits = {
+            'XKF1': {'Roll': 1.5, 'Pitch': 1.5, 'Yaw': 5.0,
+                     'VN': 0.5, 'VE': 0.5, 'VD': 0.5,
+                     'PN': 1.0, 'PE': 1.0, 'PD': 1.0,
+                     'GX': 0.2, 'GY': 0.2, 'GZ': 0.2},
+            'XKF2': {'AX': 20, 'AY': 20, 'AZ': 20, 'VWN': 0.5, 'VWE': 0.5,
+                     'MN': 50, 'ME': 50, 'MD': 50,
+                     'MX': 50, 'MY': 50, 'MZ': 50},
+            'XKF3': {'IVN': 0.5, 'IVE': 0.5, 'IVD': 0.5,
+                     'IPN': 0.5, 'IPE': 0.5, 'IPD': 0.5,
+                     'IMX': 50, 'IMY': 50, 'IMZ': 50, 'IYAW': 5.0},
+            'XKF4': {'SV': 0.5, 'SP': 0.5, 'SH': 0.5, 'SM': 0.5,
+                     'FS': 'disc', 'TS': 'disc', 'GPS': 'disc',
+                     'PI': 'disc'},
+            'XKQ': {'Q1': 0.05, 'Q2': 0.05, 'Q3': 0.05, 'Q4': 0.05},
+            'XKV1': {'V%02u' % i: 'rel' for i in range(12)},
+            'XKV2': {'V%02u' % i: 'rel' for i in range(12, 24)},
+            'XKFS': {f: 'disc' for f in ('MI', 'BI', 'GI', 'AI', 'SS')},
+        }
+        orig = {}
+        repl = {}
+        dfreader = self.dfreader_for_path(replay_log)
+        while True:
+            m = dfreader.recv_match(type=list(limits.keys()))
+            if m is None:
+                break
+            d = orig if m.C < 100 else repl
+            d.setdefault((m.get_type(), m.C % 100), []).append(m)
+        cores_orig = set(c for t, c in orig if t == 'XKF1')
+        cores_repl = set(c for t, c in repl if t == 'XKF1')
+        if not cores_orig or cores_repl != cores_orig:
+            raise NotAchievedException(
+                "Replayed cores %s do not match original cores %s" %
+                (sorted(cores_repl), sorted(cores_orig)))
+        t0 = min(m.TimeUS for m in orig[('XKF1', min(cores_orig))])
+        for (mtype, core), oms in sorted(orig.items()):
+            rms = sorted(repl.get((mtype, core), []), key=lambda m: m.TimeUS)
+            rtimes = [m.TimeUS for m in rms]
+            oms = [m for m in oms if m.TimeUS - t0 >= 5000000]  # settle
+            matched = 0
+            worst = {}
+            flips = {}
+            for mo in oms:
+                i = bisect.bisect_left(rtimes, mo.TimeUS)
+                cands = [j for j in (i - 1, i) if 0 <= j < len(rtimes)]
+                if not cands:
+                    continue
+                j = min(cands, key=lambda j: abs(rtimes[j] - mo.TimeUS))
+                if abs(rtimes[j] - mo.TimeUS) > 500000:
+                    continue
+                mr = rms[j]
+                matched += 1
+                for field, limit in limits[mtype].items():
+                    v1 = getattr(mo, field)
+                    v2 = getattr(mr, field)
+                    if limit == 'disc':
+                        if v1 != v2:
+                            flips[field] = flips.get(field, 0) + 1
+                        continue
+                    err = abs(v1 - v2)
+                    if err != err:  # NaN
+                        raise NotAchievedException(
+                            "%s core %u %s is NaN" % (mtype, core, field))
+                    if field == 'Yaw':
+                        err = min(err, 360 - err)
+                    if limit == 'rel':
+                        if err > max(0.01, 0.5 * max(abs(v1), abs(v2))):
+                            flips[field] = flips.get(field, 0) + 1
+                        continue
+                    worst[field] = max(worst.get(field, 0), err)
+                    if worst[field] > limit:
+                        raise NotAchievedException(
+                            "%s core %u %s mismatch %.3f exceeds %.3f" %
+                            (mtype, core, field, worst[field], limit))
+            if matched < min(50, len(oms) // 2):
+                raise NotAchievedException(
+                    "%s core %u: only %u matched replay samples" %
+                    (mtype, core, matched))
+            for field, count in flips.items():
+                if count > matched // 50:
+                    raise NotAchievedException(
+                        "%s core %u %s differs on %u of %u samples" %
+                        (mtype, core, field, count, matched))
+            if worst:
+                self.progress("%s core %u: %u samples, worst %s" %
+                              (mtype, core, matched,
+                               " ".join("%s=%.3f" % (f, worst[f])
+                                        for f in sorted(worst))))
+
     def DefaultIntervalsFromFiles(self):
         '''Test setting default mavlink message intervals from files'''
         ex = None
@@ -19292,6 +19429,7 @@ return update, 1000
             self.PerfInfo,
             self.ModeAllowsEntryWhenNoPilotInput,
             self.Replay,
+            self.ReplaySnapshotLog,
             self.FETtecESC,
             self.ProximitySensors,
             self.GroundEffectCompensation_touchDownExpected,

--- a/Tools/scripts/build_options.py
+++ b/Tools/scripts/build_options.py
@@ -58,6 +58,7 @@ BUILD_OPTIONS = [
     Feature('AHRS', 'EKF3_OPTFLOW', 'EK3_FEATURE_OPTFLOW_FUSION', 'Enable OpticalFlow fusion for EKF3', 0, 'EKF3,OPTICALFLOW'),
     Feature('AHRS', 'EKF3_OPTFLOW_SRTM', 'EK3_FEATURE_OPTFLOW_SRTM', 'Enable OpticalFlow using SRTM for EKF3', 0, 'EKF3_OPTFLOW'),  # noqa: E501
     Feature('AHRS', 'EKF3_RESET', 'AP_AHRS_EKF_RESET_ENABLED', 'Enable EKF bootstrap reset aux function', 1, 'EKF3'),
+    Feature('AHRS', 'EKF3_REPLAY_SNAPSHOT', 'EK3_FEATURE_REPLAY_SNAPSHOT', 'Enable EKF3 replay snapshot at arming', 0, 'EKF3'),
     Feature('AHRS', 'BARO_WIND_COMP', 'HAL_BARO_WIND_COMP_ENABLED', 'Enable Baro wind compensation', 0, None),
 
     Feature('Safety', 'PARACHUTE', 'HAL_PARACHUTE_ENABLED', 'Enable Parachute', 0, None),

--- a/Tools/scripts/extract_features.py
+++ b/Tools/scripts/extract_features.py
@@ -232,6 +232,7 @@ class ExtractFeatures(BuildScriptBase):
             ('EK3_FEATURE_OPTFLOW_FUSION', r'NavEKF3_core::FuseOptFlow'),
             ('EK3_FEATURE_OPTFLOW_SRTM', r'NavEKF3_core::writeTerrainData'),
             ('AP_AHRS_EKF_RESET_ENABLED', r'AP_AHRS::reset_configured_backend'),
+            ('EK3_FEATURE_REPLAY_SNAPSHOT', r'NavEKF3_core::serialiseSnapshot'),
 
             ('AP_RC_CHANNEL_AUX_FUNCTION_STRINGS_ENABLED', r'RC_Channel::lookuptable',),
             ('AP_SCRIPTING_ENABLED', r'AP_Scripting::init',),

--- a/libraries/AP_DAL/AP_DAL.cpp
+++ b/libraries/AP_DAL/AP_DAL.cpp
@@ -15,6 +15,14 @@
 #include <AP_NavEKF3/AP_NavEKF3.h>
 #endif
 
+// the AP_DAL_Standalone example links without AP_Logger; this exclusion
+// cannot live in AP_NavEKF3_feature.h, where APM_BUILD_TYPE must not be
+// evaluated (see there)
+#if APM_BUILD_TYPE(APM_BUILD_AP_DAL_Standalone)
+#undef EK3_FEATURE_REPLAY_SNAPSHOT
+#define EK3_FEATURE_REPLAY_SNAPSHOT 0
+#endif
+
 extern const AP_HAL::HAL& hal;
 
 AP_DAL *AP_DAL::_singleton = nullptr;
@@ -42,8 +50,23 @@ void AP_DAL::start_frame(AP_DAL::FrameType frametype)
     // we force write all msgs when logging starts
 #if HAL_LOGGING_ENABLED
     bool logging = AP::logger().logging_started() && AP::logger().allow_start_ekf();
+#if EK3_FEATURE_REPLAY_SNAPSHOT
+    if (AP::logger().log_replay_from_arm()) {
+        // hold the replay stream until the arming snapshot is written or
+        // abandoned; the gate also closes the stream at disarm
+        update_replay_snapshot_state();
+        logging = logging && _snapshot_state == SnapshotState::COMPLETE;
+    }
+#endif
     if (logging && !logging_started) {
         force_write = true;
+#if EK3_FEATURE_REPLAY_SNAPSHOT
+        if (AP::logger().log_replay_from_arm()) {
+            // drop the frame footer accumulated while gated so the
+            // stream starts with a frame header
+            _RFRF.frame_types = 0;
+        }
+#endif
     }
     logging_started = logging;
 #endif
@@ -314,6 +337,86 @@ void AP_DAL::WriteLogMessage(enum LogMessages msg_type, void *msg, const void *o
         _end = 0;
     }
 }
+
+#if EK3_FEATURE_REPLAY_SNAPSHOT
+// how long an unserviced snapshot request gates the replay stream
+static constexpr uint32_t REPLAY_SNAPSHOT_TIMEOUT_MS = 10000;
+
+void AP_DAL::update_replay_snapshot_state(void)
+{
+    const bool armed = hal.util->get_soft_armed();
+    if (armed && !_was_armed) {
+        _snapshot_state = SnapshotState::REQUESTED;
+        _snapshot_request_ms = AP_HAL::millis();
+    } else if (!armed) {
+        _snapshot_state = SnapshotState::IDLE;
+    }
+    _was_armed = armed;
+    // request not serviced in time (EKF3 disabled or a stalled writer);
+    // open the stream rather than log nothing, losing the warm start
+    if (_snapshot_state == SnapshotState::REQUESTED &&
+        AP_HAL::millis() - _snapshot_request_ms > REPLAY_SNAPSHOT_TIMEOUT_MS) {
+        _snapshot_state = SnapshotState::COMPLETE;
+    }
+}
+
+bool AP_DAL::replay_snapshot_pending(void) const
+{
+    if (_snapshot_state != SnapshotState::REQUESTED) {
+        return false;
+    }
+    // the snapshot can only go out once the log's startup messages are
+    // written, or its blocks would be dropped
+    return AP::logger().log_startup_complete();
+}
+
+/*
+  write one core's serialised snapshot as an RSNH header plus RSND
+  chunks. hdr_written/chunks_done let a write stalled by a full buffer
+  resume; the caller must keep the blob unchanged until this returns true.
+ */
+bool AP_DAL::write_replay_snapshot(uint8_t core, uint8_t version, uint8_t ftype_size,
+                                   const uint8_t *blob, uint16_t len,
+                                   bool &hdr_written, uint16_t &chunks_done)
+{
+    if (_snapshot_state != SnapshotState::REQUESTED) {
+        return false;
+    }
+    const uint16_t num_chunks = (len + RSND_CHUNK_LEN_BYTES - 1) / RSND_CHUNK_LEN_BYTES;
+    if (!hdr_written) {
+        struct log_RSNH hdr {};
+        hdr.total_len = len;
+        hdr.core = core;
+        hdr.version = version;
+        hdr.ftype_size = ftype_size;
+        hdr.num_chunks = num_chunks;
+        if (!AP::logger().WriteReplayBlock(LOG_RSNH_MSG, &hdr, offsetof(log_RSNH, _end))) {
+            return false;
+        }
+        hdr_written = true;
+    }
+    while (chunks_done < num_chunks) {
+        struct log_RSND chunk {};
+        const uint32_t ofs = chunks_done * RSND_CHUNK_LEN_BYTES;
+        chunk.seq = chunks_done;
+        chunk.core = core;
+        chunk.len = MIN(uint32_t(len) - ofs, RSND_CHUNK_LEN_BYTES);
+        memcpy(chunk.data, &blob[ofs], chunk.len);
+        if (!AP::logger().WriteReplayBlock(LOG_RSND_MSG, &chunk, offsetof(log_RSND, _end))) {
+            return false;
+        }
+        chunks_done++;
+    }
+    return true;
+}
+
+void AP_DAL::complete_replay_snapshot(void)
+{
+    if (_snapshot_state == SnapshotState::REQUESTED) {
+        _snapshot_state = SnapshotState::COMPLETE;
+    }
+}
+#endif  // EK3_FEATURE_REPLAY_SNAPSHOT
 #endif
 
 /*

--- a/libraries/AP_DAL/AP_DAL.h
+++ b/libraries/AP_DAL/AP_DAL.h
@@ -28,6 +28,7 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <cstddef>
+#include <AP_NavEKF3/AP_NavEKF3_feature.h>
 
 
 #define DAL_CORE(c) AP::dal().logging_core(c)
@@ -367,6 +368,17 @@ public:
     // write out a DAL log message. If old_msg is non-null, then
     // only write if the content has changed
     static void WriteLogMessage(enum LogMessages msg_type, void *msg, const void *old_msg, uint8_t msg_size);
+
+#if EK3_FEATURE_REPLAY_SNAPSHOT
+    // LOG_REPLAY=2 support: the EKF serialises a state snapshot into the
+    // log at arming, and the replay stream is held until it has been
+    // written or the attempt is abandoned
+    bool replay_snapshot_pending(void) const;
+    bool write_replay_snapshot(uint8_t core, uint8_t version, uint8_t ftype_size,
+                               const uint8_t *blob, uint16_t len,
+                               bool &hdr_written, uint16_t &chunks_done);
+    void complete_replay_snapshot(void);
+#endif
 #endif
 
 private:
@@ -415,6 +427,21 @@ private:
 
     bool ekf2_init_done;
     bool ekf3_init_done;
+
+#if HAL_LOGGING_ENABLED
+#if EK3_FEATURE_REPLAY_SNAPSHOT
+    // LOG_REPLAY=2 arm-edge snapshot state
+    enum class SnapshotState : uint8_t {
+        IDLE,
+        REQUESTED,
+        COMPLETE,
+    };
+    SnapshotState _snapshot_state;
+    uint32_t _snapshot_request_ms;
+    bool _was_armed;
+    void update_replay_snapshot_state(void);
+#endif
+#endif
 
     void init_sensors(void);
     bool init_done;

--- a/libraries/AP_DAL/LogStructure.h
+++ b/libraries/AP_DAL/LogStructure.h
@@ -40,7 +40,9 @@
     LOG_REVH_MSG, \
     LOG_RWOH_MSG, \
     LOG_RBOH_MSG, \
-    LOG_RTER_MSG
+    LOG_RTER_MSG, \
+    LOG_RSNH_MSG, \
+    LOG_RSND_MSG
 
 // @LoggerMessage: RFRH
 // @Description: Replay FRame Header
@@ -602,6 +604,42 @@ struct log_RTER {
     uint8_t _end;
 };
 
+// @LoggerMessage: RSNH
+// @Description: Replay EKF snapshot header, written at arming for LOG_REPLAY=2
+// @Field: Len: total snapshot length in bytes
+// @Field: C: EKF core index
+// @Field: Ver: snapshot schema version
+// @Field: FSz: size of the EKF floating point type in bytes
+// @Field: NChunk: number of RSND chunks making up this snapshot
+struct log_RSNH {
+    uint32_t total_len;
+    uint8_t core;
+    uint8_t version;
+    uint8_t ftype_size;
+    uint8_t num_chunks;
+    uint8_t _end;
+};
+
+// @LoggerMessage: RSND
+// @Description: Replay EKF snapshot data chunk
+// @Field: Seq: chunk sequence number within the snapshot
+// @Field: C: EKF core index
+// @Field: Len: number of valid bytes in this chunk
+// @Field: Data: snapshot payload bytes
+struct log_RSND {
+    uint16_t seq;
+    uint8_t core;
+    uint8_t len;
+    int16_t data[32];
+    uint8_t _end;
+};
+
+#define RSND_CHUNK_LEN_BYTES sizeof(((struct log_RSND *)nullptr)->data)
+
+// RSNH.num_chunks is a uint8_t, which bounds a snapshot's serialised size
+#define RSN_SNAPSHOT_MAX_CHUNKS UINT8_MAX
+#define RSN_SNAPSHOT_MAX_LEN_BYTES (RSN_SNAPSHOT_MAX_CHUNKS * RSND_CHUNK_LEN_BYTES)
+
 #define RLOG_SIZE(sname) 3+offsetof(struct log_ ##sname,_end)
 
 #define LOG_STRUCTURE_FROM_DAL        \
@@ -672,4 +710,8 @@ struct log_RTER {
     { LOG_RBOH_MSG, RLOG_SIZE(RBOH),                                   \
       "RBOH", "ffffffffIfffH", "Q,DPX,DPY,DPZ,DAX,DAY,DAZ,DT,TS,OX,OY,OZ,D", "-------------", "-------------" }, \
     { LOG_RTER_MSG, RLOG_SIZE(RTER),                                   \
-      "RTER", "f", "Alt", "m", "0" },
+      "RTER", "f", "Alt", "m", "0" }, \
+    { LOG_RSNH_MSG, RLOG_SIZE(RSNH),                                   \
+      "RSNH", "IBBBB", "Len,C,Ver,FSz,NChunk", "-----", "-----" }, \
+    { LOG_RSND_MSG, RLOG_SIZE(RSND),                                   \
+      "RSND", "HBBa", "Seq,C,Len,Data", "----", "----" },

--- a/libraries/AP_Logger/AP_Logger.cpp
+++ b/libraries/AP_Logger/AP_Logger.cpp
@@ -118,8 +118,8 @@ const AP_Param::GroupInfo AP_Logger::var_info[] = {
 
     // @Param: _REPLAY
     // @DisplayName: Enable logging of information needed for Replay
-    // @Description: If LOG_REPLAY is set to 1 then the EKF2 and EKF3 state estimators will log detailed information needed for diagnosing problems with the Kalman filter. LOG_DISARMED must be set to 1 or 2 or else the log will not contain the pre-flight data required for replay testing of the EKF's. It is suggested that you also raise LOG_FILE_BUFSIZE to give more buffer space for logging and use a high quality microSD card to ensure no sensor data is lost.
-    // @Values: 0:Disabled,1:Enabled
+    // @Description: If LOG_REPLAY is set to 1 then the EKF2 and EKF3 state estimators will log detailed information needed for diagnosing problems with the Kalman filter. LOG_DISARMED must be set to 1 or 2 or else the log will not contain the pre-flight data required for replay testing of the EKF's. If LOG_REPLAY is set to 2 the replay data starts at arming instead: an EKF3 snapshot is written to the log at arm and the replay stream runs only while armed, so LOG_DISARMED is only needed for LOG_REPLAY=1 and the log stays flight-sized. Replay of such logs warm-starts from the snapshot when one was successfully written; the result is close to but not bit-exact with the original flight. EKF2 is not supported. It is suggested that you also raise LOG_FILE_BUFSIZE to give more buffer space for logging and use a high quality microSD card to ensure no sensor data is lost.
+    // @Values: 0:Disabled,1:Enabled,2:Enabled from arming with EKF snapshot
     // @User: Standard
     AP_GROUPINFO("_REPLAY",  3, AP_Logger, _params.log_replay,       0),
 
@@ -1087,6 +1087,19 @@ bool AP_Logger::allow_start_ekf() const
         }
     }
 
+    return true;
+}
+
+bool AP_Logger::log_startup_complete(void) const
+{
+    if (_next_backend == 0) {
+        return false;
+    }
+    for (uint8_t i=0; i<_next_backend; i++) {
+        if (!backends[i]->allow_start_ekf()) {
+            return false;
+        }
+    }
     return true;
 }
 

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -335,6 +335,21 @@ public:
     bool in_log_persistance(void) const;
     uint8_t log_replay(void) const { return _params.log_replay; }
 
+    enum class LogReplay : uint8_t {
+        NONE = 0,
+        FROM_BOOT = 1,
+        FROM_ARM_SNAPSHOT = 2,
+    };
+
+    // true when replay data starts at arming from an EKF snapshot
+    bool log_replay_from_arm(void) const {
+        return LogReplay(_params.log_replay.get()) == LogReplay::FROM_ARM_SNAPSHOT;
+    }
+
+    // true once all backends have written their startup messages, so
+    // prioritised writes are no longer dropped
+    bool log_startup_complete(void) const;
+
     vehicle_startup_message_Writer _vehicle_messages;
 
     enum class LogDisarmed : uint8_t {

--- a/libraries/AP_Logger/AP_Logger_Backend.cpp
+++ b/libraries/AP_Logger/AP_Logger_Backend.cpp
@@ -667,7 +667,7 @@ uint16_t AP_Logger_Backend::find_oldest_log()
 void AP_Logger_Backend::vehicle_was_disarmed()
 {
     if (_front._params.file_disarm_rot &&
-        !_front._params.log_replay) {
+        (!_front.log_replay() || _front.log_replay_from_arm())) {
         // rotate our log.  Closing the current one and letting the
         // logging restart naturally based on log_disarmed should do
         // the trick:

--- a/libraries/AP_NavEKF/EKF_Buffer.cpp
+++ b/libraries/AP_NavEKF/EKF_Buffer.cpp
@@ -16,13 +16,13 @@ ekf_ring_buffer::ekf_ring_buffer(uint8_t _elsize) :
 
 bool ekf_ring_buffer::init(uint8_t _size)
 {
-    if (buffer) {
-        free(buffer);
-    }
-    buffer = calloc(_size, elsize);
-    if (buffer == nullptr) {
+    // allocate before freeing so a failure leaves the old buffer usable
+    void *newbuf = calloc(_size, elsize);
+    if (newbuf == nullptr) {
         return false;
     }
+    free(buffer);
+    buffer = newbuf;
     size = _size;
     reset();
     return true;
@@ -132,14 +132,14 @@ void *ekf_imu_buffer::get_offset(uint8_t idx) const
 // initialise buffer, returns false when allocation has failed
 bool ekf_imu_buffer::init(uint32_t size)
 {
-    if (buffer != nullptr) {
-        // allow for init twice
-        free(buffer);
-    }
-    buffer = calloc(size, elsize);
-    if (buffer == nullptr) {
+    // allow for init twice; allocate before freeing so a failure
+    // leaves the old buffer usable
+    void *newbuf = calloc(size, elsize);
+    if (newbuf == nullptr) {
         return false;
     }
+    free(buffer);
+    buffer = newbuf;
     _size = size;
     _youngest = 0;
     _oldest = 0;
@@ -199,4 +199,101 @@ void ekf_imu_buffer::reset()
 void *ekf_imu_buffer::get(uint8_t index) const
 {
     return get_offset(index);
+}
+
+/*
+  save and restore of complete buffer state, used by the EKF3 arming
+  snapshot. The layout is indices followed by the raw element data;
+  both sides must be initialised to the same size and element type.
+ */
+uint16_t ekf_ring_buffer::serialise_len(void) const
+{
+    return 3 + size*uint16_t(elsize);
+}
+
+bool ekf_ring_buffer::serialise(uint8_t *buf, uint16_t len) const
+{
+    if (len != serialise_len()) {
+        return false;
+    }
+    buf[0] = size;
+    buf[1] = oldest;
+    buf[2] = count;
+    if (size > 0) {
+        memcpy(&buf[3], buffer, size*uint32_t(elsize));
+    }
+    return true;
+}
+
+// the stored size wins: buffer sizes derive from measured sensor rates,
+// which can differ between the writer and loader of a snapshot
+bool ekf_ring_buffer::deserialise(const uint8_t *buf, uint16_t len)
+{
+    if (len < 3) {
+        return false;
+    }
+    const uint8_t stored_size = buf[0];
+    if (len != 3 + stored_size*uint16_t(elsize)) {
+        return false;
+    }
+    if (stored_size == 0) {
+        // the writer never used this buffer; keep our capacity and
+        // just clear any stale contents
+        if (buffer != nullptr) {
+            reset();
+        }
+        return true;
+    }
+    if (stored_size != size && !init(stored_size)) {
+        return false;
+    }
+    if (buf[1] >= stored_size || buf[2] > stored_size) {
+        return false;
+    }
+    oldest = buf[1];
+    count = buf[2];
+    memcpy(buffer, &buf[3], size*uint32_t(elsize));
+    return true;
+}
+
+uint16_t ekf_imu_buffer::serialise_len(void) const
+{
+    return 4 + _size*uint16_t(elsize);
+}
+
+bool ekf_imu_buffer::serialise(uint8_t *buf, uint16_t len) const
+{
+    if (len != serialise_len()) {
+        return false;
+    }
+    buf[0] = _size;
+    buf[1] = _oldest;
+    buf[2] = _youngest;
+    buf[3] = _filled ? 1 : 0;
+    if (_size > 0) {
+        memcpy(&buf[4], buffer, _size*uint32_t(elsize));
+    }
+    return true;
+}
+
+bool ekf_imu_buffer::deserialise(const uint8_t *buf, uint16_t len)
+{
+    if (len < 4) {
+        return false;
+    }
+    const uint8_t stored_size = buf[0];
+    if (stored_size == 0 || len != 4 + stored_size*uint16_t(elsize)) {
+        return false;
+    }
+    if (stored_size != _size && !init(stored_size)) {
+        return false;
+    }
+    if (buf[1] >= stored_size || buf[2] >= stored_size) {
+        return false;
+    }
+    _oldest = buf[1];
+    _youngest = buf[2];
+    _filled = buf[3] != 0;
+    memcpy(buffer, &buf[4], _size*uint32_t(elsize));
+    return true;
 }

--- a/libraries/AP_NavEKF/EKF_Buffer.h
+++ b/libraries/AP_NavEKF/EKF_Buffer.h
@@ -39,6 +39,14 @@ public:
     // zeroes all data in the ring buffer
     void reset();
 
+    // save and restore of the complete buffer state, for EKF snapshots
+    uint16_t serialise_len(void) const;
+    bool serialise(uint8_t *buf, uint16_t len) const;
+    bool deserialise(const uint8_t *buf, uint16_t len);
+    uint8_t get_size(void) const {
+        return size;
+    }
+
 private:
     const uint8_t elsize;
     void *buffer;
@@ -86,6 +94,11 @@ public:
     void reset() {
         return ekf_ring_buffer::reset();
     }
+
+    using ekf_ring_buffer::serialise_len;
+    using ekf_ring_buffer::serialise;
+    using ekf_ring_buffer::deserialise;
+    using ekf_ring_buffer::get_size;
 };
 
 
@@ -119,6 +132,14 @@ public:
 
     // zeroes all data in the ring buffer
     void reset();
+
+    // save and restore of the complete buffer state, for EKF snapshots
+    uint16_t serialise_len(void) const;
+    bool serialise(uint8_t *buf, uint16_t len) const;
+    bool deserialise(const uint8_t *buf, uint16_t len);
+    uint8_t get_size(void) const {
+        return _size;
+    }
 
     // retrieves data from the ring buffer at a specified index
     void *get(uint8_t index) const;
@@ -202,4 +223,9 @@ public:
     inline uint8_t get_youngest_index() {
         return ekf_imu_buffer::get_youngest_index();
     }
+
+    using ekf_imu_buffer::serialise_len;
+    using ekf_imu_buffer::serialise;
+    using ekf_imu_buffer::deserialise;
+    using ekf_imu_buffer::get_size;
 };

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -13,6 +13,14 @@
 
 #include <new>
 
+// the AP_DAL_Standalone example links without AP_Logger; this exclusion
+// cannot live in AP_NavEKF3_feature.h, where APM_BUILD_TYPE must not be
+// evaluated (see there)
+#if APM_BUILD_TYPE(APM_BUILD_AP_DAL_Standalone)
+#undef EK3_FEATURE_REPLAY_SNAPSHOT
+#define EK3_FEATURE_REPLAY_SNAPSHOT 0
+#endif
+
 /*
   parameter defaults for different types of vehicle. The
   APM_BUILD_DIRECTORY is taken from the main vehicle directory name
@@ -892,6 +900,14 @@ bool NavEKF3::InitialiseFilter(void)
         ret &= core[i].InitialiseFilterBootstrap();
     }
 
+#if EK3_FEATURE_REPLAY_SNAPSHOT
+    // warm-start cores from any snapshots loaded from a LOG_REPLAY=2 log;
+    // only on full init success, as a failed attempt is retried next call
+    if (ret) {
+        ret &= applyCoreSnapshots();
+    }
+#endif
+
     // set last time the cores were primary to 0
     memset(coreLastTimePrimary_us, 0, sizeof(coreLastTimePrimary_us));
 
@@ -955,6 +971,15 @@ void NavEKF3::UpdateFilter(void)
         }
         core[i].UpdateFilter(allow_state_prediction);
     }
+
+#if EK3_FEATURE_REPLAY_SNAPSHOT
+    if (dal.replay_snapshot_pending()) {
+        writeReplaySnapshots();
+    } else if (snapshot_write_buf != nullptr) {
+        // request withdrawn (e.g. disarmed mid-write); drop partial state
+        resetReplaySnapshotWriter();
+    }
+#endif
 
     // If the current core selected has a bad error score or is unhealthy, switch to a healthy core with the lowest fault score
     // Don't start running the check until the primary core has started returned healthy for at least 10 seconds to avoid switching
@@ -2112,3 +2137,161 @@ bool NavEKF3::InitialiseFilterBootstrap()
     }
     return ret;
 }
+#if EK3_FEATURE_REPLAY_SNAPSHOT
+/*
+  LOG_REPLAY=2 support: at arming, serialise each core's state into the
+  log so Replay can warm-start without pre-arm data. All cores are
+  serialised in the same frame so their snapshots stay time-consistent,
+  then drained; writes resume where they stalled, since restarting on
+  every dropped block floods the buffer faster than it can empty.
+ */
+void NavEKF3::writeReplaySnapshots(void)
+{
+    if (snapshot_write_buf == nullptr) {
+        uint32_t total = 0;
+        for (uint8_t i=0; i<num_cores; i++) {
+            // each core serialises through a Snapshot struct overlay, so
+            // its slice of the buffer must stay 8 byte aligned
+            total = (total + 7U) & ~7U;
+            snapshot_write_ofs[i] = total;
+            snapshot_write_len[i] = core[i].snapshot_len();
+            if (snapshot_write_len[i] == 0) {
+                // oversized snapshot; open the stream rather than gating
+                // the whole flight's replay data on it
+                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "EKF3 replay snapshot skipped");
+                resetReplaySnapshotWriter();
+                dal.complete_replay_snapshot();
+                return;
+            }
+            total += snapshot_write_len[i];
+        }
+        snapshot_write_buf = (uint8_t *)malloc(total);
+        if (snapshot_write_buf == nullptr) {
+            if (!snapshot_alloc_warned) {
+                snapshot_alloc_warned = true;
+                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "EKF3 replay snapshot alloc failed");
+            } else {
+                // second attempt also failed; give up and open the stream
+                resetReplaySnapshotWriter();
+                dal.complete_replay_snapshot();
+            }
+            return;
+        }
+        for (uint8_t i=0; i<num_cores; i++) {
+            core[i].serialiseSnapshot(&snapshot_write_buf[snapshot_write_ofs[i]]);
+        }
+        snapshot_write_core = 0;
+        snapshot_hdr_written = false;
+        snapshot_chunks_done = 0;
+    }
+    while (snapshot_write_core < num_cores) {
+        if (!dal.write_replay_snapshot(snapshot_write_core, NavEKF3_core::SNAPSHOT_VERSION,
+                                       sizeof(ftype),
+                                       &snapshot_write_buf[snapshot_write_ofs[snapshot_write_core]],
+                                       snapshot_write_len[snapshot_write_core],
+                                       snapshot_hdr_written, snapshot_chunks_done)) {
+            return;
+        }
+        snapshot_write_core++;
+        snapshot_hdr_written = false;
+        snapshot_chunks_done = 0;
+    }
+    resetReplaySnapshotWriter();
+    dal.complete_replay_snapshot();
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "EKF3 replay snapshot logged");
+}
+
+void NavEKF3::resetReplaySnapshotWriter(void)
+{
+    free(snapshot_write_buf);
+    snapshot_write_buf = nullptr;
+    snapshot_write_core = 0;
+    snapshot_hdr_written = false;
+    snapshot_chunks_done = 0;
+    snapshot_alloc_warned = false;
+}
+
+// accept a snapshot read from a log; applied when cores are initialised
+bool NavEKF3::loadCoreSnapshot(uint8_t core_index, uint8_t version, uint8_t ftype_size,
+                               const uint8_t *blob, uint16_t len)
+{
+    // the exact length is only checkable against a running core; a
+    // mismatch there is caught by deserialiseSnapshot
+    if (core_index >= MAX_EKF_CORES ||
+        version != NavEKF3_core::SNAPSHOT_VERSION ||
+        ftype_size != sizeof(ftype) ||
+        len < sizeof(uint32_t)) {
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "EKF3 snapshot core %u rejected, cold start", (unsigned)core_index);
+        return false;
+    }
+    uint8_t *copy = (uint8_t *)malloc(len);
+    if (copy == nullptr) {
+        return false;
+    }
+    memcpy(copy, blob, len);
+    free(pending_snapshot[core_index]);
+    pending_snapshot[core_index] = copy;
+    pending_snapshot_len[core_index] = len;
+    if (core != nullptr && core_index < num_cores) {
+        // cores already running (a later arming segment of the log);
+        // warm-start once the whole set has arrived
+        for (uint8_t i=0; i<num_cores; i++) {
+            if (pending_snapshot[i] == nullptr) {
+                return true;
+            }
+        }
+        return applyCoreSnapshots();
+    }
+    return true;
+}
+
+bool NavEKF3::applyCoreSnapshots(void)
+{
+    // apply all cores or none: a partially written snapshot set (one
+    // backend dropping the tail) must not mix warm and cold lanes
+    uint8_t have = 0;
+    for (uint8_t i=0; i<num_cores; i++) {
+        if (pending_snapshot[i] != nullptr) {
+            have++;
+        }
+    }
+    // drop snapshots for cores this build does not run (the log may come
+    // from a vehicle with more cores)
+    for (uint8_t i=num_cores; i<MAX_EKF_CORES; i++) {
+        free(pending_snapshot[i]);
+        pending_snapshot[i] = nullptr;
+    }
+    if (have != num_cores) {
+        if (have != 0) {
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "EKF3 snapshot set incomplete, cold start");
+            for (uint8_t i=0; i<num_cores; i++) {
+                free(pending_snapshot[i]);
+                pending_snapshot[i] = nullptr;
+            }
+        }
+        return true;
+    }
+    bool ok = true;
+    for (uint8_t i=0; i<num_cores; i++) {
+        if (pending_snapshot[i] == nullptr) {
+            continue;
+        }
+        if (core[i].deserialiseSnapshot(pending_snapshot[i], pending_snapshot_len[i])) {
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "EKF3 IMU%u warm start from snapshot", (unsigned)i);
+#if APM_BUILD_TYPE(APM_BUILD_Replay)
+            // the Replay tool's GCS does not log statustext, so record the
+            // warm start in the output log directly
+            AP::logger().Write_MessageF("EKF3 IMU%u warm start from snapshot", (unsigned)i);
+#endif
+        } else {
+            // the core may be part restored; attempt to put it back into
+            // a defined cold-start state
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "EKF3 IMU%u snapshot rejected, cold start", (unsigned)i);
+            ok &= core[i].InitialiseFilterBootstrap();
+        }
+        free(pending_snapshot[i]);
+        pending_snapshot[i] = nullptr;
+    }
+    return ok;
+}
+#endif  // EK3_FEATURE_REPLAY_SNAPSHOT

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -24,6 +24,7 @@
 #include <AP_Param/AP_Param.h>
 #include <AP_NavEKF/AP_Nav_Common.h>
 #include <AP_NavEKF/AP_NavEKF_Source.h>
+#include "AP_NavEKF3_feature.h"
 
 class NavEKF3_core;
 class EKFGSF_yaw;
@@ -382,6 +383,13 @@ public:
     // Do a reset and bootstrap alignment of all EKF cores
     // return true if successful for all cores
     bool InitialiseFilterBootstrap();
+#if EK3_FEATURE_REPLAY_SNAPSHOT
+    // LOG_REPLAY=2 support: accept a core snapshot read from a log by the
+    // Replay tool; applied immediately if the cores are running, else when
+    // they are initialised
+    bool loadCoreSnapshot(uint8_t core_index, uint8_t version, uint8_t ftype_size,
+                          const uint8_t *blob, uint16_t len);
+#endif
 
 private:
     class AP_DAL &dal;
@@ -550,6 +558,25 @@ private:
     
     bool runCoreSelection;                          // true when the primary core has stabilised and the core selection logic can be started
     bool coreSetupRequired[MAX_EKF_CORES];          // true when this core index needs to be setup
+
+#if EK3_FEATURE_REPLAY_SNAPSHOT
+    // LOG_REPLAY=2 support
+    uint8_t *pending_snapshot[MAX_EKF_CORES];       // snapshots loaded from a log, applied when cores exist
+    uint16_t pending_snapshot_len[MAX_EKF_CORES];
+    bool applyCoreSnapshots(void);
+    void writeReplaySnapshots(void);
+    void resetReplaySnapshotWriter(void);
+    // in-progress snapshot write; all cores are serialised together and the
+    // blobs frozen so a stalled write resumes rather than restarting with
+    // newer state
+    uint8_t *snapshot_write_buf;
+    uint8_t snapshot_write_core;
+    bool snapshot_hdr_written;
+    uint16_t snapshot_chunks_done;
+    bool snapshot_alloc_warned;
+    uint32_t snapshot_write_ofs[MAX_EKF_CORES];
+    uint16_t snapshot_write_len[MAX_EKF_CORES];
+#endif
     uint8_t coreImuIndex[MAX_EKF_CORES];            // IMU index used by this core
     float coreRelativeErrors[MAX_EKF_CORES];        // relative errors of cores with respect to primary
     float coreErrorScores[MAX_EKF_CORES];           // the instance error values used to update relative core error

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Snapshot.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Snapshot.cpp
@@ -1,0 +1,595 @@
+#include <AP_HAL/AP_HAL.h>
+
+#include "AP_NavEKF3.h"
+#include "AP_NavEKF3_core.h"
+#include <AP_DAL/AP_DAL.h>
+#include <AP_InternalError/AP_InternalError.h>
+#include <AP_Vehicle/AP_Vehicle_Type.h>
+
+// the AP_DAL_Standalone example links without AP_Logger; this exclusion
+// cannot live in AP_NavEKF3_feature.h, where APM_BUILD_TYPE must not be
+// evaluated (see there)
+#if APM_BUILD_TYPE(APM_BUILD_AP_DAL_Standalone)
+#undef EK3_FEATURE_REPLAY_SNAPSHOT
+#define EK3_FEATURE_REPLAY_SNAPSHOT 0
+#endif
+
+#if EK3_FEATURE_REPLAY_SNAPSHOT
+/*
+  LOG_REPLAY=2 snapshot support. The snapshot carries the slow-to-learn
+  filter state so Replay can warm-start at arming; the boolean order in
+  the flags word is part of the schema, so bump SNAPSHOT_VERSION when
+  changing any of this.
+ */
+
+// each buffer section is a 1 byte id plus a 2 byte length, then payload
+static constexpr uint8_t SECTION_HDR_LEN = 3;
+
+// Snapshot::flags bit layout; bits 0-17 hold the bools arrays in
+// pack/unpackSnapshotFlags, in order
+static constexpr uint8_t SNAPSHOT_FLAGS_AIDING_SHIFT = 18;   // 2 bits
+static constexpr uint32_t SNAPSHOT_FLAGS_AIDING_MASK = 3U;
+static constexpr uint32_t SNAPSHOT_FLAG_POS_TIMEOUT = 1U<<20;
+static constexpr uint32_t SNAPSHOT_FLAG_VEL_TIMEOUT = 1U<<21;
+static constexpr uint32_t SNAPSHOT_FLAG_HGT_TIMEOUT = 1U<<22;
+static constexpr uint32_t SNAPSHOT_FLAG_TAS_TIMEOUT = 1U<<23;
+static constexpr uint32_t SNAPSHOT_FLAG_DRAG_TIMEOUT = 1U<<24;
+static constexpr uint32_t SNAPSHOT_FLAG_COMMON_ORIGIN = 1U<<27;
+static constexpr uint32_t SNAPSHOT_FLAG_ARMED = 1U<<28;
+static constexpr uint32_t SNAPSHOT_FLAG_PREV_ARMED = 1U<<29;
+
+// number of entries in the pack/unpackSnapshotFlags bools arrays
+static constexpr uint8_t SNAPSHOT_FLAGS_NUM_BOOLS = 18;
+static_assert(SNAPSHOT_FLAGS_NUM_BOOLS <= SNAPSHOT_FLAGS_AIDING_SHIFT,
+              "snapshot bool flags overlap the aiding mode bits");
+
+/*
+  buffer sections are tagged with an id so a loader built with a
+  different EKF feature set can skip sections it does not have and
+  tolerate ones the writer did not include. The fixed header is not
+  feature-tagged: SNAPSHOT_VERSION and ftype_size must still match.
+ */
+enum class SnapshotSection : uint8_t {
+    IMU = 1,
+    OUTPUT = 2,
+    GPS = 3,
+    MAG = 4,
+    BARO = 5,
+    TAS = 6,
+    RANGE = 7,
+    OPTFLOW = 8,
+    BODY_ODOM = 9,
+    GPS_YAW = 10,
+    DRAG = 11,
+};
+
+/*
+  the section list lives here and nowhere else: snapshot_len and
+  serialiseSnapshot both iterate it, so the allocated length and the
+  serialised layout cannot disagree
+ */
+template <typename F>
+void NavEKF3_core::forEachSnapshotSection(F &fn) const
+{
+    fn(SnapshotSection::IMU, storedIMU);
+    fn(SnapshotSection::OUTPUT, storedOutput);
+    fn(SnapshotSection::GPS, storedGPS);
+    fn(SnapshotSection::MAG, storedMag);
+    fn(SnapshotSection::BARO, storedBaro);
+    fn(SnapshotSection::TAS, storedTAS);
+#if EK3_FEATURE_RANGEFINDER_MEASUREMENTS
+    fn(SnapshotSection::RANGE, storedRange);
+#endif
+    fn(SnapshotSection::GPS_YAW, storedYawAng);
+#if EK3_FEATURE_DRAG_FUSION
+    fn(SnapshotSection::DRAG, storedDrag);
+#endif
+#if EK3_FEATURE_OPTFLOW_FUSION
+    fn(SnapshotSection::OPTFLOW, storedOF);
+#endif
+#if EK3_FEATURE_BODY_ODOM
+    fn(SnapshotSection::BODY_ODOM, storedBodyOdm);
+#endif
+}
+
+// sums SECTION_HDR_LEN plus payload for each section
+struct SnapshotLenAccumulator {
+    uint32_t len;
+    template <typename T>
+    void operator()(SnapshotSection, const T &b) {
+        len += SECTION_HDR_LEN + b.serialise_len();
+    }
+};
+
+// writes each section's header and payload, advancing p
+struct SnapshotSectionWriter {
+    uint8_t *p;
+    template <typename T>
+    void operator()(SnapshotSection id, const T &b) {
+        const uint16_t l = b.serialise_len();
+        p[0] = uint8_t(id);
+        p[1] = l & 0xFF;
+        p[2] = l >> 8;
+        b.serialise(&p[SECTION_HDR_LEN], l);
+        p += SECTION_HDR_LEN + l;
+    }
+};
+
+uint16_t NavEKF3_core::snapshot_len(void) const
+{
+    // the serialised layout is the on-disk schema; if this fires the
+    // wire format has changed - update the size AND bump SNAPSHOT_VERSION
+    static_assert(sizeof(Snapshot) == (sizeof(ftype) == 8 ? 5472 : 2768),
+                  "Snapshot layout changed: bump SNAPSHOT_VERSION and update this size");
+    SnapshotLenAccumulator acc { sizeof(Snapshot) };
+    forEachSnapshotSection(acc);
+    // report an impossible length rather than overflowing the chunk
+    // numbering
+    if (acc.len > RSN_SNAPSHOT_MAX_LEN_BYTES) {
+        INTERNAL_ERROR(AP_InternalError::error_t::flow_of_control);
+        return 0;
+    }
+    return acc.len;
+}
+
+uint16_t NavEKF3_core::snapshot_age(uint32_t last_time_ms) const
+{
+    if (last_time_ms == 0 || last_time_ms > imuSampleTime_ms) {
+        return UINT16_MAX;
+    }
+    return MIN(imuSampleTime_ms - last_time_ms, UINT16_MAX - 1U);
+}
+
+/*
+  ages are rebased onto the recorded snapshot time, not the local
+  clock: the snapshot can be applied before the loader has processed
+  its first frame header, when the local time is still zero
+ */
+void NavEKF3_core::restore_snapshot_age(uint32_t &last_time_ms, uint16_t age, uint32_t base_time_ms) const
+{
+    if (age == UINT16_MAX || age >= base_time_ms) {
+        last_time_ms = 0;
+    } else {
+        last_time_ms = base_time_ms - age;
+    }
+}
+
+uint32_t NavEKF3_core::packSnapshotFlags(void) const
+{
+    const bool bools[] = {
+        tiltAlignComplete,
+        yawAlignComplete,
+        magStateInitComplete,
+        delAngBiasLearned,
+        magFieldLearned,
+        inhibitWindStates,
+        windStatesAligned,
+        inhibitMagStates,
+        inhibitDelAngBiasStates,
+        inhibitDelVelBiasStates,
+        validOrigin,
+        onGround,
+        prevOnGround,
+        inFlight,
+        prevInFlight,
+        onGroundNotMoving,
+        finalInflightYawInit,
+        finalInflightMagInit,
+    };
+    static_assert(ARRAY_SIZE(bools) == SNAPSHOT_FLAGS_NUM_BOOLS,
+                  "flags schema changed: bump SNAPSHOT_VERSION and update both bools arrays");
+    uint32_t flags = 0;
+    for (uint8_t i=0; i<ARRAY_SIZE(bools); i++) {
+        if (bools[i]) {
+            flags |= (1U<<i);
+        }
+    }
+    // aiding mode encoded so 0 means AID_NONE regardless of the enum
+    // values
+    switch (PV_AidingMode) {
+    case AID_NONE:
+        break;
+    case AID_ABSOLUTE:
+        flags |= 1U<<SNAPSHOT_FLAGS_AIDING_SHIFT;
+        break;
+    case AID_RELATIVE:
+        flags |= 2U<<SNAPSHOT_FLAGS_AIDING_SHIFT;
+        break;
+    }
+    if (posTimeout) {
+        flags |= SNAPSHOT_FLAG_POS_TIMEOUT;
+    }
+    if (velTimeout) {
+        flags |= SNAPSHOT_FLAG_VEL_TIMEOUT;
+    }
+    if (hgtTimeout) {
+        flags |= SNAPSHOT_FLAG_HGT_TIMEOUT;
+    }
+    if (tasTimeout) {
+        flags |= SNAPSHOT_FLAG_TAS_TIMEOUT;
+    }
+    if (dragTimeout) {
+        flags |= SNAPSHOT_FLAG_DRAG_TIMEOUT;
+    }
+    if (frontend->common_origin_valid) {
+        flags |= SNAPSHOT_FLAG_COMMON_ORIGIN;
+    }
+    if (motorsArmed) {
+        flags |= SNAPSHOT_FLAG_ARMED;
+    }
+    if (prevMotorsArmed) {
+        flags |= SNAPSHOT_FLAG_PREV_ARMED;
+    }
+    return flags;
+}
+
+void NavEKF3_core::unpackSnapshotFlags(uint32_t flags)
+{
+    bool *bools[] = {
+        &tiltAlignComplete,
+        &yawAlignComplete,
+        &magStateInitComplete,
+        &delAngBiasLearned,
+        &magFieldLearned,
+        &inhibitWindStates,
+        &windStatesAligned,
+        &inhibitMagStates,
+        &inhibitDelAngBiasStates,
+        &inhibitDelVelBiasStates,
+        &validOrigin,
+        &onGround,
+        &prevOnGround,
+        &inFlight,
+        &prevInFlight,
+        &onGroundNotMoving,
+        &finalInflightYawInit,
+        &finalInflightMagInit,
+    };
+    static_assert(ARRAY_SIZE(bools) == SNAPSHOT_FLAGS_NUM_BOOLS,
+                  "flags schema changed: bump SNAPSHOT_VERSION and update both bools arrays");
+    for (uint8_t i=0; i<ARRAY_SIZE(bools); i++) {
+        *bools[i] = (flags & (1U<<i)) != 0;
+    }
+    switch ((flags >> SNAPSHOT_FLAGS_AIDING_SHIFT) & SNAPSHOT_FLAGS_AIDING_MASK) {
+    case 1:
+        PV_AidingMode = AID_ABSOLUTE;
+        break;
+    case 2:
+        PV_AidingMode = AID_RELATIVE;
+        break;
+    default:
+        PV_AidingMode = AID_NONE;
+        break;
+    }
+    posTimeout = (flags & SNAPSHOT_FLAG_POS_TIMEOUT) != 0;
+    velTimeout = (flags & SNAPSHOT_FLAG_VEL_TIMEOUT) != 0;
+    hgtTimeout = (flags & SNAPSHOT_FLAG_HGT_TIMEOUT) != 0;
+    tasTimeout = (flags & SNAPSHOT_FLAG_TAS_TIMEOUT) != 0;
+    dragTimeout = (flags & SNAPSHOT_FLAG_DRAG_TIMEOUT) != 0;
+    motorsArmed = (flags & SNAPSHOT_FLAG_ARMED) != 0;
+    prevMotorsArmed = (flags & SNAPSHOT_FLAG_PREV_ARMED) != 0;
+}
+
+// map a logged height source byte back to the enum, defaulting to BARO
+// for values this build does not know
+static AP_NavEKF_Source::SourceZ snapshot_hgt_source(uint8_t v)
+{
+    switch (AP_NavEKF_Source::SourceZ(v)) {
+    case AP_NavEKF_Source::SourceZ::NONE:
+    case AP_NavEKF_Source::SourceZ::RANGEFINDER:
+    case AP_NavEKF_Source::SourceZ::GPS:
+    case AP_NavEKF_Source::SourceZ::BEACON:
+    case AP_NavEKF_Source::SourceZ::EXTNAV:
+        return AP_NavEKF_Source::SourceZ(v);
+    case AP_NavEKF_Source::SourceZ::BARO:
+    default:
+        return AP_NavEKF_Source::SourceZ::BARO;
+    }
+}
+
+// parse one section header at p, bounds-checked against end; false if
+// the header or its payload would overrun the blob
+static bool snapshot_get_section(const uint8_t *p, const uint8_t *end,
+                                 SnapshotSection &id, uint16_t &l)
+{
+    if (end - p < SECTION_HDR_LEN) {
+        return false;
+    }
+    id = SnapshotSection(p[0]);
+    l = p[1] | (p[2] << 8);
+    return end - p >= SECTION_HDR_LEN + l;
+}
+
+void NavEKF3_core::serialiseSnapshot(uint8_t *buf) const
+{
+    Snapshot &snap = *(Snapshot *)(void *)buf;
+    memcpy(&snap.states, &stateStruct, sizeof(snap.states));
+    memcpy(&snap.P, &P, sizeof(snap.P));
+    snap.out_new = outputDataNew;
+    snap.out_delayed = outputDataDelayed;
+    snap.del_ang_correction = delAngCorrection;
+    snap.vel_err_integral = velErrintegral;
+    snap.pos_err_integral = posErrintegral;
+    snap.vert_comp_pos = vertCompFiltState.pos;
+    snap.vert_comp_vel = vertCompFiltState.vel;
+    snap.vert_comp_acc = vertCompFiltState.acc;
+    snap.prev_tnb = prevTnb;
+    snap.dt_imu_avg = dtIMUavg;
+    snap.dt_ekf_avg = dtEkfAvg;
+    snap.hgt_rate = hgtRate;
+    snap.terrain_state = terrainState;
+    snap.baro_hgt_offset = baroHgtOffset;
+    snap.earth_mag_var = earthMagFieldVar;
+    snap.body_mag_var = bodyMagFieldVar;
+    for (uint8_t i=0; i<ARRAY_SIZE(snap.inactive_gyro_bias); i++) {
+        if (i < INS_MAX_INSTANCES) {
+            snap.inactive_gyro_bias[i] = inactiveBias[i].gyro_bias;
+            snap.inactive_accel_bias[i] = inactiveBias[i].accel_bias;
+        } else {
+            snap.inactive_gyro_bias[i].zero();
+            snap.inactive_accel_bias[i].zero();
+        }
+    }
+    snap.last_known_pos_ne = lastKnownPositionNE;
+    snap.pos_down_at_takeoff = posDownAtTakeoff;
+    snap.mea_hgt_at_takeoff = meaHgtAtTakeOff;
+#if EK3_FEATURE_OPTFLOW_FUSION
+    snap.terrain_var = Popt;
+#else
+    snap.terrain_var = 0;
+#endif
+    snap.bad_imu_vel_err_integral = badImuVelErrIntegral;
+    snap.gps_ref_hgt = ekfGpsRefHgt;
+    snap.age_vel_ms = snapshot_age(lastVelPassTime_ms);
+    snap.age_gpspos_ms = snapshot_age(lastGpsPosPassTime_ms);
+    snap.age_hgt_ms = snapshot_age(lastHgtPassTime_ms);
+    snap.age_tas_ms = snapshot_age(lastTasPassTime_ms);
+    snap.age_flow_ms = snapshot_age(prevFlowFuseTime_ms);
+    snap.age_bodyvel_ms = snapshot_age(prevBodyVelFuseTime_ms);
+    snap.age_drag_ms = snapshot_age(lastDragPassTime_ms);
+    snap.age_unused_ms = UINT16_MAX;
+    snap.snapshot_time_ms = imuSampleTime_ms;
+    snap.active_hgt_source = uint8_t(activeHgtSource);
+    snap.prev_hgt_source = uint8_t(prevHgtSource);
+    snap.source_set = frontend->sources.getActiveSourceSet(core_index);
+    snap.reserved0 = 0;
+    snap.origin_lat = EKF_origin.lat;
+    snap.origin_lng = EKF_origin.lng;
+    snap.origin_alt_cm = EKF_origin.alt;
+    snap.public_origin_lat = public_origin.lat;
+    snap.public_origin_lng = public_origin.lng;
+    snap.public_origin_alt_cm = public_origin.alt;
+    snap.age_arming_ms = snapshot_age(timeAtArming_ms);
+    snap.flags = packSnapshotFlags();
+
+    SnapshotSectionWriter writer { buf + sizeof(Snapshot) };
+    forEachSnapshotSection(writer);
+}
+
+bool NavEKF3_core::deserialiseSnapshot(const uint8_t *buf, uint16_t len)
+{
+    // sections carry their own sizes, so only the fixed header is checked
+    if (len < sizeof(Snapshot)) {
+#if APM_BUILD_TYPE(APM_BUILD_Replay)
+        ::printf("EKF3 snapshot: len %u below fixed header %u\n", unsigned(len), unsigned(sizeof(Snapshot)));
+#endif
+        return false;
+    }
+    const Snapshot &snap = *(const Snapshot *)(const void *)buf;
+    // reject numerically invalid state before touching the core
+    {
+        const ftype *sv = (const ftype *)(const void *)&snap.states;
+        for (uint8_t i=0; i<sizeof(snap.states)/sizeof(ftype); i++) {
+            if (!isfinite(float(sv[i]))) {
+                return false;
+            }
+        }
+        // unit quaternion, with generous slack for logging precision
+        const ftype qlen = snap.states.quat.length();
+        if (qlen < 0.9f || qlen > 1.1f) {
+            return false;
+        }
+        for (uint8_t i=0; i<ARRAY_SIZE(snap.P); i++) {
+            if (!isfinite(float(snap.P[i][i])) || snap.P[i][i] < 0) {
+                return false;
+            }
+        }
+        if (!check_latlng(snap.origin_lat, snap.origin_lng)) {
+            return false;
+        }
+    }
+    // a cold start runs InitialiseVariables before setting states; do the
+    // same so timers and fusion state machines start from now rather than
+    // zero, which would fire spurious timeouts and sensor switches
+    InitialiseVariables();
+    memcpy(&stateStruct, &snap.states, sizeof(stateStruct));
+    memcpy(&P, &snap.P, sizeof(P));
+    outputDataNew = snap.out_new;
+    outputDataDelayed = snap.out_delayed;
+    delAngCorrection = snap.del_ang_correction;
+    velErrintegral = snap.vel_err_integral;
+    posErrintegral = snap.pos_err_integral;
+    vertCompFiltState.pos = snap.vert_comp_pos;
+    vertCompFiltState.vel = snap.vert_comp_vel;
+    vertCompFiltState.acc = snap.vert_comp_acc;
+    prevTnb = snap.prev_tnb;
+    dtIMUavg = snap.dt_imu_avg;
+    dtEkfAvg = snap.dt_ekf_avg;
+    hgtRate = snap.hgt_rate;
+    terrainState = snap.terrain_state;
+    baroHgtOffset = snap.baro_hgt_offset;
+    earthMagFieldVar = snap.earth_mag_var;
+    bodyMagFieldVar = snap.body_mag_var;
+    for (uint8_t i=0; i<ARRAY_SIZE(snap.inactive_gyro_bias) && i<INS_MAX_INSTANCES; i++) {
+        inactiveBias[i].gyro_bias = snap.inactive_gyro_bias[i];
+        inactiveBias[i].accel_bias = snap.inactive_accel_bias[i];
+    }
+    lastKnownPositionNE = snap.last_known_pos_ne;
+    posDownAtTakeoff = snap.pos_down_at_takeoff;
+    meaHgtAtTakeOff = snap.mea_hgt_at_takeoff;
+#if EK3_FEATURE_OPTFLOW_FUSION
+    Popt = snap.terrain_var;
+#endif
+    badImuVelErrIntegral = snap.bad_imu_vel_err_integral;
+    activeHgtSource = snapshot_hgt_source(snap.active_hgt_source);
+    prevHgtSource = snapshot_hgt_source(snap.prev_hgt_source);
+    ekfGpsRefHgt = snap.gps_ref_hgt;
+    EKF_origin.lat = snap.origin_lat;
+    EKF_origin.lng = snap.origin_lng;
+    EKF_origin.alt = snap.origin_alt_cm;
+    unpackSnapshotFlags(snap.flags);
+    // the state index limit follows the inhibit flags via transitions the
+    // restored filter never went through
+    updateStateIndexLim();
+    PV_AidingModePrev = PV_AidingMode;
+    const uint32_t snap_t = snap.snapshot_time_ms;
+    restore_snapshot_age(lastVelPassTime_ms, snap.age_vel_ms, snap_t);
+    restore_snapshot_age(lastGpsPosPassTime_ms, snap.age_gpspos_ms, snap_t);
+    restore_snapshot_age(lastHgtPassTime_ms, snap.age_hgt_ms, snap_t);
+    restore_snapshot_age(lastTasPassTime_ms, snap.age_tas_ms, snap_t);
+    restore_snapshot_age(prevFlowFuseTime_ms, snap.age_flow_ms, snap_t);
+    restore_snapshot_age(prevBodyVelFuseTime_ms, snap.age_bodyvel_ms, snap_t);
+    restore_snapshot_age(lastDragPassTime_ms, snap.age_drag_ms, snap_t);
+    restore_snapshot_age(timeAtArming_ms, uint16_t(snap.age_arming_ms), snap_t);
+    statesInitialised = true;
+
+    const uint8_t *p = buf + sizeof(Snapshot);
+    const uint8_t *end = buf + len;
+    // validate the section framing, and that the IMU and output predictor
+    // buffers agree in depth, before mutating any buffer (the fixed state
+    // is already restored; callers re-bootstrap on failure)
+    {
+        const uint8_t *q = p;
+        uint8_t imu_sz = 0, out_sz = 0;
+        while (q < end) {
+            SnapshotSection id;
+            uint16_t l;
+            if (!snapshot_get_section(q, end, id, l)) {
+                statesInitialised = false;
+                return false;
+            }
+            // the first payload byte of a serialised buffer is its depth
+            if (id == SnapshotSection::IMU && l >= 1) {
+                imu_sz = q[SECTION_HDR_LEN];
+            }
+            if (id == SnapshotSection::OUTPUT && l >= 1) {
+                out_sz = q[SECTION_HDR_LEN];
+            }
+            q += SECTION_HDR_LEN + l;
+        }
+        if (imu_sz == 0 || imu_sz != out_sz) {
+            statesInitialised = false;
+            return false;
+        }
+    }
+    bool imu_restored = false;
+    bool output_restored = false;
+    bool gps_restored = false;
+    bool walk_ok = true;
+    while (p < end && walk_ok) {
+        SnapshotSection id;
+        uint16_t l;
+        if (!snapshot_get_section(p, end, id, l)) {
+            walk_ok = false;
+            break;
+        }
+        const uint8_t *payload = &p[SECTION_HDR_LEN];
+        switch (id) {
+        case SnapshotSection::IMU:
+            imu_restored = storedIMU.deserialise(payload, l);
+            walk_ok = imu_restored;
+            break;
+        case SnapshotSection::OUTPUT:
+            output_restored = storedOutput.deserialise(payload, l);
+            walk_ok = output_restored;
+            break;
+        case SnapshotSection::GPS:
+            gps_restored = storedGPS.deserialise(payload, l);
+            walk_ok = gps_restored;
+            break;
+        case SnapshotSection::MAG:
+            walk_ok = storedMag.deserialise(payload, l);
+            break;
+        case SnapshotSection::BARO:
+            walk_ok = storedBaro.deserialise(payload, l);
+            break;
+        case SnapshotSection::TAS:
+            walk_ok = storedTAS.deserialise(payload, l);
+            break;
+#if EK3_FEATURE_RANGEFINDER_MEASUREMENTS
+        case SnapshotSection::RANGE:
+            walk_ok = storedRange.deserialise(payload, l);
+            break;
+#endif
+        case SnapshotSection::GPS_YAW:
+            walk_ok = storedYawAng.deserialise(payload, l);
+            break;
+#if EK3_FEATURE_DRAG_FUSION
+        case SnapshotSection::DRAG:
+            walk_ok = storedDrag.deserialise(payload, l);
+            break;
+#endif
+#if EK3_FEATURE_OPTFLOW_FUSION
+        case SnapshotSection::OPTFLOW:
+            walk_ok = storedOF.deserialise(payload, l);
+            break;
+#endif
+#if EK3_FEATURE_BODY_ODOM
+        case SnapshotSection::BODY_ODOM:
+            walk_ok = storedBodyOdm.deserialise(payload, l);
+            break;
+#endif
+        default:
+            // written by a build with a feature this one lacks
+            break;
+        }
+        p += SECTION_HDR_LEN + l;
+    }
+    // the delayed horizon and output predictor buffers are the point of
+    // the snapshot; anything else missing just stays reset
+    if (!walk_ok || !imu_restored || !output_restored) {
+#if APM_BUILD_TYPE(APM_BUILD_Replay)
+        ::printf("EKF3 snapshot: bad section walk (ok=%u imu=%u out=%u ofs=%u len=%u)\n",
+                 unsigned(walk_ok), unsigned(imu_restored), unsigned(output_restored),
+                 unsigned(p-buf), unsigned(len));
+#endif
+        imu_buffer_length = storedIMU.get_size();
+        obs_buffer_length = storedGPS.get_size();
+        statesInitialised = false;
+        return false;
+    }
+    // the delayed-horizon processing must run over the restored buffers
+    // at their original sizes
+    imu_buffer_length = storedIMU.get_size();
+    if (gps_restored) {
+        obs_buffer_length = storedGPS.get_size();
+    }
+    // the frontend-shared state is only applied once the whole snapshot
+    // has validated, so a rejected blob cannot leave it half changed
+    frontend->sources.setPosVelYawSourceSet(AP_NavEKF_Source::SourceSetSelection(snap.source_set));
+    // refresh the change-detection latches or the first update sees a
+    // fake source change and resets position and yaw
+    posxy_source_last = frontend->sources.getPosXYSource(core_index);
+    yaw_source_last = frontend->sources.getYawSource(core_index);
+    // a restored origin never goes through setOrigin, so adopt it as the
+    // public origin or all position outputs would be offset from (0,0),
+    // and recompute the earth rotation compensation it normally provides
+    if (validOrigin) {
+        // restore the public origin as it was, not as a copy of the EKF
+        // origin: getPosNE reports the delta between the two
+        if (snap.flags & SNAPSHOT_FLAG_COMMON_ORIGIN) {
+            frontend->common_EKF_origin.lat = snap.public_origin_lat;
+            frontend->common_EKF_origin.lng = snap.public_origin_lng;
+            frontend->common_EKF_origin.alt = snap.public_origin_alt_cm;
+        } else {
+            frontend->common_EKF_origin = EKF_origin;
+        }
+        frontend->common_origin_valid = true;
+        calcEarthRateNED(earthRateNED, EKF_origin.lat);
+    }
+    // outputDataNew, storedOutput and the tracking corrections are all
+    // restored, so no StoreOutputReset() here
+
+    return true;
+}
+#endif  // EK3_FEATURE_REPLAY_SNAPSHOT

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -2252,7 +2252,7 @@ void NavEKF3_core::verifyTiltErrorVariance()
         const struct log_XKTV msg {
             LOG_PACKET_HEADER_INIT(LOG_XKTV_MSG),
             time_us      : dal.micros64(),
-            core         : core_index,
+            core         : DAL_CORE(core_index),
             tvs          : float(tiltErrorVariance),
             tvd          : float(tiltErrorVarianceAlt),
         };

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -484,6 +484,17 @@ public:
 
     // return true if states have been initialised by a bootstrap alignment
     bool isStatesInitialised(void) const { return statesInitialised; }
+#if EK3_FEATURE_REPLAY_SNAPSHOT
+    // LOG_REPLAY=2 support: serialise the filter state at arming so
+    // Replay can warm-start without pre-arm data. The blob layout is
+    // private to this class; bump SNAPSHOT_VERSION on any change. The
+    // length depends on the delayed-horizon buffer sizes, so it is only
+    // valid once the core has been set up.
+    static constexpr uint8_t SNAPSHOT_VERSION = 5;
+    uint16_t snapshot_len(void) const;
+    void serialiseSnapshot(uint8_t *buf) const;
+    bool deserialiseSnapshot(const uint8_t *buf, uint16_t len);
+#endif
 
 private:
     EKFGSF_yaw *yawEstimator;
@@ -583,11 +594,84 @@ private:
         struct state_elements stateStruct;
     };
 
+#if EK3_FEATURE_REPLAY_SNAPSHOT
+    uint32_t packSnapshotFlags(void) const;
+    void unpackSnapshotFlags(uint32_t flags);
+    // apply fn to every buffer section in this build; the single source
+    // of truth for what a snapshot contains
+    template <typename F> void forEachSnapshotSection(F &fn) const;
+#endif
+
     struct output_elements {
         QuaternionF quat;           // quaternion defining rotation from local NED earth frame to body frame
         Vector3F    velocity;       // velocity of body frame origin in local NED earth frame (m/sec)
         Vector3F    position;       // position of body frame origin in local NED earth frame (m)
     };
+
+#if EK3_FEATURE_REPLAY_SNAPSHOT
+    /*
+      fixed part of the serialised filter state written to the log at
+      arming for LOG_REPLAY=2; the delayed-horizon and output predictor
+      buffers are appended as length-prefixed sections. Members are
+      ordered so the natural layout has no padding in either single or
+      double precision builds (the ftype block stays 8-byte aligned).
+      Timer fields hold ages relative to the snapshot time so the
+      loader can rebase them; 0xFFFF means the timer had never fired.
+     */
+    struct Snapshot {
+        struct state_elements states;
+        Matrix24 P;
+        struct output_elements out_new;
+        struct output_elements out_delayed;
+        Vector3F del_ang_correction;
+        Vector3F vel_err_integral;
+        Vector3F pos_err_integral;
+        ftype vert_comp_pos;
+        ftype vert_comp_vel;
+        ftype vert_comp_acc;
+        Matrix3F prev_tnb;
+        ftype dt_imu_avg;
+        ftype dt_ekf_avg;
+        ftype hgt_rate;
+        ftype terrain_state;
+        ftype baro_hgt_offset;
+        Vector3F earth_mag_var;
+        Vector3F body_mag_var;
+        Vector3F inactive_gyro_bias[3];
+        Vector3F inactive_accel_bias[3];
+        Vector2F last_known_pos_ne;
+        ftype pos_down_at_takeoff;
+        ftype mea_hgt_at_takeoff;
+        ftype terrain_var;
+        ftype bad_imu_vel_err_integral;
+        double gps_ref_hgt;
+        uint16_t age_vel_ms;
+        uint16_t age_gpspos_ms;
+        uint16_t age_hgt_ms;
+        uint16_t age_tas_ms;
+        uint16_t age_flow_ms;
+        uint16_t age_bodyvel_ms;
+        uint16_t age_drag_ms;
+        uint16_t age_unused_ms;
+        uint32_t snapshot_time_ms;
+        uint8_t active_hgt_source;
+        uint8_t prev_hgt_source;
+        uint8_t source_set;
+        uint8_t reserved0;
+        int32_t origin_lat;
+        int32_t origin_lng;
+        int32_t origin_alt_cm;
+        // the public origin can differ from the EKF origin; getPosNE
+        // reports that delta, so it must survive the warm start
+        int32_t public_origin_lat;
+        int32_t public_origin_lng;
+        int32_t public_origin_alt_cm;
+        uint32_t age_arming_ms;     // uint16 age in a uint32 slot
+        uint32_t flags;
+    };
+    uint16_t snapshot_age(uint32_t last_time_ms) const;
+    void restore_snapshot_age(uint32_t &last_time_ms, uint16_t age, uint32_t base_time_ms) const;
+#endif
 
     struct imu_elements {
         Vector3F    delAng;         // IMU delta angle measurements in body frame (rad)

--- a/libraries/AP_NavEKF3/AP_NavEKF3_feature.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_feature.h
@@ -9,6 +9,7 @@
 #include <AP_Beacon/AP_Beacon_config.h>
 #include <AP_AHRS/AP_AHRS_config.h>
 #include <AP_OpticalFlow/AP_OpticalFlow_config.h>
+#include <AP_Logger/AP_Logger_config.h>
 
 // define for when to include all features
 #define EK3_FEATURE_ALL APM_BUILD_TYPE(APM_BUILD_AP_DAL_Standalone) || APM_BUILD_TYPE(APM_BUILD_Replay)
@@ -16,6 +17,18 @@
 // body odomotry (which includes wheel encoding) on rover or 2M boards
 #ifndef EK3_FEATURE_BODY_ODOM
 #define EK3_FEATURE_BODY_ODOM EK3_FEATURE_ALL || APM_BUILD_TYPE(APM_BUILD_Rover) || HAL_PROGRAM_SIZE_LIMIT_KB > 1024
+#endif
+
+// EKF state snapshot at arming for replay of armed-only logs
+// (LOG_REPLAY=2). On by default only in SITL builds; enable elsewhere
+// with --enable-EKF3_REPLAY_SNAPSHOT. APM_BUILD_TYPE must not be
+// evaluated here: example sketches reach this header through AP_DAL.h
+// and their APM_BUILD_DIRECTORY values are not defined macros, which
+// trips -Wundef. The AP_DAL_Standalone example, which links without
+// AP_Logger, instead compiles the implementation out in the .cpp files
+#ifndef EK3_FEATURE_REPLAY_SNAPSHOT
+#define EK3_FEATURE_REPLAY_SNAPSHOT (CONFIG_HAL_BOARD == HAL_BOARD_SITL) && \
+    HAL_LOGGING_ENABLED && HAL_NAVEKF3_AVAILABLE
 #endif
 
 // external navigation on 2M boards


### PR DESCRIPTION
### Summary

  LOG_REPLAY=1 needs LOG_DISARMED, so replay logs grow from boot and are
  impractical to leave enabled in normal operation. LOG_REPLAY=2 writes an
  EKF3 state snapshot to the log at arming and runs the replay stream only
  while armed

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

