### PR TITLE
AP_BattMonitor: Keep mavlink_charge_state instanced

### DIFF
--- a/libraries/AP_BattMonitor/AP_BattMonitor.cpp
+++ b/libraries/AP_BattMonitor/AP_BattMonitor.cpp
@@ -1202,7 +1202,7 @@ MAV_BATTERY_CHARGE_STATE AP_BattMonitor::get_mavlink_charge_state(const uint8_t 
 
     case Failsafe::None:
     case Failsafe::Unhealthy:
-        if (get_mavlink_fault_bitmask(instance) != 0 || !healthy()) {
+        if (get_mavlink_fault_bitmask(instance) != 0 || !healthy(instance)) {
             return MAV_BATTERY_CHARGE_STATE_UNHEALTHY;
         }
         return MAV_BATTERY_CHARGE_STATE_OK;


### PR DESCRIPTION
### Summary

Currently the method will report unhealthy in BATTERY_STATUS.charge_state for ALL batteries, if one battery is unhealthy.

Fix it to refer to the current instance only.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

I did a SITL flight with a Loweheiser generator and 3 battery monitors configured:

```
BATT_MONITOR     4.000000 # Analog Voltage and Current
BATT2_MONITOR    17.000000 # Generator-Elec
BATT3_MONITOR    18.000000 # Generator-Fuel
```

Mid-flight, I turned off and on `SIM_EFI_TYPE` from 2 to 0.

### Description

Currently the instanced MAVLink message `BATTERY_STATUS.charge_state` will go unhealthy for all backends.
<img width="1158" height="591" alt="Screenshot from 2026-08-14 22-36-58" src="https://github.com/user-attachments/assets/b5648cbf-e2f7-454a-ba3a-0f686b3af162" />

This PR makes it so that it responds individually and correctly per-instance.
<img width="602" height="361" alt="Screenshot from 2026-08-14 22-58-55" src="https://github.com/user-attachments/assets/7d97a47c-1823-407e-93fc-1fb7216657ff" />
