### PR TITLE
waf: refuse to build more than one firmware in a single command

### DIFF
--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -611,6 +611,44 @@ def test_summary(bld):
 
 _build_commands = {}
 
+# Build commands which each produce a firmware of their own.  These are
+# tracked so that asking for more than one of them at a time can be
+# rejected - see _check_single_firmware_command().
+_firmware_build_commands = set()
+
+def _check_single_firmware_command(bld):
+    """Refuse to build more than one firmware in a single invocation.
+
+    Each firmware compiles the shared libraries with its own set of
+    feature defines, into the same build directory.  Asking for several
+    at once lets one firmware link against objects compiled for
+    another, which shows up as an undefined reference to a symbol only
+    the other vehicle enables - or, worse, as a binary which links
+    cleanly and misbehaves.
+    """
+    wanted = []
+    for c in [bld.cmd] + list(Options.commands):
+        # asking for the same firmware twice is harmless; it is two
+        # different ones which cannot share a build directory:
+        if c in _firmware_build_commands and c not in wanted:
+            wanted.append(c)
+    if len(wanted) < 2:
+        return
+
+    bld.fatal(
+        "Cannot build more than one firmware in a single command: asked "
+        "for %s.\n"
+        "\n"
+        "Each firmware compiles the shared libraries with its own feature "
+        "defines into the same build directory, so building several at "
+        "once can link one firmware against another's objects.\n"
+        "\n"
+        "Build them one at a time instead:\n"
+        "%s" % (
+            ", ".join(repr(c) for c in wanted),
+            "".join("    ./waf %s\n" % c for c in wanted),
+        ))
+
 def _process_build_command(bld):
     if bld.cmd not in _build_commands:
         return
@@ -630,14 +668,24 @@ def _process_build_command(bld):
 def build_command(name,
                    targets=None,
                    program_group_list=[],
-                   doc='build shortcut'):
+                   doc='build shortcut',
+                   firmware=False):
     _build_commands[name] = dict(
         targets=targets,
         program_group_list=program_group_list,
     )
+    if firmware:
+        _firmware_build_commands.add(name)
 
     class context_class(Build.BuildContext):
         cmd = name
+
+        def execute(self):
+            # before recursing into the build script, so this is not
+            # buried under the output of generating the task graph:
+            _check_single_firmware_command(self)
+            return super().execute()
+
     context_class.__doc__ = doc
 
 def _select_programs_from_group(bld):

--- a/wscript
+++ b/wscript
@@ -998,6 +998,7 @@ for name in (vehicles + ['bootloader','iofirmware','AP_Periph','replay']):
     ardupilotwaf.build_command(name,
         program_group_list=name,
         doc='builds %s programs' % name,
+        firmware=True,
     )
 
 for program_group in ('all', 'bin', 'tool', 'examples', 'tests', 'benchmarks'):


### PR DESCRIPTION
### Summary

Stops people attempting to (e.g.) `./waf copter rover` as it can not just fail to compile but provide "corrupt" binaries

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
┌────────────────────────┬──────────────────────────────────────────┐
  │       Invocation       │                  Result                  │
  ├────────────────────────┼──────────────────────────────────────────┤
  │ ./waf copter plane     │ fatal, before any build work             │
  ├────────────────────────┼──────────────────────────────────────────┤
  │ ./waf copter AP_Periph │ fatal                                    │
  ├────────────────────────┼──────────────────────────────────────────┤
  │ ./waf copter           │ builds                                   │
  ├────────────────────────┼──────────────────────────────────────────┤
  │ ./waf copter copter    │ builds (same firmware twice is harmless) │
  ├────────────────────────┼──────────────────────────────────────────┤
  │ ./waf copter examples  │ builds                                   │
  ├────────────────────────┼──────────────────────────────────────────┤
  │ ./waf bin / ./waf all  │ unaffected                               │
  └────────────────────────┴──────────────────────────────────────────┘
```

### Description

`./waf copter plane` does not do what it looks like it does.  Each build command extends bld.options.program_group, and bld.options is waf's global options object rather than anything owned by the build context, so the list accumulates across the commands run by one invocation.  The second command therefore selects the first's programs as well as its own:

    ACCUM cmd=copter program_group=['copter'] (id=123652359700064)
    ACCUM cmd=plane  program_group=['copter', 'plane'] (id=123652359700064)

Same options object both times.  The vehicles compile the shared libraries with their own feature defines, so building them this way can link one firmware against objects compiled for another.  The symptom seen was a link failure naming symbols only another vehicle enables:

    undefined reference to `AC_PrecLand::get_target_location(Location&)'
    undefined reference to `AP_Winch::set_desired_rate(float)'

from `./waf plane copter rover sub blimp heli`, reproducible from a clean build directory and absent when the same tree was built one vehicle at a time.  A link which fails is the good case; the same mixing can also produce a binary which links cleanly.

Two in-tree callers already avoid this, both carrying the comment "we can't run `./waf copter blimp plane` without error, so do them one-at-a-time" - so make it a fatal error with a message saying what to do instead, rather than leaving it as folklore.

This only rejects asking for two *different* firmwares in one invocation.  Group builds such as `./waf bin` are unaffected: they are a single command producing a single task graph, in which each vehicle's objects are distinct tasks.  Repeating one firmware is also still fine.
