### PR TITLE
CAN bus regression on Linux HAL (4.7 Backport PR)

### DIFF
--- a/libraries/AP_HAL_Linux/CANSocketIface.cpp
+++ b/libraries/AP_HAL_Linux/CANSocketIface.cpp
@@ -344,10 +344,6 @@ int CANIface::_read(AP_HAL::CANFrame& frame, uint64_t& timestamp_us, bool& loopb
      */
     loopback = (msg.msg_flags & static_cast<int>(MSG_CONFIRM)) != 0;
 
-    if (!loopback) {
-        return 0;
-    }
-
     frame = makeUavcanFrame(sockcan_frame);
     /*
      * Timestamp


### PR DESCRIPTION
### Summary

Restores proper reception of CAN frames in Linux after 4.7 changes.

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [X] Tested on hardware
- [ ] Logs attached
- [X] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

Correcting an apparent mistake of https://github.com/ArduPilot/ardupilot/commit/07aef7ec311f8c2d3c37b4fd9dacfc242317098a 

Since the filter code was largely unused, the check below:
```
    if (!loopback && !_checkHWFilters(sockcan_frame)) {
        return 0;
    }
```
essentially collapsed to `if (!loopback && false)` and the clause was never active. Given the changes in the commit above it's now equivalent `if (!loopback && true)` e.g. the behaviour follows a code path of _a frame that is failing a filter check_. In other words, all incoming packets are filtered out. 

This is the behaviour I first saw when I upgraded my sandbox fork over 4.7, the outgoing frames are sent as normal, no incoming frames are processed despite clearly being received by the system (checked with `candump`). Removing the check entirely since without filters we don't actually check anything useful here. This restores CAN as expected:

<img width="368" height="277" alt="image" src="https://github.com/user-attachments/assets/dc0047b1-9a3c-418d-b83a-2bdde889e6a2" />

Tested on real HW with Linux HAL. Appreciate validating this with other Linux HAL users.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
