### PR TITLE
AP_GPS: do not treat a backwards timestamp as a delayed frame

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -843,6 +843,30 @@ bool AP_GPS::should_log() const
 
 
 /*
+  keep count of delayed frames and average frame delay for health
+  reporting. Must only be called when timing[instance].delta_time_ms is a
+  real measurement of the gap between two messages
+ */
+void AP_GPS::update_frame_timing_health(uint8_t instance)
+{
+    const uint16_t gps_max_delta_ms = 245; // 200 ms (5Hz) + 45 ms buffer
+    GPS_timing &t = timing[instance];
+
+    if (t.delta_time_ms > gps_max_delta_ms) {
+        t.delayed_count++;
+    } else {
+        t.delayed_count = 0;
+    }
+    if (t.delta_time_ms < 2000) {
+        if (t.average_delta_ms <= 0) {
+            t.average_delta_ms = t.delta_time_ms;
+        } else {
+            t.average_delta_ms = 0.98f * t.average_delta_ms + 0.02f * t.delta_time_ms;
+        }
+    }
+}
+
+/*
   update one GPS instance. This should be called at 10Hz or greater
  */
 void AP_GPS::update_instance(uint8_t instance)
@@ -891,6 +915,7 @@ void AP_GPS::update_instance(uint8_t instance)
             state[instance].vdop = GPS_UNKNOWN_DOP;
             timing[instance].last_message_time_ms = tnow;
             timing[instance].delta_time_ms = GPS_TIMEOUT_MS;
+            update_frame_timing_health(instance);
             // do not try to detect again if type is MAV or UAVCAN
             if (type == GPS_TYPE_MAV ||
                 type == GPS_TYPE_UAVCAN ||
@@ -923,9 +948,20 @@ void AP_GPS::update_instance(uint8_t instance)
             GCS_SEND_TEXT(MAV_SEVERITY_INFO, "GPS %d: detected %s", instance + 1, drivers[instance]->name());
         }
 
-        // delta will only be correct after parsing two messages
-        timing[instance].delta_time_ms = tnow - timing[instance].last_message_time_ms;
+        // delta will only be correct after parsing two messages.
+        //
+        const int32_t delta_ms = int32_t(tnow - timing[instance].last_message_time_ms);
         timing[instance].last_message_time_ms = tnow;
+        if (delta_ms < 0) {
+            // time went backwards, so we have no measurement of how long
+            // this message took to arrive. Leave the health counters
+            // alone rather than either counting a delayed frame or
+            // resetting delayed_count and masking a real stall
+            timing[instance].delta_time_ms = 0;
+        } else {
+            timing[instance].delta_time_ms = MIN(delta_ms, UINT16_MAX);
+            update_frame_timing_health(instance);
+        }
         // if GPS disabled for flight testing then don't update fix timing value
         if (state[instance].status >= AP_GPS_FixType::FIX_2D && !_force_disable_gps) {
             timing[instance].last_fix_time_ms = tnow;
@@ -952,25 +988,6 @@ void AP_GPS::update_instance(uint8_t instance)
         }
     }
 #endif
-
-    if (new_data_or_timeout) {
-        // keep count of delayed frames and average frame delay for health reporting
-        const uint16_t gps_max_delta_ms = 245; // 200 ms (5Hz) + 45 ms buffer
-        GPS_timing &t = timing[instance];
-
-        if (t.delta_time_ms > gps_max_delta_ms) {
-            t.delayed_count++;
-        } else {
-            t.delayed_count = 0;
-        }
-        if (t.delta_time_ms < 2000) {
-            if (t.average_delta_ms <= 0) {
-                t.average_delta_ms = t.delta_time_ms;
-            } else {
-                t.average_delta_ms = 0.98f * t.average_delta_ms + 0.02f * t.delta_time_ms;
-            }
-        }
-    }
 
 #if HAL_LOGGING_ENABLED
     if (new_data_or_timeout && should_log()) {

--- a/libraries/AP_GPS/AP_GPS.h
+++ b/libraries/AP_GPS/AP_GPS.h
@@ -721,6 +721,11 @@ private:
 
     void update_instance(uint8_t instance);
 
+    // fold timing[instance].delta_time_ms into the delayed-frame counters
+    // used by is_healthy(). Only called when that delta is a real
+    // measurement of the interval between two messages
+    void update_frame_timing_health(uint8_t instance);
+
     /*
       buffer for re-assembling RTCM data for GPS injection.
       The 8 bit flags field in GPS_RTCM_DATA is interpreted as:


### PR DESCRIPTION
### Summary

AP_GPS computed the inter-message interval as an unsigned subtraction into a uint16_t. The timestamps it subtracts come from JitterCorrection, which is intentionally non-monotonic — it ratchets its offset backwards on any message that beats the best transport latency seen so far. A backwards step therefore underflowed to ~65 s, which read as a badly delayed frame and incremented delayed_count; two in a row fail AP_GPS::is_healthy() and refuse the arm with "GPS 1: not healthy".
 
It affects every GPS driver using corrected timestamps. It surfaced in InertialLabsEAHRS because that test arms inside that window.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

tnow is taken from the JitterCorrection-corrected GPS timestamp when one is available.  That timestamp is deliberately not monotonic: the corrector tracks a running minimum of the transport latency and steps its estimate backwards whenever a message arrives having taken less time in transit than any seen before.  tnow also swaps between that timebase and millis() across the timeout path above.

delta_time_ms is unsigned, so a backwards step became a delta of around 65 seconds once truncated into the uint16_t.  That is far over the 245ms threshold, so it incremented delayed_count, and two in a row are enough to make AP_GPS::is_healthy() false and refuse the arm with "GPS 1: not healthy".

Take the difference as signed instead.  That stays correct across the 49.7-day millis() wrap - where the unsigned subtraction is also correct, but a "tnow < last" test is not - while still recognising a backwards step.  When one happens we have no measurement of how long the message took to arrive, so leave the health counters untouched rather than either counting a delayed frame or resetting delayed_count.

The delayed-frame accounting moves into a helper called from the two places that set delta_time_ms, so each caller decides at the point it does the arithmetic whether it has something worth counting.

Measured across 198000 GPS samples from SITL logs: 18.7% of samples in the first 10 seconds after boot stepped backwards, tailing to none after 30 seconds, consistent with the corrector converging on its minimum.
