### PR TITLE
board_types.txt: Reserve Board IDs for SED Avionics Hardware

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -660,6 +660,12 @@ AP_HW_CoreWingF405WMiniV2            7131
 # IDs 7140-7149 reserved for Lectron
 AP_HW_LECTRON_Pi5_H7            7140
 
+# IDs 7150-7159 reserved for SED
+AP_HW_SED_FC_H753                    7150
+AP_HW_SED_GPS                        7151
+AP_HW_SED_AirSpeed                   7152
+AP_HW_SED_UGNSS                      7153
+
 # IDs 7170-7179 reserved for Tykho Electronics
 AP_HW_TYKHO_TLS7V2                   7170
 AP_HW_TYKHO_TLS7-Wing                7171


### PR DESCRIPTION
### Summary

Reserving 7150-7159 Board IDs for Avionics Hardware designed by SED

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

Added IDs for four hardware devices:
- `7150`: SED FC H753
- `7151`: SED GPS Module
- `7152`: SED Airspeed Module
- `7153`: SED UGNSS Module

Trailing from #34046

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->