### PR TITLE
Copter: do not treat a stale baro sample as evidence of not falling

### DIFF
--- a/ArduCopter/crash_check.cpp
+++ b/ArduCopter/crash_check.cpp
@@ -314,8 +314,9 @@ void Copter::parachute_check()
     if (control_loss_count == 1) {
         baro_alt_start_m = baro_alt_m;
 
-    // exit if baro altitude change indicates we are not falling
-    } else if (baro_alt_m >= baro_alt_start_m) {
+    // exit if baro altitude change indicates we are climbing.  Note
+    // that >= ("not falling") must not be used here
+    } else if (baro_alt_m > baro_alt_start_m) {
         control_loss_count = 0;
         return;
 


### PR DESCRIPTION
### Summary

Removes 3.3% chance of Copter which has lost control/thrust of not deploying parachute due to beat frequency.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

parachute_check() runs as a FAST_TASK, every main loop, but the baro_alt_m it reads is only refreshed by update_altitude(), a 10Hz scheduled task.  The descent guard latched baro_alt_start_m from a sample and then, on the very next loop, compared it against a bit-identical copy of that same sample; >= was therefore true and the loss-of-control counter was reset before it could ever reach the second's worth of loops it needs to deploy.

Only a reading above the latched one is evidence that the vehicle is not falling.  An equal reading carries no new information, and with a fresh, noisy baro exact float equality does not otherwise occur - so this changes only the stale case.

Found via the Copter Parachute autotest, which failed intermittently under load.  An instrumented build showed the counter bouncing between 0 and 1 for eight consecutive seconds, reporting baro and latched altitude equal to the metre, on a vehicle demonstrably falling 150m with a steady 150 degree attitude error - every other condition for deployment satisfied throughout.

Measured by running 512 copies of that test at --parallel=32, twice, changing nothing but this comparison:

    >=   17 failures in 512 runs
    >     0 failures in 512 runs

with no other failures in either set.
