### PR TITLE
AP_Bootloader: reserve board IDs for ZenFC boards

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -582,6 +582,9 @@ AP_HW_IOMCU_F100                     5713
 
 # IDs 5730-5739 reserved for NWBlue
 
+#IDs 5740-5749 reserved for Zenithra Tech
+AP_HW_ZenFC_H743                     5740 
+
 #IDs 5800-5809 reserved for Droneer
 AP_HW_DroneerF405                    5800
 


### PR DESCRIPTION
**Reserve BOARD ID for ZENFC H743**

Board ID - 5740 for ZenFC H743

Board ID -5740-5749 for Zenithra Tech Pvt. Ltd.