### PR TITLE
autotest: budget FRSkyPassThroughStatustext in simulated time

### DIFF
--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -15128,7 +15128,15 @@ switch value'''
 
         received_frsky_texts = []
         last_len_received_statustexts = 0
-        timeout = 7 * self.speedup # it can take a *long* time to get these messages down!
+        # the queue has to drain before the text we are looking for
+        # reaches us, and how long that takes is best measured in
+        # simulated time: 58s at speedup 1, 49s at 5, 39s at 10 and 20,
+        # 10s at 100 - it falls as the speedup rises.  Scaling the budget
+        # by the speedup therefore had it backwards, handing out 700s
+        # where 10 was needed and 35s where 49 was, so this failed every
+        # time at --speedup=5.  Allow a fixed 150s, comfortably above the
+        # slowest measured and still an assertion at the default speedup.
+        timeout = 150
         while True:
             self.drain_mav()
             now = self.get_sim_time_cached()


### PR DESCRIPTION
### Summary

Corrects inverse scaling problem where we allowed more time the higher the speedup!

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

The test waits for a statustext to reach it over the FRSky passthrough link, and allowed "7 * self.speedup" simulated seconds for it.  That scales the wrong way.  Measured, with an unlimited budget, the simulated time needed to receive the wanted text is

```
    speedup    1     2     5    10    20   100
    needs    58.4  53.9  48.7  39.4  39.9   9.9 s
    allowed   7    14    35    70   140   700  s
```

The requirement falls as the speedup rises, because what has to happen first is that the queue ahead of our text drains, and at a high speedup far less simulated time passes while that happens in wall clock.  The budget rose instead, so it handed out 71 times what was needed at the default speedup - no assertion at all - and less than was needed at anything below about 7.  It failed every time at --speedup=5, three passes out of three in an overnight sweep, and had only 1.8x margin at --speedup=10.

Allow a fixed 150 simulated seconds: 2.6x the slowest measured, and still a real bound at the default speedup.  Passes at speedups 1, 5, 10 and 100.
