### PR TITLE
AP_BLHeli: reject stale motor output mappings

### DIFF
--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -174,19 +174,32 @@ AP_BLHeli::AP_BLHeli(void)
     last_control_port = -1;
 }
 
-// map an incoming BLHeli motor request to the appropriate 
+// map an incoming BLHeli motor request to the appropriate
 // output channel for use in serial output so that motor numbers
 // are observed
-uint8_t AP_BLHeli::blheli_chan_to_output_chan(uint8_t motor)
+bool AP_BLHeli::get_output_channel(uint8_t motor, uint8_t &output_chan)
 {
-    // user has overidden the default output mask, we must use the motor map
-    if (channel_mask.get() != 0) {
-        return motor_map[motor];
+    if (motor >= num_motors) {
+        return false;
     }
-    // user is using motor mask and so we can use the servo channel options
-    uint8_t chan = 0;   // 0 means motor 1 and is ok as a fallback
-    SRV_Channels::find_channel(SRV_Channels::get_motor_function(motor), chan);
-    return chan;
+
+    bool valid = uint32_t(channel_mask.get()) == initial_channel_mask;
+    if (valid) {
+        output_chan = passthrough_map[motor];
+        valid = output_chan < 32 && (motor_mask & (1U << output_chan)) != 0;
+    }
+
+    // In auto mode the output function is part of the cached mapping. This
+    // also handles frames whose ESC functions are not contiguous k_motorN.
+    if (valid && initial_channel_mask == 0) {
+        valid = uint16_t(SRV_Channels::channel_function(output_chan)) == passthrough_function[motor];
+    }
+
+    if (!valid && !output_mapping_error_reported) {
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "ESC: output mapping changed, reboot required");
+        output_mapping_error_reported = true;
+    }
+    return valid;
 }
 
 /*
@@ -484,11 +497,13 @@ void AP_BLHeli::msp_process_command(void)
         AP_BattMonitor &battery = AP::battery();
         float v;
 #if HAL_WITH_ESC_TELEM
-        if (!AP::esc_telem().get_voltage(blheli_chan_to_output_chan(blheli.chan), v)) {
+        uint8_t output_chan;
+        if (!get_output_channel(blheli.chan, output_chan) ||
+            !AP::esc_telem().get_voltage(output_chan, v)) {
             v = battery.voltage();
-        }        
+        }
 #else
-            v = battery.voltage();
+        v = battery.voltage();
 #endif
         buf[0] = battery.healthy() ? uint8_t(roundf(v / 3.85)) : 0; // cell count, 0 means no battery
         putU16(&buf[1], uint16_t(battery.pack_capacity_mah())); // capacity in mAh
@@ -511,11 +526,17 @@ void AP_BLHeli::msp_process_command(void)
 
     case MSP_MOTOR_CONFIG: {
         debug("MSP_MOTOR_CONFIG(n=%u, p=%u)", num_motors, motor_poles.get());
-        uint8_t buf[10];
-        SRV_Channel* channel = SRV_Channels::srv_channel(blheli_chan_to_output_chan(0));
-        putU16(&buf[0], channel->get_output_min()); // min throttle
-        putU16(&buf[2], channel->get_output_max()); // max throttle
-        putU16(&buf[4], channel->get_output_min()); // min command
+        uint8_t buf[10] {};
+        uint8_t output_chan;
+        SRV_Channel* channel = nullptr;
+        if (get_output_channel(0, output_chan)) {
+            channel = SRV_Channels::srv_channel(output_chan);
+        }
+        if (channel != nullptr) {
+            putU16(&buf[0], channel->get_output_min()); // min throttle
+            putU16(&buf[2], channel->get_output_max()); // max throttle
+            putU16(&buf[4], channel->get_output_min()); // min command
+        }
         // API 1.42
         buf[6] = num_motors; // motorCount
         buf[7] = motor_poles; // motorPoleCount
@@ -531,8 +552,11 @@ void AP_BLHeli::msp_process_command(void)
         uint8_t buf[16] {};
         for (uint8_t i = 0; i < num_motors; i++) {
             // if we have a mix of reversible and normal report a PWM of zero, this allows BLHeliSuite to conect
-            uint8_t chan = blheli_chan_to_output_chan(i);
-            uint16_t v = mixed_type ? 0 : hal.rcout->read(blheli_chan_to_output_chan(i));
+            uint8_t chan = UINT8_MAX;
+            uint16_t v = 0;
+            if (get_output_channel(i, chan) && !mixed_type) {
+                v = hal.rcout->read(chan);
+            }
             putU16(&buf[2*i], v);
             debug("MOTOR %u chan: %u val: %u",i,chan,v);
         }
@@ -559,7 +583,10 @@ void AP_BLHeli::msp_process_command(void)
                 debug("MSP_SET_MOTOR %u %u", i, v);
                 // map from a MSP value to a value in the range 1000 to 2000
                 uint16_t pwm = (v < 1000)?0:v;
-                hal.rcout->write(blheli_chan_to_output_chan(i), pwm);
+                uint8_t output_chan;
+                if (get_output_channel(i, output_chan)) {
+                    hal.rcout->write(output_chan, pwm);
+                }
             }
             hal.rcout->push();
         } else {
@@ -590,7 +617,9 @@ void AP_BLHeli::msp_process_command(void)
         // doing the serial setup here avoids delays when doing it on demand and makes
         // BLHeliSuite considerably more reliable
         EXPECT_DELAY_MS(1000);
-        if (!hal.rcout->serial_setup_output(blheli_chan_to_output_chan(0), 19200, motor_mask)) {
+        uint8_t output_chan;
+        if (!get_output_channel(0, output_chan) ||
+            !hal.rcout->serial_setup_output(output_chan, 19200, motor_mask)) {
             msp_send_ack(ACK_D_GENERAL_ERROR);
             break;
         } else {
@@ -666,7 +695,9 @@ bool AP_BLHeli::BL_SendBuf(const uint8_t *buf, uint16_t len)
     }
     EXPECT_DELAY_MS(1000);
     hal.scheduler->delay_microseconds(100);
-    if (!hal.rcout->serial_setup_output(blheli_chan_to_output_chan(blheli.chan), 19200, motor_mask)) {
+    uint8_t output_chan;
+    if (!get_output_channel(blheli.chan, output_chan) ||
+        !hal.rcout->serial_setup_output(output_chan, 19200, motor_mask)) {
         debug_console("serial_setup_output() failed\n");
         blheli.ack = ACK_D_GENERAL_ERROR;
         return false;
@@ -791,7 +822,9 @@ bool AP_BLHeli::BL_ReadA(uint8_t cmd, uint8_t *buf, uint16_t n)
  */
 bool AP_BLHeli::BL_ConnectEx(void)
 {
-    debug("BL_ConnectEx %u/%u at %u", blheli.chan, num_motors, blheli_chan_to_output_chan(blheli.chan));
+    uint8_t output_chan = UINT8_MAX;
+    get_output_channel(blheli.chan, output_chan);
+    debug("BL_ConnectEx %u/%u at %u", blheli.chan, num_motors, output_chan);
     setDisconnected();
     const uint8_t BootInit[] = {0,0,0,0,0,0,0,0,0,0,0,0,0x0D,'B','L','H','e','l','i',0xF4,0x7D};
     if (!BL_SendBuf(BootInit, 21)) {
@@ -1403,6 +1436,8 @@ void AP_BLHeli::serial_end()
 void AP_BLHeli::init(uint32_t mask, AP_HAL::RCOutput::output_mode otype)
 {
     initialised = true;
+    initial_channel_mask = uint32_t(channel_mask.get());
+    output_mapping_error_reported = false;
 
     run_test.set_and_notify(0);
 
@@ -1429,7 +1464,7 @@ void AP_BLHeli::init(uint32_t mask, AP_HAL::RCOutput::output_mode otype)
     }
 #endif
 
-    mask |= uint32_t(channel_mask.get());
+    mask |= initial_channel_mask;
 
     /*
       allow mode override - this makes it possible to use DShot for
@@ -1504,6 +1539,20 @@ void AP_BLHeli::init(uint32_t mask, AP_HAL::RCOutput::output_mode otype)
         }
     }
     motor_mask = mask;
+
+    // Cache the passthrough mapping. The k_motorN lookup preserves motor
+    // numbering on multicopters; motor_map handles heli, rover and frames
+    // with non-contiguous motor functions.
+    for (uint8_t i = 0; i < num_motors; i++) {
+        passthrough_map[i] = motor_map[i];
+        if (initial_channel_mask == 0) {
+            uint8_t output_chan;
+            if (SRV_Channels::find_channel(SRV_Channels::get_motor_function(i), output_chan)) {
+                passthrough_map[i] = output_chan;
+            }
+        }
+        passthrough_function[i] = uint16_t(SRV_Channels::channel_function(passthrough_map[i]));
+    }
     debug("ESC: %u motors mask=0x%08lx", num_motors, digital_mask);
 
     // check if we have a combination of reversible and normal

--- a/libraries/AP_BLHeli/AP_BLHeli.cpp
+++ b/libraries/AP_BLHeli/AP_BLHeli.cpp
@@ -571,7 +571,7 @@ void AP_BLHeli::msp_process_command(void)
             uint8_t nmotors = msp.dataSize / 2;
             debug("MSP_SET_MOTOR %u", nmotors);
             motors_disabled_mask = SRV_Channels::get_disabled_channel_mask();
-            SRV_Channels::set_disabled_channel_mask(0xFFFF);
+            SRV_Channels::set_disabled_channel_mask(UINT32_MAX);
             motors_disabled = true;
             EXPECT_DELAY_MS(1000);
             hal.rcout->cork();
@@ -1531,26 +1531,53 @@ void AP_BLHeli::init(uint32_t mask, AP_HAL::RCOutput::output_mode otype)
 #if defined(HAL_WITH_BIDIR_DSHOT) || HAL_WITH_IO_MCU_BIDIR_DSHOT
     hal.rcout->set_bidir_dshot_mask(uint32_t(channel_bidir_dshot_mask.get()) & digital_mask);
 #endif
-    // add motors from channel mask
-    for (uint8_t i=0; i<16 && num_motors < max_motors; i++) {
-        if (digital_mask & (1U<<i)) {
-            motor_map[num_motors] = i;
+    // Count the motors from the full channel mask. The passthrough mapping
+    // below decides which outputs to expose when more than max_motors are
+    // configured.
+    const uint32_t available_mask = digital_mask;
+    for (uint8_t i=0; i<32 && num_motors < max_motors; i++) {
+        if (available_mask & (1U<<i)) {
             num_motors++;
         }
     }
     motor_mask = mask;
 
-    // Cache the passthrough mapping. The k_motorN lookup preserves motor
-    // numbering on multicopters; motor_map handles heli, rover and frames
-    // with non-contiguous motor functions.
+    // Cache the passthrough mapping. Prefer k_motorN functions that are in
+    // the full available mask before limiting the exposed ESCs, then fill gaps
+    // with unused entries for heli, rover and frames with non-contiguous motor
+    // functions.
     for (uint8_t i = 0; i < num_motors; i++) {
-        passthrough_map[i] = motor_map[i];
-        if (initial_channel_mask == 0) {
+        passthrough_map[i] = UINT8_MAX;
+    }
+
+    uint32_t assigned_mask = 0;
+    if (initial_channel_mask == 0) {
+        for (uint8_t i = 0; i < num_motors; i++) {
             uint8_t output_chan;
-            if (SRV_Channels::find_channel(SRV_Channels::get_motor_function(i), output_chan)) {
+            if (SRV_Channels::find_channel(SRV_Channels::get_motor_function(i), output_chan) &&
+                output_chan < 32 &&
+                (available_mask & (1U << output_chan)) != 0 &&
+                (assigned_mask & (1U << output_chan)) == 0) {
                 passthrough_map[i] = output_chan;
+                assigned_mask |= 1U << output_chan;
             }
         }
+    }
+
+    for (uint8_t i = 0; i < num_motors; i++) {
+        if (passthrough_map[i] == UINT8_MAX) {
+            for (uint8_t output_chan = 0; output_chan < 32; output_chan++) {
+                if ((available_mask & (1U << output_chan)) == 0) {
+                    continue;
+                }
+                if ((assigned_mask & (1U << output_chan)) == 0) {
+                    passthrough_map[i] = output_chan;
+                    assigned_mask |= 1U << output_chan;
+                    break;
+                }
+            }
+        }
+        motor_map[i] = passthrough_map[i];
         passthrough_function[i] = uint16_t(SRV_Channels::channel_function(passthrough_map[i]));
     }
     debug("ESC: %u motors mask=0x%08lx", num_motors, digital_mask);
@@ -1593,7 +1620,7 @@ void AP_BLHeli::read_telemetry_packet(void)
     uint16_t new_rpm = ((buf[7]<<8) | buf[8]) * 200 / motor_poles;
     const uint8_t motor_idx = motor_map[last_telem_esc];
     // we have received valid data, mark the ESC as now active
-    hal.rcout->set_active_escs_mask(1<<motor_idx);
+    hal.rcout->set_active_escs_mask(1U << motor_idx);
     update_rpm(motor_idx, new_rpm);
 
     TelemetryData t {

--- a/libraries/AP_BLHeli/AP_BLHeli.h
+++ b/libraries/AP_BLHeli/AP_BLHeli.h
@@ -244,7 +244,11 @@ private:
 
     // mapping from BLHeli motor numbers to RC output channels
     uint8_t motor_map[max_motors];
+    uint8_t passthrough_map[max_motors];
+    uint16_t passthrough_function[max_motors];
     uint32_t motor_mask;
+    uint32_t initial_channel_mask;
+    bool output_mapping_error_reported;
 
     // convert between servo number and FMU channel number for ESC telemetry
     uint8_t chan_offset;
@@ -261,7 +265,7 @@ private:
     bool msp_process_byte(uint8_t c);
     void blheli_crc_update(uint8_t c);
     bool blheli_4way_process_byte(uint8_t c);
-    uint8_t blheli_chan_to_output_chan(uint8_t motor);
+    bool get_output_channel(uint8_t motor, uint8_t &output_chan);
     void msp_send_ack(uint8_t cmd);
     void msp_send_reply(uint8_t cmd, const uint8_t *buf, uint8_t len);
     void putU16(uint8_t *b, uint16_t v);


### PR DESCRIPTION
### Summary

Reject stale BLHeli passthrough output mappings before they can select an output whose serial/DMA state was not initialized. Preserve passthrough on frames with non-contiguous or non-`MotorN` output functions.

### Classification & Testing (check all that apply and add your own)

- [ ] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request
- [x] Built for SITL Plane
- [x] Built for BlitzWingH743 Plane with `-Werror`
- [x] Built for BlitzWingH743 Copter, Heli, Plane/QuadPlane, and Rover
- [x] Tested nine vehicle/frame configurations under Renode

Build commands:

```text
./waf configure --board sitl
./waf plane
./waf configure --board BlitzWingH743
./waf plane

# Final Renode firmware build, with a default-parameter file enabling
# MAVLink on SERIAL3 for the emulator:
./waf configure --board BlitzWingH743 --enable-APJ_TOOL_PARAMETERS \
    --default-parameters=<Renode-MAVLink-defaults.parm>
./waf copter heli plane rover
```

The Renode default-parameter file contained:

```text
SERIAL3_PROTOCOL 2
SERIAL3_BAUD 115
```

Renode testing used the patched Renode 1.16.1 build and `BlitzWingH743` model from the ArduPilot Renode tree. Each case booted the relevant vehicle and frame, enabled one representative DShot/BLHeli output, requested `SERVO_BLH_TEST=1`, and verified the physical output selected by `BL_ConnectEx`:

| Vehicle/frame | Expected output | Observed output |
|---|---:|---:|
| Copter Quad X | 1 | 1 |
| Copter Tri X (sparse) | 4 | 4 |
| Copter Single | 5 | 5 |
| Copter Dodeca with Motor1 remapped above the first eight physical outputs | 9 | 9 |
| Heli Single RSC | 8 | 8 |
| QuadPlane Quad X | 5 | 5 |
| QuadPlane Tri X (sparse) | 8 | 8 |
| Rover standard | 3 | 3 |
| Rover Omni3/Mecanum | 2 | 2 |

All nine mappings matched. Every case completed five BLHeli connection attempts through the serial/DMA send and receive-attempt path without a HardFault, UsageFault, BusFault, MemManage fault, panic, or fatal error.

The Renode model does not emulate an electrically connected ESC, so the connection test ends with the expected `ESC: Test FAILED` after the mapping and serial/DMA paths have been exercised. Enabling an entire multi-output DShot motor group also exceeds the current H743 Renode model's validated timing envelope and can stall the emulator during initialization. The frame tests therefore use one representative explicit DShot output per case; they do not claim end-to-end ESC communication or full-group DShot validation.

The mapping algorithm was additionally model-checked across all 65,536 low-16-bit masks, high-bit boundary cases including output 32, and 100,000 deterministic randomized 32-bit masks. Every result was bounded to eight ESCs, contained only initialized outputs, had no duplicate channels, and preserved every available preferred MotorN mapping.

`Tools/scripts/check_branch_conventions.py` and `git diff --check` both passed on the final commit.

### Description

This is a minimal cause-level fix for #33926, kept separate from #33933 so it can be considered for a 4.7 backport.

BLHeli cached its enabled output mask at initialization but could resolve passthrough motor functions again after a runtime parameter change. If the resolved output was outside the cached mask, `serial_setup_output()` selected its output group without initializing that group's DMA handle. The subsequent serial write could then HardFault through the missing DMA state.

The passthrough mapping and associated servo function are now cached at initialization. A later `SERVO_BLH_MASK` change, or a `SERVOn_FUNCTION` change while using automatic motor mapping, invalidates the mapping, rejects the passthrough request, and emits a one-time reboot-required warning. When a frame does not use contiguous `MotorN` functions, the initialized motor map is retained, preserving tricopter, traditional-helicopter, and rover passthrough behavior.

This change is limited to MSP/4-way passthrough mapping. ESC telemetry continues to use `motor_map[]` directly, so bidirectional-DShot RPM attribution, harmonic-notch input, ESC health, and ESC logging are unchanged.

### AI assistance

This change was developed and reviewed with AI assistance from Codex and Claude. The human submitter remains responsible for validating the code and testing it on appropriate hardware.
