### PR TITLE
remove customrotations parameter conversion

### DIFF
--- a/Tools/scripts/param_check_all.py
+++ b/Tools/scripts/param_check_all.py
@@ -45,6 +45,7 @@ sitl_params_to_skip = set([
 frame_params_to_skip = set([
     'EFlight_Convergence.param',
     'WLToys_V383_HeliQuad.param',
+    'iflight-chimera7-4.2.param',
 ])
 
 

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -174,35 +174,11 @@ const AP_Param::GroupInfo AP_AHRS::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("EKF_TYPE",  14, AP_AHRS, _ekf_type, HAL_AHRS_EKF_TYPE_DEFAULT),
 
-    // @Param: CUSTOM_ROLL
-    // @DisplayName: Board orientation roll offset
-    // @Description: Autopilot mounting position roll offset. Positive values = roll right, negative values = roll left. This parameter is only used when AHRS_ORIENTATION is set to CUSTOM.
-    // @Range: -180 180
-    // @Units: deg
-    // @Increment: 1
-    // @User: Advanced
+    // index 15 was CUSTOM_ROLL
 
-    // index 15
+    // index 16 was CUSTOM_PIT
 
-    // @Param: CUSTOM_PIT
-    // @DisplayName: Board orientation pitch offset
-    // @Description: Autopilot mounting position pitch offset. Positive values = pitch up, negative values = pitch down. This parameter is only used when AHRS_ORIENTATION is set to CUSTOM.
-    // @Range: -180 180
-    // @Units: deg
-    // @Increment: 1
-    // @User: Advanced
-
-    // index 16
-
-    // @Param: CUSTOM_YAW
-    // @DisplayName: Board orientation yaw offset
-    // @Description: Autopilot mounting position yaw offset. Positive values = yaw right, negative values = yaw left. This parameter is only used when AHRS_ORIENTATION is set to CUSTOM.
-    // @Range: -180 180
-    // @Units: deg
-    // @Increment: 1
-    // @User: Advanced
-
-    // index 17
+    // index 17 was CUSTOM_YAW
 
     // @Param: OPTIONS
     // @DisplayName: Optional AHRS behaviour

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -38,7 +38,6 @@
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 #include <GCS_MAVLink/GCS.h>
 #include <AP_InertialSensor/AP_InertialSensor.h>
-#include <AP_CustomRotations/AP_CustomRotations.h>
 
 #include <AP_Mission/AP_Mission_config.h>
 #if AP_MISSION_ENABLED
@@ -370,26 +369,6 @@ void AP_AHRS::init()
 
     // initialise this as no-change from the active type:
     last_active_ekf_type = state.active_EKF_type;
-
-#if AP_CUSTOMROTATIONS_ENABLED
-    // convert to new custom rotation
-    // PARAMETER_CONVERSION - Added: Nov-2021
-    if (_board_orientation == ROTATION_CUSTOM_OLD) {
-        _board_orientation.set_and_save(ROTATION_CUSTOM_1);
-        AP_Param::ConversionInfo info;
-        if (AP_Param::find_top_level_key_by_pointer(this, info.old_key)) {
-            info.type = AP_PARAM_FLOAT;
-            float rpy[3] = {};
-            AP_Float rpy_param;
-            for (info.old_group_element=15; info.old_group_element<=17; info.old_group_element++) {
-                if (AP_Param::find_old_parameter(&info, &rpy_param)) {
-                    rpy[info.old_group_element-15] = rpy_param.get();
-                }
-            }
-            AP::custom_rotations().convert(ROTATION_CUSTOM_1, rpy[0], rpy[1], rpy[2]);
-        }
-    }
-#endif  // AP_CUSTOMROTATIONS_ENABLED
 }
 
 // has_status returns information about the EKF health and

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -12,7 +12,6 @@
 #include <AP_Logger/AP_Logger.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 #include <AP_ExternalAHRS/AP_ExternalAHRS.h>
-#include <AP_CustomRotations/AP_CustomRotations.h>
 #include <GCS_MAVLink/GCS.h>
 #include <AP_AHRS/AP_AHRS.h>
 
@@ -744,30 +743,6 @@ void Compass::init()
         }
 #endif
     }
-
-    // convert to new custom rotation method
-    // PARAMETER_CONVERSION - Added: Nov-2021
-#if AP_CUSTOMROTATIONS_ENABLED
-    for (StateIndex i(0); i<COMPASS_MAX_INSTANCES; i++) {
-        if (_state[i].orientation != ROTATION_CUSTOM_OLD) {
-            continue;
-        }
-        _state[i].orientation.set_and_save(ROTATION_CUSTOM_2);
-        AP_Param::ConversionInfo info;
-        if (AP_Param::find_top_level_key_by_pointer(this, info.old_key)) {
-            info.type = AP_PARAM_FLOAT;
-            float rpy[3] = {};
-            AP_Float rpy_param;
-            for (info.old_group_element=49; info.old_group_element<=51; info.old_group_element++) {
-                if (AP_Param::find_old_parameter(&info, &rpy_param)) {
-                    rpy[info.old_group_element-49] = rpy_param.get();
-                }
-            }
-            AP::custom_rotations().convert(ROTATION_CUSTOM_2, rpy[0], rpy[1], rpy[2]);
-        }
-        break;
-    }
-#endif  // AP_CUSTOMROTATIONS_ENABLED
 
 #if COMPASS_MAX_INSTANCES > 1
     // Look if there was a primary compass setup in previous version

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -665,38 +665,11 @@ const AP_Param::GroupInfo Compass::var_info[] = {
     AP_GROUPINFO("DEV_ID8", 48, Compass, extra_dev_id[4], 0),
 #endif // COMPASS_MAX_UNREG_DEV
 
-    // @Param: CUS_ROLL
-    // @DisplayName: Custom orientation roll offset
-    // @Description: Compass mounting position roll offset. Positive values = roll right, negative values = roll left. This parameter is only used when COMPASS_ORIENT/2/3 is set to CUSTOM.
-    // @Range: -180 180
-    // @Units: deg
-    // @Increment: 1
-    // @RebootRequired: True
-    // @User: Advanced
+    // index 49 was CUS_ROLL
 
-    // index 49
+    // index 50 was CUS_PIT
 
-    // @Param: CUS_PIT
-    // @DisplayName: Custom orientation pitch offset
-    // @Description: Compass mounting position pitch offset. Positive values = pitch up, negative values = pitch down. This parameter is only used when COMPASS_ORIENT/2/3 is set to CUSTOM.
-    // @Range: -180 180
-    // @Units: deg
-    // @Increment: 1
-    // @RebootRequired: True
-    // @User: Advanced
-
-    // index 50
-
-    // @Param: CUS_YAW
-    // @DisplayName: Custom orientation yaw offset
-    // @Description: Compass mounting position yaw offset. Positive values = yaw right, negative values = yaw left. This parameter is only used when COMPASS_ORIENT/2/3 is set to CUSTOM.
-    // @Range: -180 180
-    // @Units: deg
-    // @Increment: 1
-    // @RebootRequired: True
-    // @User: Advanced
-
-    // index 51
+    // index 51 was CUS_YAW
 
     AP_GROUPEND
 };

--- a/libraries/AP_CustomRotations/AP_CustomRotations.cpp
+++ b/libraries/AP_CustomRotations/AP_CustomRotations.cpp
@@ -69,20 +69,6 @@ void AP_CustomRotations::init()
     }
 }
 
-void AP_CustomRotations::convert(Rotation r, float roll, float pitch, float yaw)
-{
-    AP_CustomRotation* rot = get_rotation(r);
-    if (rot == nullptr) {
-        return;
-    }
-    if (!rot->params.roll.configured() && !rot->params.pitch.configured() && !rot->params.yaw.configured()) {
-        rot->params.roll.set_and_save(roll);
-        rot->params.pitch.set_and_save(pitch);
-        rot->params.yaw.set_and_save(yaw);
-        rot->init();
-    }
-}
-
 void AP_CustomRotations::set(Rotation r, float roll, float pitch, float yaw)
 {
     AP_CustomRotation* rot = get_rotation(r);

--- a/libraries/AP_CustomRotations/AP_CustomRotations.h
+++ b/libraries/AP_CustomRotations/AP_CustomRotations.h
@@ -62,7 +62,6 @@ public:
     void rotate(enum Rotation r, Vector3d& v);
     void rotate(enum Rotation r, Vector3f& v);
 
-    void convert(Rotation r, float roll, float pitch, float yaw);
     void set(Rotation r, float roll, float pitch, float yaw);
 
     static const struct AP_Param::GroupInfo var_info[];


### PR DESCRIPTION
### Summary

Removes code which converted from 4.1-style custom rotations to modern style

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli  iofirmware  plane  rover  sub
CubeOrange-periph-heavy  *                                 *                                                   
Durandal                            -336            -336   *           -344    -344              -336   -344   -344
Hitec-Airspeed           *                                 *                                                   
KakuteH7-bdshot                     -336            -344   *           -336    -336              -344   -336   -344
MatekF405                           -344            -344   *           -344    -336              -336   -344   -336
Pixhawk1-1M-bdshot                  -344            -344               -344    -344              -344   -344   -344
SITL_x86_64_linux_gnu               4024            -72                -72     4024              -72    4032   -72
YJUAV_A6SE                          -344            -344   *           -344    -352              -344   -352   -344
f103-QiotekPeriph        *                                 *                                                   
f303-MatekGPS            *                                 *                                                   
f303-Universal           *                                 *                                                   
iomcu                                                                                *                         
revo-mini                           -344            -336   *           -336    -344              -344   -336   -336
skyviper-v2450                                                         -344                                    
speedybeef4                         -336            -336   *           -344    -344              -344   -344   -344
```

### Description

Removes some ancient conversion code.

Past this, someone moving from ArduPilot 4.1 to 4.8 who was using custom rotations will not get their new values transferred over to the new running firmware.

Also see https://github.com/ArduPilot/ardupilot_wiki/pull/7981
