### PR TITLE
autotest: let the takeoff settle before DO_CHANGE_ALTITUDE asserts

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -8099,6 +8099,9 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
         takeoff_alt = 30
         self.takeoff(alt=takeoff_alt, mode='TAKEOFF')
+        # TAKEOFF hands back to TECS 2m below target while still climbing at
+        # 9.3m/s, so let the ~10m overshoot settle before asserting altitude.
+        self.wait_altitude(takeoff_alt-2, takeoff_alt+2, minimum_duration=5, relative=True, timeout=90)
         self.wait_altitude(takeoff_alt-1, takeoff_alt+1, minimum_duration=10, relative=True, timeout=60)
 
         self.start_subtest("Home-relative altitude")


### PR DESCRIPTION
### Summary

Hacks in a settle period for DO_CHANGE_ALTITUDE's takeoff step.  TECS causes the Plane to overshoot its 30m target by 11m.  That was 1.5m in 2024.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

The test takes off to 30m and immediately asserts 30m +-1m held for 10s within 60s.  TAKEOFF hands back to TECS 2m below the target while the vehicle is still climbing at 9.3m/s, so it overshoots to about 40m, sinks to 26.5m and takes some 25s to settle - and the assertion was paying for that transient out of its own budget, using 34s of the 60.  Three runs in 26 overnight ran out of time and reported an altitude on the way back up, which is why the failures were always just below the band and never above it.

Wait for the vehicle to be established first.  Measured over three runs: +-2m held for 5s completes 25s after the handover.  A shorter hold is no use - +-2m for 2s is satisfied after 7s by the climb passing through the band on its way up, while still 10m from settled.

The overshoot itself is a vehicle-side regression, traced to three commits between August 2024 and April 2025; this only stops the test tripping over it.

Some analysis of the overshoot.  The regression from 2024 actually came in multiple tranches.

