### PR TITLE
Avoid sending GLOBAL_POSITION_INT containing 0,0,0-relative coordinates

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -1195,6 +1195,10 @@ void AP_AHRS_DCM::set_external_wind_estimate(float speed, float direction) {
 // dead-reckoning or GPS
 bool AP_AHRS_DCM::get_location(Location &loc) const
 {
+    if (_last_lat == 0 && _last_lng == 0) {
+        // we have never had a position
+        return false;
+    }
     loc.lat = _last_lat;
     loc.lng = _last_lng;
     const auto &baro = AP::baro();

--- a/libraries/SITL/SIM_Ship.cpp
+++ b/libraries/SITL/SIM_Ship.cpp
@@ -108,6 +108,9 @@ bool ShipSim::get_location(Location &loc) const
     if (!enable) {
         return false;
     }
+    if (!home.initialised()) {
+        return false;
+    }
     loc = home;
     loc.offset(ship.position.x, ship.position.y);
     return true;


### PR DESCRIPTION
### Summary

Any time somebody tries to adjust a 0,0,0 by an offset, they're probably doing something wrong.  DCM doubly so - it should not be providing its local position offset from 0,0,0

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

e.g. DCM would hand out a 0,0,0-relative location if you'd never seen GPS.  This would be Not Good in some circumstances.

```
< GLOBAL_POSITION_INT {time_boot_ms : 8524, lat : 353, lon : -129, alt : 10, relative_alt : 14, vx : 0, vy : 0, vz : 0, hdg : 33994}
< GLOBAL_POSITION_INT {time_boot_ms : 8784, lat : 365, lon : -133, alt : 100, relative_alt : 100, vx : 0, vy : 0, vz : 0, hdg : 33949}
< GLOBAL_POSITION_INT {time_boot_ms : 9024, lat : 384, lon : -140, alt : 40, relative_alt : 43, vx : 0, vy : 0, vz : 0, hdg : 33968}
AP: GPS 1: probing for u-blox at 230400 baud
AP: GPS 1: detected u-blox
< GLOBAL_POSITION_INT {time_boot_ms : 9284, lat : -353632622, lon : 1491652374, alt : 270, relative_alt : 270, vx : 0, vy : 0, vz : 0, hdg : 34044}
AP: EKF2 IMU0 MAG0 initial yaw alignment complete
AP: EKF2 IMU1 MAG0 initial yaw alignment complete
```

... a more correct fix would probably be to not set `have_gps` if we don't have a GPS fix.  That would appear to bring us in-line with the comment `use GPS for positioning with any fix, even a 2D fix`
