### PR TITLE
Plane: tiltrotor: vectoring: correct roll sign and always apply throttle scale

### DIFF
--- a/ArduPlane/tiltrotor.cpp
+++ b/ArduPlane/tiltrotor.cpp
@@ -611,7 +611,10 @@ void Tiltrotor::vectoring(void)
         SRV_Channels::set_output_scaled(SRV_Channel::k_tiltMotorRear,  1000 * constrain_float(base_output + mid,0,1));
     } else {
         const float yaw_out = motors->get_yaw()+motors->get_yaw_ff();
-        const float roll_out = motors->get_roll()+motors->get_roll_ff();
+        // the MotorsMatrix library normalises roll factor to 0.5, so
+        // we need to use the same factor here to keep the same roll
+        // gains when tilted as we have when not tilted
+        const float roll_out = (motors->get_roll()+motors->get_roll_ff()) * 0.5;
         const float yaw_range = zero_out;
 
         // Scaling yaw with throttle
@@ -627,11 +630,7 @@ void Tiltrotor::vectoring(void)
         const float tilt_rad = radians(current_tilt*90);
         const float sin_tilt = sinf(tilt_rad);
         const float cos_tilt = cosf(tilt_rad);
-        // the MotorsMatrix library normalises roll factor to 0.5, so
-        // we need to use the same factor here to keep the same roll
-        // gains when tilted as we have when not tilted
-        const float avg_roll_factor = 0.5;
-        float tilt_scale = throttle_scaler * yaw_out * cos_tilt + avg_roll_factor * roll_out * sin_tilt;
+        float tilt_scale = throttle_scaler * (yaw_out * cos_tilt - roll_out * sin_tilt);
 
         if (fabsf(tilt_scale) > 1.0) {
             tilt_scale = constrain_float(tilt_scale, -1.0, 1.0);


### PR DESCRIPTION
### Summary

fixes https://github.com/ArduPilot/ardupilot/issues/34041 It seems that vectoring for roll is backwards for tiltrotors. This only has significant effect at high tilt angles (but not at max tilt where there is no room left for vectoring).

Think of the front left motor in vtol flight. It would tilt forwards for CW (positive) yaw. If it were tilted forward then it should tilt up for right (positive) roll. Forward for yaw and up for roll are opposite so the sign in the existing calculation is incorrect.

This also applies the throttle scale factor to both roll and yaw, previously it was applied to yaw only.

<!-- Put a one or two line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

I attempted to come up with a auto test with this and failed. This really needs testing in realflight or IRL.

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
