### PR TITLE
autotest: bring the rover to rest at the end of DriveMaxRCIN

### DIFF
--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -411,7 +411,13 @@ class AutoTestRover(vehicle_test_suite.TestSuite):
             m = self.assert_receive_message('VFR_HUD')
             self.progress("Current speed: %f" % m.groundspeed)
 
+        # centre the sticks and let the rover coast to a stop before we
+        # finish.  Disarming stops the motors but not the vehicle, and
+        # the next test is entitled to start from rest.
+        self.set_rc(3, 1500)
+        self.set_rc(1, 1500)
         self.disarm_vehicle()
+        self.wait_groundspeed(0, 0.2, minimum_duration=1)
 
     #################################################
     # AUTOTEST ALL


### PR DESCRIPTION
### Summary

Stops vehicle before we go onto the next test.  "Stationary" is a reasonable thing for the next test to be able to assume, and depending on ordering lack of it can cause the next thing to fail.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

DriveMaxRCIN drives at full throttle for 30 seconds and then disarms and returns immediately.  Disarming stops the motors but not the vehicle: the rover coasts on for well over ten seconds.

Under --parallel a worker runs many tests in one SITL session, so the next test inherits that momentum.  SafetySwitch ran next and begins with "Make sure we don't start moving when safety switch enabled", asserting wait_groundspeed(0, 0.1, minimum_duration=2) immediately.  It was entering that wait at 1.68m/s and spending its whole 30s budget waiting for a coast-down it had not caused, failing when it ran out with 0.6s of the 2s settle accumulated.

Centre the sticks and wait for the rover to come to rest before finishing.  A test is entitled to assume it starts from a standstill.

The 0.2m/s bound is chosen from measurement: coasting from ~15m/s the approach to zero is asymptotic, and 0.1m/s is not reliably reachable inside wait_groundspeed's 30s budget - it timed out at 0.14m/s.  0.2m/s is reached with plenty to spare, and drops SafetySwitch's entry speed from 1.68m/s to 0.11m/s, which it now satisfies in three samples instead of twenty-eight.
