### PR TITLE
AP_MotorsHeli_Dual: fix arming check message param name typo

### DIFF
--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -560,7 +560,7 @@ bool AP_MotorsHeli_Dual::arming_checks(size_t buflen, char *buffer) const
 
     // returns false if Phase Angle is outside of range for H3 swashplate 1
     if (_swashplate1.get_phase_angle() > 30 || _swashplate1.get_phase_angle() < -30){
-        hal.util->snprintf(buffer, buflen, "H_SW1_PHANG out of range");
+        hal.util->snprintf(buffer, buflen, "H_SW_PHANG out of range");
         return false;
     }
 


### PR DESCRIPTION
### Summary

Swashplate 1's phase angle arming check reports "H_SW1_PHANG out of range", but the actual parameter (added in #32437) is `H_SW_PHANG` — there is no `H_SW1_PHANG`. Swashplate 2's equivalent check already correctly says `H_SW2_PHANG`.

### Classification & Testing (check all that apply and add your own)

- [ ] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Trivial one-line string literal change (arming-check message text only) — no behavior change.

### Description

This was noticed while updating the wiki docs for #32437, which added the `H_SW_PHANG`
parameter (swashplate 1's phase angle, no "1" in the parameter name). The arming check
message for swashplate 1 was never updated to match and still references a `H_SW1_PHANG`
parameter that doesn't exist, which would confuse a user trying to look it up. Swashplate
2's equivalent check already correctly says `H_SW2_PHANG`.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
