### PR TITLE
AP_RC_Logic: Betaflight-style RC logic engine for aux and mode switching

### DIFF
--- a/Tools/ardupilotwaf/ardupilotwaf.py
+++ b/Tools/ardupilotwaf/ardupilotwaf.py
@@ -71,6 +71,7 @@ COMMON_VEHICLE_DEPENDENT_LIBRARIES = [
     'AP_Mount',
     'AP_Module',
     'AP_Button',
+    'AP_RC_Logic',
     'AP_ICEngine',
     'AP_Networking',
     'AP_Frsky_Telem',

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -12221,6 +12221,124 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.set_message_rate_hz("EFI_STATUS", -1)
         self.set_message_rate_hz("GENERATOR_STATUS", -1)
 
+    def RCLogic(self):
+        '''Test the AP_RC_Logic range/link engine driving AUX functions'''
+        self.set_parameter("RCL_ENABLE", 1)
+        self.set_rc(9, 1000)
+        self.set_rc(10, 1000)
+
+        self.start_subtest("Range term drives fence; link term drives RTL")
+        self.set_parameters({
+            # fence enable (11) when ch9 is high (range, OR)
+            "RCL1_FUNC": 11, "RCL1_OPT": 0, "RCL1_SRC": 9,
+            "RCL1_MIN": 1800, "RCL1_MAX": 2100,
+            # RTL (4) when the fence function is active (link, OR)
+            "RCL2_FUNC": 4, "RCL2_OPT": 1, "RCL2_SRC": 11,
+        })
+        self.wait_ready_to_arm()
+        self.set_rc(9, 2000)
+        self.assert_fence_enabled()
+        self.wait_mode('RTL')
+
+        self.start_subtest("Re-targeting a source row reclaims its slot (no stale link)")
+        # ch9 still high, fence active, RTL held by the link. Disable the fence
+        # row: the fence function becomes unreferenced, its slot is reclaimed,
+        # and the RTL link must drop rather than read a stale active state.
+        self.set_parameter("RCL1_FUNC", 0)
+        tstart = self.get_sim_time()
+        while True:
+            self.wait_heartbeat()
+            if self.mav.flightmode != 'RTL':
+                break
+            if self.get_sim_time() - tstart > 10:
+                raise NotAchievedException("linked RTL did not drop after source re-targeted")
+        self.set_parameter("RCL1_FUNC", 11)   # restore for the next step
+        self.wait_mode('RTL')
+
+        self.progress("Lower ch9: fence disables and the linked RTL drops")
+        self.set_rc(9, 1000)
+        self.assert_fence_disabled()
+
+        self.start_subtest("AND combine needs both channels high")
+        self.change_mode('STABILIZE')
+        self.set_parameters({
+            "RCL2_FUNC": 0,             # drop the link row
+            "RCL1_OPT": 0x4,            # fence term now AND on ch9
+            # second AND term for fence: ch10 high
+            "RCL3_FUNC": 11, "RCL3_OPT": 0x4, "RCL3_SRC": 10,
+            "RCL3_MIN": 1800, "RCL3_MAX": 2100,
+        })
+        self.set_rc(9, 2000)
+        self.set_rc(10, 1000)
+        self.assert_fence_disabled()   # only one AND term satisfied
+        self.set_rc(10, 2000)
+        self.assert_fence_enabled()    # both AND terms satisfied
+
+        self.start_subtest("Multiple functions on one channel via PWM ranges")
+        # two ranges on ch8 select two different functions, Betaflight-style
+        self.set_rc(8, 1500)
+        self.set_parameters({
+            "RCL1_FUNC": 4, "RCL1_OPT": 0, "RCL1_SRC": 8,   # RTL on ch8 high
+            "RCL1_MIN": 1800, "RCL1_MAX": 2100,
+            "RCL3_FUNC": 11, "RCL3_OPT": 0, "RCL3_SRC": 8,  # fence on ch8 low
+            "RCL3_MIN": 1000, "RCL3_MAX": 1200,
+        })
+        self.change_mode('STABILIZE')
+        self.progress("ch8 high band -> RTL, fence off")
+        self.set_rc(8, 2000)
+        self.wait_mode('RTL')
+        self.assert_fence_disabled()
+        self.progress("ch8 low band -> fence on, not RTL")
+        self.set_rc(8, 1100)
+        self.assert_fence_enabled()
+        self.wait_mode('STABILIZE')
+        self.set_rc(8, 1500)               # neither band
+        self.set_parameters({"RCL1_FUNC": 0, "RCL3_FUNC": 0})
+
+        self.start_subtest("Condition term (armed state) drives a function")
+        self.set_parameters({
+            "RCL1_FUNC": 0, "RCL3_FUNC": 0,   # clear prior rows
+            "RCL4_FUNC": 11, "RCL4_OPT": 0x2, "RCL4_SRC": 4,  # fence when ARMED
+        })
+        self.set_rc(3, 1000)
+        self.set_rc(9, 1000)
+        self.set_rc(10, 1000)
+        self.wait_ready_to_arm()
+        self.assert_fence_disabled()   # disarmed -> condition false
+        self.arm_vehicle()
+        self.assert_fence_enabled()    # armed -> condition true -> fence on
+        self.disarm_vehicle()
+        self.assert_fence_disabled()
+        self.set_parameter("RCL4_FUNC", 0)
+
+        self.start_subtest("Held functions release on disable and re-target")
+        self.set_parameters({
+            "RCL6_FUNC": 0,
+            "RCL1_FUNC": 11, "RCL1_OPT": 0, "RCL1_SRC": 9,
+            "RCL1_MIN": 1800, "RCL1_MAX": 2100,
+        })
+        self.set_rc(9, 2000)
+        self.assert_fence_enabled()
+        self.progress("Disable engine: the held fence must release")
+        self.set_parameter("RCL_ENABLE", 0)
+        self.assert_fence_disabled()
+        self.progress("Re-enable then re-target the row: fence must release")
+        self.set_parameter("RCL_ENABLE", 1)
+        self.assert_fence_enabled()
+        self.set_parameter("RCL1_FUNC", 0)
+        self.assert_fence_disabled()
+
+        self.progress("Restore")
+        self.set_parameters({
+            "RCL_ENABLE": 0, "RCL1_FUNC": 0, "RCL3_FUNC": 0, "RCL4_FUNC": 0,
+            "RCL5_FUNC": 0, "RCL6_FUNC": 0,
+        })
+        self.set_rc(8, 1500)
+        self.set_rc(9, 1000)
+        self.set_rc(10, 1000)
+        self.set_rc(11, 1000)
+        self.set_rc(12, 1000)
+
     def AuxSwitchOptions(self):
         '''Test random aux mode options'''
         self.set_parameter("RC7_OPTION", 58) # clear waypoints
@@ -16052,6 +16170,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
              self.SetModesViaModeSwitch,
              self.BackupFence,
              self.SetModesViaAuxSwitch,
+             self.RCLogic,
              self.AuxSwitchOptions,
              self.AuxFunctionsInMission,
              self.AutoTune,

--- a/libraries/AP_RC_Logic/AP_RC_Logic.cpp
+++ b/libraries/AP_RC_Logic/AP_RC_Logic.cpp
@@ -123,7 +123,8 @@ bool AP_RC_Logic::committed_state(RC_Channel::AUX_FUNC f) const
     }
     for (uint8_t i = 0; i < AP_RC_LOGIC_NUM_TERMS; i++) {
         if (_states[i].func == (uint16_t)f) {
-            return _states[i].committed;
+            // a link watches whether the function is fully active (HIGH)
+            return _states[i].committed_pos == (uint8_t)RC_Channel::AuxSwitchPos::HIGH;
         }
     }
     return false;
@@ -193,8 +194,8 @@ AP_RC_Logic::FuncState *AP_RC_Logic::state_for(RC_Channel::AUX_FUNC f)
     }
     if (first_free != nullptr) {
         first_free->func = (uint16_t)f;
-        first_free->committed = false;
-        first_free->candidate = false;
+        first_free->committed_pos = (uint8_t)RC_Channel::AuxSwitchPos::LOW;
+        first_free->candidate_pos = (uint8_t)RC_Channel::AuxSwitchPos::LOW;
         first_free->since_ms = 0;
     }
     return first_free;
@@ -202,7 +203,7 @@ AP_RC_Logic::FuncState *AP_RC_Logic::state_for(RC_Channel::AUX_FUNC f)
 
 void AP_RC_Logic::release_slot(FuncState &st)
 {
-    if (st.func != 0 && st.committed) {
+    if (st.func != 0 && st.committed_pos != (uint8_t)RC_Channel::AuxSwitchPos::LOW) {
         const auto f = (RC_Channel::AUX_FUNC)st.func;
         // Releasing drives the function LOW so latching outputs (relays) do
         // not stay stuck on after a re-target or engine disable. Never do
@@ -272,31 +273,66 @@ void AP_RC_Logic::update()
 
         const bool arm_func = is_arm_function(f);
 
-        // combine all rows for this function using the Betaflight rule:
-        // active when all AND terms are true, or any OR term is true.
-        bool has_and = false, all_and = true, any_or = false;
-        for (uint8_t j = i; j < AP_RC_LOGIC_NUM_TERMS; j++) {
-            const Term &tj = terms[j];
-            if (!tj.enabled() || tj.func() != f) {
-                continue;
-            }
-            // arming functions honour range terms only
-            if (arm_func && tj.source_type() != Term::SourceType::RANGE) {
-                continue;
-            }
-            const bool v = eval_term(tj);
-            if (tj.combine_is_and()) {
-                has_and = true;
-                all_and = all_and && v;
-            } else {
-                any_or = any_or || v;
+        // A row may request a specific output position (OPT bits 4-5) to drive
+        // a multi-position function (e.g. VTX power) to a chosen level. If any
+        // row for this function does so, the function runs in "selector" mode:
+        // the lowest-index active row wins and drives its position; if none is
+        // active the position is LOW. Otherwise the classic boolean AND/OR
+        // combine is used. Arm functions are always strictly boolean
+        // (HIGH = arm, LOW = disarm) and never enter selector mode.
+        bool selector = false;
+        if (!arm_func) {
+            for (uint8_t j = i; j < AP_RC_LOGIC_NUM_TERMS; j++) {
+                if (terms[j].enabled() && terms[j].func() == f &&
+                    terms[j].has_output_position()) {
+                    selector = true;
+                    break;
+                }
             }
         }
-        bool raw = (has_and && all_and) || any_or;
 
-        // ARM-class functions fail toward disarm without valid RC input.
-        if (raw && arm_func && !rc_valid) {
-            raw = false;
+        RC_Channel::AuxSwitchPos target;
+        if (selector) {
+            target = RC_Channel::AuxSwitchPos::LOW;
+            for (uint8_t j = i; j < AP_RC_LOGIC_NUM_TERMS; j++) {
+                const Term &tj = terms[j];
+                if (!tj.enabled() || tj.func() != f) {
+                    continue;
+                }
+                if (eval_term(tj)) {
+                    // priority: the first (lowest-index) active row wins
+                    target = tj.output_position();
+                    break;
+                }
+            }
+        } else {
+            // combine all rows for this function using the Betaflight rule:
+            // active when all AND terms are true, or any OR term is true.
+            bool has_and = false, all_and = true, any_or = false;
+            for (uint8_t j = i; j < AP_RC_LOGIC_NUM_TERMS; j++) {
+                const Term &tj = terms[j];
+                if (!tj.enabled() || tj.func() != f) {
+                    continue;
+                }
+                // arming functions honour range terms only
+                if (arm_func && tj.source_type() != Term::SourceType::RANGE) {
+                    continue;
+                }
+                const bool v = eval_term(tj);
+                if (tj.combine_is_and()) {
+                    has_and = true;
+                    all_and = all_and && v;
+                } else {
+                    any_or = any_or || v;
+                }
+            }
+            bool raw = (has_and && all_and) || any_or;
+            // ARM-class functions fail toward disarm without valid RC input.
+            if (raw && arm_func && !rc_valid) {
+                raw = false;
+            }
+            target = raw ? RC_Channel::AuxSwitchPos::HIGH
+                         : RC_Channel::AuxSwitchPos::LOW;
         }
 
         FuncState *st = state_for(f);
@@ -304,19 +340,18 @@ void AP_RC_Logic::update()
             continue;  // no free slot (more distinct funcs than terms)
         }
 
-        // debounce: a changed raw value must settle before it is committed
-        if (raw == st->committed) {
-            st->candidate = raw;  // nothing pending
+        // debounce: a changed position must settle before it is committed
+        const uint8_t tpos = (uint8_t)target;
+        if (tpos == st->committed_pos) {
+            st->candidate_pos = tpos;  // nothing pending
             continue;
         }
-        if (st->candidate != raw) {
-            st->candidate = raw;
+        if (st->candidate_pos != tpos) {
+            st->candidate_pos = tpos;
             st->since_ms = now_ms;
         } else if (now_ms - st->since_ms >= AP_RC_LOGIC_DEBOUNCE_MS) {
-            st->committed = raw;
-            const auto pos = raw ? RC_Channel::AuxSwitchPos::HIGH
-                                 : RC_Channel::AuxSwitchPos::LOW;
-            rc().run_aux_function(f, pos,
+            st->committed_pos = tpos;
+            rc().run_aux_function(f, target,
                                   RC_Channel::AuxFuncTrigger::Source::LOGIC, i);
         }
     }

--- a/libraries/AP_RC_Logic/AP_RC_Logic.cpp
+++ b/libraries/AP_RC_Logic/AP_RC_Logic.cpp
@@ -195,7 +195,9 @@ AP_RC_Logic::FuncState *AP_RC_Logic::state_for(RC_Channel::AUX_FUNC f)
     if (first_free != nullptr) {
         first_free->func = (uint16_t)f;
         first_free->committed_pos = (uint8_t)RC_Channel::AuxSwitchPos::LOW;
+        first_free->committed_level = 0;
         first_free->candidate_pos = (uint8_t)RC_Channel::AuxSwitchPos::LOW;
+        first_free->candidate_level = 0;
         first_free->since_ms = 0;
     }
     return first_free;
@@ -273,35 +275,38 @@ void AP_RC_Logic::update()
 
         const bool arm_func = is_arm_function(f);
 
-        // A row may request a specific output position (OPT bits 4-5) to drive
-        // a multi-position function (e.g. VTX power) to a chosen level. If any
-        // row for this function does so, the function runs in "selector" mode:
-        // the lowest-index active row wins and drives its position; if none is
-        // active the position is LOW. Otherwise the classic boolean AND/OR
-        // combine is used. Arm functions are always strictly boolean
-        // (HIGH = arm, LOW = disarm) and never enter selector mode.
+        // A row may set a specific output level (OPT bit 4 = level mode, bits
+        // 5-7 = level index) to drive a multi-level function (e.g. VTX power) to
+        // a chosen level. If any row for this function does so the function runs
+        // in "selector" mode: the lowest-index active row wins and drives its
+        // level; if none is active the output is LOW/off. Otherwise the classic
+        // boolean AND/OR combine is used. Arm functions are always strictly
+        // boolean (HIGH = arm, LOW = disarm) and never enter selector mode.
         bool selector = false;
         if (!arm_func) {
             for (uint8_t j = i; j < AP_RC_LOGIC_NUM_TERMS; j++) {
                 if (terms[j].enabled() && terms[j].func() == f &&
-                    terms[j].has_output_position()) {
+                    terms[j].uses_level()) {
                     selector = true;
                     break;
                 }
             }
         }
 
-        RC_Channel::AuxSwitchPos target;
+        RC_Channel::AuxSwitchPos target_pos = RC_Channel::AuxSwitchPos::LOW;
+        uint8_t target_level = 0;
         if (selector) {
-            target = RC_Channel::AuxSwitchPos::LOW;
             for (uint8_t j = i; j < AP_RC_LOGIC_NUM_TERMS; j++) {
                 const Term &tj = terms[j];
                 if (!tj.enabled() || tj.func() != f) {
                     continue;
                 }
                 if (eval_term(tj)) {
-                    // priority: the first (lowest-index) active row wins
-                    target = tj.output_position();
+                    // priority: the first (lowest-index) active row wins. Emit
+                    // HIGH plus the row's one-based level so a multi-level
+                    // target selects that exact level.
+                    target_pos = RC_Channel::AuxSwitchPos::HIGH;
+                    target_level = tj.output_level() + 1;
                     break;
                 }
             }
@@ -331,8 +336,8 @@ void AP_RC_Logic::update()
             if (raw && arm_func && !rc_valid) {
                 raw = false;
             }
-            target = raw ? RC_Channel::AuxSwitchPos::HIGH
-                         : RC_Channel::AuxSwitchPos::LOW;
+            target_pos = raw ? RC_Channel::AuxSwitchPos::HIGH
+                             : RC_Channel::AuxSwitchPos::LOW;
         }
 
         FuncState *st = state_for(f);
@@ -340,19 +345,23 @@ void AP_RC_Logic::update()
             continue;  // no free slot (more distinct funcs than terms)
         }
 
-        // debounce: a changed position must settle before it is committed
-        const uint8_t tpos = (uint8_t)target;
-        if (tpos == st->committed_pos) {
+        // debounce: a changed (position, level) must settle before committing
+        const uint8_t tpos = (uint8_t)target_pos;
+        if (tpos == st->committed_pos && target_level == st->committed_level) {
             st->candidate_pos = tpos;  // nothing pending
+            st->candidate_level = target_level;
             continue;
         }
-        if (st->candidate_pos != tpos) {
+        if (st->candidate_pos != tpos || st->candidate_level != target_level) {
             st->candidate_pos = tpos;
+            st->candidate_level = target_level;
             st->since_ms = now_ms;
         } else if (now_ms - st->since_ms >= AP_RC_LOGIC_DEBOUNCE_MS) {
             st->committed_pos = tpos;
-            rc().run_aux_function(f, target,
-                                  RC_Channel::AuxFuncTrigger::Source::LOGIC, i);
+            st->committed_level = target_level;
+            rc().run_aux_function(f, target_pos,
+                                  RC_Channel::AuxFuncTrigger::Source::LOGIC, i,
+                                  target_level);
         }
     }
 }

--- a/libraries/AP_RC_Logic/AP_RC_Logic.cpp
+++ b/libraries/AP_RC_Logic/AP_RC_Logic.cpp
@@ -1,0 +1,332 @@
+#include "AP_RC_Logic.h"
+
+#if AP_RC_LOGIC_ENABLED
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_Notify/AP_Notify.h>
+
+extern const AP_HAL::HAL& hal;
+
+// a settling term must hold its new value this long before it is committed
+#define AP_RC_LOGIC_DEBOUNCE_MS 40
+
+// Term::var_info lives in AP_RC_Logic_Term.cpp (see the @Path below)
+
+const AP_Param::GroupInfo AP_RC_Logic::var_info[] = {
+    // @Param: _ENABLE
+    // @DisplayName: RC logic engine enable
+    // @Description: Enable the RC logic / range-function engine
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Standard
+    AP_GROUPINFO_FLAGS("_ENABLE", 0, AP_RC_Logic, enable, 0, AP_PARAM_FLAG_ENABLE),
+
+    // @Group: 1_
+    // @Path: AP_RC_Logic_Term.cpp
+    AP_SUBGROUPINFO(terms[0],  "1_",  1,  AP_RC_Logic, AP_RC_Logic::Term),
+    // @Group: 2_
+    // @Path: AP_RC_Logic_Term.cpp
+    AP_SUBGROUPINFO(terms[1],  "2_",  2,  AP_RC_Logic, AP_RC_Logic::Term),
+    // @Group: 3_
+    // @Path: AP_RC_Logic_Term.cpp
+    AP_SUBGROUPINFO(terms[2],  "3_",  3,  AP_RC_Logic, AP_RC_Logic::Term),
+    // @Group: 4_
+    // @Path: AP_RC_Logic_Term.cpp
+    AP_SUBGROUPINFO(terms[3],  "4_",  4,  AP_RC_Logic, AP_RC_Logic::Term),
+    // @Group: 5_
+    // @Path: AP_RC_Logic_Term.cpp
+    AP_SUBGROUPINFO(terms[4],  "5_",  5,  AP_RC_Logic, AP_RC_Logic::Term),
+    // @Group: 6_
+    // @Path: AP_RC_Logic_Term.cpp
+    AP_SUBGROUPINFO(terms[5],  "6_",  6,  AP_RC_Logic, AP_RC_Logic::Term),
+    // @Group: 7_
+    // @Path: AP_RC_Logic_Term.cpp
+    AP_SUBGROUPINFO(terms[6],  "7_",  7,  AP_RC_Logic, AP_RC_Logic::Term),
+    // @Group: 8_
+    // @Path: AP_RC_Logic_Term.cpp
+    AP_SUBGROUPINFO(terms[7],  "8_",  8,  AP_RC_Logic, AP_RC_Logic::Term),
+    // @Group: 9_
+    // @Path: AP_RC_Logic_Term.cpp
+    AP_SUBGROUPINFO(terms[8],  "9_",  9,  AP_RC_Logic, AP_RC_Logic::Term),
+    // @Group: 10_
+    // @Path: AP_RC_Logic_Term.cpp
+    AP_SUBGROUPINFO(terms[9],  "10_", 10, AP_RC_Logic, AP_RC_Logic::Term),
+    // @Group: 11_
+    // @Path: AP_RC_Logic_Term.cpp
+    AP_SUBGROUPINFO(terms[10], "11_", 11, AP_RC_Logic, AP_RC_Logic::Term),
+    // @Group: 12_
+    // @Path: AP_RC_Logic_Term.cpp
+    AP_SUBGROUPINFO(terms[11], "12_", 12, AP_RC_Logic, AP_RC_Logic::Term),
+
+    AP_GROUPEND
+};
+
+AP_RC_Logic *AP_RC_Logic::_singleton;
+
+AP_RC_Logic::AP_RC_Logic()
+{
+    _singleton = this;
+    AP_Param::setup_object_defaults(this, var_info);
+    // runtime (non-parameter) state must start cleared
+    memset(_states, 0, sizeof(_states));
+}
+
+// ARM-class functions (those that arm the vehicle on their HIGH edge) are
+// treated conservatively: range terms only (never links or conditions),
+// negate ignored, and only honoured with valid RC input.
+static bool is_arm_function(RC_Channel::AUX_FUNC f)
+{
+    switch (f) {
+    case RC_Channel::AUX_FUNC::ARMDISARM:
+    case RC_Channel::AUX_FUNC::ARMDISARM_AIRMODE:
+    case RC_Channel::AUX_FUNC::ARM_EMERGENCY_STOP:
+        return true;
+    default:
+        return false;
+    }
+}
+
+// functions whose LOW edge is a motor-affecting transition that must not be
+// emitted implicitly when a slot is released on reconfiguration
+static bool low_edge_affects_motors(RC_Channel::AUX_FUNC f)
+{
+    // arm functions LOW = disarm; ARM_EMERGENCY_STOP LOW also = motor e-stop
+    if (is_arm_function(f)) {
+        return true;
+    }
+    // MOTOR_ESTOP LOW clears the e-stop, which can let motors spin
+    return f == RC_Channel::AUX_FUNC::MOTOR_ESTOP;
+}
+
+bool AP_RC_Logic::eval_condition(Condition c) const
+{
+    const AP_Notify &notify = AP::notify();
+    switch (c) {
+    case Condition::RC_FAILSAFE:
+        return notify.flags.failsafe_radio;
+    case Condition::BATTERY_FAILSAFE:
+        return notify.flags.failsafe_battery;
+    case Condition::GCS_FAILSAFE:
+        return notify.flags.failsafe_gcs;
+    case Condition::EKF_FAILSAFE:
+        return notify.flags.failsafe_ekf;
+    case Condition::ARMED:
+        return hal.util->get_soft_armed();
+    }
+    return false;
+}
+
+bool AP_RC_Logic::committed_state(RC_Channel::AUX_FUNC f) const
+{
+    // func 0 doubles as the "unused slot" marker, so never match on it
+    if (f == RC_Channel::AUX_FUNC::DO_NOTHING) {
+        return false;
+    }
+    for (uint8_t i = 0; i < AP_RC_LOGIC_NUM_TERMS; i++) {
+        if (_states[i].func == (uint16_t)f) {
+            return _states[i].committed;
+        }
+    }
+    return false;
+}
+
+bool AP_RC_Logic::func_has_link_term(RC_Channel::AUX_FUNC f) const
+{
+    for (uint8_t i = 0; i < AP_RC_LOGIC_NUM_TERMS; i++) {
+        if (terms[i].enabled() && terms[i].func() == f &&
+            terms[i].source_type() == Term::SourceType::LINK) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// raw (pre-debounce) truth of a single term
+bool AP_RC_Logic::eval_term(const Term &t) const
+{
+    bool v = false;
+    switch (t.source_type()) {
+    case Term::SourceType::RANGE: {
+        const int16_t ch = t.source.get();
+        if (ch >= 1 && ch <= NUM_RC_CHANNELS) {
+            const RC_Channel *c = rc().channel(ch - 1);
+            if (c != nullptr) {
+                const uint16_t pwm = c->get_radio_in();
+                if (pwm >= RC_Channel::RC_MIN_LIMIT_PWM &&
+                    pwm <= RC_Channel::RC_MAX_LIMIT_PWM) {
+                    v = pwm >= t.pwm_min.get() && pwm <= t.pwm_max.get();
+                }
+            }
+        }
+        break;
+    }
+    case Term::SourceType::LINK: {
+        const auto watched = (RC_Channel::AUX_FUNC)t.source.get();
+        // Betaflight rule: a link may not reference a link-driven function,
+        // and never an arming function. This blocks chains and cycles.
+        if (!is_arm_function(watched) && !func_has_link_term(watched)) {
+            v = committed_state(watched);
+        }
+        break;
+    }
+    case Term::SourceType::CONDITION:
+        v = eval_condition((Condition)t.source.get());
+        break;
+    }
+    // never invert an arming term: a negated range would be "active" at
+    // centre stick and at boot, which must not be able to request arm
+    if (t.negated() && !is_arm_function(t.func())) {
+        v = !v;
+    }
+    return v;
+}
+
+AP_RC_Logic::FuncState *AP_RC_Logic::state_for(RC_Channel::AUX_FUNC f)
+{
+    FuncState *first_free = nullptr;
+    for (uint8_t i = 0; i < AP_RC_LOGIC_NUM_TERMS; i++) {
+        if (_states[i].func == (uint16_t)f) {
+            return &_states[i];
+        }
+        if (first_free == nullptr && _states[i].func == 0) {
+            first_free = &_states[i];
+        }
+    }
+    if (first_free != nullptr) {
+        first_free->func = (uint16_t)f;
+        first_free->committed = false;
+        first_free->candidate = false;
+        first_free->since_ms = 0;
+    }
+    return first_free;
+}
+
+void AP_RC_Logic::release_slot(FuncState &st)
+{
+    if (st.func != 0 && st.committed) {
+        const auto f = (RC_Channel::AUX_FUNC)st.func;
+        // Releasing drives the function LOW so latching outputs (relays) do
+        // not stay stuck on after a re-target or engine disable. Never do
+        // this for functions whose LOW edge affects the motors (arm =
+        // disarm, MOTOR_ESTOP LOW = clear e-stop): forcing that on a config
+        // change could cut motors in flight or let them spin unexpectedly.
+        // Genuine RC-loss disarm is handled by the has_valid_input gate
+        // while the term is still active.
+        if (!low_edge_affects_motors(f)) {
+            rc().run_aux_function(f, RC_Channel::AuxSwitchPos::LOW,
+                                  RC_Channel::AuxFuncTrigger::Source::LOGIC, 0);
+        }
+    }
+    st = FuncState{};
+}
+
+void AP_RC_Logic::update()
+{
+    if (!enable) {
+        // engine turned off: release any (non-arming) functions we were
+        // holding so latching outputs like relays do not stay stuck on
+        for (uint8_t i = 0; i < AP_RC_LOGIC_NUM_TERMS; i++) {
+            release_slot(_states[i]);
+        }
+        return;
+    }
+
+    const bool rc_valid = rc().has_valid_input();
+    const uint32_t now_ms = AP_HAL::millis();
+
+    // reclaim debounce slots whose function is no longer referenced by any
+    // enabled term, releasing the function so a runtime re-target frees the
+    // slot without leaving a stale committed state or a stuck output
+    for (uint8_t i = 0; i < AP_RC_LOGIC_NUM_TERMS; i++) {
+        if (_states[i].func == 0) {
+            continue;
+        }
+        bool referenced = false;
+        for (uint8_t j = 0; j < AP_RC_LOGIC_NUM_TERMS; j++) {
+            if (terms[j].enabled() && (uint16_t)terms[j].func() == _states[i].func) {
+                referenced = true;
+                break;
+            }
+        }
+        if (!referenced) {
+            release_slot(_states[i]);
+        }
+    }
+
+    for (uint8_t i = 0; i < AP_RC_LOGIC_NUM_TERMS; i++) {
+        const Term &ti = terms[i];
+        if (!ti.enabled()) {
+            continue;
+        }
+        // evaluate each distinct function once, at its first row
+        const RC_Channel::AUX_FUNC f = ti.func();
+        bool already_done = false;
+        for (uint8_t j = 0; j < i; j++) {
+            if (terms[j].enabled() && terms[j].func() == f) {
+                already_done = true;
+                break;
+            }
+        }
+        if (already_done) {
+            continue;
+        }
+
+        const bool arm_func = is_arm_function(f);
+
+        // combine all rows for this function using the Betaflight rule:
+        // active when all AND terms are true, or any OR term is true.
+        bool has_and = false, all_and = true, any_or = false;
+        for (uint8_t j = i; j < AP_RC_LOGIC_NUM_TERMS; j++) {
+            const Term &tj = terms[j];
+            if (!tj.enabled() || tj.func() != f) {
+                continue;
+            }
+            // arming functions honour range terms only
+            if (arm_func && tj.source_type() != Term::SourceType::RANGE) {
+                continue;
+            }
+            const bool v = eval_term(tj);
+            if (tj.combine_is_and()) {
+                has_and = true;
+                all_and = all_and && v;
+            } else {
+                any_or = any_or || v;
+            }
+        }
+        bool raw = (has_and && all_and) || any_or;
+
+        // ARM-class functions fail toward disarm without valid RC input.
+        if (raw && arm_func && !rc_valid) {
+            raw = false;
+        }
+
+        FuncState *st = state_for(f);
+        if (st == nullptr) {
+            continue;  // no free slot (more distinct funcs than terms)
+        }
+
+        // debounce: a changed raw value must settle before it is committed
+        if (raw == st->committed) {
+            st->candidate = raw;  // nothing pending
+            continue;
+        }
+        if (st->candidate != raw) {
+            st->candidate = raw;
+            st->since_ms = now_ms;
+        } else if (now_ms - st->since_ms >= AP_RC_LOGIC_DEBOUNCE_MS) {
+            st->committed = raw;
+            const auto pos = raw ? RC_Channel::AuxSwitchPos::HIGH
+                                 : RC_Channel::AuxSwitchPos::LOW;
+            rc().run_aux_function(f, pos,
+                                  RC_Channel::AuxFuncTrigger::Source::LOGIC, i);
+        }
+    }
+}
+
+namespace AP {
+    AP_RC_Logic &rc_logic()
+    {
+        return *AP_RC_Logic::get_singleton();
+    }
+};
+
+#endif  // AP_RC_LOGIC_ENABLED

--- a/libraries/AP_RC_Logic/AP_RC_Logic.h
+++ b/libraries/AP_RC_Logic/AP_RC_Logic.h
@@ -57,23 +57,17 @@ public:
         }
         bool combine_is_and() const { return (options.get() & 0x4) != 0; }
         bool negated() const { return (options.get() & 0x8) != 0; }
-        // Output aux position emitted when this row is active, encoded in
-        // options bits 4-5: 0=HIGH (default), 1=MIDDLE, 2=LOW. This lets a row
-        // drive a multi-position function (e.g. VTX power low/mid/high) to a
-        // specific level instead of a plain on/off. Any row with a non-default
-        // (non-HIGH) output position puts the whole function into "selector"
-        // mode: the lowest-index active row wins and drives its position.
-        RC_Channel::AuxSwitchPos output_position() const {
-            switch ((options.get() >> 4) & 0x3) {
-            case 1:  return RC_Channel::AuxSwitchPos::MIDDLE;
-            case 2:  return RC_Channel::AuxSwitchPos::LOW;
-            default: return RC_Channel::AuxSwitchPos::HIGH;
-            }
-        }
-        bool has_output_position() const { return ((options.get() >> 4) & 0x3) != 0; }
+        // Output level selection for multi-level targets. Options bit 4 enables
+        // level mode; bits 5-7 hold a zero-based level index. In level mode an
+        // active row drives the target function to that specific level (for VTX
+        // power, the one-based table power index) instead of a plain on/off.
+        // Any row using level mode puts the whole function into "selector" mode:
+        // the lowest-index active row wins and drives its level.
+        bool uses_level() const { return (options.get() & 0x10) != 0; }
+        uint8_t output_level() const { return (options.get() >> 5) & 0x7; }
 
         AP_Int16 function;   // target AUX_FUNC (0 = row disabled)
-        AP_Int16 options;    // packed: type(0-1), combine(2), negate(3), outpos(4-5)
+        AP_Int16 options;    // packed: type(0-1), combine(2), negate(3), levelmode(4), level(5-7)
         AP_Int16 source;     // channel / watched func / condition id
         AP_Int16 pwm_min;
         AP_Int16 pwm_max;
@@ -87,10 +81,12 @@ private:
 
     // per-function debounce + committed state, keyed by target AUX_FUNC
     struct FuncState {
-        uint16_t func;         // AUX_FUNC, 0 = slot unused
-        uint8_t committed_pos; // last emitted position (RC_Channel::AuxSwitchPos)
-        uint8_t candidate_pos; // position currently settling
-        uint32_t since_ms;     // when the candidate first appeared
+        uint16_t func;           // AUX_FUNC, 0 = slot unused
+        uint8_t committed_pos;   // last emitted position (RC_Channel::AuxSwitchPos)
+        uint8_t committed_level; // last emitted level (0 = none)
+        uint8_t candidate_pos;   // position currently settling
+        uint8_t candidate_level; // level currently settling
+        uint32_t since_ms;       // when the candidate first appeared
     } _states[AP_RC_LOGIC_NUM_TERMS];
 
     // raw evaluation of a single term (no debounce)

--- a/libraries/AP_RC_Logic/AP_RC_Logic.h
+++ b/libraries/AP_RC_Logic/AP_RC_Logic.h
@@ -57,9 +57,23 @@ public:
         }
         bool combine_is_and() const { return (options.get() & 0x4) != 0; }
         bool negated() const { return (options.get() & 0x8) != 0; }
+        // Output aux position emitted when this row is active, encoded in
+        // options bits 4-5: 0=HIGH (default), 1=MIDDLE, 2=LOW. This lets a row
+        // drive a multi-position function (e.g. VTX power low/mid/high) to a
+        // specific level instead of a plain on/off. Any row with a non-default
+        // (non-HIGH) output position puts the whole function into "selector"
+        // mode: the lowest-index active row wins and drives its position.
+        RC_Channel::AuxSwitchPos output_position() const {
+            switch ((options.get() >> 4) & 0x3) {
+            case 1:  return RC_Channel::AuxSwitchPos::MIDDLE;
+            case 2:  return RC_Channel::AuxSwitchPos::LOW;
+            default: return RC_Channel::AuxSwitchPos::HIGH;
+            }
+        }
+        bool has_output_position() const { return ((options.get() >> 4) & 0x3) != 0; }
 
         AP_Int16 function;   // target AUX_FUNC (0 = row disabled)
-        AP_Int16 options;    // packed: type(0-1), combine(2), negate(3)
+        AP_Int16 options;    // packed: type(0-1), combine(2), negate(3), outpos(4-5)
         AP_Int16 source;     // channel / watched func / condition id
         AP_Int16 pwm_min;
         AP_Int16 pwm_max;
@@ -73,10 +87,10 @@ private:
 
     // per-function debounce + committed state, keyed by target AUX_FUNC
     struct FuncState {
-        uint16_t func;       // AUX_FUNC, 0 = slot unused
-        bool committed;      // last emitted (debounced) state
-        bool candidate;      // raw state currently settling
-        uint32_t since_ms;   // when the candidate first appeared
+        uint16_t func;         // AUX_FUNC, 0 = slot unused
+        uint8_t committed_pos; // last emitted position (RC_Channel::AuxSwitchPos)
+        uint8_t candidate_pos; // position currently settling
+        uint32_t since_ms;     // when the candidate first appeared
     } _states[AP_RC_LOGIC_NUM_TERMS];
 
     // raw evaluation of a single term (no debounce)

--- a/libraries/AP_RC_Logic/AP_RC_Logic.h
+++ b/libraries/AP_RC_Logic/AP_RC_Logic.h
@@ -1,0 +1,101 @@
+#pragma once
+
+#include "AP_RC_Logic_config.h"
+
+#if AP_RC_LOGIC_ENABLED
+
+#include <AP_Param/AP_Param.h>
+#include <RC_Channel/RC_Channel.h>
+
+/*
+  Table-driven engine that activates RC_Channel AUX_FUNCs from RC channel
+  PWM ranges and boolean combinations. See README.md for the full design
+  and the parameter-schema contract shared with the configurator.
+ */
+class AP_RC_Logic {
+public:
+    AP_RC_Logic();
+
+    CLASS_NO_COPY(AP_RC_Logic);
+
+    static AP_RC_Logic *get_singleton() { return _singleton; }
+
+    // evaluate all terms and drive aux functions; call once per RC frame
+    void update();
+
+    static const struct AP_Param::GroupInfo var_info[];
+
+    // AP-native conditions selectable by a CONDITION source term. These map
+    // directly onto existing ArduPilot state, not any Betaflight concept.
+    enum class Condition : uint8_t {
+        RC_FAILSAFE      = 0,
+        BATTERY_FAILSAFE = 1,
+        GCS_FAILSAFE     = 2,
+        EKF_FAILSAFE     = 3,
+        ARMED            = 4,
+    };
+
+    // one row of the logic table
+    class Term {
+    public:
+        Term();
+        static const struct AP_Param::GroupInfo var_info[];
+
+        // source category held in bits 0-1 of options
+        enum class SourceType : uint8_t {
+            RANGE     = 0,   // SRC is an RC channel, active when MIN<=pwm<=MAX
+            LINK      = 1,   // SRC is an AUX_FUNC, active when that func is active
+            CONDITION = 2,   // SRC is a condition id (failsafe, etc.)
+        };
+
+        bool enabled() const { return function.get() != 0; }
+        RC_Channel::AUX_FUNC func() const {
+            return (RC_Channel::AUX_FUNC)function.get();
+        }
+        SourceType source_type() const {
+            return (SourceType)(options.get() & 0x3);
+        }
+        bool combine_is_and() const { return (options.get() & 0x4) != 0; }
+        bool negated() const { return (options.get() & 0x8) != 0; }
+
+        AP_Int16 function;   // target AUX_FUNC (0 = row disabled)
+        AP_Int16 options;    // packed: type(0-1), combine(2), negate(3)
+        AP_Int16 source;     // channel / watched func / condition id
+        AP_Int16 pwm_min;
+        AP_Int16 pwm_max;
+    };
+
+private:
+    static AP_RC_Logic *_singleton;
+
+    AP_Int8 enable;
+    Term terms[AP_RC_LOGIC_NUM_TERMS];
+
+    // per-function debounce + committed state, keyed by target AUX_FUNC
+    struct FuncState {
+        uint16_t func;       // AUX_FUNC, 0 = slot unused
+        bool committed;      // last emitted (debounced) state
+        bool candidate;      // raw state currently settling
+        uint32_t since_ms;   // when the candidate first appeared
+    } _states[AP_RC_LOGIC_NUM_TERMS];
+
+    // raw evaluation of a single term (no debounce)
+    bool eval_term(const Term &t) const;
+    bool eval_condition(Condition c) const;
+    // committed state of a watched function, for link terms
+    bool committed_state(RC_Channel::AUX_FUNC f) const;
+    // true if any enabled term targets f with a LINK source
+    bool func_has_link_term(RC_Channel::AUX_FUNC f) const;
+    // find or allocate the debounce slot for a function
+    FuncState *state_for(RC_Channel::AUX_FUNC f);
+
+    // drive a slot's function to LOW (unless its LOW edge affects the motors)
+    // and clear the slot; used when a function stops being referenced
+    void release_slot(FuncState &st);
+};
+
+namespace AP {
+    AP_RC_Logic &rc_logic();
+};
+
+#endif  // AP_RC_LOGIC_ENABLED

--- a/libraries/AP_RC_Logic/AP_RC_Logic_Term.cpp
+++ b/libraries/AP_RC_Logic/AP_RC_Logic_Term.cpp
@@ -1,0 +1,54 @@
+#include "AP_RC_Logic.h"
+
+#if AP_RC_LOGIC_ENABLED
+
+// per-term parameters, kept in their own file so the parent @Group @Path can
+// point here rather than at the file that declares the group (which would
+// make the parameter documentation parser recurse). @CopyFieldsFrom pulls the
+// full AUX_FUNC value list into FUNC so the configurator and param docs stay
+// in sync with RCx_OPTION.
+const AP_Param::GroupInfo AP_RC_Logic::Term::var_info[] = {
+    // @Param: FUNC
+    // @DisplayName: RC logic target function
+    // @Description: Auxiliary function this table row activates (0 disables the row)
+    // @CopyFieldsFrom: RC1_OPTION
+    AP_GROUPINFO_FLAGS("FUNC", 1, AP_RC_Logic::Term, function, 0, AP_PARAM_FLAG_ENABLE),
+
+    // @Param: OPT
+    // @DisplayName: RC logic term options
+    // @Description: Packed options for this row
+    // @Bitmask: 0:SourceTypeBit0,1:SourceTypeBit1,2:CombineAND,3:Negate
+    // @User: Advanced
+    AP_GROUPINFO("OPT", 2, AP_RC_Logic::Term, options, 0),
+
+    // @Param: SRC
+    // @DisplayName: RC logic term source
+    // @Description: Meaning depends on source type - RC channel (1-16) for a range term, watched function for a link term, or condition id for a condition term
+    // @User: Advanced
+    AP_GROUPINFO("SRC", 3, AP_RC_Logic::Term, source, 0),
+
+    // @Param: MIN
+    // @DisplayName: RC logic range low
+    // @Description: Lower PWM bound for a range term
+    // @Units: PWM
+    // @Range: 800 2200
+    // @User: Advanced
+    AP_GROUPINFO("MIN", 4, AP_RC_Logic::Term, pwm_min, 1700),
+
+    // @Param: MAX
+    // @DisplayName: RC logic range high
+    // @Description: Upper PWM bound for a range term
+    // @Units: PWM
+    // @Range: 800 2200
+    // @User: Advanced
+    AP_GROUPINFO("MAX", 5, AP_RC_Logic::Term, pwm_max, 2100),
+
+    AP_GROUPEND
+};
+
+AP_RC_Logic::Term::Term()
+{
+    AP_Param::setup_object_defaults(this, var_info);
+}
+
+#endif  // AP_RC_LOGIC_ENABLED

--- a/libraries/AP_RC_Logic/AP_RC_Logic_Term.cpp
+++ b/libraries/AP_RC_Logic/AP_RC_Logic_Term.cpp
@@ -16,8 +16,8 @@ const AP_Param::GroupInfo AP_RC_Logic::Term::var_info[] = {
 
     // @Param: OPT
     // @DisplayName: RC logic term options
-    // @Description: Packed options for this row. Bits 0-1 are the source type (0 range, 1 link, 2 condition), bit 2 combines this row with AND (else OR), bit 3 negates it. Bits 4-5 set the output position emitted when the row is active for a multi-position target (0 HIGH, 1 MIDDLE, 2 LOW); any row using a non-HIGH position puts the whole function into selector mode where the lowest-numbered active row drives its position (e.g. low/mid/high VTX power).
-    // @Bitmask: 0:SourceTypeBit0,1:SourceTypeBit1,2:CombineAND,3:Negate,4:OutPosBit0,5:OutPosBit1
+    // @Description: Packed options for this row. Bits 0-1 are the source type (0 range, 1 link, 2 condition), bit 2 combines this row with AND (else OR), bit 3 negates it. Bit 4 enables level mode and bits 5-7 hold a zero-based level index: when active such a row drives a multi-level target to that specific level (for VTX power, the table power level index) instead of a plain on/off. Any row using level mode puts the whole function into selector mode where the lowest-numbered active row drives its level.
+    // @Bitmask: 0:SourceTypeBit0,1:SourceTypeBit1,2:CombineAND,3:Negate,4:LevelMode,5:LevelBit0,6:LevelBit1,7:LevelBit2
     // @User: Advanced
     AP_GROUPINFO("OPT", 2, AP_RC_Logic::Term, options, 0),
 

--- a/libraries/AP_RC_Logic/AP_RC_Logic_Term.cpp
+++ b/libraries/AP_RC_Logic/AP_RC_Logic_Term.cpp
@@ -16,8 +16,8 @@ const AP_Param::GroupInfo AP_RC_Logic::Term::var_info[] = {
 
     // @Param: OPT
     // @DisplayName: RC logic term options
-    // @Description: Packed options for this row
-    // @Bitmask: 0:SourceTypeBit0,1:SourceTypeBit1,2:CombineAND,3:Negate
+    // @Description: Packed options for this row. Bits 0-1 are the source type (0 range, 1 link, 2 condition), bit 2 combines this row with AND (else OR), bit 3 negates it. Bits 4-5 set the output position emitted when the row is active for a multi-position target (0 HIGH, 1 MIDDLE, 2 LOW); any row using a non-HIGH position puts the whole function into selector mode where the lowest-numbered active row drives its position (e.g. low/mid/high VTX power).
+    // @Bitmask: 0:SourceTypeBit0,1:SourceTypeBit1,2:CombineAND,3:Negate,4:OutPosBit0,5:OutPosBit1
     // @User: Advanced
     AP_GROUPINFO("OPT", 2, AP_RC_Logic::Term, options, 0),
 

--- a/libraries/AP_RC_Logic/AP_RC_Logic_config.h
+++ b/libraries/AP_RC_Logic/AP_RC_Logic_config.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <AP_HAL/AP_HAL_Boards.h>
+#include <RC_Channel/RC_Channel_config.h>
+
+#ifndef AP_RC_LOGIC_ENABLED
+#define AP_RC_LOGIC_ENABLED AP_RC_CHANNEL_ENABLED
+#endif
+
+#ifndef AP_RC_LOGIC_NUM_TERMS
+#define AP_RC_LOGIC_NUM_TERMS 12
+#endif

--- a/libraries/AP_RC_Logic/README.md
+++ b/libraries/AP_RC_Logic/README.md
@@ -32,7 +32,7 @@ Registered on `AP_Vehicle` as subgroup `RCL` (index 33). One `_ENABLE` plus
 |--------------|-----------|---------|
 | `RCL_ENABLE` | Int8      | 0 = engine off, 1 = on |
 | `RCL<n>_FUNC`| Int16     | target `AUX_FUNC` (0 = row disabled). Reuses the `RCx_OPTION` value list. |
-| `RCL<n>_OPT` | Int16     | packed flags — bits 0-1 source type (0 range, 1 link, 2 condition), bit 2 combine (0 OR, 1 AND), bit 3 negate |
+| `RCL<n>_OPT` | Int16     | packed flags — bits 0-1 source type (0 range, 1 link, 2 condition), bit 2 combine (0 OR, 1 AND), bit 3 negate, bits 4-5 output position (0 HIGH, 1 MIDDLE, 2 LOW) |
 | `RCL<n>_SRC` | Int16     | range → RC channel 1-16; link → watched `AUX_FUNC`; condition → condition id |
 | `RCL<n>_MIN` | Int16     | range: PWM low bound |
 | `RCL<n>_MAX` | Int16     | range: PWM high bound |
@@ -81,6 +81,21 @@ Per RC frame, for each distinct `FUNC` referenced by an enabled term:
    `active = (has AND terms AND all AND terms true) OR (any OR term true)`.
 3. Debounce the combined result, then on a state edge invoke
    `run_aux_function(FUNC, active ? HIGH : LOW, Source::LOGIC)`.
+
+### Output position / selector mode
+By default a function is boolean: active rows drive it HIGH, otherwise LOW.
+A row may instead request a specific **output position** via `OPT` bits 4-5
+(0 HIGH, 1 MIDDLE, 2 LOW) so it can drive a **multi-position** target — for
+example VTX power low/mid/high — to a chosen level rather than just on/off.
+
+If any row for a function uses a non-default (non-HIGH) output position, that
+function switches to **selector** mode: the AND/OR combine is skipped and the
+**lowest-numbered active row wins**, driving its output position; if no row is
+active the position is LOW. This gives condition- or range-driven multi-level
+output (e.g. `RC_FAILSAFE` → LOW power, low battery → MIDDLE, normal → HIGH),
+which the boolean combine cannot express. Positions map onto the target's aux
+handler exactly as a physical 3-position switch would. Arm functions are
+always boolean and never enter selector mode.
 
 ### Links and cycles
 A link term may reference only a **range-driven** function, never another

--- a/libraries/AP_RC_Logic/README.md
+++ b/libraries/AP_RC_Logic/README.md
@@ -32,7 +32,7 @@ Registered on `AP_Vehicle` as subgroup `RCL` (index 33). One `_ENABLE` plus
 |--------------|-----------|---------|
 | `RCL_ENABLE` | Int8      | 0 = engine off, 1 = on |
 | `RCL<n>_FUNC`| Int16     | target `AUX_FUNC` (0 = row disabled). Reuses the `RCx_OPTION` value list. |
-| `RCL<n>_OPT` | Int16     | packed flags — bits 0-1 source type (0 range, 1 link, 2 condition), bit 2 combine (0 OR, 1 AND), bit 3 negate, bits 4-5 output position (0 HIGH, 1 MIDDLE, 2 LOW) |
+| `RCL<n>_OPT` | Int16     | packed flags — bits 0-1 source type (0 range, 1 link, 2 condition), bit 2 combine (0 OR, 1 AND), bit 3 negate, bit 4 level mode, bits 5-7 level index (0-7) |
 | `RCL<n>_SRC` | Int16     | range → RC channel 1-16; link → watched `AUX_FUNC`; condition → condition id |
 | `RCL<n>_MIN` | Int16     | range: PWM low bound |
 | `RCL<n>_MAX` | Int16     | range: PWM high bound |
@@ -50,7 +50,7 @@ mapping, several terms can share one channel with different ranges to select
 different functions or flight modes, exactly like a Betaflight range group.
 For example, on channel 6:
 
-```
+```text
 RCL1: FUNC=RTL(4)     SRC=6  MIN=1000 MAX=1300
 RCL2: FUNC=Loiter(?)  SRC=6  MIN=1400 MAX=1600
 RCL3: FUNC=Fence(11)  SRC=6  MIN=1800 MAX=2100
@@ -82,22 +82,30 @@ Per RC frame, for each distinct `FUNC` referenced by an enabled term:
 3. Debounce the combined result, then on a state edge invoke
    `run_aux_function(FUNC, active ? HIGH : LOW, Source::LOGIC)`.
 
-### Output position / selector mode
-By default a function is boolean: active rows drive it HIGH, otherwise LOW.
-A row may instead request a specific **output position** via `OPT` bits 4-5
-(0 HIGH, 1 MIDDLE, 2 LOW) so it can drive a **multi-position** target — for
-example VTX power low/mid/high — to a chosen level rather than just on/off.
+### Output level / selector mode
 
-If any row for a function uses a non-default (non-HIGH) output position, that
-function switches to **selector** mode: the AND/OR combine is skipped and the
-**lowest-numbered active row wins**, driving its output position; if no row is
-active the position is LOW. This gives condition- or range-driven multi-level
-output (e.g. `RC_FAILSAFE` → LOW power, low battery → MIDDLE, normal → HIGH),
-which the boolean combine cannot express. Positions map onto the target's aux
-handler exactly as a physical 3-position switch would. Arm functions are
-always boolean and never enter selector mode.
+By default a function is boolean: active rows drive it HIGH, otherwise LOW.
+A row may instead select a specific **output level** via `OPT` bit 4 (level
+mode) and bits 5-7 (a **zero-based** level index 0-7), so it can drive a
+**multi-level** target — for example VTX power — to an exact level rather than
+just on/off. The index stored in `OPT` is zero-based; the engine emits it
+**one-based** to the target (`run_aux_function` `level = index + 1`). For VTX
+power, index `i` selects the `i`-th supported (non-zero) power level in the
+order the `@VTX` power table lists them — so with a 25/400/800/1600 mW table,
+index 0 = 25 mW … index 3 = 1600 mW. This lets a row pick *any* table level,
+not just a coarse low/mid/high.
+
+If any row for a function uses level mode, that function switches to
+**selector** mode: the AND/OR combine is skipped and the **lowest-numbered
+active row wins**, driving its level (emitted as `run_aux_function` HIGH with a
+one-based `level`); if no row is active the output is LOW/off. This gives
+condition- or range-driven multi-level output (e.g. `RC_FAILSAFE` → level 0
+power, low battery → level 1, normal → top level), and lets you spread levels
+across several rows/switches — one row per level. Arm functions are always
+boolean and never enter selector mode.
 
 ### Links and cycles
+
 A link term may reference only a **range-driven** function, never another
 link-driven one. This is Betaflight's own restriction and it guarantees a
 single evaluation level with no cycles.
@@ -130,29 +138,39 @@ motor/throttle functions are supported as targets but with hard constraints:
   channel, **never a spring-return stick**, or the vehicle will disarm the
   moment the stick returns to centre.
 
-## Example: reduce VTX power on RC failsafe
+## Example: multi-level VTX power
 
-`VTX_POWER` (94) is now driveable through `run_aux_function`, so the engine
-(and scripting/MAVLink) can set it — previously it was only readable from a
-physical 6-position switch. The engine only ever emits HIGH or LOW, so it
-drives VTX to maximum (HIGH) or minimum (LOW) power via
-`AP_VideoTX::change_power`; the intermediate steps are only reachable from a
-physical switch or scripting. The minimum step enters pit mode only while
-disarmed; ArduPilot never enters pit mode while armed, so in flight the
-minimum drops to the lowest configured non-zero power level (video is not
-fully cut in the air).
+`VTX_POWER` (94) is driveable through `run_aux_function`, so the engine (and
+scripting/MAVLink) can set it — previously it was only readable from a physical
+6-position switch. In **level mode** a row selects an *exact* supported power
+level (`OPT` bit 4 set, zero-based index in bits 5-7), so the engine can reach
+any of the `@VTX` table's levels, not just on/off. Any row using level mode
+puts the function into selector mode: the lowest-numbered active row wins.
 
-Express "full power normally, minimum on RC failsafe" with a single
-negated condition term:
+**Range → level** — a switch position on channel 7 picks a power level (three
+rows, one per level, non-overlapping ranges):
 
-```
-RCL1_FUNC = 94     # VTX_POWER
-RCL1_OPT  = 0x0A   # condition source (2) + negate (8)
-RCL1_SRC  = 0      # condition 0 = RC failsafe
+```text
+RCL1_FUNC=94  RCL1_OPT=0x10        RCL1_SRC=7  RCL1_MIN=900   RCL1_MAX=1285   # low pos  -> level 0
+RCL2_FUNC=94  RCL2_OPT=0x10|0x20   RCL2_SRC=7  RCL2_MIN=1300  RCL2_MAX=1700   # mid pos  -> level 1
+RCL3_FUNC=94  RCL3_OPT=0x10|0x40   RCL3_SRC=7  RCL3_MIN=1750  RCL3_MAX=2100   # high pos -> level 2
 ```
 
-Not in failsafe -> negated -> HIGH -> full power. In failsafe -> LOW ->
-minimum power. (Negate is allowed here; it is only forbidden on arming
+`OPT` = `0x10` (level mode) `| (index << 5)`: index 0 → `0x10`, 1 → `0x30`,
+2 → `0x50`, … Add more rows/channels for more levels — one row per level.
+
+**Condition → level** — reduce power on RC failsafe (a condition source instead
+of a range; the firmware supports this identically):
+
+```text
+RCL1_FUNC=94  RCL1_OPT=0x02|0x10        RCL1_SRC=0   # RC-failsafe cond -> level 0 (min), highest priority
+RCL2_FUNC=94  RCL2_OPT=0x02|0x08|0x10|0x40  RCL2_SRC=0   # NOT failsafe (negate) -> level 2 (normal)
+```
+
+Row 1 (RC failsafe) wins by priority and forces the lowest level; otherwise the
+negated row selects the normal level. The lowest configured non-zero level is
+used in flight — ArduPilot never enters pit mode while armed, so video is not
+fully cut in the air. (Negate is allowed here; it is only forbidden on arming
 terms.)
 
 ## Build / footprint

--- a/libraries/AP_RC_Logic/README.md
+++ b/libraries/AP_RC_Logic/README.md
@@ -1,0 +1,153 @@
+# AP_RC_Logic — RC logic / range-function engine
+
+A table-driven engine that activates ArduPilot auxiliary functions (`AUX_FUNC`)
+— flight modes and aux-function switches — from RC channel PWM ranges and
+boolean combinations of conditions, reusing the existing `RC_Channel`
+aux-function action set. It brings Betaflight-style range mapping and a modes
+model to ArduPilot for aux/mode switching only; it tunes no parameters and
+writes no other vehicle state.
+
+This document is the authoritative contract for the parameter schema. The
+[arduconfigurator](https://github.com/j-w9/arduconfigurator) UI binds to the
+parameters defined here; the firmware is the source of truth.
+
+## Concept
+
+Each row of the table maps a source to a target function:
+
+- a **channel PWM range** — *when channel X is in [min,max], activate function F*
+- a **link** to another function's state, or a **condition** (failsafe, armed …)
+
+Several rows may target the same function (combined with AND/OR) or share one
+channel with different ranges to select different functions or flight modes —
+the Betaflight "Modes" idea, expressed as one flat table of terms that a
+configurator can render rule-centric or function-centric.
+
+## Data model (parameter schema — indices are permanent)
+
+Registered on `AP_Vehicle` as subgroup `RCL` (index 33). One `_ENABLE` plus
+`AP_RC_LOGIC_NUM_TERMS` term instances named `RCL<n>_*`.
+
+| Param        | Type      | Meaning |
+|--------------|-----------|---------|
+| `RCL_ENABLE` | Int8      | 0 = engine off, 1 = on |
+| `RCL<n>_FUNC`| Int16     | target `AUX_FUNC` (0 = row disabled). Reuses the `RCx_OPTION` value list. |
+| `RCL<n>_OPT` | Int16     | packed flags — bits 0-1 source type (0 range, 1 link, 2 condition), bit 2 combine (0 OR, 1 AND), bit 3 negate |
+| `RCL<n>_SRC` | Int16     | range → RC channel 1-16; link → watched `AUX_FUNC`; condition → condition id |
+| `RCL<n>_MIN` | Int16     | range: PWM low bound |
+| `RCL<n>_MAX` | Int16     | range: PWM high bound |
+
+Term index `n` is 1-based. `RCL<n>_FUNC == 0` disables the whole row.
+
+The engine only ever activates existing `AUX_FUNC`s (modes and aux-function
+switches) through `run_aux_function` — the same path a physical switch uses.
+It does not write any other parameter or state.
+
+### Multiple functions/modes on one channel
+
+Because every term is an independent *(channel, PWM range) → function*
+mapping, several terms can share one channel with different ranges to select
+different functions or flight modes, exactly like a Betaflight range group.
+For example, on channel 6:
+
+```
+RCL1: FUNC=RTL(4)     SRC=6  MIN=1000 MAX=1300
+RCL2: FUNC=Loiter(?)  SRC=6  MIN=1400 MAX=1600
+RCL3: FUNC=Fence(11)  SRC=6  MIN=1800 MAX=2100
+```
+
+### Condition source ids (`SRC` when source type = condition)
+
+All map onto existing ArduPilot state — no Betaflight concepts:
+
+| id | condition |
+|----|-----------|
+| 0  | RC failsafe |
+| 1  | Battery failsafe |
+| 2  | GCS failsafe |
+| 3  | EKF failsafe |
+| 4  | Armed |
+
+## Evaluation semantics
+
+Per RC frame, for each distinct `FUNC` referenced by an enabled term:
+
+1. Evaluate each of that function's terms to a boolean:
+   - **range**: `MIN <= pwm(SRC) <= MAX`
+   - **link**: watched `AUX_FUNC` (`SRC`) is currently active
+   - **condition**: a named vehicle condition (failsafe, armed, etc.)
+   - apply `negate` if set.
+2. Combine (Betaflight rule): partition into AND-terms and OR-terms.
+   `active = (has AND terms AND all AND terms true) OR (any OR term true)`.
+3. Debounce the combined result, then on a state edge invoke
+   `run_aux_function(FUNC, active ? HIGH : LOW, Source::LOGIC)`.
+
+### Links and cycles
+A link term may reference only a **range-driven** function, never another
+link-driven one. This is Betaflight's own restriction and it guarantees a
+single evaluation level with no cycles.
+
+## Safety: ARM and motor-affecting functions
+
+ARM (`ARMDISARM`, `ARMDISARM_AIRMODE`, `ARM_EMERGENCY_STOP`) and other
+motor/throttle functions are supported as targets but with hard constraints:
+
+- The engine only ever **requests** arm by calling the normal
+  `run_aux_function` arm path — it runs every prearm/arm check, respects the
+  safety switch and throttle position, and never sets `armed` directly or
+  bypasses a check.
+- **ARM is range-only**: it can never be a link target or a link source. No
+  derived/chained arming. (Matches Betaflight.)
+- Arm terms are honoured only with valid, fresh RC input and are debounced;
+  **loss of valid RC input** while an arm term is active fails toward
+  **disarm**. Reconfiguring or disabling the engine does not force a disarm
+  (that would risk an in-flight motor cut and matches native `RCx_OPTION`
+  behaviour); the RC-loss path above remains the arming failsafe.
+- `negate` is ignored on arm terms (a negated range would be active at centre
+  stick and at boot).
+- When a slot is freed on reconfiguration the engine drives the function LOW
+  so latching outputs (relays) do not stick on — **except** for functions
+  whose LOW edge affects the motors (arm = disarm, `MOTOR_ESTOP` LOW = clear
+  e-stop). Those are never toggled implicitly.
+- Arming is **level/hold**, matching ArduPilot's native `ARMDISARM` aux
+  function: the vehicle stays armed only while the channel is inside the arm
+  range, and leaving the range disarms. Assign arm to a latching switch
+  channel, **never a spring-return stick**, or the vehicle will disarm the
+  moment the stick returns to centre.
+
+## Example: reduce VTX power on RC failsafe
+
+`VTX_POWER` (94) is now driveable through `run_aux_function`, so the engine
+(and scripting/MAVLink) can set it — previously it was only readable from a
+physical 6-position switch. The engine only ever emits HIGH or LOW, so it
+drives VTX to maximum (HIGH) or minimum (LOW) power via
+`AP_VideoTX::change_power`; the intermediate steps are only reachable from a
+physical switch or scripting. The minimum step enters pit mode only while
+disarmed; ArduPilot never enters pit mode while armed, so in flight the
+minimum drops to the lowest configured non-zero power level (video is not
+fully cut in the air).
+
+Express "full power normally, minimum on RC failsafe" with a single
+negated condition term:
+
+```
+RCL1_FUNC = 94     # VTX_POWER
+RCL1_OPT  = 0x0A   # condition source (2) + negate (8)
+RCL1_SRC  = 0      # condition 0 = RC failsafe
+```
+
+Not in failsafe -> negated -> HIGH -> full power. In failsafe -> LOW ->
+minimum power. (Negate is allowed here; it is only forbidden on arming
+terms.)
+
+## Build / footprint
+
+Guarded by `AP_RC_LOGIC_ENABLED` (see `AP_RC_Logic_config.h`) so it can be
+compiled out on flash-constrained (e.g. F4) boards. `AP_RC_LOGIC_NUM_TERMS`
+sets the table size (default 12) and trades flash/storage for capacity.
+
+## Scope
+
+The engine drives **mode and aux-function switching only** — it activates
+existing `AUX_FUNC`s from range/link/condition logic and writes nothing else.
+It deliberately does not tune parameters or touch any other vehicle state.

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -297,6 +297,11 @@ const AP_Param::GroupInfo AP_Vehicle::var_info[] = {
     // @Path: ../AP_Beacon/AP_Beacon.cpp
     AP_SUBGROUPINFO(beacon, "BCN", 33, AP_Vehicle, AP_Beacon),
 #endif  // AP_BEACON_ENABLED
+#if AP_RC_LOGIC_ENABLED
+    // @Group: RCL
+    // @Path: ../AP_RC_Logic/AP_RC_Logic.cpp
+    AP_SUBGROUPINFO(rc_logic, "RCL", 34, AP_Vehicle, AP_RC_Logic),
+#endif
 
     AP_GROUPEND
 };
@@ -699,6 +704,9 @@ const AP_Scheduler::Task AP_Vehicle::scheduler_tasks[] = {
 #endif
 #if AP_GRIPPER_ENABLED
     SCHED_TASK_CLASS(AP_Gripper,   &vehicle.gripper,        update,                   10,  75, 251),
+#endif
+#if AP_RC_LOGIC_ENABLED
+    SCHED_TASK_CLASS(AP_RC_Logic,  &vehicle.rc_logic,       update,                   50, 100, 251),
 #endif
     SCHED_TASK(one_Hz_update,                                                         1, 100, 252),
 #if HAL_WITH_ESC_TELEM && HAL_GYROFFT_ENABLED

--- a/libraries/AP_Vehicle/AP_Vehicle.h
+++ b/libraries/AP_Vehicle/AP_Vehicle.h
@@ -32,6 +32,7 @@
 #include <AP_BoardConfig/AP_BoardConfig.h>     // board configuration library
 #include <AP_CANManager/AP_CANManager.h>
 #include <AP_Button/AP_Button.h>
+#include <AP_RC_Logic/AP_RC_Logic.h>
 #include <AP_Compass/AP_Compass.h>
 #include <AP_EFI/AP_EFI.h>
 #include <AP_ExternalControl/AP_ExternalControl_config.h>
@@ -363,6 +364,9 @@ protected:
 #endif
 #if HAL_BUTTON_ENABLED
     AP_Button button;
+#endif
+#if AP_RC_LOGIC_ENABLED
+    AP_RC_Logic rc_logic;
 #endif
 #if AP_RANGEFINDER_ENABLED
     RangeFinder rangefinder;

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -1457,7 +1457,7 @@ void RC_Channel::do_aux_function_retract_mount(const AuxSwitchPos ch_flag, const
 }
 #endif  // HAL_MOUNT_ENABLED
 
-bool RC_Channel::run_aux_function(AUX_FUNC ch_option, AuxSwitchPos pos, AuxFuncTrigger::Source source, uint16_t source_index)
+bool RC_Channel::run_aux_function(AUX_FUNC ch_option, AuxSwitchPos pos, AuxFuncTrigger::Source source, uint16_t source_index, uint8_t level)
 {
 #if AP_SCRIPTING_ENABLED
     rc().set_aux_cached(ch_option, pos);
@@ -1468,6 +1468,7 @@ bool RC_Channel::run_aux_function(AUX_FUNC ch_option, AuxSwitchPos pos, AuxFuncT
         pos: pos,
         source: source,
         source_index: source_index,
+        level: level,
     };
 
     const bool ret = do_aux_function(trigger);

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -456,6 +456,7 @@ public:
             MAVLINK,   // Source index is MAVLink channel number
             MISSION,   // Source index is mission item index
             SCRIPTING, // Source index is not used (always 0)
+            LOGIC,     // Source index is the RC logic table term index
         } source;
         uint16_t source_index;
     };

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -459,6 +459,9 @@ public:
             LOGIC,     // Source index is the RC logic table term index
         } source;
         uint16_t source_index;
+        // optional one-based level for multi-level functions (e.g. VTX power
+        // index). 0 = unspecified, use pos. Only some functions honour it.
+        uint8_t level;
     };
 
     AuxSwitchPos get_aux_switch_pos() const;
@@ -467,7 +470,7 @@ public:
     AuxSwitchPos get_stick_gesture_pos() const;
 
     // wrapper function around do_aux_function which allows us to log
-    bool run_aux_function(AUX_FUNC ch_option, AuxSwitchPos pos, AuxFuncTrigger::Source source, uint16_t source_index);
+    bool run_aux_function(AUX_FUNC ch_option, AuxSwitchPos pos, AuxFuncTrigger::Source source, uint16_t source_index, uint8_t level = 0);
 
 #if AP_RC_CHANNEL_AUX_FUNCTION_STRINGS_ENABLED
     const char *string_for_aux_function(AUX_FUNC function) const;
@@ -730,8 +733,8 @@ public:
 
     // method for other parts of the system (e.g. Button and mavlink)
     // to trigger auxiliary functions
-    bool run_aux_function(RC_Channel::AUX_FUNC ch_option, RC_Channel::AuxSwitchPos pos, RC_Channel::AuxFuncTrigger::Source source, uint16_t source_index) {
-        return channel(0)->run_aux_function(ch_option, pos, source, source_index);
+    bool run_aux_function(RC_Channel::AUX_FUNC ch_option, RC_Channel::AuxSwitchPos pos, RC_Channel::AuxFuncTrigger::Source source, uint16_t source_index, uint8_t level = 0) {
+        return channel(0)->run_aux_function(ch_option, pos, source, source_index, level);
     }
 
     // check if flight mode channel is assigned RC option


### PR DESCRIPTION
### Summary
Adds `AP_RC_Logic`, a new library that activates existing `RC_Channel`
auxiliary functions (flight modes and aux-function switches) from a table of
RC channel PWM ranges combined with boolean logic. It brings a
Betaflight-style "modes" configuration model to ArduPilot while reusing the
existing `AUX_FUNC` action set: functions are driven only through the normal
`run_aux_function()` path, so the engine writes no other parameter or vehicle
state.

### How it works
- Each row targets an `AUX_FUNC` and contributes a range, link or condition term.
- Several rows may share a channel with different PWM ranges to select different
  functions or flight modes.
- Terms for a function combine with the Betaflight rule (all AND terms true, or
  any OR term true) with optional negation.
- Link terms track another function's state and, following Betaflight, may not
  reference an arming function or another link-driven function, so no cycles are
  possible.
- Condition terms read native ArduPilot state (RC, battery, GCS and EKF
  failsafe, armed). Results are debounced and driven on state edges.
- A row may also select an exact output level of a multi-level function
  (selector mode), so e.g. a single switch can drive VTX power to a specific
  level.

Arming functions (`ARMDISARM`, `ARMDISARM_AIRMODE`, `ARM_EMERGENCY_STOP`) are
handled conservatively: range terms only, negate ignored, honoured only with
valid RC input, failing toward disarm on RC loss, and always routed through the
standard arming checks.

The engine is guarded by `AP_RC_LOGIC_ENABLED`, runs at 50Hz from `AP_Vehicle`,
and is available to all vehicles. See `libraries/AP_RC_Logic/README.md` for the
parameter schema.

### Testing
- New autotest `test.Copter.RCLogic` exercises the LOGIC aux source, boolean and
  selector terms, output-level selection, mode switching, and held-function
  release on disable and re-target. It is vehicle- and function-agnostic.
- Builds clean for SITL.

### Notes
This is a sizeable new subsystem; happy to discuss the API on a dev call and
iterate. Each commit is DCO signed-off.
