### PR TITLE
AP_Bootloader: add Tustin Mach board ID

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -350,6 +350,7 @@ AP_HW_SIMPLIFLYH7                    1221
 AP_HW_MUPilot                        1222
 AP_HW_HWH7                           1223
 AP_HW_BrahmaH7                       1224
+AP_HW_TUSTIN_MACH                    1225
 
 AP_HW_ATLAS_CONTROL                  1227
 AP_HW_MatekH7A3_Wing                 1228


### PR DESCRIPTION
## Description

Add bootloader board ID `1225` for the Tustin Mach flight controller.

The board already exists, and its PX4 BSP has been completed and flight-tested.

This entry is also intended to keep the board ID synchronized with the PX4 bootloader repository and avoid ID collisions.

Related PX4 Bootloader PR: https://github.com/PX4/PX4-Bootloader/pull/276

## Testing

- Ran `Tools/scripts/check_branch_conventions.py --base-branch origin/master`
- All branch convention and board ID checks passed
- No runtime code is changed

## AI assistance

AI assistance was used to inspect the repository contribution requirements, prepare the board ID entry, and check the commit. The submitted change was reviewed and remains the responsibility of the contributor.