### PR TITLE
Copter: clarify motor number in potential thrust loss message

### DIFF
--- a/ArduCopter/crash_check.cpp
+++ b/ArduCopter/crash_check.cpp
@@ -167,7 +167,7 @@ void Copter::thrust_loss_check()
         thrust_loss_counter = 0;
         LOGGER_WRITE_ERROR(LogErrorSubsystem::THRUST_LOSS_CHECK, LogErrorCode::FAILSAFE_OCCURRED);
         // send message to gcs
-        gcs().send_text(MAV_SEVERITY_EMERGENCY, "Potential Thrust Loss (%d)", (int)motors->get_lost_motor() + 1);
+        gcs().send_text(MAV_SEVERITY_EMERGENCY, "Potential Thrust Loss (Motor %d)", (int)motors->get_lost_motor() + 1);
         // enable thrust loss handling
         motors->set_thrust_boost(true);
         // the motors library disables this when it is no longer needed to achieve the commanded output


### PR DESCRIPTION
### Summary

Clarify the suspected motor index in GCS thrust loss warning message from "Potential Thrust Loss (%d)" to "Potential Thrust Loss (Motor %d)".

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Built and tested target for SITL:
```bash
./waf configure --board sitl
./waf copter
```

### Description

In `Copter::thrust_loss_check()`, when potential thrust loss is detected, an emergency text is sent to the GCS:
```cpp
gcs().send_text(MAV_SEVERITY_EMERGENCY, "Potential Thrust Loss (%d)", (int)motors->get_lost_motor() + 1);
```

For pilots and operators viewing this alert on a GCS (Mission Planner, QGroundControl, etc.), displaying only a raw number like `Potential Thrust Loss (2)` can be ambiguous (e.g., whether it indicates error code 2, severity level 2, or motor 2).

This change explicitly formats the message as `"Potential Thrust Loss (Motor %d)"` so that the affected motor is immediately obvious during an in-flight emergency.