### PR TITLE
Copter: add GPS_HACC_GOOD parameter for horizontal accuracy pre-arm c…

### DIFF
--- a/ArduCopter/AP_Arming_Copter.cpp
+++ b/ArduCopter/AP_Arming_Copter.cpp
@@ -398,6 +398,14 @@ bool AP_Arming_Copter::gps_checks(bool display_failure)
         return false;
     }
 
+    // check horizontal accuracy (HACC) if available
+    float hacc = 0.0f;
+    if (is_positive(copter.g2.gps_hacc_good) && copter.gps.horizontal_accuracy(hacc) && (hacc > copter.g2.gps_hacc_good)) {
+        check_failed(Check::GPS, display_failure, "High GPS HACC");
+        AP_Notify::flags.pre_arm_gps_check = false;
+        return false;
+    }
+
     // if we got here all must be ok
     AP_Notify::flags.pre_arm_gps_check = true;
     return true;

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1185,6 +1185,15 @@ const AP_Param::GroupInfo ParametersG2::var_info2[] = {
     AP_GROUPINFO("SURFTRAK_GLSAM", 22, ParametersG2, surf_dist_parameters.glitch_num_samples, AP_SURFACEDISTANCE_GLITCH_NUM_SAMPLES_DEFAULT),
 #endif
 
+    // @Param: GPS_HACC_GOOD
+    // @DisplayName: GPS Horizontal Accuracy Good
+    // @Description: GPS Horizontal Accuracy in meters at or below this value represents a good position. Used for pre-arm checks. Set to 0 to disable.
+    // @Units: m
+    // @Range: 0 10
+    // @Increment: 0.1
+    // @User: Advanced
+    AP_GROUPINFO("GPS_HACC_GOOD", 23, ParametersG2, gps_hacc_good, GPS_HACC_GOOD_DEFAULT),
+
     // ID 62 is reserved for the AP_SUBGROUPEXTENSION
 
     AP_GROUPEND

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -704,6 +704,9 @@ public:
     // EKF variance filter cutoff
     AP_Float fs_ekf_filt_hz;
 
+    // GPS horizontal accuracy good
+    AP_Float gps_hacc_good;
+
 #if WEATHERVANE_ENABLED
     AC_WeatherVane weathervane;
 #endif

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -97,6 +97,11 @@
  # define GPS_HDOP_GOOD_DEFAULT         140     // minimum hdop that represents a good position.  used during pre-arm checks if fence is enabled
 #endif
 
+// prearm GPS hacc check
+#ifndef GPS_HACC_GOOD_DEFAULT
+ # define GPS_HACC_GOOD_DEFAULT         1.5f    // minimum hacc (in meters) that represents a good position. used during pre-arm checks
+#endif
+
 // missing terrain data failsafe
 #ifndef FS_TERRAIN_TIMEOUT_MS
  #define FS_TERRAIN_TIMEOUT_MS          5000     // 5 seconds of missing terrain data will trigger failsafe (RTL)


### PR DESCRIPTION
### Summary

Adds `GPS_HACC_GOOD` parameter (default: 1.5m) to `ParametersG2` for Copter to enforce a maximum GPS horizontal accuracy requirement during pre-arm checks.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

#### Testing Details:
- **SITL (Copter)**:
  - Verified default parameter is loaded as `GPS_HACC_GOOD = 1.5m`.
  - In `LOITER` mode with simulated error `SIM_GPS1_ACC = 2.5m` (exceeding threshold), pre-arm check failed with `PreArm: High GPS HACC` and prevented arming.
  - Relaxing `GPS_HACC_GOOD` to `3.0m` cleared the error to `pre-arm good` and allowed arming.
  - Setting `GPS_HACC_GOOD = 0` disabled the check and allowed arming.
- **Hardware Test**:
  - Built and verified parameter registration and MAVLink telemetry on ESP32-S3 (`esp32s3m5stampfly`).

<img width="1324" height="815" alt="スクリーンショット 2026-08-17 0 48 42" src="https://github.com/user-attachments/assets/e9887efa-3672-447c-8042-25ce545b3af2" />

### Description

#### Motivation
- In high-precision operations (such as agricultural spraying drones using Network RTK), verifying actual positional accuracy (HAcc in meters) is critical to ensure accurate route execution and avoid boundary errors.
- While `GPS_HDOP_GOOD` checks satellite geometric dilution, checking `horizontal_accuracy` provides direct assurance that position estimate has converged before arming.
- Adding `GPS_HACC_GOOD` allows users to enforce a required horizontal accuracy threshold before arming (or set to `0` to disable).

#### Implementation Details
- Uses existing `AP_GPS::horizontal_accuracy(float &hacc)` method. If the connected GNSS receiver does not support/report accuracy, the check is safely bypassed.

#### Parameter Details
- **Name**: `GPS_HACC_GOOD`
- **Class**: `ParametersG2`
- **Default**: `1.5` (meters)
- **Range**: `0` to `10` (0 disables check)
- **Increment**: `0.1`
- **User**: `Advanced`

#### AI Disclosure
This contribution was developed with AI pair-programming assistance (Antigravity).

