### PR TITLE
AP_HAL_SITL: find dumpstack.sh when not run from the repo root

### DIFF
--- a/Tools/autotest/pysim/util.py
+++ b/Tools/autotest/pysim/util.py
@@ -714,9 +714,16 @@ def start_SITL(binary,
 
         first = cmd[0]
         rest = cmd[1:]
-        spawn_env = None
+        spawn_env = dict(os.environ)
+        # Tell SITL where to find dumpstack.sh and dumpcore.sh.  It looks
+        # for them relative to its working directory, which works for a
+        # serial run - that runs in the repo root - but not under
+        # --parallel, where each instance runs in its own directory and
+        # every lookup misses.  A panic there produces no backtrace at
+        # all, which is exactly when one is wanted.
+        spawn_env.setdefault('AP_SCRIPTS_DIR_PATH',
+                             os.path.abspath(reltopdir('Tools/scripts')))
         if asan:
-            spawn_env = dict(os.environ)
             log_base = asan_log_filepath(binary=binary, model=model)
             existing = spawn_env.get('ASAN_OPTIONS', '')
             # Append our options after any inherited ones so that our

--- a/libraries/AP_HAL_SITL/system.cpp
+++ b/libraries/AP_HAL_SITL/system.cpp
@@ -1,5 +1,6 @@
 #include <stdarg.h>
 #include <errno.h>
+#include <limits.h>
 #include <stdio.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -76,14 +77,22 @@ static void run_command_on_ownpid(const char *commandname)
         "APM/Tools/scripts/%s", // for autotest server
         "../Tools/scripts/%s", // when run from e.g. ArduCopter subdirectory
     };
-    char buffer[60];
+    // long enough for an absolute path from AP_SCRIPTS_DIR_PATH; the 60
+    // bytes this used to be was not - a checkout under a path of any
+    // length silently truncated, and the truncated name simply failed to
+    // stat, so the override looked as though it had been ignored
+    char buffer[PATH_MAX];
     for (uint8_t i=0; i<ARRAY_SIZE(paths); i++) {
         if (paths[i] == nullptr) {
             continue;
         }
         // form up a filepath from each path and commandname; if it
         // exists, use it
-        snprintf(buffer, sizeof(buffer), paths[i], commandname);
+        const int len = snprintf(buffer, sizeof(buffer), paths[i], commandname);
+        if (len < 0 || (unsigned)len >= sizeof(buffer)) {
+            // truncated, so this is not the path we were asked for
+            continue;
+        }
         if (::stat(buffer, &statbuf) != -1) {
             command_filepath = buffer;
             break;
@@ -113,7 +122,9 @@ static void run_command_on_ownpid(const char *commandname)
              commandname,
              p+1,
              (int)getpid());
-    char cmd[200];
+    // must fit the command filepath found above, which may now be
+    // an absolute path, plus the output filepath
+    char cmd[PATH_MAX + sizeof(output_filepath) + 32];
 	snprintf(cmd,
              sizeof(cmd),
              "sh %s %d >%s 2>&1",


### PR DESCRIPTION
### Summary

Use AP_SCRIPTS_DIR_PATH (if set) to find dumpstack and dumpcore

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)  (when things go bad under parallel testing)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

run_command_on_ownpid() looks for dumpstack.sh and dumpcore.sh relative to the working directory.  A serial autotest run works because it runs in the repo root, but under --parallel each instance runs in its own directory, every lookup misses, and we fall back to trusting PATH - where the script is not.  A panic there produced "Failed" and no backtrace at all, which is precisely when one is wanted.

The AP_SCRIPTS_DIR_PATH override already existed, but the filepath was formed into a 60-byte buffer.  An absolute path to a checkout overflows that easily - /home/user/rc/ardupilot-claude2/Tools/scripts/dumpstack.sh is 61 characters - and snprintf simply truncated, leaving a name which failed to stat, so the override looked as though it had been ignored.

Size the buffer for a path, and skip any candidate which does not fit rather than stat'ing a truncated name.
