### PR TITLE
ArduPlane: fix SCALING_SPEED documented range

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -636,7 +636,7 @@ const AP_Param::Info Plane::var_info[] = {
     // @DisplayName: speed used for speed scaling calculations
     // @Description: Airspeed in m/s to use when calculating surface speed scaling. Note that changing this value will affect all PID values
     // @Units: m/s
-    // @Range: 0 50
+    // @Range: 0.1 50
     // @Increment: 0.1
     // @User: Advanced
     GSCALAR(scaling_speed,        "SCALING_SPEED",    SCALING_SPEED),


### PR DESCRIPTION
Setting SCALING_SPEED to 0 causes a division by zero; the documented range should not include 0. Discussed in [https://discuss.ardupilot.org/t/division-by-zero-issues-with-scaling-speed-and-sim-wind-t-alt-parameters/72397/](https://discuss.ardupilot.org/t/division-by-zero-issues-with-scaling-speed-and-sim-wind-t-alt-parameters/72397/)