### PR TITLE
AP_Filesystem: close the param file on the open() failure path

### DIFF
--- a/libraries/AP_Filesystem/AP_Filesystem_Param.cpp
+++ b/libraries/AP_Filesystem/AP_Filesystem_Param.cpp
@@ -121,8 +121,7 @@ int AP_Filesystem_Param::open(const char *fname, int flags, bool allow_absolute_
     return idx;
 
 failed:
-    delete [] r.cursors;
-    r.open = false;
+    close(idx);
     errno = EINVAL;
     return -1;
 }

--- a/libraries/AP_Filesystem/tests/test_filesystem_param.cpp
+++ b/libraries/AP_Filesystem/tests/test_filesystem_param.cpp
@@ -1,0 +1,29 @@
+#include <AP_gtest.h>
+
+#include <AP_Filesystem/AP_Filesystem_Param.h>
+
+#include <fcntl.h>
+
+#if AP_FILESYSTEM_PARAM_ENABLED
+
+const AP_HAL::HAL& hal = AP_HAL::get_HAL();
+
+// the upload path allocates no cursors of its own, so a slot it reuses from a
+// failed open() is closed on a pointer that has already been freed
+TEST(FilesystemParam, OpenFailureLeavesNoStaleCursors)
+{
+    static AP_Filesystem_Param fs;
+
+    // start >= UINT16_MAX reaches failed:, after the cursors are allocated
+    EXPECT_EQ(-1, fs.open("param.pck?start=99999", O_RDONLY));
+
+    const int fd = fs.open("param.pck", O_WRONLY);
+    ASSERT_GE(fd, 0);
+
+    // an upload of no parameters legitimately fails to parse, so no EXPECT here
+    fs.close(fd);
+}
+
+#endif  // AP_FILESYSTEM_PARAM_ENABLED
+
+AP_GTEST_MAIN()

--- a/libraries/AP_Filesystem/tests/wscript
+++ b/libraries/AP_Filesystem/tests/wscript
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+def build(bld):
+    bld.ap_find_tests(
+        use='ap',
+    )


### PR DESCRIPTION
### Summary

`AP_Filesystem_Param::open()`'s `failed:` path leaves a freed cursor pointer in the `file[]` slot and leaks `writebuf`. The next `open()` on that slot double-frees. Fixes #34052.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

New `libraries/AP_Filesystem/tests/test_filesystem_param.cpp`. Under `--board sitl --debug --asan`, base aborts:

```
AddressSanitizer: attempting double-free on 0x60c0000001c0
    #2 AP_Filesystem_Param::close(int)   AP_Filesystem_Param.cpp:143
  freed by thread T0 here:
    #2 AP_Filesystem_Param::open(...)    AP_Filesystem_Param.cpp:124
```

It covers the double-free, not the leak: unit-test CI runs no ASan or valgrind.

### Description

`open()` allocates the cursors at :57, before parsing the URI arguments, so a bad `start=` reaches `failed:` at :123, which frees them without clearing the pointer and never frees `writebuf`. Both are reachable over FTP via `@PARAM/param.pck?start=70000`: a failed read-mode open, then an upload open of the same slot, double-frees, as the upload allocates no cursors.

`failed:` now calls `close(idx)`, which frees both. In write mode that runs `finish_upload` on an empty buffer, which fails `param_upload_parse`'s length check at :548 before the buffer is read, so nothing is written and `EINVAL` is unchanged.

No open PR touches this file.

AI-assisted: analysis, validation, and additional testing (Opus 5)