### PR TITLE
autotest: put AFS_TERMINATE back when the vehicle sets it

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -7346,6 +7346,8 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             "MAV_GCS_SYSID": self.mav.source_system,
             "AFS_TERM_ACTION": 42,
         })
+        # AFS_TERMINATE magically set-and-saved by code:
+        self.context_preserve_parameters(["AFS_TERMINATE"])
         self.wait_ready_to_arm()
         self.arm_vehicle()
         self.context_collect('STATUSTEXT')
@@ -7366,6 +7368,8 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             "MAV_GCS_SYSID": self.mav.source_system,
             "AFS_TERM_ACTION": 42,
         })
+        # AFS_TERMINATE magically set-and-saved by code:
+        self.context_preserve_parameters(["AFS_TERMINATE"])
         self.takeoff(50, mode='TAKEOFF', timeout=200)
 
         # lock home to avoid alt messups

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -14341,6 +14341,8 @@ switch value'''
             })
             self.drain_mav()
             self.assert_capability(mavutil.mavlink.MAV_PROTOCOL_CAPABILITY_FLIGHT_TERMINATION)
+            # AFS_TERMINATE magically set-and-saved by code:
+            self.context_preserve_parameters(["AFS_TERMINATE"])
             self.set_parameter("AFS_TERM_ACTION", 42)
             self.load_sample_mission()
             self.context_collect("STATUSTEXT")
@@ -14417,6 +14419,8 @@ switch value'''
             "AFS_QNH_PRESSURE": 1000,
             "AFS_AMSL_ERR_GPS": 10,
         })
+        # AFS_TERMINATE magically set-and-saved by code:
+        self.context_preserve_parameters(["AFS_TERMINATE"])
         self.wait_ready_to_arm()
         self.start_subtest("Ensuring breaking baros doesn't terminate")
         self.set_parameters({


### PR DESCRIPTION
### Summary

Make harness aware of AFS_TERMINATE being magically set-and-saved by the code so it can revert the value

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

AP_AdvancedFailsafe sets AFS_TERMINATE itself when it terminates, with set_and_notify(), so the value is saved and outlives the test which caused it.  The next test to enable AFS then meets

```
    if ((fence breached) || check_altlimit()) {
        if (!_terminate) {
            GCS_SEND_TEXT(..., "Terminating due to fence breach");
```

with _terminate already 1, so the vehicle terminates silently and the message never arrives.  AdvancedFailsafeBadBaro waits for exactly that message, and

```
    test.Plane.AdvancedFailsafe,AdvancedFailsafeBadBaro
```

reproduces it every time: the first test leaves AFS_TERMINATE at 1 and the second cannot see its message.  It has also been seen in the wild, in a shuffled full-suite run, having done everything right - the barometer had frozen, the GPS had dropped to no-fix 0.2s after being disabled, and a passing run terminates 0.36s after that.

The context restores parameters the suite sets, but cannot know about one the vehicle writes for itself.  Add context_preserve_parameters(), which registers such parameters with their current values so they are put back with everything else, and use it wherever a test arms AFS knowing the vehicle may terminate.
