### PR TITLE
Tools: extend compiler warning suppression to include gcc 16.2

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -481,10 +481,10 @@ class Board:
                 env.CFLAGS += [
                     '-Werror=use-after-free',
                 ]
-            if self.cc_version_gte(cfg, 14, 0) and self.cc_version_lte(cfg, 16, 1):
+            if self.cc_version_gte(cfg, 14, 0) and self.cc_version_lte(cfg, 16, 2):
                 # the following warnings appear to be buggy in later compiler versions
                 # https://github.com/ArduPilot/ardupilot/issues/33206
-                # TODO: readdress following a 16.2+ release
+                # TODO: readdress following a 16.3+ release
                 env.CXXFLAGS += [
                     '-Wno-error=maybe-uninitialized',
                     '-Wno-error=format-truncation',


### PR DESCRIPTION
### Summary

https://github.com/ArduPilot/ardupilot/issues/33206 persists on 16.2

### Classification & Testing (check all that apply and add your own)

- [ ] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
