### PR TITLE
AC_WPNav: avoid duplicate TerrainSource enum definition in AC_Circle

### DIFF
--- a/libraries/AC_WPNav/AC_Circle.h
+++ b/libraries/AC_WPNav/AC_Circle.h
@@ -4,6 +4,7 @@
 #include <AP_Param/AP_Param.h>
 #include <AP_Math/AP_Math.h>
 #include <AC_AttitudeControl/AC_PosControl.h>      // Position control library
+#include "AC_WPNav.h"
 
 class AC_Circle
 {
@@ -171,11 +172,7 @@ private:
 
     // Returns the expected source of terrain data for the circle controller.
     // Used to determine whether terrain offset comes from rangefinder, terrain database, or is unavailable.
-    enum class TerrainSource {
-        TERRAIN_UNAVAILABLE,
-        TERRAIN_FROM_RANGEFINDER,
-        TERRAIN_FROM_TERRAINDATABASE,
-    };
+    using TerrainSource = AC_WPNav::TerrainSource;
     AC_Circle::TerrainSource get_terrain_source() const;
 
     // Returns terrain offset in meters above the EKF origin at the current position.


### PR DESCRIPTION
### Summary

Avoid duplicate definition of `enum class TerrainSource` in `AC_Circle.h` by aliasing `AC_WPNav::TerrainSource`.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Built and verified with SITL:
```bash
./waf configure --board sitl
./waf copter
```

### Description

Both `AC_WPNav.h` and `AC_Circle.h` (in the `AC_WPNav` library) defined identical `enum class TerrainSource` (`TERRAIN_UNAVAILABLE`, `TERRAIN_FROM_RANGEFINDER`, `TERRAIN_FROM_TERRAINDATABASE`).

This change replaces the duplicate enum definition in `AC_Circle.h` with `using TerrainSource = AC_WPNav::TerrainSource;`, making `AC_WPNav.h` the single source of truth while maintaining full source and API compatibility.