### PR TITLE
AP_InertialSensor: Publish LSM6DSV temperature from update() to fix heater control loop

### DIFF
--- a/libraries/AP_InertialSensor/AP_InertialSensor_LSM6DSV.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_LSM6DSV.cpp
@@ -305,6 +305,7 @@ bool AP_InertialSensor_LSM6DSV::update()
 {
     update_accel(accel_instance);
     update_gyro(gyro_instance);
+    _publish_temperature(accel_instance, _temperature_degc);
     return true;
 }
 
@@ -757,8 +758,11 @@ void AP_InertialSensor_LSM6DSV::update_temperature()
         return;
     }
     const int16_t temperature_raw = int16_t(uint16_t(tbuf[0] | (tbuf[1] << 8)));
-    const float temp_degc = LSM6DSV_TEMPERATURE_ZERO_C + temperature_raw / LSM6DSV_TEMPERATURE_SENSITIVITY;
-    _publish_temperature(accel_instance, temp_degc);
+    // the value is published from update() at the front-end loop rate. The IMU
+    // heater control loop only drives the heater pin on calls that arrive
+    // between its 100ms PI updates, so it has to be fed faster than the
+    // register is read here
+    _temperature_degc = LSM6DSV_TEMPERATURE_ZERO_C + temperature_raw / LSM6DSV_TEMPERATURE_SENSITIVITY;
 }
 
 void AP_InertialSensor_LSM6DSV::poll_data()

--- a/libraries/AP_InertialSensor/AP_InertialSensor_LSM6DSV.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_LSM6DSV.h
@@ -113,6 +113,7 @@ private:
     float _gyro_scale;
     uint8_t _whoami;
     uint32_t _temperature_last_ms;
+    float _temperature_degc = 25.0f;
     uint16_t _backend_rate_hz;
     uint32_t _backend_period_us;
     bool _fast_sampling = false;


### PR DESCRIPTION
### Summary
  Publish the LSM6DSV temperature from `update()` instead of from the bus
  thread, so the IMU heater control loop is fed fast enough to actually drive
  the heater output. Without this the heater never turns on. 

### Classification & Testing (check all that apply and add your own)

- [ ] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [v ] Tested manually, description below (e.g. SITL)
- [v] Tested on hardware
- [v] Logs attached
- [v] Logs available on request


  Tested on a Godwit GA1, where IMU0 is an LSM6DSK320X driven by this driver
  at 2 kHz, with `HAL_HAVE_IMU_HEATER 1` and the heater on a local
  `HAL_HEATER_GPIO_PIN`. Two runs on the same board, left disarmed and
  undisturbed, with identical heater parameters confirmed from the logs:
  `BRD_HEAT_TARG=45`, `BRD_HEAT_P=50`, `BRD_HEAT_I=0.07`,
  `BRD_HEAT_IMAX=70`, `LOG_DISARMED=1`. Only the two-file diff in this PR
  differs between the two firmware builds.

  HEAT message, IMU0 temperature at matched elapsed times:

  | t since boot | before fix | after fix |
  | --- | --- | --- |
  | 11 s | 23.79 C | 29.05 C |
  | 101 s | 24.83 C | 37.75 C |
  | 201 s | 26.44 C | 43.49 C |
  | 251 s | 27.26 C | 44.97 C |

  Before the fix `HEAT.Out` never leaves 100% (0 of 269 samples below 100)
  and the integrator sits at `BRD_HEAT_IMAX` for 223 of those 269 samples,
  yet IMU0 only rises 3.93 C in 268 s. The uncontrolled IMU1 rises 3.75 C
  over the same period, so that 4 C is board self-heating and the heater pin
  is never being driven.

  After the fix IMU0 reaches 44 C at t=212 s and `HEAT.Out` leaves
  saturation at t=219 s. Over the last two minutes of the run the
  temperature holds at 45.52 C mean against a target of 45, with `HEAT.Out`
  averaging 34% (range 31-37%).

  Flash cost on this board: 1682784 -> 1682800 bytes, +16.

  Caveats, stated for completeness: the before-fix run was at roughly 5 C
  lower ambient (IMU1 starting at 21.5 C vs 26.4 C) and was stopped after
  268 s rather than 649 s. Neither weakens the result, since a colder room
  only increases heating demand while the controller was already asking for
  full power and getting nothing.


Test Log file：
[heater_lsm6dsv_after_00000002.zip](https://github.com/user-attachments/files/31217006/heater_lsm6dsv_after_00000002.zip)
[heater_lsm6dsv_before_00000003.zip](https://github.com/user-attachments/files/31217017/heater_lsm6dsv_before_00000003.zip)

<img width="1100" height="770" alt="heat_before_after_lsm6dsk320x" src="https://github.com/user-attachments/assets/1216aab1-25b3-4592-b3dd-67d72da55999" />


### Description
  `AP_InertialSensor_LSM6DSV::update_temperature()` is reached from the SPI
  bus thread via `poll_data()` -> `drain_fifo()` -> `publish_accel_sample()`,
  and rate-limits the register read to `LSM6DSV_TEMPERATURE_UPDATE_MS`, which
  is 100 ms. It called `_publish_temperature()` directly from there, so the
  front end saw a new temperature at an interval of 100 ms or slightly more.

  `AP_BoardConfig::set_imu_temp()` runs its PI controller every 100 ms. The
  heater GPIO is only written on the calls that arrive *between* those
  updates, where the output percentage is turned into a randomised duty
  cycle. Because the driver's rate limit is exactly equal to that PI period,
  every call landed on the `>= 100 ms` side, took the PI branch, and the
  heater pin was never written. That is why the logs show a fully saturated
  controller output with no heating.

  This failure mode is specific to a publish interval that coincides with the
  heater's 100 ms PI period. For comparison, BMI055, BMI088 and BMI270
  publish every 101 bus-callback iterations, which works out at 50-63 ms and
  lands inside the `< 100 ms` window, so those drivers do keep the heater pin
  driven. The LSM6DSV was the only one whose interval was exactly 100 ms.

  Boards driving the heater through an IOMCU are also unaffected, since
  `set_heater_duty_cycle()` is called from the PI branch. Only boards using a
  local `HAL_HEATER_GPIO_PIN` are hit.

  The fix caches the converted value and publishes it from `update()`, which
  runs at the front-end loop rate. `_publish_temperature()` is annotated
  `/* front end */` in `AP_InertialSensor_Backend.h`, so this also corrects
  the thread context the call was made from. `_temperature_degc` is
  initialised to 25 C so nothing publishes 0 C before the first read. This is
  the same arrangement already used by `AP_InertialSensor_ASM330` and
  `AP_InertialSensor_Invensensev3`.

  The register read itself is untouched and still rate-limited to 100 ms, so
  there is no additional SPI traffic. Calling the heater update at the
  front-end rate is not new behaviour either, since Invensensev3 already does
  exactly this on every board that uses it.

  Boards affected in master: Pixhawk6C lists the LSM6DSV as an alternative to
  the ICM42688 on the same CS line, so on units populated with the LSM6DSV it
  becomes IMU0, which is `AP_HEATER_IMU_INSTANCE`. That board defines
  `HAL_HAVE_IMU_HEATER 1` and uses `HAL_HEATER_GPIO_PIN 80`.

  The Godwit GA1 used for testing is not yet in master, so the test firmware
  also contains that unmerged board definition. The LSM6DSK320X variant
  itself is already supported in master.


