### PR TITLE
AP_Logger: include disk space details in out-of-space debug messages

### DIFF
--- a/libraries/AP_Logger/AP_Logger_File.cpp
+++ b/libraries/AP_Logger/AP_Logger_File.cpp
@@ -790,8 +790,12 @@ void AP_Logger_File::start_new_log(void)
         _read_fd = -1;
     }
 
-    if (disk_space_avail() < _free_space_min_avail && disk_space() > 0) {
-        DEV_PRINTF("Out of space for logging\n");
+    const int64_t avail = disk_space_avail();
+    const int64_t total = disk_space();
+    if (avail < _free_space_min_avail && total > 0) {
+        DEV_PRINTF("Out of space for logging: avail=%lld total=%lld min=%u\n",
+                   (long long)avail, (long long)total,
+                   (unsigned)_free_space_min_avail);
         return;
     }
 
@@ -949,8 +953,12 @@ void AP_Logger_File::io_timer(void)
     if (tnow - _free_space_last_check_time > _free_space_check_interval) {
         _free_space_last_check_time = tnow;
         last_io_operation = "disk_space_avail";
-        if (disk_space_avail() < _free_space_min_avail && disk_space() > 0) {
-            DEV_PRINTF("Out of space for logging\n");
+        const int64_t avail = disk_space_avail();
+        const int64_t total = disk_space();
+        if (avail < _free_space_min_avail && total > 0) {
+            DEV_PRINTF("Out of space for logging: avail=%lld total=%lld min=%u\n",
+                       (long long)avail, (long long)total,
+                       (unsigned)_free_space_min_avail);
             stop_logging();
             _open_error_ms = AP_HAL::millis(); // prevent logging starting again for 5s
             last_io_operation = "";
@@ -996,7 +1004,11 @@ void AP_Logger_File::io_timer(void)
     last_io_operation = "";
     if (nwritten <= 0) {
         if (errno == ENOSPC) {
-            DEV_PRINTF("Out of space for logging\n");
+            const int64_t avail = disk_space_avail();
+            const int64_t total = disk_space();
+            DEV_PRINTF("Out of space for logging: write failed (ENOSPC): avail=%lld total=%lld min=%u\n",
+                       (long long)avail, (long long)total,
+                       (unsigned)_free_space_min_avail);
             stop_logging();
             _open_error_ms = AP_HAL::millis(); // prevent logging starting again for 5s
             last_io_operation = "";


### PR DESCRIPTION
### Summary

Enhance "Out of space for logging" debug messages in `AP_Logger_File` to include available, total, and minimum required disk space details.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

**Testing Details:**
- Built successfully for `esp32s3m5stampfly` target.
- Tested on ESP32-S3 hardware (M5StampFly with FlashFS FAT storage).
- Verified that debug messages correctly output `avail`, `total`, and `min` values to the MAVLink/MAVProxy console when free space threshold is triggered.

AFTER
<img width="553" height="139" alt="スクリーンショット 2026-08-16 17 16 47" src="https://github.com/user-attachments/assets/8125e572-57d1-4ee3-964a-de29d4afc4e1" />

BEFORE
<img width="610" height="733" alt="スクリーンショット 2026-08-15 19 53 25" src="https://github.com/user-attachments/assets/27d96daf-2759-4bc1-b9b0-3ec9621a72a0" />

### Description

When `AP_Logger_File` encounters an "Out of space for logging" condition (during file open, periodic space checks, or `ENOSPC` write errors), it previously only printed the generic string `"Out of space for logging\n"` via `DEV_PRINTF`.

This made it difficult to diagnose why logging was refused or stopped—for example, whether the filesystem was completely full, or if the available space simply fell below the configured threshold (`_free_space_min_avail` / `LOG_FILE_MB_FREE`).

This PR enhances all 3 `DEV_PRINTF` sites in `AP_Logger_File.cpp` to report:
- `avail`: Current available disk space in bytes (`disk_space_avail()`)
- `total`: Total disk space in bytes (`disk_space()`)
- `min`: Minimum required available space threshold in bytes (`_free_space_min_avail`)

**Example Output:**
```text
Out of space for logging: avail=0 total=4771840 min=262144
