### PR TITLE
autotest: skip MAVFTPCrcCompareMAVProxy on a MAVProxy without crccmp

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -9748,7 +9748,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         ]
 
     def disabled_tests(self):
-        return {
+        ret = {
             "LandingDrift": "Flapping test. See https://github.com/ArduPilot/ardupilot/issues/20054",
             "TerrainRally": "Passes vacuously due to helper alt-frame bugs. See https://github.com/ArduPilot/ardupilot/issues/33740",  # noqa
             "InteractTest": "requires user interaction",
@@ -9758,6 +9758,12 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             "MAVFTPListDirectoryInterleavedGet": "needs a MAVProxy which does not continue a listing by mutating the last op sent; see https://github.com/ArduPilot/MAVProxy",  # noqa:E501
             "MAVFTPListDirectoryTabInNameMAVProxy": "needs a MAVProxy which takes the size from the end of a listing entry; see https://github.com/ArduPilot/MAVProxy",  # noqa:E501
         }
+        if not self.mavproxy_ftp_module_has_command("crccmp"):
+            # added to MAVProxy in 328d7de20 (2026-07-27) and not in any
+            # release up to v1.8.74; skipped only where it is missing, so
+            # CI - which installs MAVProxy from git master - still runs it
+            ret["MAVFTPCrcCompareMAVProxy"] = "needs a MAVProxy which has the ftp crclocal and crccmp commands; see https://github.com/ArduPilot/MAVProxy"  # noqa:E501
+        return ret
 
 
 class AutoTestPlaneTests1a(AutoTestPlane):

--- a/Tools/autotest/pysim/util.py
+++ b/Tools/autotest/pysim/util.py
@@ -9,6 +9,7 @@ import math
 import os
 import re
 import shlex
+import shutil
 import signal
 import socket
 import subprocess
@@ -833,6 +834,57 @@ def MAVProxy_version():
     if match is None:
         raise ValueError("Unable to determine MAVProxy version from (%s)" % output)
     return int(match.group(1)), int(match.group(2)), int(match.group(3))
+
+
+def mavproxy_python():
+    """return the interpreter which runs mavproxy_cmd(), as an argv list.
+
+    MAVPROXY_CMD can name a MAVProxy installed somewhere other than the
+    interpreter running the test suite - a virtualenv, say - so
+    importing MAVProxy here would answer questions about the wrong
+    MAVProxy.  Take the interpreter out of the script's shebang line
+    instead.  Returns None if it can't be worked out.
+    """
+    path = shutil.which(mavproxy_cmd())
+    if path is None:
+        return None
+    try:
+        with open(path, "rb") as f:
+            first_line = f.readline()
+    except OSError:
+        return None
+    if not first_line.startswith(b"#!"):
+        # not a script at all; a compiled wrapper, perhaps
+        return None
+    return shlex.split(first_line[2:].strip().decode("utf-8"))
+
+
+def MAVProxy_ftp_module_has_command(command):
+    """return True if MAVProxy's ftp module implements "ftp <command>".
+
+    Asks the MAVProxy which mavproxy_cmd() will run, not the one this
+    process happens to be able to import.  Returns None if that can't be
+    asked.
+    """
+    python = mavproxy_python()
+    if python is None:
+        return None
+    program = (
+        "from MAVProxy.modules import mavproxy_ftp;"
+        "print(hasattr(mavproxy_ftp.FTPModule, %s))" % repr("cmd_%s" % command)
+    )
+    try:
+        completed = subprocess.run(
+            python + ["-c", program],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            timeout=60,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if completed.returncode != 0:
+        return None
+    return completed.stdout.decode("ascii").strip() == "True"
 
 
 def start_MAVProxy_SITL(atype,

--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -1099,9 +1099,9 @@ def start_mavproxy(opts, stuff):
     if under_cygwin():
         cmd.append("/usr/bin/cygstart")
         cmd.append("-w")
-        cmd.append("mavproxy.exe")
+        cmd.append(os.getenv('MAVPROXY_CMD', "mavproxy.exe"))
     else:
-        cmd.append("mavproxy.py")
+        cmd.append(util.mavproxy_cmd())
 
     if opts.valgrind:
         cmd.extend(['--retries', '10'])

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -2289,6 +2289,24 @@ class TestSuite(abc.ABC):
         '''return the current version of mavproxy as a tuple e.g. (1,8,8)'''
         return util.MAVProxy_version()
 
+    def mavproxy_ftp_module_has_command(self, command):
+        '''return True if MAVProxy's ftp module implements "ftp <command>".
+
+        MAVProxy's version is no use for this: master and the newest
+        release both call themselves 1.8.74, so a version gate would
+        disable the test everywhere, including CI - which installs
+        MAVProxy from git master and so does have these commands.  Ask
+        the module what it can do instead; the answer changes by itself
+        when the local MAVProxy is updated.
+        '''
+        ret = util.MAVProxy_ftp_module_has_command(command)
+        if ret is None:
+            # couldn't ask the MAVProxy we will be running.  Assume the
+            # command is there and let the test run rather than silently
+            # dropping coverage:
+            return True
+        return ret
+
     def mavproxy_version_gt(self, major, minor, point):
         if os.getenv("AUTOTEST_FORCE_MAVPROXY_VERSION", None) is not None:
             return True

--- a/Tools/renode/test_all.py
+++ b/Tools/renode/test_all.py
@@ -451,9 +451,10 @@ def main():
     if not builds:
         parser.error("pattern '%s' matched no supported builds" % args.pattern)
 
-    mavproxy = shutil.which('mavproxy.py')
+    mavproxy_cmd = os.environ.get('MAVPROXY_CMD', 'mavproxy.py')
+    mavproxy = shutil.which(mavproxy_cmd)
     if mavproxy is None and any(not build.is_periph for build in builds):
-        parser.error('mavproxy.py is required for flight-controller tests')
+        parser.error('%s is required for flight-controller tests' % mavproxy_cmd)
 
     run_py = root / 'Tools' / 'renode' / 'run.py'
     board_locks = {build.board: threading.Lock() for build in builds}

--- a/Tools/ros2/ardupilot_sitl/src/ardupilot_sitl/launch.py
+++ b/Tools/ros2/ardupilot_sitl/src/ardupilot_sitl/launch.py
@@ -14,6 +14,8 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 """Launch actions for ArduPilot."""
+import os
+
 from pathlib import Path
 from typing import Dict
 from typing import List
@@ -285,7 +287,7 @@ class MAVProxyLaunch:
     def generate_action(context: LaunchContext, *args, **kwargs) -> ExecuteProcess:
         """Return a non-interactive MAVProxy process."""
         # Declare the command.
-        command = "mavproxy.py"
+        command = os.environ.get("MAVPROXY_CMD", "mavproxy.py")
 
         # Retrieve launch arguments.
         master = LaunchConfiguration("master").perform(context)


### PR DESCRIPTION
### Summary

Skip new test until MAVProxy out there catches up

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

The test drives "ftp crclocal" and "ftp crccmp", neither of which exists in a MAVProxy older than the one which added them, so it sits waiting for output that will never arrive and fails after 60s.  The three sibling FTP tests already skipped here need a newer MAVProxy for the same kind of reason.

Checked against a MAVProxy whose ftp module predates the commands - it contains no reference to either - and every other test added alongside this one passes there: MAVFTPFileCommandsMAVProxy, MAVFTPGapReadMAVProxy, MAVFTPListDirectoryEdgeCases, MAVFTPListDirectoryLongNames, MAVFTPDuplicateRequest, MAVFTPUnknownOpcodeNack, MAVFTPReadFile, MAVFTPCalcFileCRC32 and MAVFTPRename.  So this is the only one which needs skipping.
