### PR TITLE
AP_Bootloader: add Tustin Core board ID

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -364,6 +364,8 @@ AP_HW_YARIV6X                        1234
 AP_HW_YARI_GNSS                      1235
 AP_HW_YARI_RTK_GNSS                  1236
 
+AP_HW_TUSTIN_CORE                    1241
+
 AP_HW_PRINCIPIOT_H7PI                1248
 
 AP_HW_KT_FMU_F1                      1250


### PR DESCRIPTION
## Description

Add bootloader board ID `1241` for the Tustin Core flight controller.

This registers the board ID in ArduPilot's authoritative board ID list to prevent collisions and allow the same ID to be used by the PX4 bootloader.

After this ID is accepted, the corresponding entry will be added to the PX4 Bootloader repository:

```text
TARGET_HW_TUSTIN_CORE 1241