### PR TITLE
Add lockstep scheduling for simulated peripherals

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -5178,7 +5178,6 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.start_sup_program(instance=0, args="-M")
         self.stop_sup_program(instance=1)
         self.start_sup_program(instance=1, args="-M")
-        self.delay_sim_time(2, reason="supplemental programs to start")
         self.context_collect('STATUSTEXT')
         self.run_cmd(
             mavutil.mavlink.MAV_CMD_COMPONENT_ARM_DISARM,
@@ -5186,13 +5185,39 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             timeout=10,
             want_result=mavutil.mavlink.MAV_RESULT_FAILED,
         )
-        self.wait_statustext(".*Node .* unhealthy", check_context=True, regex=True)
+        # the peripherals take wall-clock time to restart, so at high
+        # speedup a large amount of simulation time may pass before
+        # their maintenance-mode NodeStatus is seen; the recurring
+        # prearm display emits the message once it is
+        self.wait_statustext(".*Node .* unhealthy", check_context=True, regex=True, timeout=600)
         self.stop_sup_program(instance=0)
         self.start_sup_program(instance=0)
         self.stop_sup_program(instance=1)
         self.start_sup_program(instance=1)
         self.context_stop_collecting('STATUSTEXT')
         self.context_pop()
+
+        # the restarted peripherals take wall-clock time to boot and
+        # their GPSs must then deliver on-time fixes for long enough
+        # for the GPS timing health filters to recover.  The prearm
+        # SYS_STATUS bit reflects the full arming checks, including
+        # health of every GPS instance; require it healthy
+        # continuously before flying
+        self.progress("Waiting for sustained prearm health after peripheral restart")
+        tstart = self.get_sim_time()
+        healthy_since = None
+        while True:
+            now = self.get_sim_time_cached()
+            if now - tstart > 600:
+                raise NotAchievedException("Peripherals did not return to sustained health")
+            m = self.assert_receive_message('SYS_STATUS')
+            if m.onboard_control_sensors_health & mavutil.mavlink.MAV_SYS_STATUS_PREARM_CHECK:
+                if healthy_since is None:
+                    healthy_since = now
+                if now - healthy_since > 20:
+                    break
+            else:
+                healthy_since = None
 
         self.set_parameters({
             # use DroneCAN ESCs for flight

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -18943,7 +18943,6 @@ RTL_ALT_M 111
 
         self.progress("Starting Periph simulation")
         self.context_push()
-        self.context_set_speedup(1)
         periph_exp = None
         ex = None
         try:
@@ -18970,6 +18969,8 @@ RTL_ALT_M 111
             self.progress("Reconfiguring for multicast")
             self.customise_SITL_commandline([
                 "--serial5=mcast:",
+                # do not outrun the tunnel peripheral:
+                "--sim-periph-lockstep",
             ],
                 **self.callisto_sitl_kwargs()
             )

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -5084,7 +5084,6 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             # use DroneCAN battery monitoring, and enforce with a arming voltage
             "BATT_MONITOR" : 8,
             "BATT_ARM_VOLT" : 12.0,
-            "SIM_SPEEDUP": 2,
         })
 
         self.context_push()
@@ -5225,8 +5224,6 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             # this stops us using local servo output, guaranteeing we are
             # flying on DroneCAN ESCs
             "SIM_CAN_SRV_MSK" : 0xFF,
-            # we can do the flight faster
-            "SIM_SPEEDUP" : 5,
         })
 
         self.CopterMission()

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -18962,6 +18962,8 @@ RTL_ALT_M 111
                     '--serial1', 'tcp:2',
                     '--serial2', 'tcp:3',
                 ],
+                # AP_Periph is a supplementary program (no vehicle model):
+                supplementary=True,
                 speedup=self.speedup
             )
             self.expect_list_add(periph_exp)

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -9154,8 +9154,16 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             customisations=['--serial5=tcp:{port}', '--sim-periph-lockstep'],
         )
 
-        # Plane should announce PPP backend init.
-        self.wait_statustext("PPP[0]: started", check_context=True, timeout=30)
+        # Plane should announce PPP backend init.  Time this on the wall
+        # clock: bringing the link up runs pppd, connects a TCP socket to
+        # the AP_Periph child and negotiates LCP/IPCP, none of which is
+        # paced by the simulation.  Budgeted in simulated time this
+        # allowed 0.9s of real time for all of that before giving up:
+        #     PPPPeriph ... Failed to receive text: ppp[0]: started
+        # with the plane having booted cleanly right up to "ArduPilot
+        # Ready" in the meantime.
+        self.wait_statustext("PPP[0]: started", check_context=True, timeout=30,
+                             wallclock_timeout=True)
 
         # Pre-IPCP, the first NET: IP message is the static fallback
         # (192.168.x.x). Wait for an IPCP-assigned address - matched as any
@@ -9165,7 +9173,8 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         # an assigned address on the plane implicitly proves both ends of
         # the link are running.
         m = self.wait_statustext(r"NET: IP\s+10\.\d+\.\d+\.\d+",
-                                 check_context=True, regex=True, timeout=30)
+                                 check_context=True, regex=True, timeout=30,
+                                 wallclock_timeout=True)
         self.progress("PPP link established: %s" % m.text.strip())
 
     def tests1c(self):

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -9149,7 +9149,9 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.restart_SITL_frame(
             'quadplane-PPP',
             extra_configure_args=['--debug'],
-            customisations=['--serial5=tcp:{port}'],
+            # lockstep: the periph's PPP endpoint must not fall behind
+            # simulation time when the runner is loaded
+            customisations=['--serial5=tcp:{port}', '--sim-periph-lockstep'],
         )
 
         # Plane should announce PPP backend init.

--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -835,6 +835,15 @@ if __name__ == "__main__":
     ''' main program '''
     os.environ['PYTHONUNBUFFERED'] = '1'
 
+    # pin SITL's multicast traffic (the simulation state a periph
+    # consumes, and multicast CAN) to the loopback interface.  By
+    # default it follows the routing table, which means it goes out
+    # whichever interface has the default route and stops working when
+    # that route is not up or is not multicast-capable; a test should
+    # not pass or fail on the state of the machine's network.  Every
+    # SITL we start inherits this.
+    os.environ.setdefault('SITL_MULTICAST_IF_ADDR', '127.0.0.1')
+
     if sys.platform != "darwin":
         os.putenv('TMPDIR', util.reltopdir('tmp'))
 

--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -500,9 +500,9 @@ def run_step(step):
                               "customisation" : customisation,
                               "param_file" : param_file}
                 supplementary_binaries.append(sup_binary)
-            # we are running in conjunction with a supplementary app
-            # can't have speedup
-            opts.speedup = 1.0
+            # note that speedup is permitted here: the vehicle SITL is
+            # started with --sim-periph-lockstep so it cannot outrun
+            # the supplementary peripherals
             break
 
     fly_opts = {

--- a/Tools/autotest/default_params/periph-battmon.parm
+++ b/Tools/autotest/default_params/periph-battmon.parm
@@ -1,0 +1,4 @@
+# parameters for the SITL battery-monitor peripheral
+
+BATT_MONITOR 16
+BATT_I2C_BUS 2

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -10012,6 +10012,14 @@ Also, ignores heartbeats not from our target system'''
             start_sitl_args["customisations"] = customisations
         self.sitl = util.start_SITL(binary, **start_sitl_args)
         self.expect_list_add(self.sitl)
+        # stop the previous start's supplementary programs before we
+        # forget them.  Simply resetting the list left them running,
+        # reparented to init when their test finished - and a simulated
+        # peripheral which outlives its test carries on talking on the
+        # CAN bus, during precisely the tests which care about
+        # peripherals:
+        if getattr(self, "sup_prog", None):
+            self.stop_sup_program()
         self.sup_prog = []
         count = 0
         for sup_binary in self.sup_binaries:
@@ -10036,11 +10044,16 @@ Also, ignores heartbeats not from our target system'''
     def stop_sup_program(self, instance=None):
         self.progress("Stopping supplementary program")
         if instance is None:
-            # close all sup programs
-            for prog in self.sup_prog:
+            # close all sup programs.  Iterate over a copy: removing
+            # from the list being walked skips every other entry, so
+            # this closed only half of them - with the usual two
+            # peripherals, exactly one, and the other was left running.
+            for prog in list(self.sup_prog):
+                if prog is None:
+                    continue
                 self.expect_list_remove(prog)
-                self.sup_prog.remove(prog)
                 util.pexpect_close(prog)
+            self.sup_prog = []
         else:
             # close only the instance passed
             prog = self.sup_prog[instance]

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -10002,6 +10002,14 @@ Also, ignores heartbeats not from our target system'''
         self.progress("Starting SITL", send_statustext=False)
         if binary is None:
             binary = self.binary
+        if self.sup_binaries:
+            # the vehicle must not advance its simulation past state
+            # the supplementary peripherals have yet to consume, or
+            # peripheral data streams stall in simulation time whenever
+            # a peripheral process is starved of wall-clock time
+            customisations = list(start_sitl_args.get("customisations") or [])
+            customisations.append("--sim-periph-lockstep")
+            start_sitl_args["customisations"] = customisations
         self.sitl = util.start_SITL(binary, **start_sitl_args)
         self.expect_list_add(self.sitl)
         self.sup_prog = []

--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -169,6 +169,7 @@ for t in $CI_BUILD_TARGET; do
         $waf configure --board sitl
         $waf copter
         run_autotest "Copter" "build.SITLPeriphUniversal" "test.CAN"
+        run_autotest "Copter" "build.SITLPeriphBattMon" "test.BattCAN"
         continue
     fi
     if [ "$t" == "sitltest-plane-tests1a" ]; then

--- a/libraries/AP_HAL/utility/Socket.cpp
+++ b/libraries/AP_HAL/utility/Socket.cpp
@@ -67,7 +67,8 @@ SOCKET_CLASS_NAME::SOCKET_CLASS_NAME(bool _datagram) :
 
 SOCKET_CLASS_NAME::SOCKET_CLASS_NAME(bool _datagram, int _fd) :
     datagram(_datagram),
-    fd(_fd)
+    fd(_fd),
+    multicast_interface_address(0)  // INADDR_ANY; routing table chooses
 {
 #ifdef FD_CLOEXEC
     CALL_PREFIX(fcntl)(fd, F_SETFD, FD_CLOEXEC);
@@ -143,11 +144,26 @@ bool SOCKET_CLASS_NAME::connect(const char *address, uint16_t port)
         }
 
         mreq.imr_multiaddr.s_addr = sockaddr.sin_addr.s_addr;
-        mreq.imr_interface.s_addr = htonl(INADDR_ANY);
+        mreq.imr_interface.s_addr = multicast_interface_address;
 
         ret = CALL_PREFIX(setsockopt)(fd_in, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mreq, sizeof(mreq));
         if (ret == -1) {
             goto fail_multi;
+        }
+
+        if (multicast_interface_address != 0) {
+            /*
+              also send on that interface; without this the routing
+              table chooses, which for a multicast address with no
+              specific route means whichever interface the default
+              route uses
+             */
+            struct in_addr ifaddr {};
+            ifaddr.s_addr = multicast_interface_address;
+            ret = CALL_PREFIX(setsockopt)(fd, IPPROTO_IP, IP_MULTICAST_IF, &ifaddr, sizeof(ifaddr));
+            if (ret == -1) {
+                goto fail_multi;
+            }
         }
     }
 

--- a/libraries/AP_HAL/utility/Socket.hpp
+++ b/libraries/AP_HAL/utility/Socket.hpp
@@ -41,6 +41,17 @@ public:
     bool set_cloexec() const;
     void set_broadcast(void) const;
 
+    /*
+      set the address of the local interface to send and receive
+      multicast on.  Must be called before connect().  The default of
+      zero (INADDR_ANY) leaves the choice of interface to the routing
+      table, which is what you want unless you have a reason to pin the
+      traffic to one interface.  Address is in network byte order.
+     */
+    void set_multicast_interface_address(uint32_t addr) {
+        multicast_interface_address = addr;
+    }
+
     ssize_t send(const void *pkt, size_t size) const;
     ssize_t sendto(const void *buf, size_t size, const char *address, uint16_t port);
     ssize_t sendto(const void *buf, size_t size, uint32_t address, uint16_t port);
@@ -105,6 +116,10 @@ private:
 
     // fd_in is used for multicast UDP
     int fd_in = -1;
+
+    // address of the local interface to multicast on, network byte
+    // order; zero (INADDR_ANY) leaves the choice to the routing table
+    uint32_t multicast_interface_address;
 
     bool connected;
 

--- a/libraries/AP_HAL_SITL/CAN_Multicast.cpp
+++ b/libraries/AP_HAL_SITL/CAN_Multicast.cpp
@@ -42,7 +42,7 @@ bool CAN_Multicast::init(uint8_t instance)
 
     address[strlen(address)-1] = '0' + instance;
     sock.set_multicast_interface_address(sitl_multicast_interface_address());
-    return sock.connect(address, MCAST_PORT);
+    return sock.connect(address, sitl_can_multicast_port(MCAST_PORT));
 }
 
 /*

--- a/libraries/AP_HAL_SITL/CAN_Multicast.cpp
+++ b/libraries/AP_HAL_SITL/CAN_Multicast.cpp
@@ -2,6 +2,7 @@
   multicast UDP transport for SITL CAN
  */
 #include "CAN_Multicast.h"
+#include "SITL_Multicast.h"
 
 #if HAL_NUM_CAN_IFACES
 
@@ -40,6 +41,7 @@ bool CAN_Multicast::init(uint8_t instance)
     char address[] = MCAST_ADDRESS_BASE;
 
     address[strlen(address)-1] = '0' + instance;
+    sock.set_multicast_interface_address(sitl_multicast_interface_address());
     return sock.connect(address, MCAST_PORT);
 }
 

--- a/libraries/AP_HAL_SITL/SITL_Multicast.h
+++ b/libraries/AP_HAL_SITL/SITL_Multicast.h
@@ -40,6 +40,24 @@ static inline uint32_t sitl_multicast_interface_address(void)
 }
 
 /*
+  return a port taken from the named environment variable, or the
+  supplied default if it is unset, empty or invalid
+ */
+static inline uint16_t sitl_port_from_env(const char *name, uint16_t default_port)
+{
+    const char *port_str = getenv(name);
+    if (port_str == nullptr || *port_str == 0) {
+        return default_port;
+    }
+    const long port = strtol(port_str, nullptr, 10);
+    if (port <= 0 || port > 65535) {
+        ::fprintf(stderr, "Bad %s (%s); using default\n", name, port_str);
+        return default_port;
+    }
+    return (uint16_t)port;
+}
+
+/*
   return the port for the simulation-state multicast, taking any
   override from the environment.  The compiled-in default is a fixed
   constant with no per-instance offset - unlike every other SITL port -
@@ -51,16 +69,22 @@ static inline uint32_t sitl_multicast_interface_address(void)
  */
 static inline uint16_t sitl_multicast_state_port(uint16_t default_port)
 {
-    const char *port_str = getenv("SITL_MCAST_STATE_PORT");
-    if (port_str == nullptr || *port_str == 0) {
-        return default_port;
-    }
-    const long port = strtol(port_str, nullptr, 10);
-    if (port <= 0 || port > 65535) {
-        ::fprintf(stderr, "Bad SITL_MCAST_STATE_PORT (%s); using default\n", port_str);
-        return default_port;
-    }
-    return (uint16_t)port;
+    return sitl_port_from_env("SITL_MCAST_STATE_PORT", default_port);
+}
+
+/*
+  return the port for the simulated CAN bus multicast, taking any
+  override from the environment.  The multicast group already varies
+  with the CAN bus number, keeping one simulation's buses apart from
+  each other, but the port is a fixed constant, so concurrent
+  simulations on one machine share their CAN buses: every peripheral
+  hears (and answers) every vehicle.  A per-instance
+  SITL_CAN_MCAST_PORT, exported to the vehicle and its peripherals,
+  gives each simulation a private set of buses.
+ */
+static inline uint16_t sitl_can_multicast_port(uint16_t default_port)
+{
+    return sitl_port_from_env("SITL_CAN_MCAST_PORT", default_port);
 }
 
 #endif  // CONFIG_HAL_BOARD == HAL_BOARD_SITL

--- a/libraries/AP_HAL_SITL/SITL_Multicast.h
+++ b/libraries/AP_HAL_SITL/SITL_Multicast.h
@@ -39,4 +39,28 @@ static inline uint32_t sitl_multicast_interface_address(void)
     return ret;
 }
 
+/*
+  return the port for the simulation-state multicast, taking any
+  override from the environment.  The compiled-in default is a fixed
+  constant with no per-instance offset - unlike every other SITL port -
+  so simulations run concurrently on one machine share a state bus and
+  each peripheral answers a vehicle which is not its own.  A test
+  framework running vehicles in parallel exports a per-instance
+  SITL_MCAST_STATE_PORT to the vehicle and its peripherals (environment
+  inheritance reaches both) to give each simulation its own bus.
+ */
+static inline uint16_t sitl_multicast_state_port(uint16_t default_port)
+{
+    const char *port_str = getenv("SITL_MCAST_STATE_PORT");
+    if (port_str == nullptr || *port_str == 0) {
+        return default_port;
+    }
+    const long port = strtol(port_str, nullptr, 10);
+    if (port <= 0 || port > 65535) {
+        ::fprintf(stderr, "Bad SITL_MCAST_STATE_PORT (%s); using default\n", port_str);
+        return default_port;
+    }
+    return (uint16_t)port;
+}
+
 #endif  // CONFIG_HAL_BOARD == HAL_BOARD_SITL

--- a/libraries/AP_HAL_SITL/SITL_Multicast.h
+++ b/libraries/AP_HAL_SITL/SITL_Multicast.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <AP_HAL/AP_HAL.h>
+
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <arpa/inet.h>
+
+/*
+  address of the local interface SITL should send and receive its
+  multicast traffic on, in network byte order, or zero to leave the
+  choice to the routing table.
+
+  Multicasting on whichever interface the routing table picks is
+  normally what you want; it is how an AP_Periph, or a second machine on
+  the network, gets at the simulation.  It does mean the traffic follows
+  the default route, so it stops working when that route is not up, or
+  not multicast-capable.  Set SITL_MULTICAST_IF_ADDR (e.g. to 127.0.0.1)
+  to pin the traffic to one interface where a run has to be insulated
+  from the state of the machine's network - the autotest suite does
+  this, so that a interface coming or going does not decide whether a
+  test passes.
+ */
+static inline uint32_t sitl_multicast_interface_address(void)
+{
+    const char *addr = getenv("SITL_MULTICAST_IF_ADDR");
+    if (addr == nullptr || *addr == 0) {
+        // unset, or set empty to get the default back in an environment
+        // which sets it (the autotest suite does)
+        return 0;
+    }
+    const uint32_t ret = inet_addr(addr);
+    if (ret == INADDR_NONE) {
+        ::fprintf(stderr, "Bad SITL_MULTICAST_IF_ADDR (%s); using any interface\n", addr);
+        return 0;
+    }
+    return ret;
+}
+
+#endif  // CONFIG_HAL_BOARD == HAL_BOARD_SITL

--- a/libraries/AP_HAL_SITL/SITL_Periph_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_Periph_State.cpp
@@ -162,7 +162,10 @@ void SimMCast::servo_fd_open(void)
     if (in_addr == nullptr) {
         return;
     }
-    if (!servo_sock.connect(in_addr, SITL_SERVO_PORT)) {
+    // reply to the address and port the state came from; the master
+    // sends state from its servo socket (bound to SITL_SERVO_PORT +
+    // its instance number) precisely so this works for any instance
+    if (!servo_sock.connect(in_addr, port)) {
         fprintf(stderr, "servo socket failed - %s\n", strerror(errno));
         exit(1);
     }

--- a/libraries/AP_HAL_SITL/SITL_Periph_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_Periph_State.cpp
@@ -173,7 +173,7 @@ void SimMCast::servo_fd_open(void)
 }
 
 /*
-  send servo outputs back to master
+  send servo outputs and state-consumed ack back to master
  */
 void SimMCast::servo_send(void)
 {
@@ -184,12 +184,15 @@ void SimMCast::servo_send(void)
     uint16_t out[SITL_NUM_CHANNELS] {};
     hal.rcout->read(out, SITL_NUM_CHANNELS);
 
-    float out_float[SITL_NUM_CHANNELS];
+    struct sitl_mcast_ack ack {};
+    // the timestamp echo tells the master which state packet we have
+    // consumed; it uses this for simulated-peripheral lockstep
+    ack.timestamp_us = _sitl->state.timestamp_us;
     const uint32_t mask = uint32_t(_sitl->can_servo_mask.get());
     for (uint8_t i=0; i<SITL_NUM_CHANNELS; i++) {
-        out_float[i] = (mask & (1U<<i)) ? out[i] : nanf("");
+        ack.servos[i] = (mask & (1U<<i)) ? out[i] : nanf("");
     }
-    servo_sock.send((void*)out_float, sizeof(out_float));
+    servo_sock.send((void*)&ack, sizeof(ack));
 }
 
 /*
@@ -207,6 +210,12 @@ void SimMCast::multicast_read(void)
     struct SITL::sitl_fdm state;
     while (sock.recv((void*)&state, sizeof(state), 1) != sizeof(state)) {
         // nop
+    }
+    // drain any backlog, keeping the newest state; under lockstep the
+    // master acks against the newest timestamp we report
+    struct SITL::sitl_fdm newer_state;
+    while (sock.recv((void*)&newer_state, sizeof(newer_state), 0) == sizeof(newer_state)) {
+        state = newer_state;
     }
     if (_sitl->state.timestamp_us == 0) {
         printf("Got multicast state input\n");
@@ -229,7 +238,10 @@ void SimMCast::multicast_read(void)
     HALSITL::Scheduler::timer_event();
     if (!servo_sock.is_connected()) {
         servo_fd_open();
-    } else {
+    }
+    if (servo_sock.is_connected()) {
+        // ack every consumed packet, including the first: the master's
+        // lockstep registration is driven by these replies
         servo_send();
     }
 }

--- a/libraries/AP_HAL_SITL/SITL_Periph_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_Periph_State.cpp
@@ -145,7 +145,7 @@ void SITL_State::wait_clock(uint64_t wait_time_usec)
 void SimMCast::multicast_open(void)
 {
     sock.set_multicast_interface_address(sitl_multicast_interface_address());
-    if (!sock.connect(SITL_MCAST_IP, SITL_MCAST_PORT)) {
+    if (!sock.connect(SITL_MCAST_IP, sitl_multicast_state_port(SITL_MCAST_PORT))) {
         fprintf(stderr, "multicast socket failed - %s\n", strerror(errno));
         exit(1);
     }

--- a/libraries/AP_HAL_SITL/SITL_Periph_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_Periph_State.cpp
@@ -7,6 +7,7 @@
 #include "HAL_SITL_Class.h"
 #include "UARTDriver.h"
 #include "Scheduler.h"
+#include "SITL_Multicast.h"
 
 #include <stdio.h>
 #include <signal.h>
@@ -143,6 +144,7 @@ void SITL_State::wait_clock(uint64_t wait_time_usec)
  */
 void SimMCast::multicast_open(void)
 {
+    sock.set_multicast_interface_address(sitl_multicast_interface_address());
     if (!sock.connect(SITL_MCAST_IP, SITL_MCAST_PORT)) {
         fprintf(stderr, "multicast socket failed - %s\n", strerror(errno));
         exit(1);

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -507,7 +507,7 @@ void SITL_State::multicast_state_open(void)
     mc_dest.sin_len = sizeof(mc_dest);
 #endif
     mc_dest.sin_family = AF_INET;
-    mc_dest.sin_port = htons(SITL_MCAST_PORT);
+    mc_dest.sin_port = htons(sitl_multicast_state_port(SITL_MCAST_PORT));
     mc_dest.sin_addr.s_addr = inet_addr(SITL_MCAST_IP);
 
     ::printf("multicast initialised\n");

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -452,35 +452,12 @@ void SITL_State::multicast_state_open(void)
 #ifdef HAVE_SOCK_SIN_LEN
     sockaddr.sin_len = sizeof(sockaddr);
 #endif
-    sockaddr.sin_port = htons(SITL_MCAST_PORT);
     sockaddr.sin_family = AF_INET;
-    sockaddr.sin_addr.s_addr = inet_addr(SITL_MCAST_IP);
-
-    mc_out_fd = socket(AF_INET, SOCK_DGRAM, 0);
-    if (mc_out_fd == -1) {
-        fprintf(stderr, "socket failed - %s\n", strerror(errno));
-        exit(1);
-    }
-    ret = fcntl(mc_out_fd, F_SETFD, FD_CLOEXEC);
-    if (ret == -1) {
-        fprintf(stderr, "fcntl failed on setting FD_CLOEXEC - %s\n", strerror(errno));
-        exit(1);
-    }
-
-    // try to setup for broadcast, this may fail if insufficient privileges
-    int one = 1;
-    setsockopt(mc_out_fd,SOL_SOCKET,SO_BROADCAST,(char *)&one,sizeof(one));
-
-    ret = connect(mc_out_fd, (struct sockaddr *)&sockaddr, sizeof(sockaddr));
-    if (ret == -1) {
-        fprintf(stderr, "udp connect failed on port %u - %s\n",
-                (unsigned)ntohs(sockaddr.sin_port),
-                strerror(errno));
-        exit(1);
-    }
 
     /*
-      open servo input socket
+      open the servo input socket; state is also sent from this socket
+      so that peripherals can reply to the source address and port they
+      observe, whatever this instance's servo port is
      */
     servo_in_fd = socket(AF_INET, SOCK_DGRAM, 0);
     if (servo_in_fd == -1) {
@@ -493,14 +470,28 @@ void SITL_State::multicast_state_open(void)
         exit(1);
     }
 
+    // try to setup for broadcast, this may fail if insufficient privileges
+    int one = 1;
+    setsockopt(servo_in_fd,SOL_SOCKET,SO_BROADCAST,(char *)&one,sizeof(one));
+
     sockaddr.sin_addr.s_addr = htonl(INADDR_ANY);
     sockaddr.sin_port = htons(SITL_SERVO_PORT + _instance);
 
     ret = bind(servo_in_fd, (struct sockaddr *)&sockaddr, sizeof(sockaddr));
     if (ret == -1) {
-        fprintf(stderr, "udp servo connect failed\n");
+        fprintf(stderr, "udp servo bind failed\n");
         exit(1);
     }
+
+    // destination address for the multicast state
+    mc_dest = {};
+#ifdef HAVE_SOCK_SIN_LEN
+    mc_dest.sin_len = sizeof(mc_dest);
+#endif
+    mc_dest.sin_family = AF_INET;
+    mc_dest.sin_port = htons(SITL_MCAST_PORT);
+    mc_dest.sin_addr.s_addr = inet_addr(SITL_MCAST_IP);
+
     ::printf("multicast initialised\n");
 }
 
@@ -512,11 +503,11 @@ void SITL_State::multicast_state_send(void)
     if (_sitl == nullptr) {
         return;
     }
-    if (mc_out_fd == -1) {
+    if (servo_in_fd == -1) {
         multicast_state_open();
     }
     const auto &sfdm = _sitl->state;
-    send(mc_out_fd, (void*)&sfdm, sizeof(sfdm), 0);
+    sendto(servo_in_fd, (void*)&sfdm, sizeof(sfdm), 0, (struct sockaddr *)&mc_dest, sizeof(mc_dest));
 
     check_servo_input();
 }

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -8,6 +8,7 @@
 #include "UARTDriver.h"
 #include "Scheduler.h"
 #include "CANSocketIface.h"
+#include "SITL_Multicast.h"
 
 #include <stdio.h>
 #include <signal.h>

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -20,6 +20,8 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <fcntl.h>
+#include <poll.h>
+#include <time.h>
 
 #include <AP_Param/AP_Param.h>
 #include <SITL/SIM_JSBSim.h>
@@ -510,23 +512,143 @@ void SITL_State::multicast_state_send(void)
     sendto(servo_in_fd, (void*)&sfdm, sizeof(sfdm), 0, (struct sockaddr *)&mc_dest, sizeof(mc_dest));
 
     check_servo_input();
+
+    if (_periph_lockstep) {
+        wait_periph_acks(sfdm.timestamp_us);
+    }
 }
 
 /*
-  check for servo data from peripheral
+  check for ack/servo data from peripherals
  */
 void SITL_State::check_servo_input(void)
 {
-    // drain any pending packets
-    float mc_servo_float[SITL_NUM_CHANNELS];
-    // we loop to ensure we drain all packets from all nodes
-    while (recv(servo_in_fd, (void*)mc_servo_float, sizeof(mc_servo_float), MSG_DONTWAIT) == sizeof(mc_servo_float)) {
-        for (uint8_t i=0; i<SITL_NUM_CHANNELS; i++) {
-            // nan means that node is not outputting this channel
-            if (!isnan(mc_servo_float[i])) {
-                mc_servo[i] = uint16_t(mc_servo_float[i]);
-            }
+    // drain any pending packets; we loop to ensure we drain all
+    // packets from all nodes
+    struct sitl_mcast_ack ack;
+    struct sockaddr_in src;
+    socklen_t src_len = sizeof(src);
+    ssize_t ret;
+    while ((ret = recvfrom(servo_in_fd, (void*)&ack, sizeof(ack), MSG_DONTWAIT,
+                           (struct sockaddr *)&src, &src_len)) > 0) {
+        handle_periph_ack(ack, ret, src);
+        src_len = sizeof(src);
+    }
+}
+
+/*
+  handle one ack/servo packet from a peripheral
+ */
+void SITL_State::handle_periph_ack(const struct sitl_mcast_ack &ack, ssize_t len, const struct sockaddr_in &src)
+{
+    if (len != sizeof(ack)) {
+        // unknown packet format.  The most likely cause is a
+        // peripheral built from a different source tree, sending the
+        // old servo-only reply; its servo output will be ignored and
+        // it can take no part in lockstep, so say so rather than
+        // discarding its packets in silence
+        if (!_warned_ack_size) {
+            _warned_ack_size = true;
+            ::fprintf(stderr, "SITL: ignoring %d-byte peripheral reply from %s:%u, expected %u bytes; build the peripheral from this source tree\n",
+                      int(len), inet_ntoa(src.sin_addr), (unsigned)ntohs(src.sin_port),
+                      (unsigned)sizeof(ack));
         }
+        return;
+    }
+    for (uint8_t i=0; i<SITL_NUM_CHANNELS; i++) {
+        // nan means that node is not outputting this channel
+        if (!isnan(ack.servos[i])) {
+            mc_servo[i] = uint16_t(ack.servos[i]);
+        }
+    }
+    if (!_periph_lockstep) {
+        return;
+    }
+    // register the peripheral, or update its ack state
+    struct mcast_periph *periph = nullptr;
+    for (uint8_t i=0; i<num_mcast_periphs; i++) {
+        if (mcast_periphs[i].addr.sin_addr.s_addr == src.sin_addr.s_addr &&
+            mcast_periphs[i].addr.sin_port == src.sin_port) {
+            periph = &mcast_periphs[i];
+            break;
+        }
+    }
+    if (periph == nullptr) {
+        // do not let a recently-evicted peer's stale queued acks
+        // re-register it; a live peer re-registers with fresh acks
+        // once the cooldown expires
+        const uint64_t now_ms = wall_millis();
+        for (uint8_t i=0; i<num_evicted_periphs; ) {
+            if (now_ms - evicted_periphs[i].evicted_ms > PERIPH_REJOIN_COOLDOWN_MS) {
+                evicted_periphs[i] = evicted_periphs[--num_evicted_periphs];
+                continue;
+            }
+            if (evicted_periphs[i].addr.sin_addr.s_addr == src.sin_addr.s_addr &&
+                evicted_periphs[i].addr.sin_port == src.sin_port) {
+                return;
+            }
+            i++;
+        }
+        if (num_mcast_periphs >= MAX_MCAST_PERIPHS) {
+            return;
+        }
+        periph = &mcast_periphs[num_mcast_periphs++];
+        periph->addr = src;
+        ::printf("SITL: peripheral %s:%u joined lockstep\n",
+                 inet_ntoa(src.sin_addr), (unsigned)ntohs(src.sin_port));
+    }
+    periph->last_ack_us = ack.timestamp_us;
+    periph->last_heard_ms = wall_millis();
+}
+
+// wall-clock milliseconds; the simulation clock must not be used for
+// the lockstep eviction timeout as it is frozen while we wait
+uint64_t SITL_State::wall_millis(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return uint64_t(ts.tv_sec) * 1000ULL + ts.tv_nsec / 1000000ULL;
+}
+
+/*
+  strict simulated-peripheral lockstep: do not return (and so do not
+  advance the simulation) until every registered peripheral has
+  acknowledged consuming the state packet with this timestamp.  A
+  peripheral which stops responding for a wall-clock second is
+  presumed dead (the harness SIGTERMs them with no notice) and is
+  evicted; it re-registers on its next ack
+ */
+void SITL_State::wait_periph_acks(const uint64_t timestamp_us)
+{
+    while (true) {
+        bool all_acked = true;
+        const uint64_t now_ms = wall_millis();
+        for (uint8_t i=0; i<num_mcast_periphs; ) {
+            if (mcast_periphs[i].last_ack_us >= timestamp_us) {
+                i++;
+                continue;
+            }
+            if (now_ms - mcast_periphs[i].last_heard_ms > PERIPH_EVICT_TIMEOUT_MS) {
+                ::fprintf(stderr, "SITL: evicting unresponsive peripheral %s:%u from lockstep\n",
+                          inet_ntoa(mcast_periphs[i].addr.sin_addr),
+                          (unsigned)ntohs(mcast_periphs[i].addr.sin_port));
+                if (num_evicted_periphs < MAX_MCAST_PERIPHS) {
+                    evicted_periphs[num_evicted_periphs].addr = mcast_periphs[i].addr;
+                    evicted_periphs[num_evicted_periphs].evicted_ms = now_ms;
+                    num_evicted_periphs++;
+                }
+                mcast_periphs[i] = mcast_periphs[--num_mcast_periphs];
+                continue;
+            }
+            all_acked = false;
+            i++;
+        }
+        if (all_acked) {
+            return;
+        }
+        struct pollfd pfd { servo_in_fd, POLLIN, 0 };
+        poll(&pfd, 1, PERIPH_ACK_POLL_MS);
+        check_servo_input();
     }
 }
 

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -477,6 +477,21 @@ void SITL_State::multicast_state_open(void)
     int one = 1;
     setsockopt(servo_in_fd,SOL_SOCKET,SO_BROADCAST,(char *)&one,sizeof(one));
 
+    const uint32_t mc_if_addr = sitl_multicast_interface_address();
+    if (mc_if_addr != 0) {
+        // the state is multicast from this socket, so it needs the same
+        // interface pinning the other multicast paths have: without it
+        // the state follows the routing table while the peripheral is
+        // listening on the interface it was told to use, and never sees
+        // the vehicle.  See sitl_multicast_interface_address()
+        struct in_addr ifaddr {};
+        ifaddr.s_addr = mc_if_addr;
+        if (setsockopt(servo_in_fd, IPPROTO_IP, IP_MULTICAST_IF, &ifaddr, sizeof(ifaddr)) == -1) {
+            fprintf(stderr, "failed to set multicast interface - %s\n", strerror(errno));
+            exit(1);
+        }
+    }
+
     sockaddr.sin_addr.s_addr = htonl(INADDR_ANY);
     sockaddr.sin_port = htons(SITL_SERVO_PORT + _instance);
 

--- a/libraries/AP_HAL_SITL/SITL_State.h
+++ b/libraries/AP_HAL_SITL/SITL_State.h
@@ -11,6 +11,8 @@
 #include "SITL_Periph_State.h"
 #else
 
+#include <netinet/in.h>
+
 class HAL_SITL;
 
 class HALSITL::SITL_State : public SITL_State_Common {
@@ -123,8 +125,8 @@ private:
     float _sonar_pin_voltage() const;
 
     // multicast state
-    int mc_out_fd = -1;
     int servo_in_fd = -1;
+    struct sockaddr_in mc_dest;
 
     // send out SITL state as UDP multicast
     void multicast_state_open(void);

--- a/libraries/AP_HAL_SITL/SITL_State.h
+++ b/libraries/AP_HAL_SITL/SITL_State.h
@@ -128,6 +128,41 @@ private:
     int servo_in_fd = -1;
     struct sockaddr_in mc_dest;
 
+    // simulated-peripheral lockstep: do not advance the simulation
+    // past a multicast state packet until every registered peripheral
+    // has acknowledged consuming it
+    bool _periph_lockstep;
+    static const uint8_t MAX_MCAST_PERIPHS = 16;
+    // a peripheral silent for this long in wall-clock time is presumed
+    // dead; the harness SIGTERMs them with no notice, so there is no
+    // goodbye to wait for.  Must sit above real starvation (tens of
+    // milliseconds) and below the test framework's own timeouts
+    static const uint64_t PERIPH_EVICT_TIMEOUT_MS = 1000;
+    // how long an evicted peer is held out of the registry, so that
+    // acks still queued from before its death cannot re-register it
+    static const uint64_t PERIPH_REJOIN_COOLDOWN_MS = 500;
+    // how long to block for acks before re-examining the registry for
+    // peripherals which have passed the eviction timeout
+    static const uint8_t PERIPH_ACK_POLL_MS = 5;
+    struct mcast_periph {
+        struct sockaddr_in addr;
+        uint64_t last_ack_us;    // state timestamp the periph has acked
+        uint64_t last_heard_ms;  // wall-clock time we last heard from it
+    } mcast_periphs[MAX_MCAST_PERIPHS];
+    uint8_t num_mcast_periphs;
+    // recently-evicted peers; their stale queued acks must not
+    // re-register them (a dead peripheral's last acks can still be in
+    // the socket queue when it is evicted)
+    struct evicted_periph {
+        struct sockaddr_in addr;
+        uint64_t evicted_ms;
+    } evicted_periphs[MAX_MCAST_PERIPHS];
+    uint8_t num_evicted_periphs;
+    bool _warned_ack_size;  // we have complained about a bad-sized reply
+    void handle_periph_ack(const struct sitl_mcast_ack &ack, ssize_t len, const struct sockaddr_in &src);
+    void wait_periph_acks(uint64_t timestamp_us);
+    static uint64_t wall_millis(void);
+
     // send out SITL state as UDP multicast
     void multicast_state_open(void);
     void multicast_state_send(void);

--- a/libraries/AP_HAL_SITL/SITL_State_common.h
+++ b/libraries/AP_HAL_SITL/SITL_State_common.h
@@ -65,6 +65,16 @@
 
 class HAL_SITL;
 
+/*
+  reply sent by simulated peripherals for each multicast state packet
+  consumed: servo feedback, plus a timestamp echo used for
+  simulated-peripheral lockstep
+ */
+struct sitl_mcast_ack {
+    uint64_t timestamp_us;   // echo of the consumed state timestamp
+    float servos[SITL_NUM_CHANNELS];  // nan means channel not driven
+};
+
 class HALSITL::SITL_State_Common {
     friend class HALSITL::Scheduler;
     friend class HALSITL::Util;

--- a/libraries/AP_HAL_SITL/SITL_State_common.h
+++ b/libraries/AP_HAL_SITL/SITL_State_common.h
@@ -234,9 +234,6 @@ public:
     // voltage from the sensor
     float _sonar_pin_voltage() const;
 
-    // multicast state
-    int mc_out_fd = -1;
-    
     // send out SITL state as UDP multicast
     void multicast_state_open(void);
     void multicast_state_send(void);

--- a/libraries/AP_HAL_SITL/SITL_cmdline.cpp
+++ b/libraries/AP_HAL_SITL/SITL_cmdline.cpp
@@ -97,6 +97,7 @@ void SITL_State::_usage(void)
            "\t--autotest-dir DIR       set directory for additional files\n"
            "\t--defaults path          set path to defaults file\n"
            "\t--list-models            list embedded vehicleinfo.json models and exit\n"
+           "\t--sim-periph-lockstep    do not advance the simulation until all simulated peripherals have consumed our state\n"
            "\t--serial0 device         set device string for SERIAL0\n"
            "\t--serial1 device         set device string for SERIAL1\n"
            "\t--serial2 device         set device string for SERIAL2\n"
@@ -316,6 +317,7 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
         CMDLINE_SYSID,
         CMDLINE_SLAVE,
         CMDLINE_LIST_MODELS,
+        CMDLINE_SIM_PERIPH_LOCKSTEP,
 #if STORAGE_USE_FLASH
         CMDLINE_SET_STORAGE_FLASH_ENABLED,
 #endif
@@ -381,6 +383,7 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
         {"sysid",           true,   0, CMDLINE_SYSID},
         {"slave",           true,   0, CMDLINE_SLAVE},
         {"list-models",     false,  0, CMDLINE_LIST_MODELS},
+        {"sim-periph-lockstep", false, 0, CMDLINE_SIM_PERIPH_LOCKSTEP},
 #if STORAGE_USE_FLASH
         {"set-storage-flash-enabled", true,   0, CMDLINE_SET_STORAGE_FLASH_ENABLED},
 #endif
@@ -609,6 +612,9 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
         }
         case CMDLINE_LIST_MODELS:
             list_models_and_exit();
+            break;
+        case CMDLINE_SIM_PERIPH_LOCKSTEP:
+            _periph_lockstep = true;
             break;
         default:
             _usage();


### PR DESCRIPTION
### Summary

Block the main process from continuing until fdm-consumers acknowledge each timestamp.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

```
  strict simulated-peripheral lockstep: do not return (and so do not
  advance the simulation) until every registered peripheral has
  acknowledged consuming the state packet with this timestamp.  A
  peripheral which stops responding for a wall-clock second is
  presumed dead (the harness SIGTERMs them with no notice) and is
  evicted; it re-registers on its next ack
```

Also pins the multicast traffic to the loopback address when running in autotest.  We can change the default to this - I'm worried we might break people's existing test setups, 'though.

Also tidies and fixes cleanup for supplementary peripherals.

Also fixes the battmon peripheral which was dead since merge (missing file)

Also fixes fixed-port issues.

Also removes speed constraints on the peripheral autotests.
