### PR TITLE
AC_AttitudeControl: NTF units are an index

### DIFF
--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.cpp
@@ -300,7 +300,6 @@ const AP_Param::GroupInfo AC_AttitudeControl_Heli::var_info[] = {
     // @DisplayName: Yaw Target notch filter index
     // @Description: Yaw Target notch filter index
     // @Range: 1 8
-    // @Units: Hz
     // @User: Advanced
 
     // @Param: RAT_YAW_NEF

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp
@@ -293,7 +293,6 @@ const AP_Param::GroupInfo AC_AttitudeControl_Multi::var_info[] = {
     // @DisplayName: Yaw Target notch filter index
     // @Description: Yaw Target notch filter index
     // @Range: 1 8
-    // @Units: Hz
     // @User: Advanced
 
     // @Param: RAT_YAW_NEF


### PR DESCRIPTION
### Summary

RAT_YAW_NTF selects a notch filter by index, so the `@Units: Hz` on it is wrong and ground stations render the field as a frequency.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change

### Description

Only the two yaw entries carried the annotation. The roll and pitch NTF params, and all of the NEF params, never had it, so this just brings yaw into line.
