### PR TITLE
hwdef: ARK_PI6X: fix RC input serial port number in README

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/ARK_PI6X/README.md
+++ b/libraries/AP_HAL_ChibiOS/hwdef/ARK_PI6X/README.md
@@ -136,7 +136,7 @@
 |SERIAL2|UART5 (Internally connected)|
 |SERIAL3|USART1 (GPS1)|
 |SERIAL4|UART4 (ESC Telem)|
-|SERIAL6|USART6 (RC Input)|
+|SERIAL5|USART6 (RC Input)|
 
 All UARTs support DMA except for UART4. Any UART may be re-tasked by changing its protocol parameter.
 
@@ -144,12 +144,12 @@ Ports marked _Internal_ are connected directly to the Raspberry Pi.
 
 ## RC Input
 
-RC input is configured on the RX6 (UART6_RX) pin. It supports all RC protocols except PPM. See [Radio Control Systems](https://ardupilot.org/copter/docs/common-rc-systems.html) for details for a specific RC system. [SERIAL6_PROTOCOL](https://ardupilot.org/copter/docs/parameters.html#serial6-protocol-serial6-protocol-selection) is set to “23”, by default, to enable this.
+RC input is configured on the RX6 (UART6_RX) pin. It supports all RC protocols except PPM. See [Radio Control Systems](https://ardupilot.org/copter/docs/common-rc-systems.html) for details for a specific RC system. [SERIAL5_PROTOCOL](https://ardupilot.org/copter/docs/parameters.html#serial5-protocol-serial5-protocol-selection) is set to “23”, by default, to enable this.
 
 - SBUS/DSM/SRXL connects to the RX6 pin.
-- FPort requires connection to TX6 and [SERIAL6_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial6-options-serial6-options) be set to “7”.
+- FPort requires connection to TX6 and [SERIAL5_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial5-options-serial5-options) be set to “7”.
 - CRSF also requires a TX6 connection, in addition to RX6, and automatically provides telemetry.
-- SRXL2 requires a connection to TX6 and automatically provides telemetry. Set [SERIAL6_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial6-options-serial6-options) to “4”.
+- SRXL2 requires a connection to TX6 and automatically provides telemetry. Set [SERIAL5_OPTIONS](https://ardupilot.org/copter/docs/parameters.html#serial5-options-serial5-options) to “4”.
 
 ## Battery Monitoring
 


### PR DESCRIPTION
## Summary

The ARK_PI6X README listed RC input on SERIAL6, but `SERIAL_ORDER` puts USART6 at SERIAL5 and the hwdef sets `DEFAULT_SERIAL5_PROTOCOL` to RCIN. Updated the UART mapping table and the SERIAL*_PROTOCOL/OPTIONS references to SERIAL5.

## Testing

Docs only.