### PR TITLE
AP_Filesystem: use wear levelling sector size for ESP32 FlashFS

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem_ESP32.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_ESP32.cpp
@@ -25,6 +25,12 @@
 
 extern const AP_HAL::HAL& hal;
 
+#if defined(HAL_ESP32_FLASHFS)
+#define ESP32_FILESYSTEM_SECTOR_SIZE FF_SS_WL
+#else
+#define ESP32_FILESYSTEM_SECTOR_SIZE FF_SS_SDCARD
+#endif
+
 int AP_Filesystem_ESP32::open(const char *fname, int flags, bool allow_absolute_paths)
 {
 #if FSDEBUG
@@ -170,7 +176,7 @@ int64_t AP_Filesystem_ESP32::disk_free(const char *path)
     /* Get total sectors and free sectors */
     fre_sect = fre_clust * fs->csize;
 
-    return (int64_t)fre_sect * FF_SS_SDCARD;
+    return (int64_t)fre_sect * ESP32_FILESYSTEM_SECTOR_SIZE;
 }
 
 // return total disk space in bytes
@@ -191,7 +197,7 @@ int64_t AP_Filesystem_ESP32::disk_space(const char *path)
     /* Get total sectors and free sectors */
     tot_sect = (fs->n_fatent - 2) * fs->csize;
 
-    return (int64_t)tot_sect * FF_SS_SDCARD;
+    return (int64_t)tot_sect * ESP32_FILESYSTEM_SECTOR_SIZE;
 }
 
 /*


### PR DESCRIPTION
### Summary

Use the wear levelling sector size when the ESP32 filesystem uses FlashFS.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

`AP_Filesystem_ESP32::disk_free()` and `disk_space()` currently always
convert the FatFs sector count using `FF_SS_SDCARD`.

When `HAL_ESP32_FLASHFS` is defined, the filesystem uses ESP-IDF wear
levelling, so the correct sector size is `FF_SS_WL`.

This change selects:

- `FF_SS_WL` for FlashFS
- `FF_SS_SDCARD` otherwise

The existing SD card behavior is unchanged.

### Testing

Built Copter for `esp32buzz` with the normal filesystem configuration:

- `AP_FILESYSTEM_ESP32_ENABLED=1`
- `HAL_ESP32_FLASHFS` not defined
- build passed

Built Copter for `esp32buzz` with:

```text
define HAL_ESP32_FLASHFS 1
```

supplied through `--extra-hwdef`, verifying the `FF_SS_WL` build path.

Both builds completed successfully.

`git diff --check upstream/master` also passed.
