### PR TITLE
SRV_Channel: Betaflight-style per-output servo failsafe positions

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1185,6 +1185,13 @@ const AP_Param::GroupInfo ParametersG2::var_info2[] = {
     AP_GROUPINFO("SURFTRAK_GLSAM", 22, ParametersG2, surf_dist_parameters.glitch_num_samples, AP_SURFACEDISTANCE_GLITCH_NUM_SAMPLES_DEFAULT),
 #endif
 
+    // @Param: FS_SERVO_MASK
+    // @DisplayName: Servo failsafe trigger mask
+    // @Description: Selects which failsafe conditions drive the per-servo failsafe positions (SERVOn_FSPWM). When any selected failsafe is active, every output with a non-zero SERVOn_FSPWM is forced to its configured PWM. Set to 0 to disable the servo failsafe positions entirely.
+    // @Bitmask: 0:Radio,1:Battery,2:GCS,3:EKF,4:Terrain,5:ADSB,6:DeadReckon
+    // @User: Standard
+    AP_GROUPINFO("FS_SERVO_MASK", 32, ParametersG2, fs_servo_mask, 7),
+
     // ID 62 is reserved for the AP_SUBGROUPEXTENSION
 
     AP_GROUPEND

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -638,6 +638,9 @@ public:
     // Failsafe options bitmask #36
     AP_Int32 fs_options;
 
+    // which failsafes drive the per-servo failsafe positions (SERVOn_FSPWM)
+    AP_Int16 fs_servo_mask;
+
 #if MODE_AUTOROTATE_ENABLED
     // Autonmous autorotation
     AC_Autorotation arot;

--- a/ArduCopter/motors.cpp
+++ b/ArduCopter/motors.cpp
@@ -79,6 +79,19 @@ void Copter::motors_output(bool full_push)
         ap.in_arming_delay = false;
     }
 
+    // drive the per-servo failsafe positions (SERVOn_FSPWM) when any failsafe
+    // selected by FS_SERVO_MASK is active. Evaluated here each output cycle so
+    // it is applied by SRV_Channels::calc_pwm() below.
+    uint16_t fs_bits = 0;
+    if (failsafe.radio)          { fs_bits |= (1U<<0); }
+    if (battery.has_failsafed()) { fs_bits |= (1U<<1); }
+    if (failsafe.gcs)            { fs_bits |= (1U<<2); }
+    if (failsafe.ekf)            { fs_bits |= (1U<<3); }
+    if (failsafe.terrain)        { fs_bits |= (1U<<4); }
+    if (failsafe.adsb)           { fs_bits |= (1U<<5); }
+    if (failsafe.deadreckon)     { fs_bits |= (1U<<6); }
+    SRV_Channels::set_failsafe_active((fs_bits & uint16_t(g2.fs_servo_mask.get())) != 0);
+
     // output any servo channels
     SRV_Channels::calc_pwm();
 

--- a/libraries/SRV_Channel/SRV_Channel.cpp
+++ b/libraries/SRV_Channel/SRV_Channel.cpp
@@ -171,6 +171,14 @@ const AP_Param::GroupInfo SRV_Channel::var_info[] = {
     // @RebootRequired: True
     AP_GROUPINFO("FUNCTION",  5, SRV_Channel, function, 0),
 
+    // @Param: FSPWM
+    // @DisplayName: Servo failsafe PWM position
+    // @Description: PWM value this output is driven to when a selected failsafe is active (see FS_SERVO_MASK). 0 disables the failsafe position for this channel, leaving its normal output. Use this to set a safe pose on loss of link (e.g. centre a servo, or cut a throttle channel). Applies to any output including motors, so use with care on multirotors where the failsafe flight mode already controls the motors.
+    // @Units: PWM
+    // @Range: 0 2200
+    // @User: Standard
+    AP_GROUPINFO("FSPWM",  6, SRV_Channel, servo_fs_pwm, 0),
+
     AP_GROUPEND
 };
 

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -326,6 +326,9 @@ private:
     // reversal, following convention that 1 means reversed, 0 means normal
     AP_Int8 reversed;
     AP_Enum16<Function> function;
+    // per-channel failsafe position: PWM this channel is driven to when a
+    // selected failsafe is active. 0 = disabled (leave normal output).
+    AP_Int16 servo_fs_pwm;
 
     // a pending output value as PWM
     uint16_t output_pwm;
@@ -601,6 +604,14 @@ public:
     // get E - stop
     static bool get_emergency_stop() { return emergency_stop;}
 
+    // set whether a servo failsafe is currently active. When true, any
+    // channel with a non-zero SERVOn_FSPWM is driven to that PWM. The vehicle
+    // decides which failsafe(s) qualify and sets this each loop.
+    static void set_failsafe_active(bool state) { failsafe_active = state; }
+
+    // get servo-failsafe active state
+    static bool get_failsafe_active() { return failsafe_active; }
+
     // singleton for Lua
     static SRV_Channels *get_singleton(void) {
         return _singleton;
@@ -712,6 +723,7 @@ private:
     }
 
     static bool emergency_stop;
+    static bool failsafe_active;
 
     // linked list for slew rate handling
     struct slew_list {

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -96,6 +96,16 @@ void SRV_Channel::output_ch(void)
     }
 #endif // HAL_BUILD_AP_PERIPH
 
+    // servo failsafe position: when the vehicle reports an active failsafe,
+    // force this output to its configured SERVOn_FSPWM. Done here, at the last
+    // per-channel seam before the write, so it overrides every function type
+    // uniformly (normal mixing, motors, and RC passthrough alike) and, because
+    // a functioned channel is recomputed every loop, releases cleanly when the
+    // failsafe clears. Only functioned channels are posed (0 = disabled).
+    if (SRV_Channels::get_failsafe_active() && valid_function() && servo_fs_pwm != 0) {
+        output_pwm = constrain_uint16(servo_fs_pwm.get(), 500, 2500);
+    }
+
     if (!(SRV_Channels::disabled_mask & (1U<<ch_num))) {
         hal.rcout->write(ch_num, output_pwm);
     }

--- a/libraries/SRV_Channel/SRV_Channels.cpp
+++ b/libraries/SRV_Channel/SRV_Channels.cpp
@@ -51,6 +51,7 @@ uint32_t SRV_Channels::invalid_mask;
 bool SRV_Channels::disabled_passthrough;
 bool SRV_Channels::initialised;
 bool SRV_Channels::emergency_stop;
+bool SRV_Channels::failsafe_active;
 Bitmask<SRV_Channel::k_nr_aux_servo_functions> SRV_Channels::function_mask;
 SRV_Channels::srv_function SRV_Channels::functions[SRV_Channel::k_nr_aux_servo_functions];
 SRV_Channels::slew_list *SRV_Channels::_slew;


### PR DESCRIPTION
### Summary
Adds Betaflight-style per-output servo failsafe positions.

- `SERVOn_FSPWM`: a per-channel PWM the output is driven to while a servo
  failsafe is active. It is applied at the last per-channel seam (`output_ch`),
  after normal mixing and RC passthrough, so it overrides every output type
  uniformly - servos, motors and RC passthrough alike. Only functioned channels
  are posed and `0` disables it, so a channel recomputes and releases cleanly
  once the condition clears. The vehicle signals the condition via a new
  `SRV_Channels::set_failsafe_active()`.
- `FS_SERVO_MASK` (Copter): a bitmask selecting which failsafes (radio, battery,
  GCS, EKF, terrain, ADSB, dead-reckoning) activate the poses. Each output cycle
  Copter ORs the active failsafe bits, masks them with `FS_SERVO_MASK`, and calls
  `set_failsafe_active()`, so configured outputs snap to their failsafe pose on
  the selected losses and release when the condition clears.

### Rationale
Lets a specific servo (e.g. a payload release, parachute arm, or camera tilt) be
commanded to a known-safe position on a chosen set of failsafe conditions,
independent of the flight-mode failsafe response.

### Testing
- Builds clean for SITL. Injection point verified at `output_ch` so motor and
  passthrough channels are covered uniformly.

### Notes
Each commit is DCO signed-off.
