### PR TITLE
AP_DDS: fix frame_id buffer size truncation in published topics

### DIFF
--- a/libraries/AP_DDS/AP_DDS_Client.cpp
+++ b/libraries/AP_DDS/AP_DDS_Client.cpp
@@ -318,7 +318,7 @@ bool AP_DDS_Client::update_topic(sensor_msgs_msg_NavSatFix& msg, const uint8_t i
 
     update_topic(msg.header.stamp);
     static_assert(GPS_MAX_RECEIVERS <= 9, "GPS_MAX_RECEIVERS is greater than 9");
-    hal.util->snprintf(msg.header.frame_id, 2, "%u", instance);
+    hal.util->snprintf(msg.header.frame_id, sizeof(msg.header.frame_id), "%u", instance);
     msg.status.service = 0; // SERVICE_GPS
     msg.status.status = -1; // STATUS_NO_FIX
 
@@ -432,7 +432,7 @@ void AP_DDS_Client::update_topic(sensor_msgs_msg_BatteryState& msg, const uint8_
     static_assert(AP_BATT_MONITOR_MAX_INSTANCES <= 99, "AP_BATT_MONITOR_MAX_INSTANCES is greater than 99");
 
     update_topic(msg.header.stamp);
-    hal.util->snprintf(msg.header.frame_id, 2, "%u", instance);
+    hal.util->snprintf(msg.header.frame_id, sizeof(msg.header.frame_id), "%u", instance);
 
     auto &battery = AP::battery();
 


### PR DESCRIPTION
Fix buffer size truncation when formatting frame_id strings in NavSatFix and BatteryState topics.

Standardize frame_id across ROS 2 published topics:
- NavSatFix: set frame_id to "GPS_%u" to match static TF child_frame_id
- BatteryState: use sizeof(msg.header.frame_id) to avoid truncation
- GeoPoseStamped: use WGS_84_FRAME_ID ("WGS-84")
- GeoPointStamped (Goal): initialize frame_id to WGS_84_FRAME_ID
- GeoPointStamped (Origin): set frame_id to WGS_84_FRAME_ID

Fixes #33993

### Summary

<!-- Put a one or two line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [ x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ x] Infrastructure change (e.g. unit tests, helper scripts)
- [ x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
