### PR TITLE
board_types.txt: Reserve board IDs for Tykho Electronics

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -647,6 +647,10 @@ AP_HW_Accton_Godwit_GFH7             7122
 AP_HW_CoreWingF405WingV2             7130
 AP_HW_CoreWingF405WMiniV2            7131
 
+# IDs 7170-7179 reserved for Tykho Electronics
+AP_HW_TYKHO_TLS7V2                   7170
+AP_HW_TYKHO_TLS7-Wing                7171
+
 # please fill gaps in the above ranges rather than adding past ID #7199
 
 


### PR DESCRIPTION
- Reserved pool of 10 board IDs for Tykho Electronics boards
- Added board IDs for TYKHO_TLS7V2 and TYKHO_TLS7-WING upcoming boards

Please approve.

Thank you!