### PR TITLE
Correct AC_Fence pre-arm check for alts-in-different-frame

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -29,6 +29,7 @@ import vehicle_test_suite
 from pysim import util
 from pysim import vehicleinfo
 from vehicle_test_suite import MAV_POS_TARGET_TYPE_MASK
+from vehicle_test_suite import AltFrame
 from vehicle_test_suite import AutoTestTimeoutException
 from vehicle_test_suite import NotAchievedException
 from vehicle_test_suite import PreconditionFailedException
@@ -2801,6 +2802,49 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             "SIM_GPS1_ENABLE": 1,
         })
         self.min_alt_fence_frame(1, 20)    # above home
+
+    def FenceAltFrameComparison(self):
+        '''check the alt fence limits are compared in a common frame'''
+        # FENCE_ALT_MIN and FENCE_ALT_MAX each carry their own frame, so
+        # their raw values can be measured from different datums.  A
+        # minimum 20m above home and a maximum of 100m above home leave
+        # 80m of usable airspace whichever way the minimum is expressed.
+        self.poll_home_position(quiet=False)
+        home_alt = self.get_location().get_alt_m(AltFrame.ABSOLUTE)
+
+        self.context_push()
+        self.set_parameters({
+            "FENCE_ENABLE": 1,
+            "FENCE_TYPE": 9,          # min and max altitude
+            "FENCE_ALT_MAX": 100,
+            "FENCE_ALT_MAX_TP": 1,    # above home
+            "FENCE_ALT_MIN": 20,
+            "FENCE_ALT_MIN_TP": 1,    # above home
+        })
+        self.wait_ready_to_arm()
+
+        self.start_subtest("same limits, minimum expressed in absolute frame")
+        self.set_parameters({
+            "FENCE_ALT_MIN": home_alt + 20,
+            "FENCE_ALT_MIN_TP": 0,    # absolute
+        })
+        # the numbers now read 604 against 100, but they describe the
+        # same 20m-above-home floor as above:
+        self.wait_ready_to_arm()
+
+        self.start_subtest("absolute minimum which really is above the maximum")
+        self.set_parameters({
+            "FENCE_ALT_MIN": home_alt + 150,
+        })
+        self.assert_prearm_failure("FENCE_ALT_MAX < FENCE_ALT_MIN")
+
+        self.start_subtest("back to a sane minimum")
+        self.set_parameters({
+            "FENCE_ALT_MIN": home_alt + 20,
+        })
+        self.wait_ready_to_arm()
+
+        self.context_pop()
 
     # MinAltFenceAvoid - fly down and make sure fence action does not trigger
     # Also check that the vehicle will not try and ascend too fast when trying to backup from a min alt fence due to avoidance
@@ -16249,6 +16293,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
              self.MaxAltFence,
              self.MaxAltFenceAvoid,
              self.MinAltFence,
+             self.FenceAltFrameComparison,
              self.MinAltFenceAvoid,
              self.FenceFloorEnabledLanding,
              self.FenceFloorAutoDisableLanding,

--- a/libraries/AC_Fence/AC_Fence.cpp
+++ b/libraries/AC_Fence/AC_Fence.cpp
@@ -560,12 +560,28 @@ bool AC_Fence::pre_arm_check(char *failure_msg, const uint8_t failure_msg_len) c
         return false;
     }
 
-    if (_alt_max_m < _alt_min_m) {
+    // change min-alt into the same frame as max-alt to make them comparable:
+    const Location::AltFrame alt_max_frame = get_alt_max_frame();
+    float framed_alt_min_m = _alt_min_m;
+    if (get_alt_min_frame() != alt_max_frame) {
+        Location loc;
+        if (!AP::ahrs().get_location(loc)) {
+            hal.util->snprintf(failure_msg, failure_msg_len, "Fence requires position");
+            return false;
+        }
+        loc.set_alt_m(_alt_min_m, get_alt_min_frame());
+        if (!loc.get_alt_m(alt_max_frame, framed_alt_min_m)) {
+            hal.util->snprintf(failure_msg, failure_msg_len, "Fence requires terrain");
+            return false;
+        }
+    }
+
+    if (_alt_max_m < framed_alt_min_m) {
         hal.util->snprintf(failure_msg, failure_msg_len, "FENCE_ALT_MAX < FENCE_ALT_MIN");
         return false;
     }
 
-    if (_alt_max_m - _alt_min_m <= 2.0f * _margin_m) {
+    if (_alt_max_m - framed_alt_min_m <= 2.0f * _margin_m) {
         hal.util->snprintf(failure_msg, failure_msg_len, "FENCE_MARGIN too big");
         return false;
     }


### PR DESCRIPTION
### Summary

Corrects pre-arm check comparing min-alt and max-alt in different frames

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

    FENCE_ALT_MIN and FENCE_ALT_MAX each carry their own reference frame,
    but pre_arm_check() compared their raw values.  Those values are
    measured from different datums whenever the frames differ, so the
    comparison is between unlike quantities: a floor 20m above home, held
    as an absolute 604.09, read as being above a 100m ceiling which is also
    20m above the floor, and the vehicle refused to arm with
    
        PreArm: FENCE_ALT_MAX < FENCE_ALT_MIN
    
    The FENCE_MARGIN check immediately below subtracts the same two values
    and had the same problem.
    
    Add get_alt_limits_in_common_frame_m(), which converts the minimum into
    the maximum's frame and hands back both values and the frame they are
    now in.  Where the frames already match it converts nothing, so a
    comparison which used to work without home, an origin or terrain data
    still does.  Where the conversion is not possible - an above-terrain
    limit with no terrain height, or above-home with no home - the check
    reports that rather than comparing regardless.
    
    Found by an autotest: ArduCopter's MinAltFence sets an absolute floor
    in its first sub-case and takes off again in the second, and whether it
    failed depended on the fence still being enabled at that moment.

This does include a new failure path - if the alts are in different frames we can fail to convert (e.g. one is terrain, one is not).  Flying when you're expecting a fence and don't have one is probably worse than not being able to arm.
