### PR TITLE
autotest: send STATUSTEXT as UTF-8 rather than ASCII

### DIFF
--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -9587,8 +9587,11 @@ Also, ignores heartbeats not from our target system'''
                       (self.terrain_data_messages_sent,))
 
     def send_statustext(self, text):
-        if not isinstance(text, bytes):
-            text = bytes(text, "ascii")
+        # STATUSTEXT is UTF-8, so send UTF-8: accept it and nothing else.
+        if isinstance(text, bytes):
+            text = text.decode("utf-8", "replace").encode("utf-8")
+        else:
+            text = text.encode("utf-8")
         seq = 0
         while len(text):
             self.mav.mav.statustext_send(mavutil.mavlink.MAV_SEVERITY_WARNING, text[:50], id=self.statustext_id, chunk_seq=seq)


### PR DESCRIPTION
### Summary

Stops a decode error when sending statustext from test failing with a unicode error message

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest) (well, when they die...)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

send_statustext() encoded with bytes(text, "ascii"), which raises UnicodeEncodeError on any character outside ASCII.  progress() calls it unconditionally for every progress line, and not everything routed through progress() is ASCII - a simulator is free to print what it likes.  SIM_Kebni_SensAItion reports offsets in micro-g and micro-degrees per second, so its output carries a micro sign:

  arduplane: SensAItion: IMU packet #1000 sent - accel_x=0 ug, gyro_x=-16912 udeg/s

STATUSTEXT is a UTF-8 field, so send UTF-8: accept that and nothing else.  Encoding a str as UTF-8 cannot fail, and bytes are round-tripped through a replacing decode so an invalid sequence is replaced rather than passed on.  Encoding as ASCII with errors="replace" would also stop the exception, but it throws away characters which are perfectly valid in the field being filled.

The chunking below splits on bytes and so can cut a multi-byte character in half; the receiver reassembles the chunks before decoding, so that is harmless.

Reachable wherever non-ASCII reaches progress().  Echoing a failing test's SITL output through it, as the parallel autotest work does, hits it reliably: serially the traceback replaces the real failure, and under --parallel the exception kills the test runner without it posting a result, so the parent waits for that test for the rest of the run - a 238-test Plane block sat at 236 with 30 of 32 workers idle.
