### PR TITLE
AP_Bootloader: Reserve IDs 1930-1949 for Agam Robotics

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -443,7 +443,7 @@ AP_HW_AGAM_GNSSPLUS                  1931
 AP_HW_AGAM_BASE-RTK                  1932
 AP_HW_AGAM_CAN-RTK                   1933
 AP_HW_AGAM_FloRange                  1939
-AP_HW_AGAM_MEGH7                     1940
+AP_HW_AGAM_MegH7                     1940
 AP_HW_AGAM_v6XRT                     1949
 
 # IDs 1950-1979 reserved for HC Robotics

--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -437,8 +437,14 @@ AP_HW_A2M6X                          1850
 AP_HW_A2M6X_NANO                     1855
 AP_HW_A2M6X_V2                       1860
 
-# IDs 1940–1949 reserved for Agam Robotics
+# IDs 1930–1949 reserved for Agam Robotics
+AP_HW_AGAM_GNSS-CAN                  1930
+AP_HW_AGAM_GNSSPLUS                  1931
+AP_HW_AGAM_BASE-RTK                  1932
+AP_HW_AGAM_CAN-RTK                   1933
+AP_HW_AGAM_FloRange                  1939
 AP_HW_AGAM_MEGH7                     1940
+AP_HW_AGAM_v6XRT                     1949
 
 # IDs 1950-1979 reserved for HC Robotics
 AP_HW_HCR-504                        1950

--- a/libraries/AP_HAL_ChibiOS/hwdef/Agam_MegH7/hwdef-bl.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Agam_MegH7/hwdef-bl.dat
@@ -5,7 +5,7 @@
 MCU STM32H7xx STM32H743xx
 
 # board ID. See Tools/AP_Bootloader/board_types.txt
-APJ_BOARD_ID AP_HW_AGAM_MEGH7
+APJ_BOARD_ID AP_HW_AGAM_MegH7
 
 # crystal frequency, setup to use external oscillator
 OSCILLATOR_HZ 8000000

--- a/libraries/AP_HAL_ChibiOS/hwdef/Agam_MegH7/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/Agam_MegH7/hwdef.dat
@@ -5,7 +5,7 @@
 MCU STM32H7xx STM32H743xx
 
 # board ID. See Tools/AP_Bootloader/board_types.txt
-APJ_BOARD_ID AP_HW_AGAM_MEGH7
+APJ_BOARD_ID AP_HW_AGAM_MegH7
 
 # crystal frequency, setup to use external oscillator
 OSCILLATOR_HZ 8000000


### PR DESCRIPTION
Reserved IDs for Agam Robotics in board_types.txt

### Summary

Reserve IDs 1930-1949 for Agam Robotics (expands the previously reserved 1940-1949 block) and assign IDs to existing hardware:

- `AP_HW_AGAM_GNSS-CAN` = 1930
- `AP_HW_AGAM_GNSSPLUS` = 1931
- `AP_HW_AGAM_BASE-RTK` = 1932
- `AP_HW_AGAM_CAN-RTK` = 1933
- `AP_HW_AGAM_FloRange` = 1939
- `AP_HW_AGAM_MegH7` = 1940 (renamed from `AP_HW_AGAM_MEGH7`)
- `AP_HW_AGAM_v6XRT` = 1949

### Classification & Testing (check all that apply and add your own)

- [ ] Checked by a human programmer
- [x] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
