### PR TITLE
autotest: clear the simulated baro's drift offset before the next test

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -4335,6 +4335,11 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.do_RTL()
 
+        # we have played with SIM_BARO_DRIFT and that causes the
+        # estimators to build up state that takes time to decay - so
+        # just reboot.
+        self.reboot_sitl()
+
     def OpticalFlowCalibration(self):
         '''test optical flow calibration'''
         ex = None
@@ -12656,6 +12661,11 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.do_RTL()
 
+        # we have played with SIM_BARO_DRIFT and that causes the
+        # estimators to build up state that takes time to decay - so
+        # just reboot.
+        self.reboot_sitl()
+
     def AHRSSwitchBackendPositionNEReset(self):
         '''vehicle must not lurch when the active AHRS estimator is changed with divergent NE positions'''
         # glitch the GPS; EKF3 eventually adopts the glitched position
@@ -12774,6 +12784,11 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.progress("In-filter height reset handled cleanly")
 
         self.do_RTL()
+
+        # we have played with SIM_BARO_DRIFT and that causes the
+        # estimators to build up state that takes time to decay - so
+        # just reboot.
+        self.reboot_sitl()
 
     def AHRSSwitchBackendYawReset(self):
         '''vehicle must not spin when the active AHRS estimator is changed with divergent yaws'''

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -9111,6 +9111,11 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
                 "(stale baro buffer not flushed on resetHeightDatum)" %
                 peak_excursion)
 
+        # we have played with SIM_BARO_DRIFT and that causes the
+        # estimators to build up state that takes time to decay - so
+        # just reboot.
+        self.reboot_sitl()
+
     def PPPPeriph(self):
         '''verify PPP-over-TCP link to an AP_Periph (sitl_periph_PPP) companion'''
         self.context_collect('STATUSTEXT')

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -3418,6 +3418,17 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         })
         self.do_RTL()
 
+        # SIM_BARO_DRIFT is a rate: zeroing it stops the offset it has
+        # accumulated from growing but leaves it in place for the life
+        # of the SITL process, and no parameter records it, so a
+        # context revert cannot undo it.  Recalibrating the barometer
+        # moves the ground reference but leaves the EKF to absorb the
+        # resulting step over several seconds, during which the next
+        # test can arm and take home from a height still being
+        # corrected.  Reboot instead: it discards the simulator and
+        # filter state together, with no transient to race.
+        self.reboot_sitl()
+
     def TECSThrSpikeOnModeChange(self):
         ''' Regression test for issue #33871. '''
 


### PR DESCRIPTION
### Summary

Resets barometer offset after landing in tests that play around with `SIM_BARO_DRIFT` to avoid nuking subsequent tests.

This does kind of raise the question as to why we don't reset the thing on disarm in the firmware itself...

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

SIM_BARO_DRIFT is a rate.  Setting it back to zero stops the offset it has accumulated from growing, but leaves that offset in place for the life of the SITL process, and no parameter records it - so the context revert restores every parameter correctly and still cannot see or undo this.

A test which drifts the baro therefore hands the next test in its session an altitude estimate wrong by however far it drifted.  That test sets home from the wrong estimate when it arms, leaving home and the EKF origin disagreeing, and every relative-altitude mission item it flies is displaced by the same amount.

Caught as Copter DO_CHANGE_SPEED failing after
AHRSSwitchBackendPositionReset, which drifts at -0.3m/s for 75s.  The arithmetic in the captured log is exact:

    drift ran 252.2s -> 327.8s = 75.6s at 0.3m/s = 22.68m
    home fell 584.09m -> 561.41m, origin unmoved = 22.68m

so the mission's "20m relative to home" resolved 22.7m below the vehicle, which spent the leg descending at WPNAV_SPEED_DN.  That capped its groundspeed at 2.09m/s against a commanded 4m/s, so it never reached the band the test was waiting for:

    Failed to attain groundspeed between 3.5 and 4.5, reached 14.95

14.95 being the *next* leg's speed by the time the check timed out.

Recalibrate the barometer once the vehicle is landed, which absorbs the offset into a new ground reference.  The helper refuses to calibrate while armed, since doing so in the air would make the ground read as minus the current altitude.

Only AHRSSwitchBackendPositionReset is shown to break a successor: it is the one which drifts for a full 75s.  The other four callers accumulate far less and their successors currently pass either way -

    test.Copter.EK3SrcSwitchPosDownReset,DO_CHANGE_SPEED   passes
    test.Copter.ModeFlowHold,DO_CHANGE_SPEED               passes

- so those calls are preventative rather than fixes for an observed failure.  They leak the same way and would bite a more altitude sensitive successor, and the test ordering already places drifting tests directly before others: upstream tests2b runs AHRSSwitchBackendPositionReset immediately before
AHRSSwitchBackendPositionNEReset, and EK3SrcSwitchPosDownReset immediately before SIMCompare.

This is not load sensitivity.  It is deterministic whenever the two tests land next to each other, which is only why it looked like a parallel-only flake:

    test.Copter.AHRSSwitchBackendPositionReset,DO_CHANGE_SPEED

runs both in one SITL session and fails every time without this change, and passes with it.  Under --parallel=32, 256 interleaved copies of DO_CHANGE_SPEED failed once per iteration in each of three iterations before, and 0/768 after.

