### PR TITLE
autotest: fix reporting of timeouts occurring outside tests

### DIFF
--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -13631,6 +13631,11 @@ switch value'''
 
         result_list = []
 
+        # a timeout raised before any test has started - during init,
+        # for example - is attributed to this placeholder, rather than
+        # dying with an UnboundLocalError in the handler below:
+        test = Test(self.run_tests)
+
         try:
             self.init()
 


### PR DESCRIPTION
### Summary

Corrects use of variable before it has been created during early autotest suite init

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

A pexpect timeout raised before the test loop had started - during init, for example - crashed run_tests' exception handler with an UnboundLocalError on the loop variable, masking the actual failure. Bind a placeholder first so such timeouts are reported as what they are.

This is what turned test.BattCAN's peripheral startup panic into "cannot access local variable 'test'".
