### PR TITLE
AP_HAL_ESP32: allow UART0 to use USB Serial/JTAG

### DIFF
--- a/libraries/AP_HAL_ESP32/UARTDriver.cpp
+++ b/libraries/AP_HAL_ESP32/UARTDriver.cpp
@@ -18,6 +18,15 @@
 
 #include "esp_log.h"
 
+#ifndef HAL_ESP32_UART0_USB_SERIAL_JTAG
+#define HAL_ESP32_UART0_USB_SERIAL_JTAG 0
+#endif
+
+#if HAL_ESP32_UART0_USB_SERIAL_JTAG
+#include "driver/usb_serial_jtag.h"
+#include "driver/usb_serial_jtag_vfs.h"
+#endif
+
 extern const AP_HAL::HAL& hal;
 
 namespace ESP32
@@ -25,11 +34,22 @@ namespace ESP32
 
 UARTDesc uart_desc[] = {HAL_ESP32_UART_DEVICES};
 
+bool UARTDriver::using_usb_serial_jtag() const
+{
+#if HAL_ESP32_UART0_USB_SERIAL_JTAG
+    return uart_num == 0;
+#else
+    return false;
+#endif
+}
+
 void UARTDriver::vprintf(const char *fmt, va_list ap)
 {
 
     uart_port_t p = uart_desc[uart_num].port;
-    if (p == 0) {
+    if (using_usb_serial_jtag() && _initialized) {
+        AP_HAL::UARTDriver::vprintf(fmt, ap);
+    } else if (p == 0) {
         esp_log_writev(ESP_LOG_INFO, "", fmt, ap);
     } else {
         AP_HAL::UARTDriver::vprintf(fmt, ap);
@@ -45,6 +65,29 @@ void UARTDriver::_begin(uint32_t b, uint16_t rxS, uint16_t txS)
     }
 
     if (uart_num < ARRAY_SIZE(uart_desc)) {
+        if (using_usb_serial_jtag()) {
+#if HAL_ESP32_UART0_USB_SERIAL_JTAG
+            if (!_initialized) {
+                usb_serial_jtag_driver_config_t config = USB_SERIAL_JTAG_DRIVER_CONFIG_DEFAULT();
+                config.tx_buffer_size = TX_BUF_SIZE;
+                config.rx_buffer_size = RX_BUF_SIZE;
+                const esp_err_t err = usb_serial_jtag_driver_install(&config);
+                if (err == ESP_OK || err == ESP_ERR_INVALID_STATE) {
+                    _usb_serial_jtag_driver_installed = (err == ESP_OK);
+                    usb_serial_jtag_vfs_use_driver();
+                    _readbuf.set_size(RX_BUF_SIZE);
+                    _writebuf.set_size(TX_BUF_SIZE);
+                    _uart_owner_thd = xTaskGetCurrentTaskHandle();
+                    _initialized = true;
+                }
+            } else {
+                flush();
+            }
+#endif
+            _baudrate = b;
+            return;
+        }
+
         uart_port_t p = uart_desc[uart_num].port;
         if (!_initialized) {
 
@@ -79,7 +122,17 @@ void UARTDriver::_begin(uint32_t b, uint16_t rxS, uint16_t txS)
 void UARTDriver::_end()
 {
     if (_initialized) {
-        uart_driver_delete(uart_desc[uart_num].port);
+        if (using_usb_serial_jtag()) {
+#if HAL_ESP32_UART0_USB_SERIAL_JTAG
+            if (_usb_serial_jtag_driver_installed) {
+                usb_serial_jtag_vfs_use_nonblocking();
+                usb_serial_jtag_driver_uninstall();
+                _usb_serial_jtag_driver_installed = false;
+            }
+#endif
+        } else {
+            uart_driver_delete(uart_desc[uart_num].port);
+        }
         _readbuf.set_size(0);
         _writebuf.set_size(0);
     }
@@ -88,6 +141,10 @@ void UARTDriver::_end()
 
 void UARTDriver::_flush()
 {
+    if (using_usb_serial_jtag()) {
+        write_data();
+        return;
+    }
     uart_port_t p = uart_desc[uart_num].port;
     uart_flush(p);
 }
@@ -154,6 +211,19 @@ void IRAM_ATTR UARTDriver::_timer_tick(void)
 
 void IRAM_ATTR UARTDriver::read_data()
 {
+    if (using_usb_serial_jtag()) {
+#if HAL_ESP32_UART0_USB_SERIAL_JTAG
+        int count = 0;
+        do {
+            count = usb_serial_jtag_read_bytes(_buffer, sizeof(_buffer), 0);
+            if (count > 0) {
+                _readbuf.write(_buffer, count);
+            }
+        } while (count > 0);
+#endif
+        return;
+    }
+
     uart_port_t p = uart_desc[uart_num].port;
     int count = 0;
     do {
@@ -166,13 +236,19 @@ void IRAM_ATTR UARTDriver::read_data()
 
 void IRAM_ATTR UARTDriver::write_data()
 {
-    uart_port_t p = uart_desc[uart_num].port;
     int count = 0;
     _write_mutex.take_blocking();
     do {
         count = _writebuf.peekbytes(_buffer, sizeof(_buffer));
         if (count > 0) {
-            count = uart_tx_chars(p, (const char*) _buffer, count);
+            if (using_usb_serial_jtag()) {
+#if HAL_ESP32_UART0_USB_SERIAL_JTAG
+                count = usb_serial_jtag_write_bytes(_buffer, count, 0);
+#endif
+            } else {
+                uart_port_t p = uart_desc[uart_num].port;
+                count = uart_tx_chars(p, (const char*) _buffer, count);
+            }
             _writebuf.advance(count);
         }
     } while (count > 0);

--- a/libraries/AP_HAL_ESP32/UARTDriver.h
+++ b/libraries/AP_HAL_ESP32/UARTDriver.h
@@ -43,6 +43,7 @@ public:
         : AP_HAL::UARTDriver()
     {
         _initialized = false;
+        _usb_serial_jtag_driver_installed = false;
         uart_num = serial_num;
     }
 
@@ -72,8 +73,8 @@ public:
       that have no baudrate (such as USB) the time estimate may be
       less accurate.
       A return value of zero means the HAL does not support this API */
-     
-    uint64_t receive_time_constraint_us(uint16_t nbytes) override; 
+
+    uint64_t receive_time_constraint_us(uint16_t nbytes) override;
 
     uint32_t get_baud_rate() const override { return _baudrate; }
 
@@ -81,12 +82,14 @@ private:
     bool _initialized;
     const size_t TX_BUF_SIZE = 1024;
     const size_t RX_BUF_SIZE = 1024;
-    uint8_t _buffer[32];
+    uint8_t _buffer[512];
     ByteBuffer _readbuf{0};
     ByteBuffer _writebuf{0};
     Semaphore _write_mutex;
     void read_data();
     void write_data();
+    bool using_usb_serial_jtag() const;
+    bool _usb_serial_jtag_driver_installed;
 
     uint8_t uart_num;
 

--- a/libraries/AP_HAL_ESP32/hwdef/esp32s3m5stampfly/hwdef.dat
+++ b/libraries/AP_HAL_ESP32/hwdef/esp32s3m5stampfly/hwdef.dat
@@ -43,12 +43,13 @@ IMU BMI270 SPI:bmi270 ROTATION_ROLL_180_YAW_90
 # one Baro:
 BARO BMP280 I2C:0:0x76
 
-# HARDWARE UARTS. UART 0 apparently goes over USB? so we assign it to pins we
-# don't have mapped to anything. might be fixable in the HAL...
+# HARDWARE UARTS. UART 0 uses ESP32-S3 USB Serial/JTAG for console/MAVLink.
 # UART 1 (SERIAL3) is the black grove connector
 #             PORT        RXPIN        TXPIN
 ESP32_SERIAL  UART_NUM_0  GPIO_NUM_18  GPIO_NUM_17
 ESP32_SERIAL  UART_NUM_1  GPIO_NUM_1   GPIO_NUM_2
+
+define HAL_ESP32_UART0_USB_SERIAL_JTAG 1
 
 # RC Output (r-up, l-down, l-up, r-down (quad X order))
 ESP32_RCOUT GPIO_NUM_42


### PR DESCRIPTION
### Summary

Allow ESP32 boards to opt in to using ESP32-S3 USB Serial/JTAG for UART0.

This enables M5StampFly to use USB Serial/JTAG as the console/MAVLink port instead of the unused UART0 GPIO pins.

### Classification & Testing

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

Built Copter for `esp32s3m5stampfly`.

Flashed to M5StampFly and confirmed bidirectional MAVLink communication over `/dev/ttyACM0` using ESP32-S3 USB Serial/JTAG:

```bash
mavproxy.py --master=/dev/ttyACM0 --baudrate 921600
```

Confirmed MAVLink heartbeat, parameter download, and command input.

<img width="1312" height="769" alt="スクリーンショット 2026-08-15 16 37 03" src="https://github.com/user-attachments/assets/2995ba7c-2fc2-4a12-86ae-7b19fd2cbe24" />

### Description

M5StampFly is an ESP32-S3 based vehicle. Its UART0 GPIO pins are not useful as an external telemetry connection, but ESP32-S3 provides USB Serial/JTAG over the USB connector.

This PR adds an opt-in `HAL_ESP32_UART0_USB_SERIAL_JTAG` hwdef define. Existing ESP32 board behavior is unchanged unless a board explicitly enables this define.

When enabled for UART0, the ESP32 UART driver uses the ESP-IDF USB Serial/JTAG driver for reads and writes. This allows the console/MAVLink port to work over USB while keeping `SERIAL0_PROTOCOL` as the normal MAVLink protocol selection. `SERIAL0_BAUD` remains a compatibility setting; the physical transport is USB, not a GPIO UART baudrate.
