### PR TITLE
SITL: fix buoyancy math

### DIFF
--- a/libraries/SITL/SIM_Submarine.cpp
+++ b/libraries/SITL/SIM_Submarine.cpp
@@ -232,20 +232,14 @@ void Submarine::calculate_angular_drag_torque(const Vector3f &angular_velocity, 
 */
 float Submarine::calculate_buoyancy_acceleration()
 {
-    float below_water_level = position.z - frame_property.height/2;
+    // position.z is the depth of the centre of the frame, so the frame starts to enter the
+    // water at -height/2 and is completely below the water level at +height/2
+    const float submerged_proportion = constrain_float(position.z + frame_property.height/2, 0, frame_property.height) / frame_property.height;
 
-    // Completely above water level
-    if (below_water_level < 0) {
-        return 0.0f;
-    }
-
-    // Completely below water level
-    if (below_water_level > frame_property.height/2) {
-        return GRAVITY_MSS + sitl->buoyancy / frame_property.mass;
-    }
-
-    // bouyant force is proportional to fraction of height in water
-    return GRAVITY_MSS + (sitl->buoyancy * below_water_level/frame_property.height) / frame_property.mass;
+    // Gravity is applied separately in Aircraft::update_dynamics. This return is buoyant
+    // acceleration only (upward in NED), which scales with displaced volume. Fully
+    // submerged with SIM_BUOYANCY=0 yields GRAVITY_MSS, cancelling gravity.
+    return submerged_proportion * (GRAVITY_MSS + sitl->buoyancy / frame_property.mass);
 };
 
 /*

--- a/libraries/SITL/SITL.cpp
+++ b/libraries/SITL/SITL.cpp
@@ -544,7 +544,7 @@ const AP_Param::GroupInfo SIM::var_info3[] = {
 
     // @Param{Sub}: BUOYANCY
     // @DisplayName: Buoyancy
-    // @Description: Buyoancy for submarines
+    // @Description: Net buoyancy force (in Newtons). 0 is neutrally buoyant, negative means the vehicle sinks.
     AP_GROUPINFO_FRAME("BUOYANCY", 15, SIM, buoyancy, 1, AP_PARAM_FRAME_SUB),
 
     // @Param: RATE_HZ


### PR DESCRIPTION
Math was wrong, this now scales properly from not-submerged to fully-submerged

### Summary

<!-- Put a one or two line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [ ] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

