### PR TITLE
autotest: add missing battery-monitor periph defaults file

### DIFF
--- a/Tools/autotest/default_params/periph-battmon.parm
+++ b/Tools/autotest/default_params/periph-battmon.parm
@@ -1,0 +1,4 @@
+# parameters for the SITL battery-monitor peripheral
+
+BATT_MONITOR 16
+BATT_I2C_BUS 2


### PR DESCRIPTION
### Summary

Adds a file which has been missing since the simulated periph went in

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

test.BattCAN has referenced periph-battmon.parm since it was added in 364452ffc8, but the file was never committed: the battery-monitor peripheral panicked on startup failing to load its defaults, and the vehicle timed out waiting for it.  Configure the SMBus battery simulation as the universal peripheral does.
