### PR TITLE
AP_Logger: record RADIO_STATUS source

### DIFF
--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -261,7 +261,7 @@ public:
 #endif
     void Write_NamedValueFloat(const char *name, float value);
     void Write_Power(void);
-    void Write_Radio(const mavlink_radio_t &packet);
+    void Write_Radio(const mavlink_radio_t &packet, uint8_t source_system, uint8_t source_component);
     void Write_Message(const char *message);
     // support for multi-chunk messages:
     uint8_t get_MSG_id() {

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -415,11 +415,18 @@ void AP_Logger::Write_Power(void)
 #endif
 }
 
-void AP_Logger::Write_Radio(const mavlink_radio_t &packet)
+void AP_Logger::Write_Radio(const mavlink_radio_t &packet,
+                            uint8_t source_system,
+                            uint8_t source_component)
 {
+    // NOTE: source_component is used as an instance field
+    // Radios assumed to belong to the system doing the logging,
+    // so source_system is recorded, but not used in instance designation
     const struct log_Radio pkt{
         LOG_PACKET_HEADER_INIT(LOG_RADIO_MSG),
         time_us      : AP_HAL::micros64(),
+        source_system   : source_system,
+        source_component: source_component,
         rssi         : packet.rssi,
         remrssi      : packet.remrssi,
         txbuf        : packet.txbuf,

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -385,6 +385,8 @@ struct PACKED log_MAVLink_Command {
 struct PACKED log_Radio {
     LOG_PACKET_HEADER;
     uint64_t time_us;
+    uint8_t source_system;
+    uint8_t source_component;
     uint8_t rssi;
     uint8_t remrssi;
     uint8_t txbuf;
@@ -909,6 +911,8 @@ struct PACKED log_VER {
 // @LoggerMessage: RAD
 // @Description: Telemetry radio statistics
 // @Field: TimeUS: Time since system startup
+// @Field: SS: source system of the RADIO_STATUS sender
+// @Field: SC: source component of the RADIO_STATUS sender (instance field)
 // @Field: RSSI: RSSI
 // @Field: RemRSSI: RSSI reported from remote radio
 // @Field: TxBuf: number of bytes in radio ready to be sent
@@ -1189,7 +1193,7 @@ LOG_STRUCTURE_FROM_MISSION \
     { LOG_MAVLINK_COMMAND_MSG, sizeof(log_MAVLink_Command), \
       "MAVC", "QBBBBBHffffiifBB","TimeUS,TS,TC,SS,SC,Fr,Cmd,P1,P2,P3,P4,X,Y,Z,Res,WL", "s---------------", "F---------------" }, \
     { LOG_RADIO_MSG, sizeof(log_Radio), \
-      "RAD", "QBBBBBHH", "TimeUS,RSSI,RemRSSI,TxBuf,Noise,RemNoise,RxErrors,Fixed", "s-------", "F-------", true }, \
+      "RAD", "QBBBBBBBHH", "TimeUS,SS,SC,RSSI,RemRSSI,TxBuf,Noise,RemNoise,RxErrors,Fixed", "s-#-------", "F---------", true }, \
 LOG_STRUCTURE_FROM_CAMERA \
 LOG_STRUCTURE_FROM_MOUNT \
     { LOG_ARSP_MSG, sizeof(log_ARSP), "ARSP",  "QBffcffBBffB", "TimeUS,I,Airspeed,DiffPress,Temp,RawPress,Offset,U,H,Hp,TR,Pri", "s#nPOPP-----", "F-00B00-----", true }, \

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -945,7 +945,7 @@ void GCS_MAVLINK::handle_radio_status(const mavlink_message_t &msg)
 #if HAL_LOGGING_ENABLED
     //log rssi, noise, etc if logging Performance monitoring data
     if (AP::logger().should_log(log_radio_bit())) {
-        AP::logger().Write_Radio(packet);
+        AP::logger().Write_Radio(packet, msg.sysid, msg.compid);
     }
 #endif
 }


### PR DESCRIPTION
### Summary

Allows to distinguish between data coming from multiple radios connected to the same system.

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [X] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [X] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

Quality of life change for logging multiple redundant radios at the same time and being able to tell them apart. Assuming the system integrator is supposed to ensure differing (sysid,compid) designation. Works in SITL, e.g. when sending mock `RADIO_STATUS` from a python script:

```
$ mavlogdump.py --types RAD logs/00000013.BIN
2026-08-15 21:46:50.02: RAD {TimeUS : 29065036, RSSI : 80, RemRSSI : 75, TxBuf : 100, Noise : 10, RemNoise : 5, RxErrors : 0, Fixed : 0, SS : 51, SC : 3}
2026-08-15 21:46:51.01: RAD {TimeUS : 30064636, RSSI : 85, RemRSSI : 80, TxBuf : 100, Noise : 12, RemNoise : 7, RxErrors : 1, Fixed : 0, SS : 52, SC : 1}
2026-08-15 21:46:52.02: RAD {TimeUS : 31065069, RSSI : 90, RemRSSI : 85, TxBuf : 100, Noise : 14, RemNoise : 9, RxErrors : 2, Fixed : 0, SS : 53, SC : 2}
```