### PR TITLE
Fix yaw logging in the EKF, use it to verify GPS-for-yaw is used

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -2185,6 +2185,93 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.context_pop()
         self.reboot_sitl()
 
+    def EK3YawFusionLogging(self):
+        '''Test EKF3 logs which yaw observation it is fusing'''
+        # XKFS.YF values, from NavEKF3_core::yawFusionMethod:
+        yf_not_fusing = 0
+        yf_magnetometer = 1
+        yf_mag_3axis = 7
+        yf_compass = [yf_magnetometer, yf_mag_3axis]
+
+        self.set_parameters({
+            "LOG_DISARMED": 1,
+        })
+        self.set_message_rate_hz("EKF_STATUS_REPORT", 10)
+        self.wait_ready_to_arm()
+
+        # the compass is the default yaw source:
+        self.delay_sim_time(5, reason="XKFS to be logged while fusing the compass")
+
+        self.start_subtest("Removing the compass as a yaw source")
+        self.set_parameter("EK3_SRC1_YAW", 8)  # 8 is GSF
+
+        # EKF3 zeroes the compass innovation test ratios once it stops
+        # fusing the compass; waiting for that both proves the source
+        # change has taken effect and leaves us a window in the log we
+        # can assert over:
+        self.wait_message_field_values(
+            "EKF_STATUS_REPORT",
+            {"compass_variance": 0},
+            epsilon=0.0001,
+            minimum_duration=10,
+            timeout=60,
+        )
+
+        self.progress("Examining XKFS in the onboard log")
+        dfreader = self.dfreader_for_current_onboard_log()
+        switch_us = None
+        fusing_count = 0
+        checked_count = 0
+        still_fusing = []
+        not_fusing = []
+        max_age_ms = 0
+        while True:
+            m = dfreader.recv_match(type=["PARM", "XKFS"])
+            if m is None:
+                break
+            if m.get_type() == "PARM":
+                if m.Name == "EK3_SRC1_YAW" and int(m.Value) == 8:
+                    switch_us = m.TimeUS
+                continue
+            if m.C != 0:
+                # only examine the first EKF core
+                continue
+            if switch_us is None:
+                if m.YF in yf_compass:
+                    fusing_count += 1
+                continue
+            if m.TimeUS - switch_us < 3 * 1000000:
+                # allow the EKF time to stop fusing the compass
+                continue
+            checked_count += 1
+            if m.YF in yf_compass:
+                still_fusing.append(m.TimeUS)
+            if m.YF == yf_not_fusing:
+                not_fusing.append(m.TimeUS)
+            max_age_ms = max(max_age_ms, m.YFA)
+
+        if switch_us is None:
+            raise NotAchievedException("EK3_SRC1_YAW change not found in log")
+        if fusing_count == 0:
+            raise NotAchievedException("Compass was never logged as being fused")
+        if checked_count == 0:
+            raise NotAchievedException("No XKFS logged after the yaw source change")
+        self.progress("%u XKFS fusing the compass, %u checked after the change "
+                      "(max YFA %ums)" % (fusing_count, checked_count, max_age_ms))
+        if len(still_fusing) > 0:
+            raise NotAchievedException(
+                "XKFS.YF still reports compass fusion on %u of %u messages after the "
+                "compass stopped being fused (first at %u)" %
+                (len(still_fusing), checked_count, still_fusing[0]))
+        if len(not_fusing) > 0:
+            raise NotAchievedException(
+                "XKFS.YF reports no yaw fusion on %u of %u messages (first at %u)" %
+                (len(not_fusing), checked_count, not_fusing[0]))
+        # the replacement yaw observation is fused at 7Hz:
+        if max_age_ms > 1000:
+            raise NotAchievedException(
+                "XKFS.YFA reached %ums; yaw is not being fused" % max_age_ms)
+
     def EK3_AccelBiasInhibitOnGroundMoving(self):
         '''Test EKF3 inhibits accel bias learning when vehicle is moved on ground'''
         # When a copter is on the ground and being moved (carried, on a ship),
@@ -16476,6 +16563,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
              self.BatteryMissing,
              self.VibrationFailsafe,
              self.EK3AccelBias,
+             self.EK3YawFusionLogging,
              self.EK3_AccelBiasInhibitOnGroundMoving,
              self.EK3_AccelBiasZeroVelOptFlow,
              self.EK3_ZeroVelFusionNotUsedWithGPS,

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -45,6 +45,21 @@ from vehicle_test_suite import WaitModeTimeout
 CAMERA_IMAGE_STATUS_IDLE = 0
 CAMERA_IMAGE_STATUS_INTERVAL_IDLE = 2
 
+
+# Values for XKFS.YF, from NavEKF3_core::yawFusionMethod
+class YawFuseSel():
+    NOT_FUSING = 0
+    MAGNETOMETER = 1
+    GPS = 2
+    GSF = 3
+    STATIC = 4
+    PREDICTED = 5
+    EXTNAV = 6
+    MAG_3AXIS = 7
+
+
+YAW_FUSE_SEL_COMPASS = [YawFuseSel.MAGNETOMETER, YawFuseSel.MAG_3AXIS]
+
 # get location of scripts
 testdir = os.path.dirname(os.path.realpath(__file__))
 SITL_START_LOCATION = Location(
@@ -2187,12 +2202,6 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
     def EK3YawFusionLogging(self):
         '''Test EKF3 logs which yaw observation it is fusing'''
-        # XKFS.YF values, from NavEKF3_core::yawFusionMethod:
-        yf_not_fusing = 0
-        yf_magnetometer = 1
-        yf_mag_3axis = 7
-        yf_compass = [yf_magnetometer, yf_mag_3axis]
-
         self.set_parameters({
             "LOG_DISARMED": 1,
         })
@@ -2237,16 +2246,16 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 # only examine the first EKF core
                 continue
             if switch_us is None:
-                if m.YF in yf_compass:
+                if m.YF in YAW_FUSE_SEL_COMPASS:
                     fusing_count += 1
                 continue
             if m.TimeUS - switch_us < 3 * 1000000:
                 # allow the EKF time to stop fusing the compass
                 continue
             checked_count += 1
-            if m.YF in yf_compass:
+            if m.YF in YAW_FUSE_SEL_COMPASS:
                 still_fusing.append(m.TimeUS)
-            if m.YF == yf_not_fusing:
+            if m.YF == YawFuseSel.NOT_FUSING:
                 not_fusing.append(m.TimeUS)
             max_age_ms = max(max_age_ms, m.YFA)
 
@@ -15622,6 +15631,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             "GPS2_POS_X": 0.0, "GPS2_POS_Y": 0.0, "GPS2_POS_Z": 0.45,
             "SIM_GPS1_POS_X": 0.0, "SIM_GPS1_POS_Y": 0.0, "SIM_GPS1_POS_Z": -0.45,
             "SIM_GPS2_POS_X": 0.0, "SIM_GPS2_POS_Y": 0.0, "SIM_GPS2_POS_Z": 0.45,
+            "LOG_DISARMED": 1,  # so that XKFS is logged without arming
         })
         self.reboot_sitl()
 
@@ -15636,6 +15646,29 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             if m.yaw not in [0, 65535]:
                 raise NotAchievedException(
                     "Got GPS yaw %.1f deg from a baseline with no horizontal separation" % (m.yaw * 0.01))
+
+        # EK3_SRC1_YAW is 2, so with no GPS yaw to fuse the EKF falls back to
+        # synthesising a yaw observation to keep the filter stable.  XKFS.YF
+        # says which observation was last fused, so it must never name the
+        # GPS here
+        self.progress("Checking the EKF never fused GPS yaw")
+        dfreader = self.dfreader_for_current_onboard_log()
+        synthesised = 0
+        while True:
+            m = dfreader.recv_match(type="XKFS")
+            if m is None:
+                break
+            if m.C != 0:
+                # only examine the first EKF core
+                continue
+            if m.YF == YawFuseSel.GPS:
+                raise NotAchievedException(
+                    "EKF fused GPS yaw from a baseline with no horizontal separation (at %u)" % m.TimeUS)
+            if m.YF in [YawFuseSel.STATIC, YawFuseSel.PREDICTED] and m.YFA < 1000:
+                synthesised += 1
+        if synthesised == 0:
+            raise NotAchievedException("EKF never fused a synthesised yaw observation")
+        self.progress("%u XKFS fusing a synthesised yaw" % synthesised)
 
     def GPSForYawCompassFallback(self):
         '''EKF3 must fall back to the compass when GPS yaw is present but unusable'''
@@ -15690,6 +15723,77 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 "Yaw not tracking truth under compass fallback (err=%.1f deg)" % yaw_err_deg)
 
         self.do_RTL()
+
+        # The GPS keeps publishing yaw once the baseline goes vertical, so a
+        # rejected measurement looks exactly like a fused one from outside the
+        # EKF.  XKFS.YF names the observation last fused and XKFS.YFA says how
+        # long ago, which is the only trace the rejection leaves: YF stays on
+        # the GPS while YFA climbs to the ten seconds the fallback waits for.
+        self.progress("Checking the yaw fusion trace in the onboard log")
+        rtl_mode = self.get_mode_from_mode_mapping('RTL')
+        dfreader = self.dfreader_for_current_onboard_log()
+        fallback_us = None
+        rtl_us = None
+        gps_fused = 0
+        max_gps_age_ms = 0
+        compass_ages = []
+        not_compass = []
+        while True:
+            m = dfreader.recv_match(type=["MSG", "MODE", "XKFS"])
+            if m is None:
+                break
+            if m.get_type() == "MODE":
+                if m.ModeNum == rtl_mode and rtl_us is None:
+                    rtl_us = m.TimeUS
+                continue
+            if m.get_type() == "MSG":
+                # the test's own progress text is logged as MSG as well, so
+                # match the EKF's message rather than any mention of fallback
+                if (fallback_us is None and m.Message.startswith("EKF3 IMU") and
+                        "yaw fallback active" in m.Message):
+                    fallback_us = m.TimeUS
+                continue
+            if m.C != 0:
+                # only examine the first EKF core
+                continue
+            if fallback_us is None:
+                if m.YF != YawFuseSel.GPS:
+                    continue
+                if m.YFA < 1000:
+                    gps_fused += 1
+                else:
+                    max_gps_age_ms = max(max_gps_age_ms, m.YFA)
+                continue
+            if rtl_us is not None:
+                # the descent and landing legitimately pause mag fusion
+                continue
+            if m.TimeUS - fallback_us < 2 * 1000000:
+                # allow the compass to take over
+                continue
+            if m.YF not in YAW_FUSE_SEL_COMPASS:
+                not_compass.append(m.TimeUS)
+            compass_ages.append(m.YFA)
+
+        if gps_fused == 0:
+            raise NotAchievedException("GPS yaw was never logged as being fused")
+        if fallback_us is None:
+            raise NotAchievedException("Fallback message not found in log")
+        # the fallback waits ten seconds for a usable GPS yaw
+        if max_gps_age_ms < 5000:
+            raise NotAchievedException(
+                "XKFS.YFA only reached %ums; GPS yaw was still being fused" % max_gps_age_ms)
+        if len(compass_ages) < 10:
+            raise NotAchievedException(
+                "Only %u XKFS logged between the fallback and the RTL" % len(compass_ages))
+        if len(not_compass) > 0:
+            raise NotAchievedException(
+                "XKFS.YF not reporting compass fusion on %u of %u messages after the "
+                "fallback (first at %u)" % (len(not_compass), len(compass_ages), not_compass[0]))
+        if max(compass_ages) > 1000:
+            raise NotAchievedException(
+                "XKFS.YFA reached %ums under compass fallback" % max(compass_ages))
+        self.progress("%u XKFS fusing GPS yaw, rejection ran for %ums, "
+                      "%u checked under fallback" % (gps_fused, max_gps_age_ms, len(compass_ages)))
 
     def SMART_RTL_EnterLeave(self):
         '''check SmartRTL behaviour when entering/leaving'''

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -15565,13 +15565,19 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.wait_ready_to_arm()
         self.takeoff(20, mode='GUIDED')
 
-        # fly a gentle circle to hold a steady, modest lean angle.  A large
-        # radius keeps the turn rate (and hence any residual yaw lag) small.
+        # Hold the heading fixed and drive the vehicle hard from side to side
+        # in GUIDED.  With the nose fixed a lateral acceleration is a pure
+        # roll, so the levelled antenna offset keeps the lateral component the
+        # correction acts on, and there is no coupling between the axes to
+        # reason about.  The velocity target is reversed before the vehicle
+        # reaches it, so the vehicle is always accelerating and the bank is
+        # held for as long as we need to sample it.
         self.set_parameters({
-            "CIRCLE_RADIUS_M": 50,
-            "CIRCLE_RATE": 12,
+            "WP_YAW_BEHAVIOR": 0,  # never change yaw
+            "WP_ACC": 4,           # m/s/s: bank hard, ~22 degrees
         })
-        self.change_mode('CIRCLE')
+        self.set_message_rate_hz("EKF_STATUS_REPORT", 10)
+        self.guided_achieve_heading(0)
 
         # Sample the EKF attitude against truth while the vehicle is banked.
         # copter-gps-for-yaw.parm sets EK3_SRC1_YAW=2 so the moving-baseline
@@ -15585,11 +15591,33 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         max_yaw_err_deg = 15
         wanted_samples = 10
         good_samples = 0
+        vel_ms = 20
+        reverse_interval_s = 5
         tstart = self.get_sim_time()
+        last_reverse = tstart
         while True:
-            if self.get_sim_time_cached() - tstart > 90:
+            now = self.get_sim_time_cached()
+            if now - tstart > 90:
                 raise NotAchievedException(
                     "Only gathered %u/%u banked GPS-yaw samples" % (good_samples, wanted_samples))
+            if now - last_reverse > reverse_interval_s:
+                vel_ms = -vel_ms
+                last_reverse = now
+            # the nose is held north, so an east/west velocity is lateral
+            self.mav.mav.set_position_target_local_ned_send(
+                0,  # timestamp
+                1,  # target system_id
+                1,  # target component id
+                mavutil.mavlink.MAV_FRAME_LOCAL_NED,
+                MAV_POS_TARGET_TYPE_MASK.POS_IGNORE |
+                MAV_POS_TARGET_TYPE_MASK.YAW_IGNORE |
+                MAV_POS_TARGET_TYPE_MASK.YAW_RATE_IGNORE |
+                MAV_POS_TARGET_TYPE_MASK.LAST_BYTE,
+                0, 0, 0,          # x, y, z
+                0, vel_ms, 0,     # vx, vy, vz
+                0, 0, 0,          # afx, afy, afz
+                0, 0,             # yaw, yawrate
+            )
             att = self.assert_receive_message("ATTITUDE")
             sim = self.assert_receive_message("SIMSTATE")
             roll_deg = math.degrees(sim.roll)

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp
@@ -91,6 +91,11 @@ void NavEKF3_core::Log_Write_XKF2(uint64_t time_us) const
 
 void NavEKF3_core::Log_Write_XKFS(uint64_t time_us) const
 {
+    // how long ago the yaw observation in yawFusionSel was fused.  This
+    // saturates rather than wrapping so that a stale selection can be told
+    // from a live one without the EKF having to decide what stale means.
+    const uint32_t yaw_fusion_age_ms = MIN(imuSampleTime_ms - lastYawFuseTime_ms, (uint32_t)UINT16_MAX);
+
     // Write sensor selection EKF packet
     const struct log_XKFS pkt {
         LOG_PACKET_HEADER_INIT(LOG_XKFS_MSG),
@@ -103,7 +108,9 @@ void NavEKF3_core::Log_Write_XKFS(uint64_t time_us) const
         source_set     : frontend->sources.getActiveSourceSet(core_index),
         gps_good_to_align : gpsGoodToAlign,
         wait_for_gps_checks : waitingForGpsChecks,
-        mag_fusion: (uint8_t) magFusionSel
+        mag_fusion: (uint8_t) magFusionSel,
+        yaw_fusion: (uint8_t) yawFusionSel,
+        yaw_fusion_age_ms : (uint16_t)yaw_fusion_age_ms
     };
     AP::logger().WriteBlock(&pkt, sizeof(pkt));
 }

--- a/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_MagFusion.cpp
@@ -707,6 +707,9 @@ void NavEKF3_core::FuseMagnetometer()
         return;
     }
 
+    // record the yaw observation being fused for logging
+    recordYawFused(yawFusionMethod::MAG_3AXIS);
+
     Vector24 H_MAG;
     // index of H_MAG which is exactly 1, for more efficient computation below
     int H_MAG_unit_index;
@@ -938,6 +941,13 @@ void NavEKF3_core::FuseMagnetometer()
     }
 }
 
+// record the yaw observation which has just been fused so that it can be logged
+void NavEKF3_core::recordYawFused(yawFusionMethod method)
+{
+    yawFusionSel = method;
+    lastYawFuseTime_ms = imuSampleTime_ms;
+}
+
 /*
  * Fuse direct yaw measurements using explicit algebraic equations auto-generated from
  * derivation/generate_2.py with output recorded in derivation/generated/yaw_generated.cpp
@@ -945,6 +955,23 @@ void NavEKF3_core::FuseMagnetometer()
 */
 bool NavEKF3_core::fuseEulerYaw(yawFusionMethod method)
 {
+    // reject the methods which only describe the state of yaw fusion for
+    // logging.  This switch has no default so that a method added later
+    // must be classified here rather than being silently fused.
+    switch (method) {
+    case yawFusionMethod::MAGNETOMETER:
+    case yawFusionMethod::GPS:
+    case yawFusionMethod::GSF:
+    case yawFusionMethod::STATIC:
+    case yawFusionMethod::PREDICTED:
+    case yawFusionMethod::EXTNAV:
+        break;
+
+    case yawFusionMethod::MAG_3AXIS:
+    case yawFusionMethod::NOT_FUSING:
+        return false;
+    }
+
     const ftype &q0 = stateStruct.quat[0];
     const ftype &q1 = stateStruct.quat[1];
     const ftype &q2 = stateStruct.quat[2];
@@ -1238,6 +1265,9 @@ bool NavEKF3_core::fuseEulerYaw(yawFusionMethod method)
     const ftype innovFusion = constrain_ftype(innovYaw, -0.5f, 0.5f);
     // finish fusion from KHP and Kfusion then record health status
     faultStatus.bad_yaw = FinishFusion(innovFusion);
+
+    // record the yaw observation being fused for logging
+    recordYawFused(method);
 
     return true;
 }

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -465,6 +465,8 @@ void NavEKF3_core::InitialiseVariablesMag()
     needMagBodyVarReset = false;
     needEarthBodyVarReset = false;
     magFusionSel = MagFuseSel::NOT_FUSING;
+    yawFusionSel = yawFusionMethod::NOT_FUSING;
+    lastYawFuseTime_ms = 0;
 }
 
 /*

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -712,14 +712,20 @@ private:
         EXTNAV=7        // Use external nav data
     };
 
-    // specifies the method to be used when fusing yaw observations
+    // specifies the method to be used when fusing yaw observations.
+    // MAG_3AXIS and NOT_FUSING describe the state of yaw fusion for
+    // logging and are not observations which can be fused.  NOT_FUSING
+    // is zero so that the state before the filter is initialised is
+    // reported correctly.
     enum class yawFusionMethod {
-	    MAGNETOMETER=0,
-	    GPS=1,
-        GSF=2,
-        STATIC=3,
-        PREDICTED=4,
-        EXTNAV=5,
+        NOT_FUSING=0,   // no yaw observation has been fused
+        MAGNETOMETER=1, // simple yaw fusion of magnetometer data
+        GPS=2,          // yaw from a GPS or other external yaw sensor
+        GSF=3,          // yaw from the EKF-GSF yaw estimator
+        STATIC=4,       // yaw held from before the vehicle stopped moving
+        PREDICTED=5,    // zero innovation fused to bound the yaw variance
+        EXTNAV=6,       // yaw from an external navigation system
+        MAG_3AXIS=7,    // 3-axis fusion of magnetometer data
     };
 
     // update the navigation filter status
@@ -996,6 +1002,9 @@ private:
     // Fuse compass measurements using a direct yaw angle observation (doesn't require magnetic field states)
     // Returns true if the fusion was successful
     bool fuseEulerYaw(yawFusionMethod method);
+
+    // record the yaw observation which has just been fused so that it can be logged
+    void recordYawFused(yawFusionMethod method);
 
     // return the best Tait-Bryan rotation order to use
     void bestRotationOrder(rotationOrder &order);
@@ -1512,6 +1521,8 @@ private:
     ftype yawInnovAtLastMagReset;   // magnetic yaw innovation last time the yaw and mag field states were reset (rad)
     QuaternionF quatAtLastMagReset;  // quaternion states last time the mag states were reset
     MagFuseSel magFusionSel;        // magnetometer fusion selection
+    yawFusionMethod yawFusionSel;   // yaw observation last fused
+    uint32_t lastYawFuseTime_ms;    // time yawFusionSel was fused (msec)
 
     // Used by on ground movement check required when operating on ground without a yaw reference
     ftype gyro_diff;                    // filtered gyro difference (rad/s)

--- a/libraries/AP_NavEKF3/LogStructure.h
+++ b/libraries/AP_NavEKF3/LogStructure.h
@@ -373,6 +373,9 @@ struct PACKED log_XKQ {
 // @Field: GPS_GTA: GPS good to align
 // @Field: GPS_CHK_WAIT: Waiting for GPS checks to pass
 // @Field: MAG_FUSION: Magnetometer fusion (0=not fusing/1=fuse yaw/2=fuse mag/3=fuse mag with yaw anchored)
+// @Field: YF: yaw observation last fused
+// @FieldValueEnum: YF: NavEKF3_core::yawFusionMethod
+// @Field: YFA: time since the observation in YF was fused; saturates
 struct PACKED log_XKFS {
     LOG_PACKET_HEADER;
     uint64_t time_us;
@@ -385,6 +388,8 @@ struct PACKED log_XKFS {
     uint8_t gps_good_to_align;
     uint8_t wait_for_gps_checks;
     uint8_t mag_fusion;
+    uint8_t yaw_fusion;
+    uint16_t yaw_fusion_age_ms;
 };
 
 // @LoggerMessage: XKTV
@@ -473,7 +478,7 @@ struct PACKED log_XKV {
     { LOG_XKFM_MSG, sizeof(log_XKFM),   \
       "XKFM", "QBBffff", "TimeUS,C,OGNM,GLR,ALR,GDR,ADR", "s#-----", "F------", true }, \
     { LOG_XKFS_MSG, sizeof(log_XKFS), \
-      "XKFS","QBBBBBBBBB","TimeUS,C,MI,BI,GI,AI,SS,GPS_GTA,GPS_CHK_WAIT,MAG_FUSION", "s#--------", "F---------" , true }, \
+      "XKFS","QBBBBBBBBBBH","TimeUS,C,MI,BI,GI,AI,SS,GPS_GTA,GPS_CHK_WAIT,MAG_FUSION,YF,YFA", "s#---------s", "F----------C" , true }, \
     { LOG_XKQ_MSG, sizeof(log_XKQ), "XKQ", "QBffff", "TimeUS,C,Q1,Q2,Q3,Q4", "s#????", "F-????" , true }, \
     { LOG_XKT_MSG, sizeof(log_XKT),   \
       "XKT", "QBIffffffff", "TimeUS,C,Cnt,IMUMin,IMUMax,EKFMin,EKFMax,AngMin,AngMax,VMin,VMax", "s#sssssssss", "F-000000000", true }, \


### PR DESCRIPTION
### Summary

The EKF can silently discard (from a log perspective) GPS-for-yaw information and just start to rely on aggregating the gyro data.  Add logging so we can see it there!

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Removes the old "MAG_FUSION" logging - which could become stale, giving a false impression in the log as to what the EKF is consuming.  Replaces that with "what yaw source did I last fuse and when?" fields.

Adjusts various tests to (a) use the new logging in place of the old logging and (b) take advantage of the new logging to ensure that what we think is going on *is* going on.

Also changes the newly-added gps-for-yaw test to use guided rather than circle mode.  It was only a transient attitude which was allowing the test to pass - pushing the thing hard in guided allows a constant angle past the limit without having to worry about roll/pitch angles in circle mode (i.e. a single axis is easier to reason about).  The circle-mode test was also not setting the throttle input, so the vehicle was descending at 2.5 m/s....


