### PR TITLE
autotest: use new Location object in place of mavutil.location

### DIFF
--- a/Tools/autotest/antennatracker.py
+++ b/Tools/autotest/antennatracker.py
@@ -14,11 +14,14 @@ from pymavlink import mavutil
 
 import vehicle_test_suite
 
+from vehicle_test_suite import AltFrame
+from vehicle_test_suite import Location
 from vehicle_test_suite import NotAchievedException
 
 # get location of scripts
 testdir = os.path.dirname(os.path.realpath(__file__))
-SITL_START_LOCATION = mavutil.location(-27.274439, 151.290064, 343, 8.7)
+SITL_START_LOCATION = Location(-27.274439, 151.290064, 343, AltFrame.ABSOLUTE)
+SITL_START_HEADING = 8.7
 
 
 class AutoTestTracker(vehicle_test_suite.TestSuite):
@@ -31,6 +34,9 @@ class AutoTestTracker(vehicle_test_suite.TestSuite):
 
     def sitl_start_location(self):
         return SITL_START_LOCATION
+
+    def sitl_start_heading(self):
+        return SITL_START_HEADING
 
     def default_mode(self):
         return "AUTO"
@@ -202,7 +208,7 @@ class AutoTestTracker(vehicle_test_suite.TestSuite):
         self.set_home(home_loc)
 
         self.assert_received_message_field_values("GLOBAL_POSITION_INT", {
-            "alt": int(home_loc.alt * 1000),
+            "alt": int(home_loc.get_alt_m(AltFrame.ABSOLUTE) * 1000),
         })
 
     def LoggerMsgChunks(self):

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -47,12 +47,13 @@ CAMERA_IMAGE_STATUS_INTERVAL_IDLE = 2
 
 # get location of scripts
 testdir = os.path.dirname(os.path.realpath(__file__))
-SITL_START_LOCATION = mavutil.location(
+SITL_START_LOCATION = Location(
     -35.362938,
     149.165085,
     584.0805053710938,
-    270
+    AltFrame.ABSOLUTE,
 )
+SITL_START_HEADING = 270
 
 # Flight mode switch positions are set-up in arducopter.param to be
 #   switch 1 = Circle
@@ -95,6 +96,9 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
     def sitl_start_location(self):
         return SITL_START_LOCATION
+
+    def sitl_start_heading(self):
+        return SITL_START_HEADING
 
     def max_distance_from_startup_location_at_end_of_test(self):
         # Copter's tests start from the point the simulation puts the
@@ -215,11 +219,12 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
     # Climb/descend to a given altitude
     def setAlt(self, desiredAlt=50):
-        pos = self.mav.location(relative_alt=True)
-        if pos.alt > desiredAlt:
+        pos = self.get_location(frame=AltFrame.ABOVE_HOME)
+        pos_alt = pos.get_alt_m(AltFrame.ABOVE_HOME)
+        if pos_alt > desiredAlt:
             self.set_rc(3, 1300)
             self.wait_altitude((desiredAlt-5), desiredAlt, relative=True)
-        if pos.alt < (desiredAlt-5):
+        if pos_alt < (desiredAlt-5):
             self.set_rc(3, 1800)
             self.wait_altitude((desiredAlt-5), desiredAlt, relative=True)
         self.hover()
@@ -270,13 +275,13 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         m = self.assert_receive_message('VFR_HUD')
         start_altitude = m.alt
-        start = self.mav.location()
+        start = self.get_location()
         tstart = self.get_sim_time()
         self.progress("Holding loiter at %u meters for %u seconds" %
                       (start_altitude, holdtime))
         while self.get_sim_time_cached() < tstart + holdtime:
             m = self.assert_receive_message('VFR_HUD')
-            pos = self.mav.location()
+            pos = self.get_location()
             delta = self.get_distance(start, pos)
             alt_delta = math.fabs(m.alt - start_altitude)
             self.progress("Loiter Dist: %.2fm, alt:%u" % (delta, m.alt))
@@ -907,7 +912,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.start_subtest("Should arc if we start with a waypoint")
         self.change_mode('STABILIZE')  # needed to ensure Copter mission state machine works
         pos, radius = self.circle_from_arc((0, 0), (90, 0), 90)
-        loc = self.offset_location_ne(self.home_position_as_mav_location(), pos[0], pos[1])
+        loc = self.offset_location_ne(self.home_position_as_location(), pos[0], pos[1])
         self.start_flying_simple_relhome_mission([
             (mavutil.mavlink.MAV_CMD_NAV_TAKEOFF, 0, 0, 20),
             (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 0, 0, 20),
@@ -930,7 +935,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.change_mode('STABILIZE')  # needed to ensure Copter mission state machine works
         self.context_push()
         pos, radius = self.circle_from_arc((0, 0), (90, 0), -90)
-        loc = self.offset_location_ne(self.home_position_as_mav_location(), pos[0], pos[1])
+        loc = self.offset_location_ne(self.home_position_as_location(), pos[0], pos[1])
         self.start_flying_simple_relhome_mission([
             (mavutil.mavlink.MAV_CMD_NAV_TAKEOFF, 0, 0, 20),
             (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 0, 0, 20),
@@ -953,7 +958,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.change_mode('STABILIZE')  # needed to ensure Copter mission state machine works
         self.context_push()
         pos, radius = self.circle_from_arc((0, 0), (90, 0), 90)
-        loc = self.offset_location_ne(self.home_position_as_mav_location(), pos[0], pos[1])
+        loc = self.offset_location_ne(self.home_position_as_location(), pos[0], pos[1])
         self.start_flying_simple_relhome_mission([
             (mavutil.mavlink.MAV_CMD_NAV_TAKEOFF, 0, 0, 20),
             (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 0, 0, 20),
@@ -977,7 +982,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.context_push()
         pos = (45, 0)
         radius = 45
-        loc = self.offset_location_ne(self.home_position_as_mav_location(), pos[0], pos[1])
+        loc = self.offset_location_ne(self.home_position_as_location(), pos[0], pos[1])
         self.start_flying_simple_relhome_mission([
             (mavutil.mavlink.MAV_CMD_NAV_TAKEOFF, 0, 0, 20),
             (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 0, 0, 20),
@@ -1138,7 +1143,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.set_parameter("CSPD_SPEED", expected_groundspeed)
         radius_m = self.get_parameter('CIRCLE_RADIUS_M')
         circle_point = self.offset_location_heading_distance(
-            self.mav.location(),
+            self.get_location(),
             270,  # see SITL_START_LOCATION, FIXME!
             radius_m
         )
@@ -2400,7 +2405,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         m = self.assert_receive_message('VFR_HUD')
         start_altitude = m.alt
-        start = self.mav.location()
+        start = self.get_location()
         tstart = self.get_sim_time()
         self.progress("Holding loiter at %u meters for %u seconds" %
                       (start_altitude, holdtime))
@@ -2414,7 +2419,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         while self.get_sim_time_cached() < tstart + holdtime:
             m = self.assert_receive_message('VFR_HUD')
-            pos = self.mav.location()
+            pos = self.get_location()
             delta = self.get_distance(start, pos)
             alt_delta = math.fabs(m.alt - start_altitude)
             self.progress("Loiter Dist: %.2fm, alt:%u" % (delta, m.alt))
@@ -2667,15 +2672,14 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
     def MaxAltFence(self):
         '''Test Max Alt Fences'''
         self.poll_home_position(quiet=False)
-        home_loc = self.mav.location()
-        origin_alt = home_loc.alt
+        home_loc = self.get_location()
+        origin_alt = home_loc.get_alt_m(AltFrame.ABSOLUTE)
 
         self.max_alt_fence_frame(0, origin_alt + 80, origin_alt + 80)      # absolute
         self.max_alt_fence_frame(1, 100, origin_alt + 100)                 # above home
 
         # set home 50m higher than origin to test that frame 2 uses origin not home
-        home_loc.alt = origin_alt + 50
-        self.set_home(home_loc)
+        self.set_home(self.offset_location_up(home_loc, 50))
         self.max_alt_fence_frame(2, 120, origin_alt + 120)                 # above origin
 
         self.max_alt_fence_frame(3, 90, origin_alt + 90, terrain=1)        # above terrain
@@ -2789,15 +2793,15 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
     def MinAltFence(self):
         '''Test Min Alt Fences'''
         self.poll_home_position(quiet=False)
-        home_loc = self.mav.location()
+        home_loc = self.get_location()
         self.set_home(home_loc)
 
-        self.min_alt_fence_frame(0, home_loc.alt + 20)    # absolute
+        self.min_alt_fence_frame(0, home_loc.get_alt_m(AltFrame.ABSOLUTE) + 20)    # absolute
         self.min_alt_fence_frame(3, 20, 1) # above terrain
         self.min_alt_fence_frame(2, 20)    # above origin
 
         # set origin below home alt - test should still pass
-        nz = mavutil.location(home_loc.lat, home_loc.lng, home_loc.alt - 20, 270)
+        nz = self.offset_location_up(home_loc, -20)
         self.set_origin(nz)
         self.set_parameters({
             "SIM_GPS1_ENABLE": 1,
@@ -3061,7 +3065,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         m = self.poll_home_position(quiet=False)
 
         # 110m polyfence
-        home_loc = self.mav.location()
+        home_loc = self.get_location()
         radius = self.get_parameter("FENCE_RADIUS")
         if self.use_map and self.mavproxy is not None:
             self.mavproxy.send("map circle %f %f %f green\n" % (home_loc.lat, home_loc.lng, radius))
@@ -3143,7 +3147,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.poll_home_position(quiet=False)
 
-        home_loc = self.mav.location()
+        home_loc = self.get_location()
 
         fence_loc = [
             self.offset_location_ne(home_loc, -110, -110),
@@ -3219,7 +3223,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             "FENCE_ENABLE": 1,
         })
         self.takeoff(10, mode='GUIDED')
-        here = self.mav.location()
+        here = self.get_location()
 
         inside_loc = self.offset_location_ne(here, 10, 0)
         outside_loc = self.offset_location_ne(here, 200, 0)
@@ -3229,7 +3233,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             mavutil.mavlink.MAV_CMD_DO_REPOSITION,
             x=int(inside_loc.lat * 1e7),
             y=int(inside_loc.lng * 1e7),
-            z=here.alt,
+            z=here.get_alt_m(AltFrame.ABSOLUTE),
             frame=mavutil.mavlink.MAV_FRAME_GLOBAL,
             want_result=mavutil.mavlink.MAV_RESULT_ACCEPTED,
         )
@@ -3239,7 +3243,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             mavutil.mavlink.MAV_CMD_DO_REPOSITION,
             x=int(outside_loc.lat * 1e7),
             y=int(outside_loc.lng * 1e7),
-            z=here.alt,
+            z=here.get_alt_m(AltFrame.ABSOLUTE),
             frame=mavutil.mavlink.MAV_FRAME_GLOBAL,
             want_result=mavutil.mavlink.MAV_RESULT_FAILED,
         )
@@ -3321,7 +3325,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         # record time and position
         tstart = self.get_sim_time()
         tnow = tstart
-        start_pos = self.sim_location()
+        start_pos = self.get_location('SIMSTATE')
 
         # initialise current glitch
         glitch_current = 0
@@ -3357,7 +3361,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             if glitch_current == -1:
                 m = self.assert_receive_message(type='GLOBAL_POSITION_INT')
                 alt = m.alt/1000.0 # mm -> m
-                curr_pos = self.sim_location()
+                curr_pos = self.get_location('SIMSTATE')
                 moved_distance = self.get_distance(curr_pos, start_pos)
                 self.progress("Alt: %.02f  Moved: %.0f" %
                               (alt, moved_distance))
@@ -4356,9 +4360,9 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.wait_groundspeed(1.0, 100, timeout=10)
         self.set_rc(2, 1500)
         self.wait_groundspeed(0, 0.3, timeout=30, minimum_duration=5)
-        loc = self.mav.location()
+        loc = self.get_location()
         self.delay_sim_time(15, "watch for drift")
-        drift_m = self.get_distance(loc, self.mav.location())
+        drift_m = self.get_distance(loc, self.get_location())
         self.progress("Drifted %.2fm while holding" % drift_m)
         if drift_m > 3:
             raise NotAchievedException("Drifted %.2fm in FlowHold" % drift_m)
@@ -4959,12 +4963,12 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.install_message_hook_context(verify_innov)
 
         self.takeoff(50, mode='GUIDED')
-        current_alt = self.mav.location().alt
-        target_position = mavutil.location(
+        current_alt = self.get_location().get_alt_m(AltFrame.ABSOLUTE)
+        target_position = Location(
             -35.362938,
             149.165185,
             current_alt,
-            0
+            AltFrame.ABSOLUTE,
         )
 
         self.fly_guided_move_to(target_position, timeout=300)
@@ -5028,10 +5032,10 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             lng_1e7 = loc.lon
             alt_mm = loc.alt
         else:
-            # assume a mavutil.Location
+            # assume a Location; the origin's altitude is AMSL
             lat_1e7 = int(loc.lat * 1e7)
             lng_1e7 = int(loc.lng * 1e7)
-            alt_mm = int(loc.alt * 1e3)
+            alt_mm = int(loc.get_alt_m(AltFrame.ABSOLUTE) * 1e3)
 
         tstart = self.get_sim_time()
         while True:
@@ -5105,7 +5109,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             "SIM_GPS1_ENABLE": 0,
         })
         self.reboot_sitl()
-        nz = mavutil.location(-43.730171, 169.983118, 1466.3, 270)
+        nz = Location(-43.730171, 169.983118, 1466.3, AltFrame.ABSOLUTE)
         self.set_origin(nz)
         self.set_parameters({
             "SIM_GPS1_ENABLE": 1,
@@ -6187,8 +6191,8 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             self.assert_vehicle_location_is_at_startup_location()
 
             self.takeoff(10, mode="LOITER")
-            lower_surface_pos = mavutil.location(-35.362421, 149.164534, 584, 270)
-            here = self.mav.location()
+            lower_surface_pos = Location.latlon_only(-35.362421, 149.164534)
+            here = self.get_location()
             bearing = self.get_bearing(here, lower_surface_pos)
 
             self.change_mode("GUIDED")
@@ -6206,9 +6210,9 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             while True:
                 if self.get_sim_time() - tstart > 200:
                     raise NotAchievedException("Did not reach lower point")
-                x = self.get_mav_location()
+                x = self.get_location()
                 dist = self.get_distance(x, lower_surface_pos)
-                delta = orig_absolute_alt_mm/1000.0 - x.alt
+                delta = orig_absolute_alt_mm/1000.0 - x.get_alt_m(AltFrame.ABSOLUTE)
 
                 self.progress("Distance: %fm abs-alt-delta: %fm" %
                               (dist, delta))
@@ -6588,7 +6592,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 # position - which is the spawn position.  Sampling the
                 # position before the reboot places the target wherever
                 # the previous test happened to leave the vehicle:
-                start = self.mav.location()
+                start = self.get_location()
                 target = start
                 (target.lat, target.lng) = mavextra.gps_offset(start.lat, start.lng, 4, -4)
                 self.progress("Setting target to %f %f" % (target.lat, target.lng))
@@ -6603,7 +6607,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 self.zero_throttle()
                 self.wait_landed_and_disarmed()
                 self.assert_receive_message('GLOBAL_POSITION_INT')
-                new_pos = self.mav.location()
+                new_pos = self.get_location()
                 delta = self.get_distance(target, new_pos)
                 self.progress("Landed %f metres from target position" % delta)
                 max_delta = 1.5
@@ -7326,11 +7330,8 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.wait_text("Gripper load releas(ed|ing)", timeout=90, regex=True)
         dist_limit = 1
         # this is a copy of the point in the mission file:
-        target_loc = mavutil.location(-35.363106,
-                                      149.165436,
-                                      0,
-                                      0)
-        dist = self.get_distance(target_loc, self.mav.location())
+        target_loc = Location.latlon_only(-35.363106, 149.165436)
+        dist = self.get_distance(target_loc, self.get_location())
         self.progress("dist=%f" % (dist,))
         if dist > dist_limit:
             raise NotAchievedException("Did not honour target lat/lng (dist=%f want <%f" %
@@ -7626,7 +7627,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         alt = 50
 
-        loc = self.mav.location()
+        loc = self.get_location()
 
         items = [
             self.mission_item_home(),
@@ -7973,7 +7974,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
             self.progress("Testing mount ROI behaviour")
             self.test_mount_pitch(0, rc_targetting_pitch_tolerance, mavutil.mavlink.MAV_MOUNT_MODE_RC_TARGETING)
-            start = self.mav.location()
+            start = self.get_location()
             self.progress("start=%s" % str(start))
             (roi_lat, roi_lon) = mavextra.gps_offset(start.lat,
                                                      start.lng,
@@ -8012,7 +8013,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             self.run_cmd_int(mavutil.mavlink.MAV_CMD_DO_SET_ROI_NONE)
             self.test_mount_pitch(0, 1, mavutil.mavlink.MAV_MOUNT_MODE_RC_TARGETING)
 
-            start = self.mav.location()
+            start = self.get_location()
             (roi_lat, roi_lon) = mavextra.gps_offset(start.lat,
                                                      start.lng,
                                                      -100,
@@ -8027,7 +8028,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             )
             self.test_mount_pitch(-7.5, 1, mavutil.mavlink.MAV_MOUNT_MODE_GPS_POINT)
 
-            start = self.mav.location()
+            start = self.get_location()
             (roi_lat, roi_lon) = mavextra.gps_offset(start.lat,
                                                      start.lng,
                                                      -100,
@@ -8066,7 +8067,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
             self.progress("Testing mount roi-sysid behaviour")
             self.test_mount_pitch(0, 0.1, mavutil.mavlink.MAV_MOUNT_MODE_NEUTRAL)
-            start = self.mav.location()
+            start = self.get_location()
             self.progress("start=%s" % str(start))
             (roi_lat, roi_lon) = mavextra.gps_offset(start.lat,
                                                      start.lng,
@@ -8777,7 +8778,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.setup_servo_mount()
         self.reboot_sitl() # to handle MNT_TYPE changing
 
-        takeoff_loc = self.mav.location()
+        takeoff_loc = self.get_location()
 
         self.takeoff(20, mode='GUIDED')
         self.guided_achieve_heading(315, direction=1, accuracy=1)
@@ -9001,7 +9002,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.progress("Pointing North")
         self.guided_achieve_heading(0, direction=1, accuracy=1)
         self.delay_sim_time(5, reason="heading to stabilise")
-        start = self.mav.location()
+        start = self.get_location()
         (roi_lat, roi_lon) = mavextra.gps_offset(start.lat,
                                                  start.lng,
                                                  -100,
@@ -9021,7 +9022,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         # the following numbers are 1-degree-latitude and
         # 0-degrees longitude - just so that we start to
         # really move a lot.
-        there = mavutil.location(1, 0, 0, 0)
+        there = Location(1, 0, 0, AltFrame.ABOVE_HOME)
 
         self.progress("Starting to move")
         self.mav.mav.set_position_target_global_int_send(
@@ -9032,7 +9033,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             MAV_POS_TARGET_TYPE_MASK.POS_ONLY | MAV_POS_TARGET_TYPE_MASK.LAST_BYTE, # mask specifying use-only-lat-lon-alt
             there.lat, # lat
             there.lng, # lon
-            there.alt, # alt
+            there.get_alt_m(AltFrame.ABOVE_HOME), # alt
             0, # vx
             0, # vy
             0, # vz
@@ -10237,8 +10238,10 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.do_RTL()
         self.progress("Ran brake  mode")
 
-    def fly_guided_move_to(self, destination, timeout=30):
-        '''move to mavutil.location location; absolute altitude'''
+    def fly_guided_move_to(self, destination: Location, timeout=30):
+        '''move to a (frame-aware) Location; the destination is sent as an
+        absolute (AMSL) altitude'''
+        destination = self.change_alt_frame(destination, AltFrame.ABSOLUTE)
         tstart = self.get_sim_time()
         self.mav.mav.set_position_target_global_int_send(
             0, # timestamp
@@ -10248,7 +10251,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             MAV_POS_TARGET_TYPE_MASK.POS_ONLY | MAV_POS_TARGET_TYPE_MASK.LAST_BYTE, # mask specifying use-only-lat-lon-alt
             int(destination.lat * 1e7), # lat
             int(destination.lng * 1e7), # lon
-            destination.alt, # alt
+            destination.get_alt_m(AltFrame.ABSOLUTE), # alt
             0, # vx
             0, # vy
             0, # vz
@@ -10261,10 +10264,15 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         while True:
             if self.get_sim_time() - tstart > timeout:
                 raise NotAchievedException()
-            delta = self.get_distance(self.mav.location(), destination)
+            delta = self.get_distance(self.get_location(), destination)
             self.progress("delta=%f (want <1)" % delta)
             if delta < 1:
                 break
+        # the vehicle crosses the 1m threshold while still travelling at
+        # a couple of metres/second, and callers go on to land or to
+        # measure where it ended up; wait for it to settle on the
+        # destination rather than catching it mid-approach
+        self.wait_groundspeed(0, 0.5, timeout=30)
 
     def AltTypes(self):
         '''Test Different Altitude Types'''
@@ -10294,9 +10302,9 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.user_takeoff(5)
 
         self.progress("Flying to low position")
-        current_alt = self.mav.location().alt
-# 10m delta        low_position = mavutil.location(-35.358273, 149.169165, current_alt, 0)
-        low_position = mavutil.location(-35.36200016, 149.16415599, current_alt, 0)
+        current_alt = self.get_location().get_alt_m(AltFrame.ABSOLUTE)
+# 10m delta        low_position = Location(-35.358273, 149.169165, current_alt, AltFrame.ABSOLUTE)
+        low_position = Location(-35.36200016, 149.16415599, current_alt, AltFrame.ABSOLUTE)
         self.fly_guided_move_to(low_position, timeout=240)
         self.change_mode('LAND')
         # expecting home to change when disarmed
@@ -10597,28 +10605,20 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
     def check_avoidance_corners(self):
         self.takeoff(10, mode="LOITER")
-        here = self.mav.location()
+        here = self.get_location()
+        here_alt_amsl = here.get_alt_m(AltFrame.ABSOLUTE)
         # the vehicle starts a test at home but with whatever heading
         # the previous test left it; face west like the other corner
         # legs explicitly face their travel direction:
         self.reach_heading_manual(270)
         self.set_rc(2, 1400)
-        west_loc = mavutil.location(-35.363007,
-                                    149.164911,
-                                    here.alt,
-                                    0)
+        west_loc = Location(-35.363007, 149.164911, here_alt_amsl, AltFrame.ABSOLUTE)
         self.wait_location(west_loc, accuracy=6)
-        north_loc = mavutil.location(-35.362908,
-                                     149.165051,
-                                     here.alt,
-                                     0)
+        north_loc = Location(-35.362908, 149.165051, here_alt_amsl, AltFrame.ABSOLUTE)
         self.reach_heading_manual(0)
         self.wait_location(north_loc, accuracy=6, timeout=200)
         self.reach_heading_manual(90)
-        east_loc = mavutil.location(-35.363013,
-                                    149.165194,
-                                    here.alt,
-                                    0)
+        east_loc = Location(-35.363013, 149.165194, here_alt_amsl, AltFrame.ABSOLUTE)
         self.wait_location(east_loc, accuracy=6)
         self.reach_heading_manual(225)
         self.wait_location(west_loc, accuracy=6, timeout=200)
@@ -10937,12 +10937,12 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.do_RTL()
 
-    def mav_location_from_message_cache(self) -> mavutil.location:
-        return mavutil.location(
+    def location_from_message_cache(self) -> Location:
+        '''return a lat/lng-only Location from the most recently received
+        GPS_RAW_INT; only the horizontal position is of interest here'''
+        return Location.latlon_only(
             self.mav.messages['GPS_RAW_INT'].lat*1.0e-7,
             self.mav.messages['GPS_RAW_INT'].lon*1.0e-7,
-            self.mav.messages['VFR_HUD'].alt,  # relative alt only
-            self.mav.messages['VFR_HUD'].heading
         )
 
     def ModeFollow(self):
@@ -10958,7 +10958,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.context_push()
         self.context_set_speedup(1)
         self.change_mode("FOLLOW")
-        new_loc = self.mav.location()
+        new_loc = self.get_location()
         new_loc_offset_n = 20
         new_loc_offset_e = 30
         self.location_offset_ne(new_loc, new_loc_offset_n, new_loc_offset_e)
@@ -10988,8 +10988,8 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                     int(now * 1000), # time_boot_ms
                     int(new_loc.lat * 1e7),
                     int(new_loc.lng * 1e7),
-                    int(new_loc.alt * 1000), # alt in mm
-                    int(new_loc.alt * 1000 - origin.altitude), # relative alt - urp.
+                    int(new_loc.get_alt_m(AltFrame.ABSOLUTE) * 1000), # alt in mm
+                    int(new_loc.get_alt_m(AltFrame.ABSOLUTE) * 1000 - origin.altitude), # relative alt - urp.
                     vx=0,
                     vy=0,
                     vz=0,
@@ -10998,7 +10998,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 gpi.pack(self.mav.mav)
                 self.mav.mav.send(gpi)
             self.assert_receive_message('GLOBAL_POSITION_INT')
-            pos = self.mav_location_from_message_cache()
+            pos = self.location_from_message_cache()
             delta = self.get_distance(expected_loc, pos)
             max_delta = 3
             self.progress("position delta=%f (want <%f)" % (delta, max_delta))
@@ -11008,10 +11008,10 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.start_subtest("Trying relative-follow mode")
         self.change_mode('LOITER')
         self.set_parameter('FOLL_ALT_TYPE', 1)  # use relative-home data
-        new_loc = self.mav.location()
+        new_loc = self.get_location()
         new_loc_offset_n = -40
         new_loc_offset_e = 60
-        new_loc.alt += 1
+        new_loc.offset_up_m(1)
         self.location_offset_ne(new_loc, new_loc_offset_n, new_loc_offset_e)
         expected_loc = copy.copy(new_loc)
         self.location_offset_ne(expected_loc, -foll_ofs_x, 0)
@@ -11033,7 +11033,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                     int(new_loc.lat * 1e7),
                     int(new_loc.lng * 1e7),
                     666, # alt in mm - note incorrect data!
-                    int(new_loc.alt * 1000 - origin.altitude), # relative alt - urp.
+                    int(new_loc.get_alt_m(AltFrame.ABSOLUTE) * 1000 - origin.altitude), # relative alt - urp.
                     vx=0,
                     vy=0,
                     vz=0,
@@ -11042,7 +11042,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 gpi.pack(self.mav.mav)
                 self.mav.mav.send(gpi)
             self.assert_receive_message('GLOBAL_POSITION_INT')
-            pos = self.mav_location_from_message_cache()
+            pos = self.location_from_message_cache()
             delta = self.get_distance(expected_loc, pos)
             max_delta = 3
             self.progress("position delta=%f (want <%f)" % (delta, max_delta))
@@ -11052,7 +11052,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.start_subtest("Trying follow-with-velocity mode")
         self.change_mode('LOITER')
         self.set_parameter('FOLL_ALT_TYPE', 1)  # use relative-home data
-        new_loc = self.mav.location()
+        new_loc = self.get_location()
         vel_n = 3  # m/s
         vel_e = 2
         vel_d = -1
@@ -11070,7 +11070,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             new_loc_offset_u = vel_d * dt * -1
 
             self.location_offset_ne(new_loc, new_loc_offset_n, new_loc_offset_e)
-            new_loc.alt += new_loc_offset_u
+            new_loc.offset_up_m(new_loc_offset_u)
             expected_loc = copy.copy(new_loc)
             self.location_offset_ne(expected_loc, -foll_ofs_x, 0)
             self.progress("expected_loc: %s" % str(expected_loc))
@@ -11087,7 +11087,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                     int(new_loc.lat * 1e7),
                     int(new_loc.lng * 1e7),
                     666, # alt in mm - note incorrect data!
-                    int(new_loc.alt * 1000 - origin.altitude), # relative alt - urp.
+                    int(new_loc.get_alt_m(AltFrame.ABSOLUTE) * 1000 - origin.altitude), # relative alt - urp.
                     vx=int(vel_n*100),
                     vy=int(vel_e*100),
                     vz=int(vel_d*100),
@@ -11096,7 +11096,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 gpi.pack(self.mav.mav)
                 self.mav.mav.send(gpi)
             self.assert_receive_message('GLOBAL_POSITION_INT')
-            pos = self.mav.location()
+            pos = self.get_location()
             delta = self.get_distance(expected_loc, pos)
             want_delta = foll_ofs_x
             self.progress("position delta=%f (want <%f)" % (delta, max_delta))
@@ -11119,7 +11119,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.context_push()
         self.context_set_speedup(1)
         self.change_mode("FOLLOW")
-        new_loc = self.mav.location()
+        new_loc = self.get_location()
         new_loc_offset_n = 40
         new_loc_offset_e = 60
         self.location_offset_ne(new_loc, new_loc_offset_n, new_loc_offset_e)
@@ -11152,7 +11152,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 1 << 0 | 1 << 1 | 1 << 3,  # pos, vel, att+rates
                 int(new_loc.lat * 1e7),
                 int(new_loc.lng * 1e7),
-                new_loc.alt, # alt in m
+                new_loc.get_alt_m(AltFrame.ABSOLUTE), # alt in m
                 [0, 0, 0],  # velocity m/s
                 [0, 0, 0],  # acceleration m/s/s
                 attitude,   # attitude quaternion
@@ -11171,7 +11171,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.start_subtest("Trying follow-with-velocity mode")
         self.change_mode('LOITER')
         self.set_parameter('FOLL_ALT_TYPE', 1)  # use relative-home data
-        new_loc = self.mav.location()
+        new_loc = self.get_location()
         self.change_mode('FOLLOW')
         last_loop_s = self.get_sim_time_cached()
 
@@ -11193,7 +11193,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             new_loc_offset_e = vel_e * dt
             new_loc_offset_u = vel_d * dt * -1
             self.location_offset_ne(new_loc, new_loc_offset_n, new_loc_offset_e)
-            new_loc.alt += new_loc_offset_u
+            new_loc.offset_up_m(new_loc_offset_u)
 
             # update heading
             heading = math.atan2(vel_n, vel_e)
@@ -11208,7 +11208,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 1 << 0 | 1 << 1 | 1 << 3,  # pos, vel, att+rates
                 int(new_loc.lat * 1e7),
                 int(new_loc.lng * 1e7),
-                new_loc.alt, # alt in m
+                new_loc.get_alt_m(AltFrame.ABSOLUTE), # alt in m
                 [vel_n, vel_e, vel_d],  # velocity m/s
                 [0, 0, 0],  # acceleration m/s/s
                 attitude,   # attitude quaternion
@@ -11291,7 +11291,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.set_parameters({
             "BCN_LATITUDE": SITL_START_LOCATION.lat,
             "BCN_LONGITUDE": SITL_START_LOCATION.lng,
-            "BCN_ALT": SITL_START_LOCATION.alt,
+            "BCN_ALT": SITL_START_LOCATION.get_alt_m(AltFrame.ABSOLUTE),
             "BCN_ORIENT_YAW": 0,
             "AVOID_ENABLE": 4,
             "GPS1_TYPE": 0,
@@ -11340,19 +11340,20 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
             self.takeoff(10, mode="LOITER")
             self.set_rc(2, 1400)
-            here = self.mav.location()
-            west_loc = mavutil.location(-35.362919, 149.165055, here.alt, 0)
+            here = self.get_location()
+            here_alt_amsl = here.get_alt_m(AltFrame.ABSOLUTE)
+            west_loc = Location(-35.362919, 149.165055, here_alt_amsl, AltFrame.ABSOLUTE)
             self.wait_location(west_loc, accuracy=1)
             self.reach_heading_manual(0)
-            north_loc = mavutil.location(-35.362881, 149.165103, here.alt, 0)
+            north_loc = Location(-35.362881, 149.165103, here_alt_amsl, AltFrame.ABSOLUTE)
             self.wait_location(north_loc, accuracy=1)
             self.set_rc(2, 1500)
             self.set_rc(1, 1600)
-            east_loc = mavutil.location(-35.362986, 149.165227, here.alt, 0)
+            east_loc = Location(-35.362986, 149.165227, here_alt_amsl, AltFrame.ABSOLUTE)
             self.wait_location(east_loc, accuracy=1)
             self.set_rc(1, 1500)
             self.set_rc(2, 1600)
-            south_loc = mavutil.location(-35.363025, 149.165182, here.alt, 0)
+            south_loc = Location(-35.363025, 149.165182, here_alt_amsl, AltFrame.ABSOLUTE)
             self.wait_location(south_loc, accuracy=1)
             self.set_rc(2, 1500)
             self.do_RTL()
@@ -12867,7 +12868,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.reboot_sitl()
 
         self.wait_ready_to_arm()
-        home = self.mav.location()
+        home = self.get_location()
 
         self.context_collect('STATUSTEXT')
 
@@ -12975,11 +12976,11 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         while divergence < 15:
             if self.get_sim_time_cached() - tstart > 120:
                 raise PreconditionFailedException(f"estimates did not diverge ({divergence:.1f}m)")
-            divergence = self.get_distance(self.sim_location(), self.get_mav_location())
+            divergence = self.get_distance(self.get_location('SIMSTATE'), self.get_location())
             self.progress(f"NE divergence={divergence:.1f}m")
         self.delay_sim_time(10, reason="let position controller settle after glitch adoption")
 
-        start_loc = self.sim_location()
+        start_loc = self.get_location('SIMSTATE')
         self.context_collect('STATUSTEXT')
         self.progress("Switching active estimator from EKF3 to SIM")
         self.set_parameter("AHRS_EKF_TYPE", 10)
@@ -12991,7 +12992,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         moved = 0
         tstart = self.get_sim_time()
         while self.get_sim_time() - tstart < 20:
-            moved = self.get_distance(start_loc, self.sim_location())
+            moved = self.get_distance(start_loc, self.get_location('SIMSTATE'))
             self.progress(f"moved={moved:.1f}m")
             if moved > 8:
                 raise NotAchievedException(f"Vehicle lurched {moved:.1f}m after estimator switch")
@@ -13010,7 +13011,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         # truth about where it is:
         tstart = self.get_sim_time()
         while True:
-            residual = self.get_distance(self.sim_location(), self.get_mav_location())
+            residual = self.get_distance(self.get_location('SIMSTATE'), self.get_location())
             self.progress(f"post-switch-back residual={residual:.1f}m")
             if residual < 5:
                 break
@@ -14766,7 +14767,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.takeoff(20, mode='GUIDED')
 
         # Set home current location, this gives a large home vs origin difference
-        self.set_home(self.mav.location())
+        self.set_home(self.get_location())
 
         self.progress("fly 50m North (or whatever)")
         self.fly_guided_move_local(50, 0, 50)
@@ -15490,7 +15491,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.wait_ready_to_arm()
 
-        here = self.mav.location()
+        here = self.get_location()
 
         self.context_push()
 
@@ -15511,7 +15512,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.start_subtest("F_ALT_MIN 16m relative - arm in face of threat")
         self.context_push()
         self.set_parameters({
-            "AVD_F_ALT_MIN": int(16 + here.alt),
+            "AVD_F_ALT_MIN": int(16 + here.get_alt_m(AltFrame.ABSOLUTE)),
         })
         self.wait_ready_to_arm()
         self.test_adsb_send_threatening_adsb_message(here)
@@ -15559,7 +15560,8 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         # send vehicle to global position target
         target_alt = 30
-        location = self.home_relative_loc_neu(300, 0, target_alt)
+        location = self.offset_location_ne(self.home_position_as_location(), 300, 0)
+        location.set_alt_m(target_alt, AltFrame.ABOVE_HOME)
         target_typemask = MAV_POS_TARGET_TYPE_MASK.POS_ONLY
         self.mav.mav.set_position_target_global_int_send(
             0, # timestamp
@@ -15590,7 +15592,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.guided_achieve_heading(heading=270)
 
         # move vehicle on x direction
-        location = self.offset_location_ne(location=self.mav.location(), metres_north=0, metres_east=-300)
+        location = self.offset_location_ne(location=self.get_location(), metres_north=0, metres_east=-300)
         self.mav.mav.set_position_target_global_int_send(
             0, # system time in milliseconds
             1, # target system
@@ -15994,7 +15996,8 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         '''Check RTL to rally point'''
         self.wait_ready_to_arm()
         rally_alt = 37
-        rally_loc = self.home_relative_loc_neu(50, -25, rally_alt)
+        rally_loc = self.offset_location_ne(self.home_position_as_location(), 50, -25)
+        rally_loc.set_alt_m(rally_alt, AltFrame.ABOVE_HOME)
         items = [
             self.mav.mav.mission_item_int_encode(
                 target_system,
@@ -16056,7 +16059,8 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.change_mode('LOITER')
         self.wait_ready_to_arm()
         takeoff_alt = 10
-        target = self.home_relative_loc_neu(0, 0, takeoff_alt)
+        target = self.home_position_as_location()
+        target.set_alt_m(takeoff_alt, AltFrame.ABOVE_HOME)
         self.set_parameters({
             "AHRS_EKF_TYPE": 10,
 
@@ -16656,7 +16660,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         # test GPS_POINT (ROI)
         self.start_subtest("GPS_POINT (ROI)")
-        takeoff_loc = self.mav.location()
+        takeoff_loc = self.get_location()
         t = self.offset_location_ne(takeoff_loc, 20, 0)
         self.run_cmd_int(
             mavutil.mavlink.MAV_CMD_DO_SET_ROI_LOCATION,
@@ -17065,14 +17069,14 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         '''test Copter DO_CHANGE_SPEED handling in guided mode'''
         self.takeoff(20, mode='GUIDED')
 
-        new_loc = self.mav.location()
+        new_loc = self.get_location()
         new_loc_offset_n = 2000
         new_loc_offset_e = 0
         self.location_offset_ne(new_loc, new_loc_offset_n, new_loc_offset_e)
 
         second_loc_offset_n = -1000
         second_loc_offset_e = 0
-        second_loc = self.mav.location()
+        second_loc = self.get_location()
         self.location_offset_ne(second_loc, second_loc_offset_n, second_loc_offset_e)
 
         # for run_cmd we fly away from home
@@ -17085,7 +17089,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 p4=float("nan"),  # nan means do whatever you want to do
                 p5=int(tloc.lat * 1e7),
                 p6=int(tloc.lng * 1e7),
-                p7=tloc.alt,
+                p7=tloc.get_alt_m(AltFrame.ABSOLUTE),
                 frame=mavutil.mavlink.MAV_FRAME_GLOBAL,
             )
             for speed in [2, 10, 4]:
@@ -17158,7 +17162,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.change_mode('AUTO')
         self.wait_ready_to_arm()
         self.arm_vehicle()
-        home_loc = self.mav.location()
+        home_loc = self.get_location()
 
         cmd_ids = [
             mavutil.mavlink.MAV_CMD_DO_SET_ROI,
@@ -17170,7 +17174,10 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 self.wait_waypoint(2, 2)
 
                 # Set an ROI at the Home location, expect to point at Home
-                self.run_cmd(mavutil.mavlink.MAV_CMD_DO_SET_ROI_LOCATION, p5=home_loc.lat, p6=home_loc.lng, p7=home_loc.alt)
+                self.run_cmd(mavutil.mavlink.MAV_CMD_DO_SET_ROI_LOCATION,
+                             p5=home_loc.lat,
+                             p6=home_loc.lng,
+                             p7=home_loc.get_alt_m(AltFrame.ABSOLUTE))
                 self.wait_heading(180)
 
                 # Clear the ROI, expect to point at the next Waypoint
@@ -17328,7 +17335,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.wait_mode('LOITER')
         # be careful of AC_FENCE_GIVE_UP_DISTANCE here (100m default)
         self.progress("Move home 60m North")
-        pos = self.offset_location_ne(self.mav.location(relative_alt=True), 60, 0)
+        pos = self.offset_location_ne(self.get_location(frame=AltFrame.ABOVE_HOME), 60, 0)
         self.context_push()
         self.context_collect('STATUSTEXT')
         self.set_home(pos)
@@ -17422,7 +17429,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         # a broken one uses the stale EKF-origin offset and keeps the vehicle
         # pinned to the old boundary (8m short of the new inner_radius).
         new_home = self.offset_location_ne(
-            self.home_position_as_mav_location(), 0, -10,
+            self.home_position_as_location(), 0, -10,
         )
         self.set_home(new_home)
         self.poll_home_position()
@@ -17483,7 +17490,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         # reset home 20 metres above current location
         current_alt_abs = self.get_altitude(relative=False)
 
-        loc = self.mav.location()
+        loc = self.get_location()
 
         home_z_ofs = 20
         self.run_cmd(
@@ -17517,7 +17524,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         # reset home 20 metres above current location
         current_alt_abs = self.get_altitude(relative=False)
 
-        loc = self.mav.location()
+        loc = self.get_location()
 
         home_z_ofs = 20
         self.run_cmd(
@@ -17768,11 +17775,12 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             "SIM_TERRAIN": 1,
         })
         self.takeoff(10, mode='GUIDED')
-        here = self.mav.location()
+        here = self.get_location()
+        here_alt_amsl = here.get_alt_m(AltFrame.ABSOLUTE)
         self.set_home(here)
         self.hover()
         self.change_mode('LOITER')
-        self.wait_altitude(here.alt-1, here.alt+1, minimum_duration=10)
+        self.wait_altitude(here_alt_amsl-1, here_alt_amsl+1, minimum_duration=10)
         self.disarm_vehicle(force=True)
 
     def GuidedModeThrust(self):
@@ -17799,8 +17807,8 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
     def AutoRTL(self):
         '''Test Auto RTL mode using do land start and return path start mission items'''
         alt = 50
-        guided_loc = self.home_relative_loc_ne(1000, 0)
-        guided_loc.alt += alt
+        guided_loc = self.offset_location_ne(self.home_position_as_location(), 1000, 0)
+        guided_loc.set_alt_m(alt, AltFrame.ABOVE_HOME)
 
         # Arm, take off and fly to guided location
         self.takeoff(mode='GUIDED')
@@ -17886,8 +17894,8 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.assert_current_waypoint(8)
 
         # Move a bit closer in guided
-        return_path_test = self.home_relative_loc_ne(600, 0)
-        return_path_test.alt += alt
+        return_path_test = self.offset_location_ne(self.home_position_as_location(), 600, 0)
+        return_path_test.set_alt_m(alt, AltFrame.ABOVE_HOME)
         self.change_mode('GUIDED')
         self.fly_guided_move_to(return_path_test, timeout=100)
 
@@ -17897,8 +17905,8 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.assert_current_waypoint(5)
 
         # fly over home
-        home = self.home_relative_loc_ne(0, 0)
-        home.alt += alt
+        home = self.home_position_as_location()
+        home.set_alt_m(alt, AltFrame.ABOVE_HOME)
         self.change_mode('GUIDED')
         self.fly_guided_move_to(home, timeout=140)
 
@@ -17965,16 +17973,16 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.change_mode('GUIDED')
         self.arm_vehicle(force=True)
         self.takeoff(20, mode='GUIDED')
-        location = self.offset_location_ne(self.sim_location(), metres_north=0, metres_east=-300)
+        location = self.offset_location_ne(self.get_location('SIMSTATE'), metres_north=0, metres_east=-300)
         self.progress("Ensure we don't move for 10 seconds")
         tstart = self.get_sim_time()
-        startpos = self.sim_location_int()
+        startpos = self.get_location('SIMSTATE')
         while True:
             now = self.get_sim_time_cached()
             if now - tstart > 10:
                 break
             self.send_set_position_target_global_int(int(location.lat*1e7), int(location.lng*1e7), 10)
-            dist = self.get_distance_int(startpos, self.sim_location_int())
+            dist = self.get_distance(startpos, self.get_location('SIMSTATE'))
             if dist > 10:
                 raise NotAchievedException("Wandered too far from start position")
             self.delay_sim_time(1, reason="poll interval")
@@ -18084,10 +18092,10 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.change_mode('LOITER')
         self.context_pop()
 
-        here = self.mav.location()
+        here = self.get_location()
         loc = self.offset_location_ne(here, 10, 0)
         self.takeoff(5, mode='GUIDED')
-        self.send_do_reposition(loc, frame=mavutil.mavlink.MAV_FRAME_GLOBAL)
+        self.send_do_reposition(loc)
         self.wait_location(loc, timeout=120)
         self.land_and_disarm()
 
@@ -18485,7 +18493,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         # confirm the ExternalAHRS really was the source: its origin matches
         # the true home rather than the ~100m-glitched SITL GPS position
-        ext_loc = mavutil.location(ext_origin.latitude * 1e-7, ext_origin.longitude * 1e-7)
+        ext_loc = Location.latlon_only(ext_origin.latitude * 1e-7, ext_origin.longitude * 1e-7)
         dist = self.get_distance(self.sitl_start_location(), ext_loc)
         if dist > 30:
             raise NotAchievedException(
@@ -18903,7 +18911,7 @@ RTL_ALT_M 111
         self.change_mode('STABILIZE')
 
         # Set home current location, this gives a large home vs origin difference
-        self.set_home(self.mav.location())
+        self.set_home(self.get_location())
 
         self.set_rc(4, 2000)
         self.wait_armed()
@@ -18953,7 +18961,7 @@ RTL_ALT_M 111
         self.start_subtest("Start circle when on edge of circle")
         radius = 30
         self.wait_ready_to_arm()
-        here = self.mav.location()
+        here = self.get_location()
         circle_centre_loc = self.offset_location_ne(here, radius, 0)
         self.upload_simple_relhome_mission([
             (mavutil.mavlink.MAV_CMD_NAV_TAKEOFF, 0, 0, 20),
@@ -19440,7 +19448,7 @@ RTL_ALT_M 111
         '''test we ignore takeoff location'''
         self.change_mode('LOITER')
         self.wait_ready_to_arm()
-        arming_loc = self.mav.location()
+        arming_loc = self.get_location()
         # the location here should be ignored:
         self.start_flying_simple_relhome_mission([
             (mavutil.mavlink.MAV_CMD_NAV_TAKEOFF, 10, 10, 20),
@@ -19452,7 +19460,7 @@ RTL_ALT_M 111
             (mavutil.mavlink.MAV_CMD_NAV_RETURN_TO_LAUNCH, 0, 0, 0),
         ])
         self.wait_current_waypoint(2)
-        delay_loc = self.mav.location()
+        delay_loc = self.get_location()
         if self.get_distance(arming_loc, delay_loc) > 1:
             raise NotAchievedException("Should not move during takeoff")
         self.wait_altitude(18, 21, minimum_duration=10, relative=True)

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -4,7 +4,6 @@ Fly ArduPlane in SITL
 AP_FLAKE8_CLEAN
 '''
 
-import copy
 import math
 import operator
 import os
@@ -32,7 +31,8 @@ from vehicle_test_suite import WaitModeTimeout
 
 # get location of scripts
 testdir = os.path.dirname(os.path.realpath(__file__))
-SITL_START_LOCATION = mavutil.location(-35.362938, 149.165085, 585, 354)
+SITL_START_LOCATION = Location(-35.362938, 149.165085, 585, AltFrame.ABSOLUTE)
+SITL_START_HEADING = 354
 WIND = "0,180,0.2"  # speed,direction,variance
 
 
@@ -65,6 +65,9 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
     def sitl_start_location(self):
         return SITL_START_LOCATION
+
+    def sitl_start_heading(self):
+        return SITL_START_HEADING
 
     def set_current_test_name(self, name):
         self.current_test_name_directory = "ArduPlane_Tests/" + name + "/"
@@ -183,8 +186,8 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
     def fly_RTL(self):
         """Fly to home."""
         self.progress("Flying home in RTL")
-        target_loc = self.home_position_as_mav_location()
-        target_loc.alt += 100
+        target_loc = self.home_position_as_location()
+        target_loc.offset_up_m(100)
         self.change_mode('RTL')
         self.wait_location(target_loc,
                            accuracy=120,
@@ -288,7 +291,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
     def change_altitude(self, altitude, accuracy=30, relative=False):
         """Get to a given altitude."""
         if relative:
-            altitude += self.home_position_as_mav_location().alt
+            altitude += self.home_position_as_location().get_alt_m(AltFrame.ABSOLUTE)
         self.change_mode('FBWA')
         alt_error = self.mav.messages['VFR_HUD'].alt - altitude
         if alt_error > 0:
@@ -597,7 +600,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.set_rc(3, 1500)
         self.progress("Entering guided and flying somewhere constant")
         self.change_mode("GUIDED")
-        loc = self.mav.location()
+        loc = self.get_location()
         self.location_offset_ne(loc, 500, 500)
 
         new_alt = 100
@@ -671,7 +674,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.arm_vehicle()
         self.wait_altitude(48, 52, relative=True)
 
-        loc = self.mav.location()
+        loc = self.get_location()
         self.location_offset_ne(loc, 2000, 2000)
 
         # setting external position fail while we have GPS lock
@@ -703,7 +706,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
         self.progress("getting base position")
         gpi = self.assert_receive_message('GLOBAL_POSITION_INT', timeout=5)
-        loc = mavutil.location(gpi.lat*1e-7, gpi.lon*1e-7, 0, 0)
+        loc = Location.latlon_only(gpi.lat*1e-7, gpi.lon*1e-7)
 
         self.progress("set new position with no GPS")
         self.run_cmd_int(
@@ -724,7 +727,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.wait_heartbeat()
 
         gpi2 = self.assert_receive_message('GLOBAL_POSITION_INT', timeout=5)
-        loc2 = mavutil.location(gpi2.lat*1e-7, gpi2.lon*1e-7, 0, 0)
+        loc2 = Location.latlon_only(gpi2.lat*1e-7, gpi2.lon*1e-7)
         dist = self.get_distance(loc, loc2)
 
         self.progress("dist is %.1f" % dist)
@@ -1289,7 +1292,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         if abs(x.alt_msl - (original_alt+30)) > 10:
             raise NotAchievedException("Bad absalt (want=%f vs got=%f)" % (original_alt+30, x.alt_msl))
 
-        loc = self.mav.location()
+        loc = self.get_location()
         self.run_cmd_int(
             mavutil.mavlink.MAV_CMD_DO_REPOSITION,
             p2=mavutil.mavlink.MAV_DO_REPOSITION_FLAGS_CHANGE_MODE,
@@ -1677,10 +1680,10 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.set_parameter("FENCE_TYPE", 4) # Enables polygon fence types
         self.upload_fences_from_locations([(
             mavutil.mavlink.MAV_CMD_NAV_FENCE_POLYGON_VERTEX_INCLUSION, [
-                mavutil.location(1.000, 1.000, 0, 0),
-                mavutil.location(1.000, 1.001, 0, 0),
-                mavutil.location(1.001, 1.001, 0, 0),
-                mavutil.location(1.001, 1.000, 0, 0)
+                Location.latlon_only(1.000, 1.000),
+                Location.latlon_only(1.000, 1.001),
+                Location.latlon_only(1.001, 1.001),
+                Location.latlon_only(1.001, 1.000)
             ]
         )])
         self.delay_sim_time(10, reason="fence check to run") # let fence check run so it loads-from-eeprom
@@ -1693,12 +1696,12 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
         self.progress("Test arming while vehicle inside exclusion zone")
         self.set_parameter("FENCE_TYPE", 4) # Enables polygon fence types
-        home_loc = self.mav.location()
+        home_loc = self.get_location()
         locs = [
-            mavutil.location(home_loc.lat - 0.001, home_loc.lng - 0.001, 0, 0),
-            mavutil.location(home_loc.lat - 0.001, home_loc.lng + 0.001, 0, 0),
-            mavutil.location(home_loc.lat + 0.001, home_loc.lng + 0.001, 0, 0),
-            mavutil.location(home_loc.lat + 0.001, home_loc.lng - 0.001, 0, 0),
+            Location.latlon_only(home_loc.lat - 0.001, home_loc.lng - 0.001),
+            Location.latlon_only(home_loc.lat - 0.001, home_loc.lng + 0.001),
+            Location.latlon_only(home_loc.lat + 0.001, home_loc.lng + 0.001),
+            Location.latlon_only(home_loc.lat + 0.001, home_loc.lng - 0.001),
         ]
         self.upload_fences_from_locations([
             (mavutil.mavlink.MAV_CMD_NAV_FENCE_POLYGON_VERTEX_EXCLUSION, locs),
@@ -1757,14 +1760,15 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.progress("Testing FENCE_ACTION_RTL no rally point")
         # have to disable the fence once we've breached or we breach
         # it as part of the loiter-at-home!
-        self.test_fence_breach_circle_at(self.home_position_as_mav_location())
+        self.test_fence_breach_circle_at(self.home_position_as_location())
 
     def FenceRTLRally(self):
         '''Test Fence RTL Rally'''
         self.progress("Testing FENCE_ACTION_RTL with rally point")
 
         self.wait_ready_to_arm()
-        loc = self.home_relative_loc_neu(50, -50, 15)
+        loc = self.offset_location_ne(self.home_position_as_location(), 50, -50)
+        loc.set_alt_m(15, AltFrame.ABOVE_HOME)
         self.upload_rally_points_from_locations([loc])
         self.test_fence_breach_circle_at(loc)
 
@@ -1778,7 +1782,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.wait_ready_to_arm()
 
         # Grab a location for fence return point, and upload it.
-        fence_loc = self.home_position_as_mav_location()
+        fence_loc = self.home_position_as_location()
         self.location_offset_ne(fence_loc, 50, 50)
         fence_return_mission_items = [
             self.mav.mav.mission_item_int_encode(
@@ -1804,7 +1808,8 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.delay_sim_time(1, reason="fence upload to complete")
 
         # Grab a location for rally point, and upload it.
-        rally_loc = self.home_relative_loc_neu(-50, 50, 15)
+        rally_loc = self.offset_location_ne(self.home_position_as_location(), -50, 50)
+        rally_loc.set_alt_m(15, AltFrame.ABOVE_HOME)
         self.upload_rally_points_from_locations([rally_loc])
 
         return_radius = 100
@@ -1877,10 +1882,18 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.progress("Got required terrain")
 
         self.wait_ready_to_arm()
-        homeloc = self.mav.location()
+        homeloc = self.get_location()
+        homeloc_alt_amsl = homeloc.get_alt_m(AltFrame.ABSOLUTE)
 
-        guided_loc = mavutil.location(-35.39723762, 149.07284612, homeloc.alt+99.0, 0)
-        rally_loc = mavutil.location(-35.3654952000, 149.1558698000, homeloc.alt+100, 0)
+        guided_loc = Location(-35.39723762, 149.07284612, homeloc_alt_amsl+99.0, AltFrame.ABSOLUTE)
+        rally_loc = Location(-35.3654952000, 149.1558698000, homeloc_alt_amsl+100, AltFrame.ABSOLUTE)
+
+        # the reposition and rally altitudes below go out in the terrain
+        # frame while carrying these AMSL magnitudes; that mismatch is the
+        # alt-frame confusion this (disabled) test is filed against, so it
+        # is preserved rather than fixed here
+        guided_loc_terrain = guided_loc.copy()
+        guided_loc_terrain.set_alt_m(homeloc_alt_amsl+99.0, AltFrame.ABOVE_TERRAIN)
 
         terrain_wait_path(homeloc, rally_loc, 10)
 
@@ -1898,7 +1911,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.install_message_hook_context(terrain_following_above_80m)
 
         self.change_mode("GUIDED")
-        self.send_do_reposition(guided_loc, frame=mavutil.mavlink.MAV_FRAME_GLOBAL_TERRAIN_ALT)
+        self.send_do_reposition(guided_loc_terrain)
         self.progress("Flying to guided location")
         self.wait_location(
             guided_loc,
@@ -1921,7 +1934,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
         # Fly back to guided location
         self.change_mode("GUIDED")
-        self.send_do_reposition(guided_loc, frame=mavutil.mavlink.MAV_FRAME_GLOBAL_TERRAIN_ALT)
+        self.send_do_reposition(guided_loc_terrain)
         self.progress("Flying to back to guided location")
 
         # Disable terrain following and re-load rally point with relative to terrain altitude
@@ -1931,7 +1944,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             mavutil.mavlink.MAV_CMD_NAV_RALLY_POINT,
             x=int(rally_loc.lat*1e7),
             y=int(rally_loc.lng*1e7),
-            z=rally_loc.alt,
+            z=rally_loc.get_alt_m(AltFrame.ABSOLUTE),
             frame=mavutil.mavlink.MAV_FRAME_GLOBAL_TERRAIN_ALT,
             mission_type=mavutil.mavlink.MAV_MISSION_TYPE_RALLY
         )]
@@ -2187,7 +2200,8 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
                 self.set_parameter("ARSPD_USE", 0)
 
             target_alt = 100
-            loc = self.home_relative_loc_neu(500, 500, target_alt)
+            loc = self.offset_location_ne(self.home_position_as_location(), 500, 500)
+            loc.set_alt_m(target_alt, AltFrame.ABOVE_HOME)
             self.takeoff(50)
             self.run_cmd_int(
                 mavutil.mavlink.MAV_CMD_DO_REPOSITION,
@@ -2266,12 +2280,12 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.change_mode("RTL")
         expected_alt = self.get_parameter("RTL_ALTITUDE")
 
-        home = self.home_position_as_mav_location()
-        distance = self.get_distance(home, self.mav.location())
+        home = self.home_position_as_location()
+        distance = self.get_distance(home, self.get_location())
 
         self.wait_altitude(expected_alt - 10, expected_alt + 10, relative=True, timeout=80)
 
-        new_distance = self.get_distance(home, self.mav.location())
+        new_distance = self.get_distance(home, self.get_location())
         # We should be closer to home.
         if new_distance > distance:
             raise NotAchievedException(
@@ -2295,12 +2309,12 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.wait_distance_to_home(500, 1000, timeout=60)
         self.change_mode("RTL")
 
-        home = self.home_position_as_mav_location()
-        distance = self.get_distance(home, self.mav.location())
+        home = self.home_position_as_location()
+        distance = self.get_distance(home, self.get_location())
 
         self.wait_altitude(expected_alt - 10, expected_alt + 10, relative=True, timeout=80)
 
-        new_distance = self.get_distance(home, self.mav.location())
+        new_distance = self.get_distance(home, self.get_location())
         # We should be farther from to home.
         if new_distance < distance:
             raise NotAchievedException(
@@ -2513,7 +2527,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         # fly North, create thread to east, wait for flying east
         self.start_subtest("Testing loiter resume")
         self.reach_heading_manual(0)
-        here = self.mav.location()
+        here = self.get_location()
         self.test_adsb_send_threatening_adsb_message(here, offset_ne=(0, 30))
         self.wait_mode('AVOID_ADSB')
         # recovery has the vehicle circling a point... but we don't
@@ -2550,7 +2564,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         })
         self.reboot_sitl()
         self.wait_ready_to_arm()
-        here = self.mav.location()
+        here = self.get_location()
         self.change_mode("FBWA")
         self.delay_sim_time(2, reason="mode change to settle") # TODO: work out why this is required...
         self.test_adsb_send_threatening_adsb_message(here)
@@ -2569,7 +2583,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             int(here.lat+1 * 1e7),
             int(here.lng * 1e7),
             mavutil.mavlink.ADSB_ALTITUDE_TYPE_PRESSURE_QNH,
-            int(here.alt*1000 + 10000), # 10m up
+            int(here.get_alt_m(AltFrame.ABSOLUTE)*1000 + 10000), # 10m up
             0, # heading in cdeg
             0, # horizontal velocity cm/s
             0, # vertical velocity cm/s
@@ -2607,7 +2621,9 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.set_rc(3, 1500)
         self.start_subtest("Ensure command bounced outside guided mode")
         desired_relative_alt = 33
-        loc = self.home_relative_loc_neu(300, 300, desired_relative_alt)
+        home = self.home_position_as_location()
+        loc = self.offset_location_ne(home, 300, 300)
+        loc.set_alt_m(desired_relative_alt, AltFrame.ABOVE_HOME)
         self.mav.mav.mission_item_int_send(
             target_system,
             target_component,
@@ -2622,7 +2638,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             0, # p4
             int(loc.lat * 1e7), # latitude
             int(loc.lng * 1e7), # longitude
-            loc.alt, # altitude
+            home.get_alt_m(AltFrame.ABSOLUTE) + desired_relative_alt, # altitude
             mavutil.mavlink.MAV_MISSION_TYPE_MISSION)
         m = self.assert_receive_message('MISSION_ACK', timeout=5)
         if m.type != mavutil.mavlink.MAV_MISSION_ERROR:
@@ -3184,9 +3200,9 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.progress("Entering guided and flying somewhere constant")
         self.change_mode("GUIDED")
         new_alt = 280
-        loc = self.mav.location()
+        loc = self.get_location()
         self.location_offset_ne(loc, 350, 0)
-        loc.alt = self.home_position_as_mav_location().alt + new_alt
+        loc.set_alt_m(new_alt, AltFrame.ABOVE_HOME)
         self.run_cmd_int(
             mavutil.mavlink.MAV_CMD_DO_REPOSITION,
             p5=int(loc.lat * 1e7),
@@ -3219,7 +3235,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.install_terrain_handlers_context()
 
         self.wait_ready_to_arm()
-        loc = self.mav.location()
+        loc = self.get_location()
 
         lng_int = int(loc.lng * 1e7)
         lat_int = int(loc.lat * 1e7)
@@ -4248,7 +4264,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
         def fail_speed():
             self.change_mode("GUIDED")
-            loc = self.mav.location()
+            loc = self.get_location()
             self.run_cmd_int(
                 mavutil.mavlink.MAV_CMD_DO_REPOSITION,
                 p5=int(loc.lat * 1e7),
@@ -4310,7 +4326,8 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
         # Grab Home Position
         self.wait_ready_to_arm()
-        startpos = self.mav.location()
+        startpos = self.get_location()
+        startpos_alt_amsl = startpos.get_alt_m(AltFrame.ABSOLUTE)
 
         cruise_alt = 150
         self.takeoff(cruise_alt)
@@ -4321,17 +4338,17 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.do_fence_enable()
 
         self.progress("Fly above ceiling and check for breach")
-        self.change_altitude(startpos.alt + cruise_alt + 80)
+        self.change_altitude(startpos_alt_amsl + cruise_alt + 80)
         self.assert_fence_sys_status(True, False, False)
 
         self.progress("Return to cruise alt")
-        self.change_altitude(startpos.alt + cruise_alt)
+        self.change_altitude(startpos_alt_amsl + cruise_alt)
 
         self.progress("Ensure breach has clearned")
         self.assert_fence_sys_status(True, False, True)
 
         self.progress("Fly below floor and check for breach")
-        self.change_altitude(startpos.alt + cruise_alt - 80)
+        self.change_altitude(startpos_alt_amsl + cruise_alt - 80)
 
         self.progress("Ensure breach has clearned")
         self.assert_fence_sys_status(True, False, False)
@@ -4609,7 +4626,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             "RTL_AUTOLAND" : 2,
         })
 
-        fence_loc = self.home_position_as_mav_location()
+        fence_loc = self.home_position_as_location()
         self.location_offset_ne(fence_loc, 300, 0)
 
         self.upload_fences_from_locations([(
@@ -4639,7 +4656,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.takeoff(alt=50, mode='TAKEOFF')
         self.change_mode("GUIDED")
         # the fence is centered on home, so reference offsets from home
-        home = self.home_position_as_mav_location()
+        home = self.home_position_as_location()
 
         inside_loc = self.offset_location_ne(home, 100, 0)
         outside_loc = self.offset_location_ne(home, 2000, 0)
@@ -4836,12 +4853,12 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             "FENCE_ACTION": 1,
             "FENCE_TYPE": 4,
         })
-        home_loc = self.mav.location()
+        home_loc = self.get_location()
         locs = [
-            mavutil.location(home_loc.lat - 0.001, home_loc.lng - 0.001, 0, 0),
-            mavutil.location(home_loc.lat - 0.001, home_loc.lng + 0.001, 0, 0),
-            mavutil.location(home_loc.lat + 0.001, home_loc.lng + 0.001, 0, 0),
-            mavutil.location(home_loc.lat + 0.001, home_loc.lng - 0.001, 0, 0),
+            Location.latlon_only(home_loc.lat - 0.001, home_loc.lng - 0.001),
+            Location.latlon_only(home_loc.lat - 0.001, home_loc.lng + 0.001),
+            Location.latlon_only(home_loc.lat + 0.001, home_loc.lng + 0.001),
+            Location.latlon_only(home_loc.lat + 0.001, home_loc.lng - 0.001),
         ]
         self.upload_fences_from_locations([
             (mavutil.mavlink.MAV_CMD_NAV_FENCE_POLYGON_VERTEX_INCLUSION, locs),
@@ -4896,12 +4913,12 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             "RTL_RADIUS": want_radius,
             "NAVL1_LIM_BANK": 60,
         })
-        home_loc = self.mav.location()
+        home_loc = self.get_location()
         locs = [
-            mavutil.location(home_loc.lat - 0.003, home_loc.lng - 0.001, 0, 0),
-            mavutil.location(home_loc.lat - 0.003, home_loc.lng + 0.003, 0, 0),
-            mavutil.location(home_loc.lat + 0.001, home_loc.lng + 0.003, 0, 0),
-            mavutil.location(home_loc.lat + 0.001, home_loc.lng - 0.001, 0, 0),
+            Location.latlon_only(home_loc.lat - 0.003, home_loc.lng - 0.001),
+            Location.latlon_only(home_loc.lat - 0.003, home_loc.lng + 0.003),
+            Location.latlon_only(home_loc.lat + 0.001, home_loc.lng + 0.003),
+            Location.latlon_only(home_loc.lat + 0.001, home_loc.lng - 0.001),
         ]
         self.upload_fences_from_locations([
             (mavutil.mavlink.MAV_CMD_NAV_FENCE_POLYGON_VERTEX_INCLUSION, locs),
@@ -4933,8 +4950,8 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
         # Work out the approximate return point when no fence return point present
         # Logic taken from AC_PolyFence_loader.cpp
-        min_loc = self.mav.location()
-        max_loc = self.mav.location()
+        min_loc = self.get_location()
+        max_loc = self.get_location()
         for new_loc in locs:
             if new_loc.lat < min_loc.lat:
                 min_loc.lat = new_loc.lat
@@ -4948,7 +4965,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         # Generate the return location based on min and max locs
         ret_lat = (min_loc.lat + max_loc.lat) / 2
         ret_lng = (min_loc.lng + max_loc.lng) / 2
-        ret_loc = mavutil.location(ret_lat, ret_lng, 0, 0)
+        ret_loc = Location.latlon_only(ret_lat, ret_lng)
         self.progress("Return loc: (%s)" % str(ret_loc))
 
         # Wait for guided return to vehicle calculated fence return location
@@ -4977,7 +4994,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
         self.delay_sim_time(1, reason="fence clear to complete")
         self.wait_ready_to_arm()
-        home_loc = self.mav.location()
+        home_loc = self.get_location()
         self.takeoff(alt=50)
         self.set_rc(3, 1500)
         self.change_mode("CRUISE")
@@ -5244,8 +5261,8 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.wait_disarmed(400)
         self.progress("Check the landed heading matches takeoff plus offset")
         self.wait_heading(218, accuracy=5, timeout=1)
-        loc = mavutil.location(-35.362938, 149.165085, 585, 218)
-        if self.get_distance(loc, self.mav.location()) > 35:
+        loc = Location.latlon_only(-35.362938, 149.165085)
+        if self.get_distance(loc, self.get_location()) > 35:
             raise NotAchievedException("Did not land close to home")
         self.set_parameters({
             "TKOFF_OPTIONS": 2,
@@ -5938,11 +5955,13 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             "COMPASS_USE2": 0,
             "COMPASS_USE3": 0,
         })
-        import copy
-        start_loc = copy.copy(SITL_START_LOCATION)
-        start_loc.heading = 175
+        start_loc = SITL_START_LOCATION
+        start_heading = 175
         self.customise_SITL_commandline(["--home=%.9f,%.9f,%.2f,%.1f" % (
-            start_loc.lat, start_loc.lng, start_loc.alt, start_loc.heading)])
+            start_loc.lat,
+            start_loc.lng,
+            start_loc.get_alt_m(AltFrame.ABSOLUTE),
+            start_heading)])
         self.reboot_sitl()
         self.change_mode("TAKEOFF")
 
@@ -5957,11 +5976,11 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.delay_sim_time(5, reason="takeoff altitude to settle")
 
         bearing_margin = 35
-        loc = self.mav.location()
+        loc = self.get_location()
         bearing_from_home = self.get_bearing(start_loc, loc)
         if bearing_from_home < 0:
             bearing_from_home += 360
-        if abs(bearing_from_home - start_loc.heading) > bearing_margin:
+        if abs(bearing_from_home - start_heading) > bearing_margin:
             raise NotAchievedException(f"Did not takeoff in the right direction {bearing_from_home}")
 
         self.fly_home_land_and_disarm()
@@ -6302,9 +6321,10 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         alt = 100
         seq = 0
         items = []
+        home = self.home_position_as_location()
         tests = [
-            (self.home_relative_loc_ne(50, -50), 100, 0.3),
-            (self.home_relative_loc_ne(100, 50), 1005, 3),
+            (self.offset_location_ne(home, 50, -50), 100, 0.3),
+            (self.offset_location_ne(home, 100, 50), 1005, 3),
         ]
         # add a home position:
         items.append(self.mav.mav.mission_item_int_encode(
@@ -6548,8 +6568,8 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.wait_disarmed(120)
         self.progress("Check the landed heading matches takeoff")
         self.wait_heading(173, accuracy=5, timeout=1)
-        loc = mavutil.location(-35.362938, 149.165085, 585, 173)
-        if self.get_distance(loc, self.mav.location()) > 35:
+        loc = Location.latlon_only(-35.362938, 149.165085)
+        if self.get_distance(loc, self.get_location()) > 35:
             raise NotAchievedException("Did not land close to home")
 
     def SDCardWPTest(self):
@@ -6895,7 +6915,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         '''test handling of MAV_CMD_GUIDED_CHANGE_ALTITUDE'''
         target_alt = 750
         # this location is chosen to be fairly flat, but at a different terrain height to home
-        higher_ground = mavutil.location(-35.35465024, 149.13974996, target_alt, 0)
+        higher_ground = Location(-35.35465024, 149.13974996, target_alt, AltFrame.ABSOLUTE)
         self.install_terrain_handlers_context()
         self.start_subtest("set home relative altitude")
         self.takeoff(30, relative=True)
@@ -6903,11 +6923,11 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.change_mode('GUIDED')
 
         # remember home
-        home_loc = self.home_position_as_mav_location()
-        height_diff = target_alt - home_loc.alt
+        home_loc = self.home_position_as_location()
+        height_diff = target_alt - home_loc.get_alt_m(AltFrame.ABSOLUTE)
 
         # fly to higher ground
-        self.send_do_reposition(higher_ground, frame=mavutil.mavlink.MAV_FRAME_GLOBAL)
+        self.send_do_reposition(higher_ground)
         self.wait_location(
             higher_ground,
             accuracy=200,
@@ -7007,29 +7027,31 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         )
 
         self.start_subtest("test flyto with relative alt")
-        dest = copy.copy(higher_ground)
-        dest.alt = higher_ground.alt + 100 - home_loc.alt
-        self.progress("dest.alt=%.1f" % dest.alt)
-        self.send_do_reposition(dest, frame=mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT)
+        dest = higher_ground.copy()
+        dest_alt = height_diff + 100
+        dest.set_alt_m(dest_alt, AltFrame.ABOVE_HOME)
+        self.progress("dest alt=%.1f" % dest_alt)
+        self.send_do_reposition(dest)
         self.wait_location(
             dest,
             accuracy=200,
             timeout=600,
-            height_accuracy=None,  # dest.alt is relative; alt checked below
+            height_accuracy=None,  # dest's altitude is relative; alt checked below
         )
         self.wait_altitude(
-            dest.alt-5,
-            dest.alt+5,
+            dest_alt-5,
+            dest_alt+5,
             minimum_duration=10,
             timeout=30,
             relative=True
         )
 
         self.start_subtest("test flyto with absolute alt")
-        dest = copy.copy(higher_ground)
-        dest.alt = higher_ground.alt + 60
-        self.progress("dest.alt=%.1f" % dest.alt)
-        self.send_do_reposition(dest, frame=mavutil.mavlink.MAV_FRAME_GLOBAL)
+        dest = higher_ground.copy()
+        dest_alt = target_alt + 60
+        dest.set_alt_m(dest_alt, AltFrame.ABSOLUTE)
+        self.progress("dest alt=%.1f" % dest_alt)
+        self.send_do_reposition(dest)
         self.wait_location(
             dest,
             accuracy=200,
@@ -7037,27 +7059,28 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             height_accuracy=10,
         )
         self.wait_altitude(
-            dest.alt-5,
-            dest.alt+5,
+            dest_alt-5,
+            dest_alt+5,
             minimum_duration=10,
             timeout=30,
             relative=False
         )
 
         self.start_subtest("test flyto with terrain alt")
-        dest = copy.copy(higher_ground)
-        dest.alt = 130
-        self.progress("dest.alt=%.1f" % dest.alt)
-        self.send_do_reposition(dest, frame=mavutil.mavlink.MAV_FRAME_GLOBAL_TERRAIN_ALT)
+        dest = higher_ground.copy()
+        dest_alt = 130
+        dest.set_alt_m(dest_alt, AltFrame.ABOVE_TERRAIN)
+        self.progress("dest alt=%.1f" % dest_alt)
+        self.send_do_reposition(dest)
         self.wait_location(
             dest,
             accuracy=200,
             timeout=600,
-            height_accuracy=None,  # dest.alt is above-terrain; alt checked below
+            height_accuracy=None,  # dest's altitude is above-terrain; alt checked below
         )
         self.wait_altitude(
-            dest.alt-10,
-            dest.alt+10,
+            dest_alt-10,
+            dest_alt+10,
             minimum_duration=10,
             timeout=30,
             relative=False,
@@ -7277,7 +7300,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.takeoff(50, mode='TAKEOFF', timeout=200)
 
         # lock home to avoid alt messups
-        original_home = self.home_position_as_mav_location()
+        original_home = self.home_position_as_location()
         self.set_home(original_home)
 
         self.context_collect('STATUSTEXT')
@@ -7439,16 +7462,16 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.set_current_waypoint(2)
         self.fly_home_land_and_disarm()
 
-    def location_from_ADSB_VEHICLE(self, m):
-        '''return a mavutil.location extracted from an ADSB_VEHICLE mavlink
-        message'''
+    def location_from_ADSB_VEHICLE(self, m) -> Location:
+        '''return a Location extracted from an ADSB_VEHICLE mavlink
+        message; a geometric ADSB altitude is AMSL'''
         if m.altitude_type != mavutil.mavlink.ADSB_ALTITUDE_TYPE_GEOMETRIC:
             raise ValueError("Expected geometric alt")
-        return mavutil.location(
+        return Location(
             m.lat*1e-7,
             m.lon*1e-7,
             m.altitude/1000.0585,  # mm -> m
-            m.heading * 0.01  # centidegrees -> degrees
+            AltFrame.ABSOLUTE,
         )
 
     def SagetechMXS(self):
@@ -7464,7 +7487,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         m = self.assert_receive_message("ADSB_VEHICLE")
         adsb_vehicle_loc = self.location_from_ADSB_VEHICLE(m)
         self.progress("ADSB Vehicle at loc %s" % str(adsb_vehicle_loc))
-        home = self.home_position_as_mav_location()
+        home = self.home_position_as_location()
         self.assert_distance(home, adsb_vehicle_loc, 0, 10000)
 
     def MinThrottle(self):
@@ -7587,22 +7610,27 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         for mode in 'FBWB', 'CRUISE', 'LOITER':
             self.set_rc(3, 1000)
             self.wait_ready_to_arm()
-            home = self.home_position_as_mav_location()
+            home = self.home_position_as_location()
+            home_alt_amsl = home.get_alt_m(AltFrame.ABSOLUTE)
             target_alt = 20
             self.takeoff(target_alt, mode="TAKEOFF")
             self.wait_altitude(
-                home.alt+target_alt-5,
-                home.alt+target_alt+5,
+                home_alt_amsl+target_alt-5,
+                home_alt_amsl+target_alt+5,
                 relative=False,
                 minimum_duration=20,
                 timeout=60,
             )
             self.set_rc(3, 1500)
             self.change_mode(mode)
-            higher_home = copy.copy(home)
-            higher_home.alt += 40
-            self.set_home(higher_home)
-            self.wait_altitude(home.alt+target_alt-5, home.alt+target_alt+5, relative=False, minimum_duration=10, timeout=15)
+            self.set_home(self.offset_location_up(home, 40))
+            self.wait_altitude(
+                home_alt_amsl+target_alt-5,
+                home_alt_amsl+target_alt+5,
+                relative=False,
+                minimum_duration=10,
+                timeout=15,
+            )
             self.disarm_vehicle(force=True)
             self.reboot_sitl()
 
@@ -7614,7 +7642,8 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         '''
         self.set_parameter('TRIM_THROTTLE', 70)
         self.wait_ready_to_arm()
-        home = self.home_position_as_mav_location()
+        home = self.home_position_as_location()
+        home_alt_amsl = home.get_alt_m(AltFrame.ABSOLUTE)
         target_alt = 20
         self.takeoff(target_alt, mode="TAKEOFF")
         self.change_mode("LOITER")
@@ -7625,32 +7654,41 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         pub_freq = 10
         for i in range(test_time*pub_freq):
             tnow = self.get_sim_time()
-            higher_home = copy.copy(home)
             # Produce 1Hz sine waves in home altitude change.
-            higher_home.alt += 40*math.sin((tnow-tstart)*(2*math.pi))
-            self.set_home(higher_home)
+            self.set_home(self.offset_location_up(home, 40*math.sin((tnow-tstart)*(2*math.pi))))
             if tnow-tstart > test_time:
                 break
             self.delay_sim_time(1.0/pub_freq, reason="home update interval")
 
         # Test if the altitude is still within bounds.
-        self.wait_altitude(home.alt+target_alt-5, home.alt+target_alt+5, relative=False, minimum_duration=1, timeout=2)
+        self.wait_altitude(
+            home_alt_amsl+target_alt-5,
+            home_alt_amsl+target_alt+5,
+            relative=False,
+            minimum_duration=1,
+            timeout=2,
+        )
         self.disarm_vehicle(force=True)
         self.reboot_sitl()
 
     def SetHomeAltChange3(self):
         '''same as SetHomeAltChange, but the home alt change occurs during TECS operation'''
         self.wait_ready_to_arm()
-        home = self.home_position_as_mav_location()
+        home = self.home_position_as_location()
+        home_alt_amsl = home.get_alt_m(AltFrame.ABSOLUTE)
         target_alt = 20
         self.takeoff(target_alt, mode="TAKEOFF")
         self.change_mode("LOITER")
         self.delay_sim_time(20, reason="plane to settle") # Let the plane settle.
 
-        higher_home = copy.copy(home)
-        higher_home.alt += 40
-        self.set_home(higher_home)
-        self.wait_altitude(home.alt+target_alt-5, home.alt+target_alt+5, relative=False, minimum_duration=10, timeout=10.1)
+        self.set_home(self.offset_location_up(home, 40))
+        self.wait_altitude(
+            home_alt_amsl+target_alt-5,
+            home_alt_amsl+target_alt+5,
+            relative=False,
+            minimum_duration=10,
+            timeout=10.1,
+        )
 
         self.disarm_vehicle(force=True)
         self.reboot_sitl()
@@ -7760,7 +7798,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
         fence_centre_ne = (0, -500)
 
-        fence_centre = self.mav.location()
+        fence_centre = self.get_location()
         fence_centre = self.offset_location_ne(fence_centre, fence_centre_ne[0], fence_centre_ne[1])
 
         self.set_parameters({
@@ -8298,7 +8336,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
         def guided_hold_alt(alt_rel_m, timeout=600):
             # loiter at the current position and climb/hold the target altitude
-            loc = self.mav.location()
+            loc = self.get_location()
             self.run_cmd_int(
                 mavutil.mavlink.MAV_CMD_DO_REPOSITION,
                 p5=int(loc.lat * 1e7),
@@ -8508,8 +8546,9 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         alt = self.get_parameter("RTL_ALTITUDE")
         waypoint_radius = 100
 
-        loiter_turns_loc_ccw = self.home_relative_loc_ne(offset, offset)
-        loiter_turns_loc_cw = self.home_relative_loc_ne(offset, -offset)
+        home = self.home_position_as_location()
+        loiter_turns_loc_ccw = self.offset_location_ne(home, offset, offset)
+        loiter_turns_loc_cw = self.offset_location_ne(home, offset, -offset)
 
         # upload a mission plan containing zero-turn loiters
         self.upload_simple_relhome_mission([
@@ -8837,7 +8876,8 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
         self.start_subsubtest("ArmCk: Rally Point must be < ARM_V_RALLY_MAX meters away")
         self.progress("Currently RALLY_LIMIT_KM is %f" % self.get_parameter('RALLY_LIMIT_KM'))
-        loc = self.home_relative_loc_neu(6500, -50, 100)
+        loc = self.offset_location_ne(self.home_position_as_location(), 6500, -50)
+        loc.set_alt_m(100, AltFrame.ABOVE_HOME)
         self.upload_rally_points_from_locations([loc])
         self.wait_text("warn: Rally too far", check_context=True)
         self.set_parameter("RALLY_LIMIT_KM", 7)

--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -19,12 +19,15 @@ from pymavlink import mavutil
 import vehicle_test_suite
 
 from pysim import util
+from vehicle_test_suite import AltFrame
+from vehicle_test_suite import Location
 from vehicle_test_suite import NotAchievedException
 
 # get location of scripts
 testdir = os.path.dirname(os.path.realpath(__file__))
 
-SITL_START_LOCATION = mavutil.location(33.810313, -118.393867, 0, 185)
+SITL_START_LOCATION = Location(33.810313, -118.393867, 0, AltFrame.ABSOLUTE)
+SITL_START_HEADING = 185
 
 # Extract true range from STATUSTEXT messages sent by sub_test_synthetic_seafloor.lua
 RE_TR_SEARCH = re.compile(r'#TR#\s*([-+]?\d*\.?\d+)')
@@ -90,6 +93,9 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
 
     def sitl_start_location(self):
         return SITL_START_LOCATION
+
+    def sitl_start_heading(self):
+        return SITL_START_HEADING
 
     def default_frame(self):
         return 'vectored'
@@ -529,11 +535,11 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
 
         # Save starting point
         self.assert_receive_message('GLOBAL_POSITION_INT', timeout=5)
-        start_pos = self.mav.location()
+        start_pos = self.get_location()
         # Hold in perfect conditions
         self.progress("Testing position hold in perfect conditions")
         self.delay_sim_time(10, reason="position hold measurement period")
-        distance_m = self.get_distance(start_pos, self.mav.location())
+        distance_m = self.get_distance(start_pos, self.get_location())
         if distance_m > 1:
             raise NotAchievedException(f"Position Hold was unable to keep position in calm waters within 1 meter after 10 seconds, drifted {distance_m} meters")  # noqa
 
@@ -542,17 +548,17 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.set_parameter("SIM_WIND_SPD", 1)
         self.set_parameter("SIM_WIND_T", 1)
         self.delay_sim_time(10, reason="drift measurement in 1m/s current")
-        distance_m = self.get_distance(start_pos, self.mav.location())
+        distance_m = self.get_distance(start_pos, self.get_location())
         if distance_m > 1:
             raise NotAchievedException(f"Position Hold was unable to keep position in 1m/s current within 1 meter after 10 seconds, drifted {distance_m} meters")  # noqa
 
         # Move forward slowly in 1 m/s current
-        start_pos = self.mav.location()
+        start_pos = self.get_location()
         self.progress("Testing moving forward in position hold in 1m/s current")
         self.set_rc(Joystick.Forward, 1600)
         self.delay_sim_time(10, reason="forward movement")
-        distance_m = self.get_distance(start_pos, self.mav.location())
-        bearing = self.get_bearing(start_pos, self.mav.location())
+        distance_m = self.get_distance(start_pos, self.get_location())
+        bearing = self.get_bearing(start_pos, self.get_location())
         if distance_m < 2 or (bearing > 30 and bearing < 330):
             raise NotAchievedException(f"Position Hold was unable to move north 2 meters, moved {distance_m} at {bearing} degrees instead")  # noqa
         self.disarm_vehicle()
@@ -881,25 +887,23 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.dive(start_altitude)
         self.change_mode('GUIDED')
 
-        loc = self.mav.location()
+        loc = self.get_location()
 
         # Reposition, alt relative to surface
         loc = self.offset_location_ne(loc, 10, 10)
-        loc.alt = start_altitude
-        self.send_do_reposition(loc, frame=mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT)
+        loc.set_alt_m(start_altitude, AltFrame.ABOVE_HOME)
+        self.send_do_reposition(loc)
         self.wait_location(loc, timeout=120)
 
         # Reposition, alt relative to seafloor.  The SITL seafloor is
         # ~50m deep here, so holding 25m above it is ~-25m AMSL.
-        # target_terrain abuses the location's alt field to carry a
-        # terrain-frame altitude, as send_do_reposition requires
         seafloor_depth = 50
         alt_above_seafloor = 25
         target_terrain = self.offset_location_ne(loc, 10, 10)
-        target_terrain.alt = alt_above_seafloor
+        target_terrain.set_alt_m(alt_above_seafloor, AltFrame.ABOVE_TERRAIN)
         target_global = self.offset_location_ne(loc, 10, 10)
-        target_global.alt = alt_above_seafloor - seafloor_depth
-        self.send_do_reposition(target_terrain, frame=mavutil.mavlink.MAV_FRAME_GLOBAL_TERRAIN_ALT)
+        target_global.set_alt_m(alt_above_seafloor - seafloor_depth, AltFrame.ABSOLUTE)
+        self.send_do_reposition(target_terrain)
         self.wait_location(target_global, timeout=120, height_accuracy=5)
 
         self.disarm_vehicle()
@@ -1104,7 +1108,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
     def wait_for_stop(self):
         """Watch the sub slow down and stop"""
         tstart = self.get_sim_time_cached()
-        lstart = self.mav.location()
+        lstart = self.get_location()
 
         dmax = 0
         dprev = 0
@@ -1112,7 +1116,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         while True:
             self.delay_sim_time(1, reason="movement measurement interval")
 
-            dcurr = self.get_distance(lstart, self.mav.location())
+            dcurr = self.get_distance(lstart, self.get_location())
 
             if dcurr - dmax < -0.2:
                 raise NotAchievedException(f"Bounced back from {dmax:.2f}m to {dcurr:.2f}m")
@@ -1573,10 +1577,10 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.change_mode('POSHOLD')
         self.set_parameter("SIM_GPS1_HNSE", 2)
         self.wait_location(
-            self.sim_location(),
+            self.get_location('SIMSTATE'),
             location_source="SIMSTATE",
             minimum_duration=10,
-            height_accuracy=10.0,
+            height_accuracy=None,  # SIMSTATE carries no altitude
             accuracy=1.0,
             timeout=60.0,
         )
@@ -1601,11 +1605,21 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.wait_altitude(altitude_min=-0.5, altitude_max=1, relative=False, timeout=60)
         self.set_rc(Joystick.Throttle, 1500)
 
-        self.progress("Re-enabling GPS, expecting position to converge within 2m")
+        self.progress("Re-enabling GPS, expecting position to converge on the truth")
         self.set_parameters({
             "SIM_GPS1_ENABLE": 1,
         })
-        self.wait_location(self.mav.location(), minimum_duration=5, accuracy=2, timeout=60.0)
+        # check the estimate settles near the vehicle's true position;
+        # the noisy GPS (SIM_GPS1_HNSE=2, above) pulls it a couple of
+        # metres away from the ExternalNav-only solution as it is fused
+        # back in, so allow for that:
+        self.wait_location(
+            self.get_location('SIMSTATE'),
+            minimum_duration=5,
+            accuracy=4,
+            height_accuracy=None,  # SIMSTATE carries no altitude
+            timeout=60.0,
+        )
 
         self.progress("Driving forward 10m with GPS+VISO")
         self.set_rc(Joystick.Forward, 1900)

--- a/Tools/autotest/blimp.py
+++ b/Tools/autotest/blimp.py
@@ -10,12 +10,15 @@ import shutil
 from pymavlink import mavutil
 from pymavlink.rotmat import Vector3
 
+from vehicle_test_suite import AltFrame
+from vehicle_test_suite import Location
 from vehicle_test_suite import NotAchievedException
 from vehicle_test_suite import TestSuite
 
 # get location of scripts
 testdir = os.path.dirname(os.path.realpath(__file__))
-SITL_START_LOCATION = mavutil.location(-35.362938, 149.165085, 584, 0)
+SITL_START_LOCATION = Location(-35.362938, 149.165085, 584, AltFrame.ABSOLUTE)
+SITL_START_HEADING = 0
 
 # Flight mode switch positions are set-up in blimp.parm to be
 #   switch 1 = Land
@@ -61,6 +64,9 @@ class AutoTestBlimp(TestSuite):
 
     def sitl_start_location(self):
         return SITL_START_LOCATION
+
+    def sitl_start_heading(self):
+        return SITL_START_HEADING
 
     def sitl_streamrate(self):
         return 5
@@ -195,7 +201,7 @@ class AutoTestBlimp(TestSuite):
         tim = 60
 
         # make sure we don't drift:
-        bl = self.mav.location()
+        bl = self.get_location()
         tl = self.offset_location_ne(location=bl, metres_north=siz, metres_east=0)
         tr = self.offset_location_ne(location=bl, metres_north=siz, metres_east=siz)
         br = self.offset_location_ne(location=bl, metres_north=0, metres_east=siz)
@@ -228,7 +234,7 @@ class AutoTestBlimp(TestSuite):
         self.wait_distance_to_location(bl, 0, 0.5, timeout=tim)
         self.set_rc(1, 1500)
 
-        fin = self.mav.location()
+        fin = self.get_location()
 
         self.progress("Yawing right.")
         self.set_rc(4, 1700)

--- a/Tools/autotest/helicopter.py
+++ b/Tools/autotest/helicopter.py
@@ -14,13 +14,16 @@ import vehicle_test_suite
 
 from arducopter import AutoTestCopter
 from pysim import vehicleinfo
+from vehicle_test_suite import AltFrame
 from vehicle_test_suite import AutoTestTimeoutException
+from vehicle_test_suite import Location
 from vehicle_test_suite import NotAchievedException
 
 
 class AutoTestHelicopter(AutoTestCopter):
 
-    sitl_start_loc = mavutil.location(40.072842, -105.230575, 1586, 0)     # Sparkfun AVC Location
+    sitl_start_loc = Location(40.072842, -105.230575, 1586, AltFrame.ABSOLUTE)  # Sparkfun AVC Location
+    sitl_start_heading_deg = 0
 
     def max_distance_from_startup_location_at_end_of_test(self):
         # this class inherits ArduCopter's tests but not its
@@ -42,6 +45,9 @@ class AutoTestHelicopter(AutoTestCopter):
 
     def sitl_start_location(self):
         return self.sitl_start_loc
+
+    def sitl_start_heading(self):
+        return self.sitl_start_heading_deg
 
     def is_heli(self):
         return True
@@ -789,7 +795,7 @@ class AutoTestHelicopter(AutoTestCopter):
         '''returns a mission which attempts to give the SCurve library
         indigestion.  The same destination is given several times.'''
 
-        wp2_loc = self.mav.location()
+        wp2_loc = self.get_location()
         wp2_offset_n = 20
         wp2_offset_e = 30
         self.location_offset_ne(wp2_loc, wp2_offset_n, wp2_offset_e)
@@ -811,7 +817,7 @@ class AutoTestHelicopter(AutoTestCopter):
             31.0000, # altitude
             mavutil.mavlink.MAV_MISSION_TYPE_MISSION)
 
-        wp5_loc = self.mav.location()
+        wp5_loc = self.get_location()
         wp5_offset_n = -20
         wp5_offset_e = 30
         self.location_offset_ne(wp5_loc, wp5_offset_n, wp5_offset_e)
@@ -855,7 +861,7 @@ class AutoTestHelicopter(AutoTestCopter):
         '''returns a mission which attempts to give the SCurve library
         indigestion.  The same destination is given several times but with differing altitudes.'''
 
-        wp2_loc = self.mav.location()
+        wp2_loc = self.get_location()
         wp2_offset_n = 20
         wp2_offset_e = 30
         self.location_offset_ne(wp2_loc, wp2_offset_n, wp2_offset_e)
@@ -881,7 +887,7 @@ class AutoTestHelicopter(AutoTestCopter):
         wp4 = copy.copy(wp2)
         wp4.alt = 31
 
-        wp5_loc = self.mav.location()
+        wp5_loc = self.get_location()
         wp5_offset_n = -20
         wp5_offset_e = 30
         self.location_offset_ne(wp5_loc, wp5_offset_n, wp5_offset_e)
@@ -1022,7 +1028,9 @@ class AutoTestHelicopter(AutoTestCopter):
         # so every later start_SITL() would come up at CMAC rather than
         # at the heli's own start location; put it back afterwards.
         self.context_preserve_attribute("sitl_start_loc")
-        self.sitl_start_loc = mavutil.location(-35.362881, 149.165222, 582.000000, 90.0)   # CMAC
+        self.context_preserve_attribute("sitl_start_heading_deg")
+        self.sitl_start_loc = Location(-35.362881, 149.165222, 582.000000, AltFrame.ABSOLUTE)   # CMAC
+        self.sitl_start_heading_deg = 90.0
         self.customise_SITL_commandline(["--home", "%s,%s,%s,%s"
                                          % (-35.362881, 149.165222, 582.000000, 90.0)])
 

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -5,7 +5,6 @@ AP_FLAKE8_CLEAN
 
 '''
 
-import copy
 import math
 import operator
 import os
@@ -19,7 +18,9 @@ from pymavlink.rotmat import Vector3
 
 import vehicle_test_suite
 
+from vehicle_test_suite import AltFrame
 from vehicle_test_suite import AutoTestTimeoutException
+from vehicle_test_suite import Location
 from vehicle_test_suite import NotAchievedException
 from vehicle_test_suite import PreconditionFailedException
 from vehicle_test_suite import Test
@@ -27,7 +28,8 @@ from vehicle_test_suite import Test
 # get location of scripts
 testdir = os.path.dirname(os.path.realpath(__file__))
 WIND = "0,180,0.2"  # speed,direction,variance
-SITL_START_LOCATION = mavutil.location(-27.274439, 151.290064, 343, 8.7)
+SITL_START_LOCATION = Location(-27.274439, 151.290064, 343, AltFrame.ABSOLUTE)
+SITL_START_HEADING = 8.7
 
 
 class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
@@ -63,6 +65,9 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
 
     def sitl_start_location(self):
         return SITL_START_LOCATION
+
+    def sitl_start_heading(self):
+        return SITL_START_HEADING
 
     def log_name(self):
         return "QuadPlane"
@@ -1002,12 +1007,12 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             raise NotAchievedException("pitch should be -3.0 +- 0.5 deg, got %f" % (pitch))
         self.set_rc(2, 1500)
         self.delay_sim_time(5, reason="position to stabilise")
-        loc1 = self.mav.location()
+        loc1 = self.get_location()
         self.set_parameter("SIM_ENGINE_FAIL", 1 << 2) # simulate a complete loss of forward motor thrust
         self.delay_sim_time(20, reason="engine failure effect")
         self.change_mode('QLAND')
         self.wait_disarmed(timeout=60)
-        loc2 = self.mav.location()
+        loc2 = self.get_location()
         position_drift = self.get_distance(loc1, loc2)
         if position_drift > 5.0 :
             raise NotAchievedException("position drift high, want < 5.0 m got %f m" % (position_drift))
@@ -1187,15 +1192,15 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
 
         # Test alt assist, climb to 60m and set assist alt to 50m
         self.context_push()
-        guided_loc = self.home_relative_loc_ne(0, 0)
-        guided_loc.alt = 60
+        guided_loc = self.home_position_as_location()
+        guided_loc.set_alt_m(60, AltFrame.ABOVE_HOME)
         self.change_mode("GUIDED")
         self.send_do_reposition(guided_loc)
         self.wait_altitude(58, 62, relative=True, timeout=120)
         self.set_parameter("Q_ASSIST_ALT", 50)
 
         # Try and descent to 40m
-        guided_loc.alt = 40
+        guided_loc.set_alt_m(40, AltFrame.ABOVE_HOME)
         self.send_do_reposition(guided_loc)
 
         # Expect alt assist to kick in, eg "Alt assist 48.9m"
@@ -1234,7 +1239,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.reboot_sitl()
         takeoff_alt = 5
         self.takeoff(takeoff_alt, mode='QLOITER')
-        loc = self.mav.location()
+        loc = self.get_location()
         self.location_offset_ne(loc, 500, 500)
         new_alt = 100
         initial_altitude = self.get_altitude(relative=False, timeout=2)
@@ -1295,7 +1300,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         )
         takeoff_alt = 5
         self.takeoff(takeoff_alt, mode='QLOITER')
-        loc = self.mav.location()
+        loc = self.get_location()
         self.location_offset_ne(loc, ofs_n, ofs_e)
         initial_altitude = self.get_altitude(relative=False, timeout=2)
         self.run_cmd_int(
@@ -1958,7 +1963,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         # position before the reboot places the target wherever the
         # previous test happened to leave the vehicle, which can be
         # hundreds of metres from where QRTL will descend:
-        here = self.mav.location()
+        here = self.get_location()
         target = self.offset_location_ne(here, 20, 0)
         self.set_parameters({
             "SIM_PLD_LAT": target.lat,
@@ -1975,7 +1980,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.wait_text("PLND: Target Acquired", check_context=True, timeout=60)
 
         self.wait_disarmed(timeout=180)
-        loc2 = self.mav.location()
+        loc2 = self.get_location()
         error = self.get_distance(target, loc2)
         self.progress("Target error %.1fm" % error)
         if error > 2:
@@ -2231,7 +2236,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         # reset home 20 metres above current location
         current_alt_abs = self.get_altitude(relative=False)
 
-        loc = self.mav.location()
+        loc = self.get_location()
 
         home_z_ofs = 20
         self.run_cmd(
@@ -2265,7 +2270,8 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.wait_altitude(14, 16, relative=True)
 
         target_alt = 30
-        loc = self.home_relative_loc_neu(50, 50, target_alt)
+        loc = self.offset_location_ne(self.home_position_as_location(), 50, 50)
+        loc.set_alt_m(target_alt, AltFrame.ABOVE_HOME)
 
         # set position target
         self.run_cmd_int(
@@ -2550,7 +2556,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.change_mode('AUTO')
         self.wait_ready_to_arm()
 
-        here = self.mav.location()
+        here = self.get_location()
         guided_loc = self.offset_location_ne(here, 500, -500)
 
         self.arm_vehicle()
@@ -2928,8 +2934,11 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.start_subtest("test reposition with terrain alt")
         self.wait_ready_to_arm()
 
-        dest = copy.copy(SITL_START_LOCATION)
-        dest.alt = 45
+        dest_alt = 45
+        dest = Location(SITL_START_LOCATION.lat,
+                        SITL_START_LOCATION.lng,
+                        dest_alt,
+                        AltFrame.ABOVE_TERRAIN)
 
         self.set_parameters({
             'Q_GUIDED_MODE': 1,
@@ -2938,16 +2947,16 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.takeoff(30, mode='GUIDED')
 
         # fly to higher ground
-        self.send_do_reposition(dest, frame=mavutil.mavlink.MAV_FRAME_GLOBAL_TERRAIN_ALT)
+        self.send_do_reposition(dest)
         self.wait_location(
             dest,
             accuracy=200,
             timeout=600,
-            height_accuracy=None,  # dest.alt is above-terrain; alt checked below
+            height_accuracy=None,  # dest's altitude is above-terrain; alt checked below
         )
         self.wait_altitude(
-            dest.alt-10,  # NOTE: reuse of alt from abovE
-            dest.alt+10,  # use a 10m buffer as the plane needs to go up and down a bit to maintain terrain distance
+            dest_alt-10,
+            dest_alt+10,  # use a 10m buffer as the plane needs to go up and down a bit to maintain terrain distance
             minimum_duration=10,
             timeout=50,  # includes time for the terrain altitude to settle
             relative=False,
@@ -2968,16 +2977,14 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.install_message_hook_context(terrain_height_range)
 
         # two locations 500m apart
-        loc1 = copy.copy(dest)
-        self.location_offset_ne(loc1, -250, 0)
-        loc1.alt = 100
+        loc1 = self.offset_location_ne(dest, -250, 0)
+        loc1.set_alt_m(100, AltFrame.ABOVE_TERRAIN)
 
-        loc2 = copy.copy(dest)
-        self.location_offset_ne(loc2, 250, 0)
-        loc2.alt = 150
+        loc2 = self.offset_location_ne(dest, 250, 0)
+        loc2.set_alt_m(150, AltFrame.ABOVE_TERRAIN)
 
-        loc3 = copy.copy(loc2)
-        loc3.alt = 100
+        loc3 = loc2.copy()
+        loc3.set_alt_m(100, AltFrame.ABOVE_TERRAIN)
 
         positions = [
             ("Loc1", loc1),
@@ -2997,18 +3004,19 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             terrain_height_min = start_alt
             terrain_height_max = start_alt
 
-            self.progress(f"Flying to {name} at {loc.alt:.1f} from {start_alt:.1f}")
-            self.send_do_reposition(loc, frame=mavutil.mavlink.MAV_FRAME_GLOBAL_TERRAIN_ALT)
+            loc_alt = loc.get_alt_m(AltFrame.ABOVE_TERRAIN)
+            self.progress(f"Flying to {name} at {loc_alt:.1f} from {start_alt:.1f}")
+            self.send_do_reposition(loc)
 
             self.wait_location(
                 loc,
                 accuracy=10,
                 timeout=600,
-                height_accuracy=None,  # loc.alt is above-terrain; alt checked below
+                height_accuracy=None,  # loc's altitude is above-terrain; alt checked below
             )
             self.wait_altitude(
-                loc.alt-5,
-                loc.alt+5,
+                loc_alt-5,
+                loc_alt+5,
                 minimum_duration=10,
                 timeout=40,  # includes time for the terrain altitude to settle
                 relative=False,
@@ -3016,15 +3024,15 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             )
             self.wait_groundspeed(0, 2)
             self.wait_altitude(
-                loc.alt-5,
-                loc.alt+5,
+                loc_alt-5,
+                loc_alt+5,
                 minimum_duration=10,
                 timeout=30,
                 relative=False,
                 altitude_source="TERRAIN_REPORT.current_height"
             )
-            min_alt_ok = min(start_alt, loc.alt) - 10
-            max_alt_ok = max(start_alt, loc.alt) + 10
+            min_alt_ok = min(start_alt, loc_alt) - 10
+            max_alt_ok = max(start_alt, loc_alt) + 10
             self.progress(f"theight {terrain_height_min:.0f} to {terrain_height_max:.0f} accept {min_alt_ok:.0f}:{max_alt_ok:.0f}") # noqa:E501
             if terrain_height_min < min_alt_ok or terrain_height_max > max_alt_ok:
                 raise NotAchievedException(f"terrain range breach {start_alt:.1f} {terrain_height_min:.1f} {terrain_height_max:.1f}")  # noqa:E501
@@ -3037,15 +3045,13 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.install_terrain_handlers_context()
         self.start_subtest("test reposition terrain alt2")
 
-        takeoff_loc = mavutil.location(-35.28243788, 149.00502473, 583.7)
+        takeoff_loc = Location(-35.28243788, 149.00502473, 583.7, AltFrame.ABSOLUTE)
+        takeoff_alt_amsl = takeoff_loc.get_alt_m(AltFrame.ABSOLUTE)
         self.customise_SITL_commandline(
-            ["--home", f"{takeoff_loc.lat},{takeoff_loc.lng},{takeoff_loc.alt},0"]
+            ["--home", f"{takeoff_loc.lat},{takeoff_loc.lng},{takeoff_alt_amsl},0"]
         )
         self.reboot_sitl(check_position=False)
         self.wait_ready_to_arm()
-
-        dest = copy.copy(takeoff_loc)
-        dest.alt = 45
 
         self.set_parameters({
             'Q_GUIDED_MODE': 1,
@@ -3066,13 +3072,13 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
 
         self.install_message_hook_context(terrain_height_range)
 
-        loc1 = mavutil.location(-35.27502040, 148.98635977, 75)
-        loc2 = mavutil.location(-35.28505202, 148.98604378, 75)
+        loc1 = Location(-35.27502040, 148.98635977, 75, AltFrame.ABOVE_TERRAIN)
+        loc2 = Location(-35.28505202, 148.98604378, 75, AltFrame.ABOVE_TERRAIN)
 
-        loc3 = mavutil.location(-35.27502040, 148.98635977, 120)
-        loc4 = mavutil.location(-35.28505202, 148.98604378, 120)
+        loc3 = Location(-35.27502040, 148.98635977, 120, AltFrame.ABOVE_TERRAIN)
+        loc4 = Location(-35.28505202, 148.98604378, 120, AltFrame.ABOVE_TERRAIN)
 
-        loc5 = mavutil.location(-35.28505202, 148.98604378, 100)
+        loc5 = Location(-35.28505202, 148.98604378, 100, AltFrame.ABOVE_TERRAIN)
 
         positions = [
             ("Loc1", loc1),
@@ -3093,18 +3099,19 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             terrain_height_min = start_alt
             terrain_height_max = start_alt
 
-            self.progress(f"Flying to {name} at {loc.alt:.1f} from {start_alt:.1f}")
-            self.send_do_reposition(loc, frame=mavutil.mavlink.MAV_FRAME_GLOBAL_TERRAIN_ALT)
+            loc_alt = loc.get_alt_m(AltFrame.ABOVE_TERRAIN)
+            self.progress(f"Flying to {name} at {loc_alt:.1f} from {start_alt:.1f}")
+            self.send_do_reposition(loc)
 
             self.wait_location(
                 loc,
                 accuracy=10,
                 timeout=600,
-                height_accuracy=None,  # loc.alt is above-terrain; alt checked below
+                height_accuracy=None,  # loc's altitude is above-terrain; alt checked below
             )
             self.wait_altitude(
-                loc.alt-5,
-                loc.alt+5,
+                loc_alt-5,
+                loc_alt+5,
                 minimum_duration=10,
                 timeout=40,  # includes time for the terrain altitude to settle
                 relative=False,
@@ -3113,15 +3120,15 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
 
             self.wait_groundspeed(0, 2)
             self.wait_altitude(
-                loc.alt-5,
-                loc.alt+5,
+                loc_alt-5,
+                loc_alt+5,
                 minimum_duration=10,
                 timeout=30,
                 relative=False,
                 altitude_source="TERRAIN_REPORT.current_height"
             )
-            min_alt_ok = min(start_alt, loc.alt) - 10
-            max_alt_ok = max(start_alt, loc.alt) + 25
+            min_alt_ok = min(start_alt, loc_alt) - 10
+            max_alt_ok = max(start_alt, loc_alt) + 25
             self.progress(f"theight {terrain_height_min:.0f} to {terrain_height_max:.0f} accept {min_alt_ok:.0f}:{max_alt_ok:.0f}") # noqa:E501
             if terrain_height_min < min_alt_ok or terrain_height_max > max_alt_ok:
                 raise NotAchievedException(f"terrain range breach {start_alt:.1f} {terrain_height_min:.1f} {terrain_height_max:.1f}") # noqa:E501
@@ -3209,9 +3216,10 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
 
         # We do this in a real-world scenario in Alaska where we take off from the Top of the World
         # and fly a mission that goes down into the valley to purposefully trigger Pitcing, Quading and CMTC events
-        topofworld_loc = mavutil.location(64.1624778, -139.8402246, 1109.0)
+        topofworld_loc = Location(64.1624778, -139.8402246, 1109.0, AltFrame.ABSOLUTE)
+        topofworld_alt_amsl = topofworld_loc.get_alt_m(AltFrame.ABSOLUTE)
         self.customise_SITL_commandline(
-            ["--home", f"{topofworld_loc.lat},{topofworld_loc.lng},{topofworld_loc.alt},0"]
+            ["--home", f"{topofworld_loc.lat},{topofworld_loc.lng},{topofworld_alt_amsl},0"]
         )
 
         self.context_collect("STATUSTEXT")
@@ -3265,7 +3273,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.change_mode("AUTO")
 
         # check that we got terrain data, this test doesn't work if we don't have the correct terrain.
-        loc = self.mav.location()
+        loc = self.get_location()
 
         lng_int = int(loc.lng * 1e7)
         lat_int = int(loc.lat * 1e7)
@@ -3600,7 +3608,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.delay_sim_time(5, reason="let things settle")
 
         truth_yaw_deg = math.degrees(self.assert_receive_message('SIMSTATE').yaw)
-        truth_loc = self.sim_location()
+        truth_loc = self.get_location('SIMSTATE')
         truth_alt = self.get_altitude(altitude_source='SIM_STATE.alt')
 
         self.context_collect('STATUSTEXT')
@@ -3611,7 +3619,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         # ensure the switch really implied resets on each axis, else
         # this test is vacuous:
         yaw_divergence = self.heading_delta(self.get_heading(), truth_yaw_deg)
-        ne_divergence = self.get_distance(self.get_mav_location(), truth_loc)
+        ne_divergence = self.get_distance(self.get_location(), truth_loc)
         alt_divergence = abs(self.get_altitude(altitude_source='GLOBAL_POSITION_INT.alt') - truth_alt)
         self.progress(f"divergences: yaw={yaw_divergence:.1f}deg NE={ne_divergence:.1f}m alt={alt_divergence:.1f}m")
         if yaw_divergence < 20:
@@ -3630,7 +3638,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         tstart = self.get_sim_time()
         while self.get_sim_time() - tstart < 20:
             rotated = self.heading_delta(math.degrees(self.assert_receive_message('SIMSTATE').yaw), truth_yaw_deg)
-            moved_ne = self.get_distance(truth_loc, self.sim_location())
+            moved_ne = self.get_distance(truth_loc, self.get_location('SIMSTATE'))
             moved_alt = abs(self.get_altitude(altitude_source='SIM_STATE.alt') - truth_alt)
             self.progress(f"rotated={rotated:.1f}deg moved_ne={moved_ne:.1f}m moved_alt={moved_alt:.1f}m")
             if rotated > 20:

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -30,10 +30,11 @@ from vehicle_test_suite import Test
 # get location of scripts
 testdir = os.path.dirname(os.path.realpath(__file__))
 
-SITL_START_LOCATION = mavutil.location(40.071374969556928,
-                                       -105.22978898137808,
-                                       1583.702759,
-                                       246)
+SITL_START_LOCATION = Location(40.071374969556928,
+                               -105.22978898137808,
+                               1583.702759,
+                               AltFrame.ABSOLUTE)
+SITL_START_HEADING = 246
 
 
 class AutoTestRover(vehicle_test_suite.TestSuite):
@@ -68,6 +69,9 @@ class AutoTestRover(vehicle_test_suite.TestSuite):
 
     def sitl_start_location(self):
         return SITL_START_LOCATION
+
+    def sitl_start_heading(self):
+        return SITL_START_HEADING
 
     def default_frame(self):
         return "rover"
@@ -4781,11 +4785,11 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.wait_ready_to_arm()
         self.arm_vehicle()
         self.set_parameter("FENCE_ENABLE", 1)
-        target_loc = mavutil.location(40.073800, -105.229172)
+        target_loc = Location.latlon_only(40.073800, -105.229172)
         self.send_guided_mission_item(target_loc,
                                       target_system=target_system,
                                       target_component=target_component)
-        self.wait_location(target_loc, timeout=300)
+        self.wait_location(target_loc, height_accuracy=None, timeout=300)
         self.do_RTL(timeout=300)
         self.disarm_vehicle()
 
@@ -4820,7 +4824,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
 
     def test_poly_fence_object_avoidance_guided_two_squares(self, target_system=1, target_component=1):
         self.start_subtest("Ensure we can steer around obstacles in guided mode")
-        here = self.mav.location()
+        here = self.get_location()
         self.upload_fences_from_locations([
             (mavutil.mavlink.MAV_CMD_NAV_FENCE_POLYGON_VERTEX_EXCLUSION, [
                 # east
@@ -4851,11 +4855,11 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             self.arm_vehicle()
 
             self.change_mode("GUIDED")
-            target = mavutil.location(40.071382, -105.228340, 0, 0)
+            target = Location.latlon_only(40.071382, -105.228340)
             self.send_guided_mission_item(target,
                                           target_system=target_system,
                                           target_component=target_component)
-            self.wait_location(target, timeout=300)
+            self.wait_location(target, height_accuracy=None, timeout=300)
             self.do_RTL()
             self.disarm_vehicle()
         except Exception as e:  # noqa: BLE001
@@ -4947,7 +4951,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.change_mode('GUIDED')
         self.wait_ready_to_arm()
         self.arm_vehicle()
-        target_loc = mavutil.location(40.071060, -105.227734, 1584, 0)
+        target_loc = Location(40.071060, -105.227734, 1584, AltFrame.ABSOLUTE)
         self.send_guided_mission_item(target_loc,
                                       target_system=target_system,
                                       target_component=target_component)
@@ -5832,7 +5836,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         # mode with a 0m altitude in MAV_FRAME_GLOBAL_RELATIVE_ALT_INT.
         # At the SITL start location (~1584m AMSL) the correct AMSL altitude
         # is ~1584m, not 0m.
-        home_alt_amsl = SITL_START_LOCATION.alt  # ~1583.7m
+        home_alt_amsl = SITL_START_LOCATION.get_alt_m(AltFrame.ABSOLUTE)  # ~1583.7m
 
         home_loc = self.home_position_as_location()
         # NAV_LOITER_TURNS: param1=number of turns, param3=radius in metres
@@ -6358,7 +6362,7 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
             "BCN_TYPE": 10,    # SITL
             "BCN_LATITUDE": SITL_START_LOCATION.lat,
             "BCN_LONGITUDE": SITL_START_LOCATION.lng,
-            "BCN_ALT": SITL_START_LOCATION.alt,
+            "BCN_ALT": SITL_START_LOCATION.get_alt_m(AltFrame.ABSOLUTE),
             "BCN_ORIENT_YAW": 0,
             "GPS1_TYPE": 0,    # no GPS
             "EK3_ENABLE": 1,
@@ -6379,8 +6383,8 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.wait_ready_to_arm(require_absolute=False)
 
         # use get_location() (GLOBAL_POSITION_INT, the EKF/beacon-fused
-        # position) rather than self.mav.location(), which blocks waiting for a
-        # GPS 3D fix that never arrives with the GPS disabled:
+        # position) rather than pymavlink's mavfile.location(), which blocks
+        # waiting for a GPS 3D fix that never arrives with the GPS disabled:
         start_loc = self.get_location()
         self.progress("Beacon-derived start location: %s" % str(start_loc))
 

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -228,6 +228,11 @@ class Location(object):
     misinterpreting the altitude.
     '''
 
+    # __slots__ so that an assignment to a mistyped or frameless
+    # attribute - loc.alt = 5 in particular - raises rather than
+    # silently creating an attribute nothing then reads
+    __slots__ = ('lat', 'lng', '_alt_m', '_alt_frame')
+
     def __init__(self, lat_deg: float, lng_deg: float, alt_m: float, alt_frame: AltFrame):
         if not isinstance(alt_frame, AltFrame):
             raise ValueError("alt_frame must be an AltFrame, got %s" % str(alt_frame))
@@ -244,12 +249,6 @@ class Location(object):
         ret._alt_m = None
         ret._alt_frame = None
         return ret
-
-    @classmethod
-    def from_mavutil(cls, loc) -> Location:
-        '''create from a mavutil.location, whose alt is AMSL by
-        convention; the caller must ensure that is true of this one'''
-        return cls(loc.lat, loc.lng, loc.alt, AltFrame.ABSOLUTE)
 
     @property
     def alt_frame(self) -> AltFrame:
@@ -711,9 +710,9 @@ class WaitAndMaintain(object):
 
 
 class WaitAndMaintainLocation(WaitAndMaintain):
-    def __init__(self, test_suite, target, accuracy=5, height_accuracy=1, location_source=None, **kwargs):
+    def __init__(self, test_suite, target: Location, accuracy=5, height_accuracy=1, location_source=None, **kwargs):
         super(WaitAndMaintainLocation, self).__init__(test_suite, **kwargs)
-        if isinstance(target, Location) and height_accuracy is not None:
+        if height_accuracy is not None:
             if not target.has_alt():
                 raise ValueError("lat/lng-only target Location requires height_accuracy=None")
             # comparisons are made against AMSL current position, so
@@ -726,10 +725,7 @@ class WaitAndMaintainLocation(WaitAndMaintain):
 
     def target_alt_amsl_m(self):
         '''target altitude in metres AMSL'''
-        if isinstance(self.target, Location):
-            return self.target.get_alt_m(AltFrame.ABSOLUTE)
-        # mavutil.location alt is AMSL-by-convention:
-        return self.target.alt
+        return self.target.get_alt_m(AltFrame.ABSOLUTE)
 
     def announce_start_text(self):
         t = self.target
@@ -743,15 +739,13 @@ class WaitAndMaintainLocation(WaitAndMaintain):
         return self.loc
 
     def get_current_value(self):
-        if self.location_source is None:
-            return self.test_suite.mav.location()
-        return self.test_suite.get_mav_location(self.location_source)
+        return self.test_suite.get_location(self.location_source)
 
     def horizontal_error(self, value):
         return self.test_suite.get_distance(value, self.target)
 
     def vertical_error(self, value):
-        return math.fabs(value.alt - self.target_alt_amsl_m())
+        return math.fabs(value.get_alt_m(AltFrame.ABSOLUTE) - self.target_alt_amsl_m())
 
     def validate_value(self, value):
         if self.horizontal_error(value) > self.accuracy:
@@ -773,7 +767,7 @@ class WaitAndMaintainLocation(WaitAndMaintain):
 
     def progress_text(self, current_value):
         if self.height_accuracy is not None:
-            return (f"Want=({self.target.lat:.7f},{self.target.lng:.7f},{self.target_alt_amsl_m():.2f}) Got=({current_value.lat:.7f},{current_value.lng:.7f},{current_value.alt:.2f}) dist={self.horizontal_error(current_value):.2f} vdist={self.vertical_error(current_value):.2f}")  # noqa
+            return (f"Want=({self.target.lat:.7f},{self.target.lng:.7f},{self.target_alt_amsl_m():.2f}) Got=({current_value.lat:.7f},{current_value.lng:.7f},{current_value.get_alt_m(AltFrame.ABSOLUTE):.2f}) dist={self.horizontal_error(current_value):.2f} vdist={self.vertical_error(current_value):.2f}")  # noqa
 
         return (f"Want=({self.target.lat},{self.target.lng}) distance={self.horizontal_error(current_value)}")
 
@@ -1113,10 +1107,6 @@ class MSP_DJI(MSP_Generic):
 
         def lon(self):
             return self.int32(6) / 1e7
-
-        def LocationInt(self):
-            # other fields are available, I'm just lazy
-            return LocationInt(self.int32(2), self.int32(6), 0, 0)
 
     def command_callback(self, frametype, data):
         # print("X: %s %s" % (str(frametype), str(data)))
@@ -2276,12 +2266,18 @@ class TestSuite(abc.ABC):
     def buildlogs_dirpath():
         return os.getenv("BUILDLOGS", util.reltopdir("../buildlogs"))
 
+    def sitl_start_heading(self) -> float:
+        '''heading, in degrees, the simulation should start the vehicle
+        at.  Location carries no heading, so the start pose's heading
+        lives here rather than beside sitl_start_location()'''
+        return 0
+
     def sitl_home(self):
         HOME = self.sitl_start_location()
         return "%f,%f,%u,%u" % (HOME.lat,
                                 HOME.lng,
-                                HOME.alt,
-                                HOME.heading)
+                                HOME.get_alt_m(AltFrame.ABSOLUTE),
+                                self.sitl_start_heading())
 
     def mavproxy_version(self):
         '''return the current version of mavproxy as a tuple e.g. (1,8,8)'''
@@ -2428,7 +2424,7 @@ class TestSuite(abc.ABC):
             m = re.match(r"([-\d.]+)\s+([-\d.]+)\s*", line.decode('ascii'))
             if m is None:
                 raise ValueError("Did not match (%s)" % line)
-            locs.append(mavutil.location(float(m.group(1)), float(m.group(2)), 0, 0))
+            locs.append(Location.latlon_only(float(m.group(1)), float(m.group(2))))
         self.upload_fences_from_locations([
             (mavutil.mavlink.MAV_CMD_NAV_FENCE_POLYGON_VERTEX_INCLUSION, locs),
         ])
@@ -2720,7 +2716,7 @@ class TestSuite(abc.ABC):
             int(new.lat * 1e7),
             int(new.lng * 1e7),
             mavutil.mavlink.ADSB_ALTITUDE_TYPE_PRESSURE_QNH,
-            int(here.alt*1000 + 10000), # 10m up
+            int(here.get_alt_m(AltFrame.ABSOLUTE)*1000 + 10000), # 10m up
             0, # heading in cdeg
             0, # horizontal velocity cm/s
             0, # vertical velocity cm/s
@@ -3896,8 +3892,8 @@ class TestSuite(abc.ABC):
         self.wait_sensor_state(mavutil.mavlink.MAV_SYS_STATUS_SENSOR_GPS, True, True, True, timeout=10)
         m = self.poll_message("HIGH_LATENCY2")
         self.progress(self.dump_message_verbose(m))
-        loc = mavutil.location(m.latitude, m.longitude, m.altitude, 0)
-        dist = self.get_distance_int(loc, self.sim_location_int())
+        loc = Location.latlon_only(m.latitude * 1e-7, m.longitude * 1e-7)
+        dist = self.get_distance(loc, self.get_location('SIMSTATE'))
 
         if dist > 1:
             raise NotAchievedException("Bad location from HIGH_LATENCY2")
@@ -4463,23 +4459,6 @@ class TestSuite(abc.ABC):
                 raise AutoTestTimeoutException("sim_time_cached is not updating!")
         return ret
 
-    def sim_location(self):
-        """Return current simulator location.  Deprecated; use
-        get_location('SIMSTATE') instead."""
-        m = self.assert_receive_message('SIMSTATE')
-        return mavutil.location(m.lat*1.0e-7,
-                                m.lng*1.0e-7,
-                                0,
-                                math.degrees(m.yaw))
-
-    def sim_location_int(self):
-        """Return current simulator location."""
-        m = self.assert_receive_message('SIMSTATE')
-        return mavutil.location(m.lat,
-                                m.lng,
-                                0,
-                                math.degrees(m.yaw))
-
     def save_wp(self, ch=7):
         """Trigger RC Aux to save waypoint."""
         self.set_rc(ch, 1000)
@@ -4498,7 +4477,7 @@ class TestSuite(abc.ABC):
 
     def create_simple_relhome_mission(self, items_in, target_system=1, target_component=1):
         return self.create_simple_relloc_mission(
-            self.home_position_as_mav_location(),
+            self.home_position_as_location(),
             items_in,
             target_system=target_system,
             target_component=target_component,
@@ -5742,7 +5721,7 @@ class TestSuite(abc.ABC):
 
     def get_home_location_from_mission(self, filename):
         (home_lat, home_lon, home_alt, heading) = self.get_home_tuple_from_mission("rover-path-planning-mission.txt")
-        return mavutil.location(home_lat, home_lon)
+        return Location.latlon_only(home_lat, home_lon)
 
     def get_home_tuple_from_mission_filepath(self, filepath):
         '''gets item 0 from the mission file, returns a tuple suitable for
@@ -6141,17 +6120,6 @@ class TestSuite(abc.ABC):
         location.lat = lat
         location.lng = lng
         print("new: %f %f" % (location.lat, location.lng))
-
-    def home_relative_loc_ne(self, n, e):
-        ret = self.home_position_as_mav_location()
-        self.location_offset_ne(ret, n, e)
-        return ret
-
-    def home_relative_loc_neu(self, n, e, u):
-        ret = self.home_position_as_mav_location()
-        self.location_offset_ne(ret, n, e)
-        ret.alt += u
-        return ret
 
     def zero_throttle(self):
         """Set throttle to zero."""
@@ -7656,7 +7624,7 @@ class TestSuite(abc.ABC):
 
     def location_from_utm_global_position_next_wp(self, m):
         """Return the next waypoint in a UTM_GLOBAL_POSITION message as a Location."""
-        return mavutil.location(m.next_lat * 1e-7, m.next_lon * 1e-7, 0, 0)
+        return Location.latlon_only(m.next_lat * 1e-7, m.next_lon * 1e-7)
 
     @staticmethod
     def get_distance_accurate(loc1, loc2):
@@ -7722,12 +7690,12 @@ class TestSuite(abc.ABC):
         loc2_lon = TestSuite.get_lon_attr(loc2)
 
         return TestSuite.get_distance_accurate(
-            mavutil.location(loc1_lat*1e-7, loc1_lon*1e-7),
-            mavutil.location(loc2_lat*1e-7, loc2_lon*1e-7))
+            Location.latlon_only(loc1_lat*1e-7, loc1_lon*1e-7),
+            Location.latlon_only(loc2_lat*1e-7, loc2_lon*1e-7))
 
     def bearing_to(self, loc):
         '''return bearing from here to location'''
-        here = self.mav.location()
+        here = self.get_location()
         return self.get_bearing(here, loc)
 
     @staticmethod
@@ -7948,7 +7916,7 @@ class TestSuite(abc.ABC):
             self.set_rc(1, 1500)
 
     def assert_vehicle_location_is_at_startup_location(self, dist_max=1):
-        here = self.mav.location()
+        here = self.get_location()
         start_loc = self.sitl_start_location()
         dist = self.get_distance(here, start_loc)
         data = "dist=%f max=%f (here: %s start-loc: %s)" % (dist, dist_max, here, start_loc)
@@ -7966,7 +7934,7 @@ class TestSuite(abc.ABC):
         return None
 
     def assert_simstate_location_is_at_startup_location(self, dist_max=1):
-        simstate_loc = self.sim_location()
+        simstate_loc = self.get_location('SIMSTATE')
         start_loc = self.sitl_start_location()
         dist = self.get_distance(simstate_loc, start_loc)
         data = "dist=%f max=%f (simstate: %s start-loc: %s)" % (dist, dist_max, simstate_loc, start_loc)
@@ -8057,7 +8025,7 @@ class TestSuite(abc.ABC):
             tnow = self.get_sim_time(drain_mav=False)
 
     def send_terrain_check_message(self):
-        here = self.mav.location()
+        here = self.get_location()
         self.mav.mav.terrain_check_send(int(here.lat * 1e7), int(here.lng * 1e7))
 
     def get_terrain_height(self, verbose=False):
@@ -8682,27 +8650,6 @@ class TestSuite(abc.ABC):
             **kwargs
         )
 
-    def get_mav_location(self, location_source: str = None):
-        '''return a mavutil.location object for the given source;
-        source must produce a good lat/lng or exception will be
-        raised.  Deprecated; use get_location() instead'''
-        if location_source is None:
-            location_source = 'GLOBAL_POSITION_INT'
-        m = self.assert_receive_message(location_source)
-        m_type = m.get_type()
-        if m_type == "GLOBAL_POSITION_INT":
-            lat = m.lat * 1e-7
-            lon = m.lon * 1e-7
-            alt_m = m.alt * 0.001
-        elif m_type == "SIMSTATE":
-            lat = m.lat * 1e-7
-            lon = m.lng * 1e-7
-            alt_m = 0  # not available in SIMSTATE
-        if lat == 0 and lon == 0:
-            raise ValueError(f"Bad lat/lng {lat=} {lon=}")
-
-        return mavutil.location(lat, lon, alt_m, 0)
-
     def get_location(self,
                      location_source: str = None,
                      frame: AltFrame = AltFrame.ABSOLUTE,
@@ -8710,12 +8657,12 @@ class TestSuite(abc.ABC):
                      ) -> Location:
         '''return the current vehicle location as a (frame-aware)
         Location, with the altitude taken in the requested frame.  Use
-        this in preference to the mavutil.location producers
-        (mav.location(), get_mav_location()).  Note that lat/lng and
-        (for ABSOLUTE and ABOVE_HOME) altitude come from a single
-        GLOBAL_POSITION_INT, unlike mav.location() which mixes
-        GPS_RAW_INT and VFR_HUD.  location_source of SIMSTATE returns a
-        lat/lng-only Location as SIMSTATE carries no altitude'''
+        this in preference to pymavlink's mavfile.location().  Note
+        that lat/lng and (for ABSOLUTE and ABOVE_HOME) altitude come
+        from a single GLOBAL_POSITION_INT, unlike mavfile.location()
+        which mixes GPS_RAW_INT and VFR_HUD.  location_source of
+        SIMSTATE returns a lat/lng-only Location as SIMSTATE carries no
+        altitude'''
         # drain the link so the message we then block for reflects the
         # current position rather than being one which has sat in the
         # receive queue:
@@ -8755,10 +8702,10 @@ class TestSuite(abc.ABC):
 
     def wait_distance(self, distance, accuracy=2, timeout=30, location_source=None, **kwargs):
         """Wait for flight of a given distance."""
-        start = self.get_mav_location(location_source)
+        start = self.get_location(location_source)
 
         def get_distance():
-            return self.get_distance(start, self.get_mav_location(location_source))
+            return self.get_distance(start, self.get_location(location_source))
 
         def validator(value2, target2):
             return math.fabs(value2 - target2) <= accuracy
@@ -8778,7 +8725,7 @@ class TestSuite(abc.ABC):
         wps = self.download_using_mission_protocol(mavutil.mavlink.MAV_MISSION_TYPE_MISSION)
         m = wps[wp_num]
         self.progress("m: %s" % str(m))
-        loc = mavutil.location(m.x / 1.0e7, m.y / 1.0e7, 0, 0)
+        loc = Location.latlon_only(m.x / 1.0e7, m.y / 1.0e7)
         self.progress("loc: %s" % str(loc))
         self.wait_distance_to_location(loc, distance_min, distance_max, **kwargs)
 
@@ -8787,7 +8734,7 @@ class TestSuite(abc.ABC):
         assert distance_min <= distance_max, "Distance min should be less than distance max."
 
         def get_distance():
-            return self.get_distance(location, self.mav.location())
+            return self.get_distance(location, self.get_location())
 
         def validator(value2, target2=None):
             return distance_min <= value2 <= distance_max
@@ -9130,20 +9077,10 @@ class TestSuite(abc.ABC):
             self.delay_sim_time(0.2, "let RC inputs settle")
             self.context_pop()
 
-    def send_do_reposition(self, loc, frame=None):
-        '''send a DO_REPOSITION command for a location.  loc is ideally
-        a (frame-aware) Location, in which case the MAV_FRAME comes
-        from the Location itself and frame must be left None.  Passing
-        a mavutil.location and a frame is deprecated, as the object's
-        altitude frame can silently contradict the passed frame'''
-        if isinstance(loc, Location):
-            if frame is not None:
-                raise ValueError("frame comes from the Location; do not pass one")
-            frame, alt = self.mav_frame_and_alt_m(loc)
-        else:
-            if frame is None:
-                frame = mavutil.mavlink.MAV_FRAME_GLOBAL_RELATIVE_ALT
-            alt = loc.alt
+    def send_do_reposition(self, loc: Location):
+        '''send a DO_REPOSITION command for a Location; the MAV_FRAME
+        comes from the Location's own altitude frame'''
+        frame, alt = self.mav_frame_and_alt_m(loc)
         self.run_cmd_int(
             mavutil.mavlink.MAV_CMD_DO_REPOSITION,
             0,
@@ -10688,10 +10625,13 @@ Also, ignores heartbeats not from our target system'''
         self.progress("Polled home position (%s)" % str(m))
         return m
 
-    def position_target_loc(self):
+    def position_target_loc(self) -> Location:
         '''returns target location based on POSITION_TARGET_GLOBAL_INT'''
         m = self.mav.messages.get("POSITION_TARGET_GLOBAL_INT", None)
-        return mavutil.location(m.lat_int*1e-7, m.lon_int*1e-7, m.alt)
+        return Location(m.lat_int*1e-7,
+                        m.lon_int*1e-7,
+                        m.alt,
+                        Location.alt_frame_from_mav_frame(m.coordinate_frame))
 
     def current_waypoint(self):
         m = self.assert_receive_message('MISSION_CURRENT')
@@ -10710,11 +10650,6 @@ Also, ignores heartbeats not from our target system'''
             m = self.poll_home_position(quiet=True)
         here = self.assert_receive_message('GLOBAL_POSITION_INT')
         return self.get_distance_int(m, here)
-
-    def home_position_as_mav_location(self):
-        '''deprecated; use home_position_as_location() instead'''
-        m = self.poll_home_position()
-        return mavutil.location(m.latitude*1.0e-7, m.longitude*1.0e-7, m.altitude*1.0e-3, 0)
 
     def home_position_as_location(self) -> Location:
         '''return home position as a (frame-aware) Location; home
@@ -10762,69 +10697,44 @@ Also, ignores heartbeats not from our target system'''
             loc = self.change_alt_frame(loc, AltFrame.ABOVE_HOME)
         return loc.mav_frame(), loc.get_alt_m(loc.alt_frame)
 
-    def offset_location_ne(self, location, metres_north, metres_east):
-        '''return a new location offset from passed-in location;
-        preserves the type (and, for Location, the altitude frame) of
-        its input'''
+    def offset_location_ne(self, location: Location, metres_north, metres_east) -> Location:
+        '''return a new Location offset from passed-in Location,
+        preserving its altitude frame'''
         (target_lat, target_lng) = mavextra.gps_offset(location.lat,
                                                        location.lng,
                                                        metres_east,
                                                        metres_north)
-        if isinstance(location, Location):
-            ret = location.copy()
-            ret.lat = target_lat
-            ret.lng = target_lng
-            return ret
-        return mavutil.location(target_lat,
-                                target_lng,
-                                location.alt,
-                                location.heading)
+        ret = location.copy()
+        ret.lat = target_lat
+        ret.lng = target_lng
+        return ret
 
-    def offset_location_up(self, location, metres_up):
-        '''return a new location offset from passed-in location;
-        preserves the type (and, for Location, the altitude frame) of
-        its input'''
-        if isinstance(location, Location):
-            ret = location.copy()
-            ret.offset_up_m(metres_up)
-            return ret
-        return mavutil.location(
-            location.lat,
-            location.lng,
-            location.alt + metres_up,
-            location.heading
-        )
+    def offset_location_up(self, location: Location, metres_up) -> Location:
+        '''return a new Location offset from passed-in Location,
+        preserving its altitude frame'''
+        ret = location.copy()
+        ret.offset_up_m(metres_up)
+        return ret
 
-    def offset_location_heading_distance(self, location, bearing, distance):
-        '''return a new location offset from passed-in location;
-        preserves the type (and, for Location, the altitude frame) of
-        its input'''
+    def offset_location_heading_distance(self, location: Location, bearing, distance) -> Location:
+        '''return a new Location offset from passed-in Location,
+        preserving its altitude frame'''
         (target_lat, target_lng) = mavextra.gps_newpos(
             location.lat,
             location.lng,
             bearing,
             distance
         )
-        if isinstance(location, Location):
-            ret = location.copy()
-            ret.lat = target_lat
-            ret.lng = target_lng
-            return ret
-        return mavutil.location(
-            target_lat,
-            target_lng,
-            location.alt,
-            location.heading
-        )
+        ret = location.copy()
+        ret.lat = target_lat
+        ret.lng = target_lng
+        return ret
 
-    def set_home(self, loc):
+    def set_home(self, loc: Location):
         '''set home to supplied loc - adds implicit reboot at end of test.
         The command's altitude is AMSL; a Location in another frame is
         converted (against the *current* home/origin/terrain)'''
-        if isinstance(loc, Location):
-            alt = self.change_alt_frame(loc, AltFrame.ABSOLUTE).get_alt_m(AltFrame.ABSOLUTE)
-        else:
-            alt = loc.alt
+        alt = self.change_alt_frame(loc, AltFrame.ABSOLUTE).get_alt_m(AltFrame.ABSOLUTE)
         self.run_cmd_int(
             mavutil.mavlink.MAV_CMD_DO_SET_HOME,
             p5=int(loc.lat*1e7),
@@ -10866,9 +10776,10 @@ Also, ignores heartbeats not from our target system'''
             self.progress("### Rover skipping altitude check unti position fixes in")
         else:
             home_alt_m = orig_home.altitude * 1.0e-3
-            if abs(home_alt_m - start_loc.alt) > 2: # metres
+            start_alt_m = start_loc.get_alt_m(AltFrame.ABSOLUTE)
+            if abs(home_alt_m - start_alt_m) > 2: # metres
                 raise ValueError("homes differ in alt got=%fm want=%fm" %
-                                 (home_alt_m, start_loc.alt))
+                                 (home_alt_m, start_alt_m))
         new_x = orig_home.latitude + 1000
         new_y = orig_home.longitude + 2000
         new_z = orig_home.altitude + 300000 # 300 metres
@@ -13014,7 +12925,7 @@ Also, ignores heartbeats not from our target system'''
         if self.is_copter() or self.is_heli():
             self.user_takeoff(alt_min=50)
 
-        targetpos = self.mav.location()
+        targetpos = self.get_location()
         wp_accuracy = None
         if self.is_copter() or self.is_heli():
             wp_accuracy = self.get_parameter("WP_RADIUS_M", attempts=2)
@@ -13028,8 +12939,8 @@ Also, ignores heartbeats not from our target system'''
                              "MAV_FRAME_GLOBAL_RELATIVE_ALT_INT",
                              "MAV_FRAME_GLOBAL_TERRAIN_ALT",
                              "MAV_FRAME_GLOBAL_TERRAIN_ALT_INT"]:
-                home = self.home_position_as_mav_location()
-                return alt - home.alt
+                home = self.home_position_as_location()
+                return alt - home.get_alt_m(AltFrame.ABSOLUTE)
             else:
                 return alt
 
@@ -13056,8 +12967,11 @@ Also, ignores heartbeats not from our target system'''
                 0,  # yawrate
             )
 
-        def testpos(self, targetpos: mavutil.location, test_alt: bool, frame_name: str, frame):
-            send_target_position(targetpos.lat, targetpos.lng, to_alt_frame(targetpos.alt, frame_name), frame)
+        def testpos(self, targetpos: Location, test_alt: bool, frame_name: str, frame):
+            send_target_position(targetpos.lat,
+                                 targetpos.lng,
+                                 to_alt_frame(targetpos.get_alt_m(AltFrame.ABSOLUTE), frame_name),
+                                 frame)
             self.wait_location(
                 targetpos,
                 accuracy=wp_accuracy,
@@ -13072,25 +12986,25 @@ Also, ignores heartbeats not from our target system'''
             self.start_subtest("Changing Latitude")
             targetpos.lat += 0.0001
             if test_alt:
-                targetpos.alt += 5
+                targetpos.offset_up_m(5)
             testpos(self, targetpos, test_alt, frame_name, frame)
 
             self.start_subtest("Changing Longitude")
             targetpos.lng += 0.0001
             if test_alt:
-                targetpos.alt -= 5
+                targetpos.offset_up_m(-5)
             testpos(self, targetpos, test_alt, frame_name, frame)
 
             self.start_subtest("Revert Latitude")
             targetpos.lat -= 0.0001
             if test_alt:
-                targetpos.alt += 5
+                targetpos.offset_up_m(5)
             testpos(self, targetpos, test_alt, frame_name, frame)
 
             self.start_subtest("Revert Longitude")
             targetpos.lng -= 0.0001
             if test_alt:
-                targetpos.alt -= 5
+                targetpos.offset_up_m(-5)
             testpos(self, targetpos, test_alt, frame_name, frame)
 
             if test_heading:
@@ -13098,7 +13012,7 @@ Also, ignores heartbeats not from our target system'''
                 self.progress("Changing Latitude and Heading")
                 targetpos.lat += 0.0001
                 if test_alt:
-                    targetpos.alt += 5
+                    targetpos.offset_up_m(5)
                 self.mav.mav.set_position_target_global_int_send(
                     0,  # timestamp
                     self.sysid_thismav(),  # target system_id
@@ -13109,7 +13023,7 @@ Also, ignores heartbeats not from our target system'''
                     MAV_POS_TARGET_TYPE_MASK.YAW_RATE_IGNORE,
                     int(targetpos.lat * 1.0e7),  # lat
                     int(targetpos.lng * 1.0e7),  # lon
-                    to_alt_frame(targetpos.alt, frame_name),  # alt
+                    to_alt_frame(targetpos.get_alt_m(AltFrame.ABSOLUTE), frame_name),  # alt
                     0,  # vx
                     0,  # vy
                     0,  # vz
@@ -13131,7 +13045,7 @@ Also, ignores heartbeats not from our target system'''
                 self.start_subtest("Revert Latitude and Heading")
                 targetpos.lat -= 0.0001
                 if test_alt:
-                    targetpos.alt -= 5
+                    targetpos.offset_up_m(-5)
                 self.mav.mav.set_position_target_global_int_send(
                     0,  # timestamp
                     self.sysid_thismav(),  # target system_id
@@ -13142,7 +13056,7 @@ Also, ignores heartbeats not from our target system'''
                     MAV_POS_TARGET_TYPE_MASK.YAW_RATE_IGNORE,
                     int(targetpos.lat * 1.0e7),  # lat
                     int(targetpos.lng * 1.0e7),  # lon
-                    to_alt_frame(targetpos.alt, frame_name),  # alt
+                    to_alt_frame(targetpos.get_alt_m(AltFrame.ABSOLUTE), frame_name),  # alt
                     0,  # vx
                     0,  # vy
                     0,  # vz
@@ -13175,7 +13089,7 @@ Also, ignores heartbeats not from our target system'''
                         MAV_POS_TARGET_TYPE_MASK.YAW_IGNORE,
                         int(targetpos.lat * 1.0e7),  # lat
                         int(targetpos.lng * 1.0e7),  # lon
-                        to_alt_frame(targetpos.alt, frame_name),  # alt
+                        to_alt_frame(targetpos.get_alt_m(AltFrame.ABSOLUTE), frame_name),  # alt
                         0,  # vx
                         0,  # vy
                         0,  # vz
@@ -13190,7 +13104,7 @@ Also, ignores heartbeats not from our target system'''
                 target_rate = 1.0  # in rad/s
                 targetpos.lat += 0.0001
                 if test_alt:
-                    targetpos.alt += 5
+                    targetpos.offset_up_m(5)
                 self.wait_yaw_speed(target_rate, timeout=timeout,
                                     called_function=lambda plop, empty: send_yaw_rate(
                                         target_rate, None), minimum_duration=5)
@@ -13205,7 +13119,7 @@ Also, ignores heartbeats not from our target system'''
                 target_rate = -1.0
                 targetpos.lat -= 0.0001
                 if test_alt:
-                    targetpos.alt -= 5
+                    targetpos.offset_up_m(-5)
                 self.wait_yaw_speed(target_rate, timeout=timeout,
                                     called_function=lambda plop, empty: send_yaw_rate(
                                         target_rate, None), minimum_duration=5)
@@ -13739,17 +13653,12 @@ Also, ignores heartbeats not from our target system'''
 
         self.check_fence_upload_download(items)
 
-    def rally_MISSION_ITEM_INT_from_loc(self, loc):
-        '''create a rally point MISSION_ITEM_INT from loc.  A
-        (frame-aware) Location's altitude frame is carried into the
-        item's frame, above-origin being converted to above-home as
-        missions have no origin-relative frame.  A mavutil.location's
-        alt is taken as AMSL'''
-        if isinstance(loc, Location):
-            frame, alt = self.mav_frame_and_alt_m(loc)
-        else:
-            frame = mavutil.mavlink.MAV_FRAME_GLOBAL
-            alt = loc.alt
+    def rally_MISSION_ITEM_INT_from_loc(self, loc: Location):
+        '''create a rally point MISSION_ITEM_INT from loc; the
+        Location's altitude frame is carried into the item's frame,
+        above-origin being converted to above-home as missions have no
+        origin-relative frame'''
+        frame, alt = self.mav_frame_and_alt_m(loc)
         return self.create_MISSION_ITEM_INT(
             mavutil.mavlink.MAV_CMD_NAV_RALLY_POINT,
             x=int(loc.lat*1e7),
@@ -14678,7 +14587,10 @@ switch value'''
         HOME = self.sitl_start_location()
         for heading in 0, 90:
             self.customise_SITL_commandline([
-                "--home", "%s,%s,%s,%s" % (HOME.lat, HOME.lng, HOME.alt, heading)
+                "--home", "%s,%s,%s,%s" % (HOME.lat,
+                                           HOME.lng,
+                                           HOME.get_alt_m(AltFrame.ABSOLUTE),
+                                           heading)
             ])
 
             # Test all simulated ExternalAHRS backends
@@ -15936,7 +15848,8 @@ switch value'''
                 f = msp.get_frame(msp.FRAME_GPS_RAW)
             except KeyError:
                 continue
-            dist = self.get_distance_int(f.LocationInt(), self.sim_location_int())
+            dist = self.get_distance(Location.latlon_only(f.lat(), f.lon()),
+                                     self.get_location('SIMSTATE'))
             print("lat=%f lon=%f dist=%f" % (f.lat(), f.lon(), dist))
             if dist < 1:
                 break
@@ -16375,8 +16288,8 @@ switch value'''
 
             # the secondary position should be close to the primary (POS):
             if pos is not None and m.Lat != 0 and m.Lng != 0:
-                secondary_loc = mavutil.location(m.Lat, m.Lng, 0, 0)
-                primary_loc = mavutil.location(pos.Lat, pos.Lng, 0, 0)
+                secondary_loc = Location.latlon_only(m.Lat, m.Lng)
+                primary_loc = Location.latlon_only(pos.Lat, pos.Lng)
                 dist = self.get_distance(primary_loc, secondary_loc)
                 if dist > 50:
                     raise NotAchievedException(
@@ -17717,7 +17630,7 @@ SERIAL5_BAUD 128
         descend below the min altitude fence floor.
         Caller must call wait_mode('RTL') to confirm the fence breach.
         '''
-        current_loc = self.mav.location()
+        current_loc = self.get_location()
         target_loc = self.offset_location_heading_distance(current_loc, 0, north_m)
 
         # At KalaupapaCliffs the terrain rises ~40 m in the first 100 m
@@ -17736,7 +17649,7 @@ SERIAL5_BAUD 128
         # must still be well past the cliff edge for the min-alt fence
         # floor (~150 m AMSL in both cliff tests) to sit clearly above
         # the terrain below.
-        reposition_alt_amsl = max(current_loc.alt, 215.0)
+        reposition_alt_amsl = max(current_loc.get_alt_m(AltFrame.ABSOLUTE), 215.0)
 
         # fly to target using GUIDED mode waypoint navigation
         self.run_cmd_int(
@@ -17773,7 +17686,7 @@ SERIAL5_BAUD 128
         ])
         self.set_parameters(self.FenceRelative_params())
         self.wait_ready_to_arm()
-        original_home = self.home_position_as_mav_location()
+        original_home = self.home_position_as_location()
 
         self.start_subtest("Above home-relative fence")
         self.set_home(self.offset_location_up(original_home, -2))
@@ -17819,7 +17732,7 @@ SERIAL5_BAUD 128
         '''fence max-alt threshold is measured relative to home, not EKF origin'''
         self.set_parameters(self.FenceRelativeToHome_params())
         self.wait_ready_to_arm()
-        original_home = self.home_position_as_mav_location()
+        original_home = self.home_position_as_location()
         home_ofs = 20
         fence_alt_max = 20  # m above home = 40 m above origin
         offset_home = self.offset_location_up(original_home, home_ofs)
@@ -17833,7 +17746,7 @@ SERIAL5_BAUD 128
         self.assert_mode_is(self.FenceRelative_TakeoffMode())
         self.set_rc(3, 1800)
         self.wait_mode('RTL', timeout=120)
-        expected_breach_alt = offset_home.alt + fence_alt_max
+        expected_breach_alt = offset_home.get_alt_m(AltFrame.ABSOLUTE) + fence_alt_max
         self.assert_altitude(expected_breach_alt, accuracy=10)
         self.disarm_vehicle(force=True)
 
@@ -17848,7 +17761,7 @@ SERIAL5_BAUD 128
         })
         self.set_parameters(params)
         self.wait_ready_to_arm()
-        original_home = self.home_position_as_mav_location()
+        original_home = self.home_position_as_location()
         home_ofs = 20
         offset_home = self.offset_location_up(original_home, home_ofs)
         self.set_home(offset_home)
@@ -17856,7 +17769,7 @@ SERIAL5_BAUD 128
         self.do_fence_enable()
         self.set_rc(3, 1200)
         self.wait_mode('RTL', timeout=120)
-        expected_breach_alt = offset_home.alt + fence_alt_min
+        expected_breach_alt = offset_home.get_alt_m(AltFrame.ABSOLUTE) + fence_alt_min
         self.assert_altitude(expected_breach_alt, accuracy=10)
         self.disarm_vehicle(force=True)
 
@@ -17864,7 +17777,7 @@ SERIAL5_BAUD 128
         '''fence max-alt relative to home when origin is above home'''
         self.set_parameters(self.FenceRelativeToHome_params())
         self.wait_ready_to_arm()
-        original_home = self.home_position_as_mav_location()
+        original_home = self.home_position_as_location()
         home_ofs = -20
         fence_alt_max = 30  # m above home = 10 m above origin
         offset_home = self.offset_location_up(original_home, home_ofs)
@@ -17878,7 +17791,7 @@ SERIAL5_BAUD 128
         self.assert_mode_is(self.FenceRelative_TakeoffMode())
         self.set_rc(3, 1800)
         self.wait_mode('RTL', timeout=120)
-        expected_breach_alt = offset_home.alt + fence_alt_max
+        expected_breach_alt = offset_home.get_alt_m(AltFrame.ABSOLUTE) + fence_alt_max
         self.assert_altitude(expected_breach_alt, accuracy=10)
         self.disarm_vehicle(force=True)
 
@@ -17895,7 +17808,7 @@ SERIAL5_BAUD 128
         })
         self.set_parameters(params)
         self.wait_ready_to_arm()
-        original_home = self.home_position_as_mav_location()
+        original_home = self.home_position_as_location()
         home_ofs = -20
         offset_home = self.offset_location_up(original_home, home_ofs)
         self.set_home(offset_home)
@@ -17904,7 +17817,7 @@ SERIAL5_BAUD 128
         self.assert_mode_is(self.FenceRelative_TakeoffMode())
         self.set_rc(3, 1200)
         self.wait_mode('RTL', timeout=120)
-        expected_breach_alt = offset_home.alt + fence_alt_min
+        expected_breach_alt = offset_home.get_alt_m(AltFrame.ABSOLUTE) + fence_alt_min
         self.assert_altitude(expected_breach_alt, accuracy=10)
         self.disarm_vehicle(force=True)
 
@@ -17923,7 +17836,7 @@ SERIAL5_BAUD 128
         })
         self.set_parameters(params)
         self.wait_ready_to_arm()
-        original_home = self.home_position_as_mav_location()
+        original_home = self.home_position_as_location()
         home_ofs = -20
         offset_home = self.offset_location_up(original_home, home_ofs)
         self.set_home(offset_home)
@@ -17932,7 +17845,7 @@ SERIAL5_BAUD 128
         self.assert_mode_is(self.FenceRelative_TakeoffMode())
         self.FenceRelative_fly_north_then_descend(300)
         self.wait_mode('RTL', timeout=120)
-        expected_breach_alt = offset_home.alt + fence_alt_min
+        expected_breach_alt = offset_home.get_alt_m(AltFrame.ABSOLUTE) + fence_alt_min
         self.assert_altitude(expected_breach_alt, accuracy=10)
         self.disarm_vehicle(force=True)
         self.customise_SITL_commandline([])
@@ -17943,7 +17856,7 @@ SERIAL5_BAUD 128
         self.wait_ready_to_arm()
         origin_alt_m = self.poll_message("GPS_GLOBAL_ORIGIN").altitude / 1000.0
         fence_alt_max = 10  # m above origin = 30 m above home
-        original_home = self.home_position_as_mav_location()
+        original_home = self.home_position_as_location()
         self.set_home(self.offset_location_up(original_home, -20))
         self.set_parameters({
             "FENCE_TYPE": 1,   # ALT_MAX only
@@ -17970,7 +17883,7 @@ SERIAL5_BAUD 128
         self.set_parameters(params)
         self.wait_ready_to_arm()
         origin_alt_m = self.poll_message("GPS_GLOBAL_ORIGIN").altitude / 1000.0
-        original_home = self.home_position_as_mav_location()
+        original_home = self.home_position_as_location()
         self.set_home(self.offset_location_up(original_home, -20))
         self.takeoff(25, mode=self.FenceRelative_TakeoffMode())
         self.do_fence_enable()
@@ -17990,7 +17903,7 @@ SERIAL5_BAUD 128
         self.takeoff(10, mode=self.FenceRelative_TakeoffMode())
         # now move home 20 m above origin; vehicle at 10 m above origin
         # is safely below the fence max at 50 m above origin
-        original_home = self.mav.location()
+        original_home = self.get_location()
         self.set_home(self.offset_location_up(original_home, 10))
         self.set_parameters({
             "FENCE_TYPE": 1,   # ALT_MAX only
@@ -18024,7 +17937,7 @@ SERIAL5_BAUD 128
         self.takeoff(30, mode=self.FenceRelative_TakeoffMode())
         # now move home 20 m above origin; vehicle at 30 m above origin
         # is safely above the fence min at 15 m above origin
-        original_home = self.mav.location()
+        original_home = self.get_location()
         self.set_home(self.offset_location_up(original_home, -10))
         self.do_fence_enable()
         self.assert_mode_is(self.FenceRelative_TakeoffMode())
@@ -18110,9 +18023,9 @@ SERIAL5_BAUD 128
         self.install_terrain_handlers_context()
         self.set_parameters(self.FenceRelativeToTerrain_params())
         self.wait_ready_to_arm()
-        original_home = self.home_position_as_mav_location()
-        # home is placed 20 m below terrain; terrain AMSL ≈ original_home.alt
-        terrain_alt_amsl = original_home.alt
+        original_home = self.home_position_as_location()
+        # home is placed 20 m below terrain; terrain AMSL ≈ original home alt
+        terrain_alt_amsl = original_home.get_alt_m(AltFrame.ABSOLUTE)
         fence_alt_max = 10  # m AGL = 30 m above home
         offset_home = self.offset_location_up(original_home, -20)
         self.set_home(offset_home)
@@ -18141,9 +18054,9 @@ SERIAL5_BAUD 128
         })
         self.set_parameters(params)
         self.wait_ready_to_arm()
-        original_home = self.home_position_as_mav_location()
-        # home is placed 20 m below terrain; terrain AMSL ≈ original_home.alt
-        terrain_alt_amsl = original_home.alt
+        original_home = self.home_position_as_location()
+        # home is placed 20 m below terrain; terrain AMSL ≈ original home alt
+        terrain_alt_amsl = original_home.get_alt_m(AltFrame.ABSOLUTE)
         offset_home = self.offset_location_up(original_home, -20)
         self.set_home(offset_home)
         self.takeoff(25, mode=self.FenceRelative_TakeoffMode())
@@ -18358,7 +18271,7 @@ SERIAL5_BAUD 128
             now = self.get_sim_time()
             if now - tstart > timeout:
                 raise AutoTestTimeoutException("Did not get onto circle")
-            here = self.mav.location()
+            here = self.get_location()
             got_radius = self.get_distance(loc, here)
             average_radius = 0.95*average_radius + 0.05*got_radius
             on_radius = abs(got_radius - want_radius) < epsilon

--- a/Tools/scripts/check_mavutil_location_ratchet.py
+++ b/Tools/scripts/check_mavutil_location_ratchet.py
@@ -8,12 +8,12 @@ altitudes into its alt attribute has been a recurring source of bugs.
 It is being replaced by vehicle_test_suite.Location, which tags its
 altitude with an AltFrame.
 
-This script counts uses of mavutil.location (and of the deprecated
-helpers which produce one) per file, both in the working tree and at
-the merge-base with --base-ref, and fails if any file's count has
-increased.  There is deliberately no stored budget: the invariant is
-simply that a branch must not add uses, whatever the current number
-happens to be.
+This script counts uses of mavutil.location (and of pymavlink's
+mavfile.location(), which returns one) per file, both in the working
+tree and at the merge-base with --base-ref, and fails if any file's
+count has increased.  There is deliberately no stored budget: the
+invariant is simply that a branch must not add uses, whatever the
+current number happens to be.  The autotest suite currently has none.
 
 AP_FLAKE8_CLEAN
 '''
@@ -32,20 +32,6 @@ PATTERNS = [
      "or Location.latlon_only() where the altitude is unused"),
     (re.compile(r"\.mav\.location\("),
      "self.get_location(); frame=AltFrame.ABOVE_HOME replaces relative_alt=True"),
-    (re.compile(r"\.get_mav_location\("),
-     "self.get_location()"),
-    (re.compile(r"\.home_position_as_mav_location\("),
-     "self.home_position_as_location()"),
-    (re.compile(r"\.sim_location\("),
-     "self.get_location('SIMSTATE')"),
-    (re.compile(r"\.home_relative_loc_ne\("),
-     "self.offset_location_ne(self.home_position_as_location(), n, e)"),
-    (re.compile(r"\.home_relative_loc_neu\("),
-     "self.offset_location_ne(self.home_position_as_location(), n, e) "
-     "then set_alt_m(u, AltFrame.ABOVE_HOME)"),
-    (re.compile(r"\.position_target_loc\("),
-     "a Location built from POSITION_TARGET_GLOBAL_INT carrying the frame "
-     "the target was commanded in"),
 ]
 
 AUTOTEST_DIR = os.path.join(


### PR DESCRIPTION
### Summary

Use the new Location object in place of mavutil.location

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

The robots were continuing to use the old mavutil.location stuff and that just causes workflow issues for us.

Remove all examples which the robots are following.
