### PR TITLE
AP_Baro: ICP201XX lower noise mode and FIR settling fix

### DIFF
--- a/libraries/AP_Baro/AP_Baro_ICP201XX.cpp
+++ b/libraries/AP_Baro/AP_Baro_ICP201XX.cpp
@@ -406,7 +406,7 @@ bool AP_Baro_ICP201XX::configure()
     /* FIFO Readout Mode Selection: Pressure first. */
     reg_value |= (reg_value & (~0x03)) | ((uint8_t)(_fifo_readout_mode));
 
-    /* Measurement Configuration: Mode2*/
+    /* Measurement Configuration */
     reg_value |= (reg_value & (~0xE0)) | (((uint8_t)_op_mode) << 5);
 
     /* Measurement Mode Selection: Continuous Measurements (duty cycled) */

--- a/libraries/AP_Baro/AP_Baro_ICP201XX.cpp
+++ b/libraries/AP_Baro/AP_Baro_ICP201XX.cpp
@@ -428,7 +428,7 @@ void AP_Baro_ICP201XX::wait_read()
         hal.scheduler->delay(10);
         read_reg(REG_FIFO_FILL, &fifo_packets);
         fifo_packets = (uint8_t)(fifo_packets & 0x1F);
-    } while (fifo_packets >= fifo_packets_to_skip);
+    } while (fifo_packets < fifo_packets_to_skip);
 
     flush_fifo();
     fifo_packets = 0;

--- a/libraries/AP_Baro/AP_Baro_ICP201XX.h
+++ b/libraries/AP_Baro/AP_Baro_ICP201XX.h
@@ -53,7 +53,7 @@ private:
 		OP_MODE2,       /* Mode 2: Bw:10 Hz ODR: 40Hz */
 		OP_MODE3,       /* Mode 3: Bw:0.5 Hz ODR: 2Hz */
 		OP_MODE4,       /* Mode 4: User configurable Mode */
-	} _op_mode{OP_MODE::OP_MODE2};
+	} _op_mode{OP_MODE::OP_MODE1};  /* mode 2 is 2.5x noisier per sample and saves only 170uA */
 
 	enum class FIFO_READOUT_MODE : uint8_t {
 		FIFO_READOUT_MODE_PRES_TEMP = 0,   /* Pressure and temperature as pair and address wraps to the start address of the Pressure value ( pressure first ) */


### PR DESCRIPTION
### Summary

Run the ICP201XX in mode 1 instead of the low power mode 2, and fix the FIR settling discard at init, which tested the wrong sense and so discarded nothing.

### Classification & Testing

- [x] Checked by a human programmer
- [x] Tested on hardware
- [ ] Logs available on request

Bench measurement on a SkySakuraH743. Not yet flown, and not measured with props running - see the bandwidth note below.

### Description

Mode 2 is the low power mode - 2.5 Pa per sample at 49uA, against 1 Pa at 222uA for mode 1. 170uA is not a saving worth the noise on a flight controller. At the 10Hz frontend rate mode 2 measured 1.10 Pa sd on the bench, against the 1.25 Pa expected from averaging four 40Hz samples of the datasheet 2.5 Pa. Mode 1 puts twelve 120Hz samples into each update instead.

Mode 0 is quieter per sample but only runs at 25Hz, so it ends up at the same output noise for several times the FIR group delay.

The higher ODR does not disturb the read path: the FIFO is drained and averaged in full on every poll, and the timer runs at 80Hz into a 16 packet FIFO.

Two consequences worth flagging. Bandwidth goes from 10Hz to 30Hz, so mode 1 passes airframe and prop-wash pressure content that mode 2 attenuated; a stationary bench measurement cannot distinguish that from the sensor noise it is meant to measure, so the in-flight behaviour is not yet characterised. And on AP_Periph baro nodes (CUAV_GPS, HolybroG4_GPS) the DroneCAN StaticPressure/StaticTemperature rate roughly doubles, from about 40 to about 80 updates a second, because a broadcast is emitted per successful driver poll and at 120Hz ODR every 80Hz poll now finds data.

Separately, wait_read() was meant to wait for the 14 FIR settling samples to reach the FIFO before flushing them, but tested the opposite sense, so it fell through on the first poll and discarded at most one sample. This does not change a vehicle's ground reference - AP_Baro::calibrate() discards a second of readings before it averages ground pressure, so the transient never reached it. AP_Periph never calibrates, and there the first readings go straight out over CAN. The wait costs about 120ms of bus-semaphore hold during probe at 120Hz, against about 350ms had it been fixed at the old 40Hz.
