### PR TITLE
SITL: scale mission-upload timeouts by SIM_SPEEDUP

### DIFF
--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -10113,7 +10113,12 @@ Also, ignores heartbeats not from our target system'''
                                             mission_type)
         remaining_to_send = set(range(item_base, item_base + len(items)))
         sent = set()
-        timeout = (10 + len(items)/10.0)
+        # get_sim_time_cached() below is simulated time, so this needs the
+        # same self.speedup scaling download_using_mission_protocol()'s
+        # timeout already gets -- otherwise the real-time budget available
+        # to the GCS side of the handshake shrinks as SIM_SPEEDUP rises,
+        # even though the real cost of each round trip does not.
+        timeout = (10 + len(items)/10.0) * self.speedup / 10.0
         while True:
             if self.get_sim_time_cached() - tstart > timeout:
                 raise NotAchievedException("timeout uploading %s" % str(mission_type))

--- a/libraries/GCS_MAVLink/MissionItemProtocol.cpp
+++ b/libraries/GCS_MAVLink/MissionItemProtocol.cpp
@@ -6,6 +6,10 @@
 
 #include "GCS.h"
 
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+#include <SITL/SITL.h>
+#endif
+
 void MissionItemProtocol::init_send_requests(GCS_MAVLINK &_link,
                                              const mavlink_message_t &msg,
                                              const int16_t _request_first,
@@ -388,7 +392,20 @@ void MissionItemProtocol::update()
     }
     // stop waypoint receiving if timeout
     const uint32_t tnow = AP_HAL::millis();
-    if (tnow - timelast_receive_ms > upload_timeout_ms) {
+    uint32_t effective_upload_timeout_ms = upload_timeout_ms;
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    // AP_HAL::millis() is simulated time here, so upload_timeout_ms -- a
+    // real-world tolerance for an unresponsive/slow GCS -- shrinks in real
+    // time as SIM_SPEEDUP rises, while the real (wall-clock) cost of the
+    // GCS's side of the protocol (socket I/O, message parsing, etc) does
+    // not get any smaller. Scale it back up so it reflects roughly the
+    // same real-time budget regardless of speedup.
+    const SITL::SIM *sitl = AP::sitl();
+    if (sitl != nullptr && sitl->speedup > 0) {
+        effective_upload_timeout_ms *= sitl->speedup;
+    }
+#endif
+    if (tnow - timelast_receive_ms > effective_upload_timeout_ms) {
         receiving = false;
         timeout();
         const mavlink_channel_t chan = link->get_chan();


### PR DESCRIPTION
### Summary

Both the vehicle and the GCS/autotest sides of the mission-item upload handshake compare a fixed, wall-clock-intended timeout against simulated time in SITL. At high SIM_SPEEDUP, that simulated-time budget shrinks in real terms while the real cost of the GCS's side of the protocol (socket I/O, message parsing, retries) does not — so uploads that are working correctly get cancelled anyway once speedup is high enough. This is the same bug behind the known flakiness of RTLSpeed at default speedup.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

What's fixed

- `GCS_MAVLink::MissionItemProtocol::update()` compares `AP_HAL::millis()` (simulated time under SITL) against a fixed `upload_timeout_ms = 8000`. Scaled by `SITL::SIM::speedup` when built for SITL, matching the existing pattern in `AP_Logger_File::io_thread_alive()` for the identical class of problem.
- `Tools/autotest/vehicle_test_suite.py`'s `upload_using_mission_protocol()` has the same problem on the harness side, comparing its own timeout against `get_sim_time_cached()`. Its sibling function, `download_using_mission_protocol()`, already scales its equivalent timeout by `self.speedup / 10.0` — `upload_using_mission_protocol()` was simply missing the same treatment. Applied identically.

# Testing

- Confirmed the failure first: `Copter.RTLSpeed` reproducibly failed with `NotAchievedException('timeout uploading 0')` at default speedup before this fix.
- With both commits applied, `RTLSpeed` no longer fails during mission upload at all — it now progresses through arming and takeoff before failing on an unrelated, pre-existing climb-rate issue that is out of scope for this PR.
- Primary validation is a two-SITL-instance test (a separate, in-progress PR) that uploads small missions to both vehicles: without this fix it had a hard ceiling around 15–18x `SIM_SPEEDUP` (`MAV_MISSION_OPERATION_CANCELLED` / `timeout uploading 0`); with both commits here and nothing else changed, it passes reliably at 40x.
- `./waf plane` and `./waf copter` both build clean.
- `Tools/scripts/check_branch_conventions.py` passes (2 commits, one per subsystem: `GCS_MAVLink`, `Tools`).

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
