### PR TITLE
AP_BLHeli,SRV_Channel: allow BLHeli support to be disabled

### DIFF
--- a/libraries/AP_BLHeli/AP_BLHeli.h
+++ b/libraries/AP_BLHeli/AP_BLHeli.h
@@ -24,9 +24,11 @@
 #include <AP_Common/AP_Common.h>
 #include <AP_HAL/AP_HAL.h>
 
+#ifndef HAVE_AP_BLHELI_SUPPORT
 #define HAVE_AP_BLHELI_SUPPORT HAL_SUPPORT_RCOUT_SERIAL
+#endif
 
-#if HAL_SUPPORT_RCOUT_SERIAL
+#if HAVE_AP_BLHELI_SUPPORT
 
 #include <AP_ESC_Telem/AP_ESC_Telem_Backend.h>
 
@@ -295,4 +297,4 @@ private:
     bool protocol_handler(uint8_t , AP_HAL::UARTDriver *);
 };
 
-#endif // HAL_SUPPORT_RCOUT_SERIAL
+#endif // HAVE_AP_BLHELI_SUPPORT

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -661,7 +661,7 @@ private:
     AP_RobotisServo robotis;
 #endif
 
-#if HAL_SUPPORT_RCOUT_SERIAL
+#if HAVE_AP_BLHELI_SUPPORT
     // support for BLHeli protocol
     AP_BLHeli blheli;
 #endif

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -282,7 +282,7 @@ void SRV_Channels::enable_aux_servos()
     // propagate channel masks to the ESCS
     hal.rcout->update_channel_masks();
 
-#if HAL_SUPPORT_RCOUT_SERIAL
+#if HAVE_AP_BLHELI_SUPPORT
     blheli.update();
 #endif
 }

--- a/libraries/SRV_Channel/SRV_Channels.cpp
+++ b/libraries/SRV_Channel/SRV_Channels.cpp
@@ -181,7 +181,7 @@ const AP_Param::GroupInfo SRV_Channels::var_info[] = {
     AP_SUBGROUPINFO(sbus, "_SBUS_",  20, SRV_Channels, AP_SBusOut),
 #endif
 
-#if HAL_SUPPORT_RCOUT_SERIAL
+#if HAVE_AP_BLHELI_SUPPORT
     // @Group: _BLH_
     // @Path: ../AP_BLHeli/AP_BLHeli.cpp
     AP_SUBGROUPINFO(blheli, "_BLH_",  21, SRV_Channels, AP_BLHeli),
@@ -365,7 +365,7 @@ SRV_Channels::SRV_Channels(void)
 void SRV_Channels::init(uint32_t motor_mask, AP_HAL::RCOutput::output_mode mode)
 {
     // initialize BLHeli late so that all of the masks it might setup don't get trodden on by motor initialization
-#if HAL_SUPPORT_RCOUT_SERIAL
+#if HAVE_AP_BLHELI_SUPPORT
     blheli.init(motor_mask, mode);
 #endif
 #ifndef HAL_BUILD_AP_PERIPH
@@ -502,7 +502,7 @@ void SRV_Channels::push()
     robotis.update();
 #endif
 
-#if HAL_SUPPORT_RCOUT_SERIAL
+#if HAVE_AP_BLHELI_SUPPORT
     // give blheli telemetry a chance to update
     blheli.update_telemetry();
 #endif


### PR DESCRIPTION
### Summary

Allows `HAVE_AP_BLHELI_SUPPORT` to be overridden by board configuration, and uses it consistently in `SRV_Channel`.

This lets boards with serial RC output support disable BLHeli pass-through support when the board does not use BLHeli ESCs.

### Classification & Testing

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

Built Copter for `esp32s3m5stampfly` with an extra hwdef setting:

```text
define HAVE_AP_BLHELI_SUPPORT 0
```

The build completed successfully. I also checked the generated ELF and confirmed that no `AP_BLHeli` symbols were present.

### Description

`AP_BLHeli` already had a `HAVE_AP_BLHELI_SUPPORT` define, but it was fixed to `HAL_SUPPORT_RCOUT_SERIAL`, and `SRV_Channel` still used `HAL_SUPPORT_RCOUT_SERIAL` directly for the BLHeli member, parameters, init, and telemetry update.

This change makes `HAVE_AP_BLHELI_SUPPORT` board-overridable and uses it consistently for BLHeli integration in `SRV_Channel`.