### PR TITLE
board_types.txt: Reserve board IDs for Tykho Electronics

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -660,6 +660,10 @@ AP_HW_CoreWingF405WMiniV2            7131
 # IDs 7140-7149 reserved for Lectron
 AP_HW_LECTRON_Pi5_H7            7140
 
+# IDs 7170-7179 reserved for Tykho Electronics
+AP_HW_TYKHO_TLS7V2                   7170
+AP_HW_TYKHO_TLS7-Wing                7171
+
 # please fill gaps in the above ranges rather than adding past ID #7199
 
 


### PR DESCRIPTION
### Summary

Added ID for board that already in production:
- TYKHO_TLS7V2

Added ID for upcoming board currently in pre-release stage:
- TYKHO_TLS7-WING

### Classification & Testing

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

### Description

TLS7v2 is in production for a few months and works perfectly by running ArduCopter-4.6.3 firmware. Tested on several multicopter UAV types including QUAD-X frame with 8 motors

PRs for appropriate **AP_Bootloader**'s and **HWDEF** files will come just after this one would be accepted.

Please review and approve. 
Thank you in advance!

With kind regards,
Tykho Ops Team
