### PR TITLE
autotest: remove the script we installed, not the one we installed from

### DIFF
--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -5405,11 +5405,12 @@ class TestSuite(abc.ABC):
         self.install_mavlink_module()
         self.context_get().installed_modules.append("mavlink")
 
-    def install_applet_script_context(self, scriptname, **kwargs):
+    def install_applet_script_context(self, scriptname, install_name=None):
         '''installs an applet script which will be removed when the context goes
         away'''
-        self.install_applet_script(scriptname, **kwargs)
-        self.context_get().installed_scripts.append(scriptname)
+        self.install_applet_script(scriptname, install_name=install_name)
+        installed_name = install_name if install_name is not None else scriptname
+        self.context_get().installed_scripts.append(installed_name)
 
     def install_driver_script_context(self, scriptname, install_name=None):
         '''installs a driver script which will be removed when the context goes


### PR DESCRIPTION
### Summary

Correct tidy-up after script tests - so trick72.txt doesn't linger

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

install_script() honours install_name when choosing the destination, but install_applet_script_context() recorded the source name for removal, so a script installed under a different name was never cleaned up when the context went away.

AerobaticsScripting installs Aerobatics/FixedWing/Schedules/AirShow.txt as trick72.txt: context pop then tried to unlink scripts/AirShow.txt, which had never existed, and left scripts/trick72.txt behind after every run.  A stale file in scripts/ is loaded by the scripting engine on the next run.

install_script_module_context() already resolves install_name this way; do the same here.
