### PR TITLE
Rover: Add guided mode timeout parameter

### DIFF
--- a/Rover/Parameters.cpp
+++ b/Rover/Parameters.cpp
@@ -667,6 +667,14 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("CRASH_TIMEOUT", 61, ParametersG2, crash_timeout, 2.0),
 
+    // @Param: GUID_TIMEOUT
+    // @DisplayName: Guided mode timeout
+    // @Description: Guided mode timeout after which vehicle will stop if no updates are received from caller. Only applicable during velocity, throttle, heading or turn rate control
+    // @Units: s
+    // @Range: 0.1 5
+    // @User: Advanced
+    AP_GROUPINFO("GUID_TIMEOUT", 62, ParametersG2, guided_timeout, 3.0),
+
     AP_GROUPEND
 };
 

--- a/Rover/Parameters.h
+++ b/Rover/Parameters.h
@@ -429,6 +429,9 @@ public:
     // FS GCS timeout trigger time
     AP_Float fs_gcs_timeout;
 
+    // GUIDED mode timeout
+    AP_Float guided_timeout;
+
     class ModeCircle mode_circle;
 };
 

--- a/Rover/mode.h
+++ b/Rover/mode.h
@@ -576,6 +576,9 @@ public:
     void limit_init_time_and_location();
     bool limit_breached() const;
 
+    // return guided mode timeout in milliseconds. Only used for velocity and acceleration control
+    uint32_t get_timeout_ms() const;
+
 protected:
 
     enum class SubMode: uint8_t {

--- a/Rover/mode_guided.cpp
+++ b/Rover/mode_guided.cpp
@@ -51,9 +51,9 @@ void ModeGuided::update()
 
         case SubMode::HeadingAndSpeed:
         {
-            // stop vehicle if target not updated within 3 seconds
-            if (have_attitude_target && (millis() - _des_att_time_ms) > 3000) {
-                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "target not received last 3secs, stopping");
+            // stop vehicle if target not updated within GUID_TIMEOUT seconds
+            if (have_attitude_target && (millis() - _des_att_time_ms) > get_timeout_ms()) {
+                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "target not received last %.1f secs, stopping", get_timeout_ms()/1000.0f);
                 have_attitude_target = false;
             }
             if (have_attitude_target) {
@@ -75,9 +75,9 @@ void ModeGuided::update()
 
         case SubMode::TurnRateAndSpeed:
         {
-            // stop vehicle if target not updated within 3 seconds
-            if (have_attitude_target && (millis() - _des_att_time_ms) > 3000) {
-                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "target not received last 3secs, stopping");
+            // stop vehicle if target not updated within GUID_TIMEOUT seconds
+            if (have_attitude_target && (millis() - _des_att_time_ms) > get_timeout_ms()) {
+                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "target not received last %.1f secs, stopping", get_timeout_ms()/1000.0f);
                 have_attitude_target = false;
             }
             if (have_attitude_target) {
@@ -110,9 +110,9 @@ void ModeGuided::update()
         case SubMode::SteeringAndThrottle:
         {
             // handle timeout
-            if (_have_strthr && (AP_HAL::millis() - _strthr_time_ms) > 3000) {
+            if (_have_strthr && (AP_HAL::millis() - _strthr_time_ms) > get_timeout_ms()) {
                 _have_strthr = false;
-                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "target not received last 3secs, stopping");
+                GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "target not received last %.1f secs, stopping", get_timeout_ms()/1000.0f);
             }
             if (_have_strthr) {
                 // pass latest steering and throttle directly to motors library
@@ -452,4 +452,10 @@ bool ModeGuided::limit_breached() const
 bool ModeGuided::use_scurves_for_navigation() const
 {
     return ((g2.guided_options.get() & uint32_t(Options::SCurvesUsedForNavigation)) != 0);
+}
+
+// return guided mode timeout in milliseconds. Only used for velocity, throttle, heading or turn rate control
+uint32_t ModeGuided::get_timeout_ms() const
+{
+    return MAX(g2.guided_timeout, 0.1) * 1000;
 }


### PR DESCRIPTION
### Summary

Added ``GUID_TIMEOUT`` parameter to Rover (copied from Copter implementation). Rover previously used a hard-coded 3000ms timeout.

When under velocity, throttle, heading or turn rate control under GUIDED mode, if a command is not received within ``GUID_TIMEOUT``, the vehicle will stop.

Tested in SITL.

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [X] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

