### PR TITLE
Fix starting conditions for various tests

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -17834,6 +17834,14 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
     def Clamp(self):
         '''test Copter docking clamp'''
+        # the simulated clamp only grabs within 0.5m of home
+        # (SIM_Aircraft.cpp), but the suite lets a test leave the vehicle
+        # up to max_distance_from_startup_location_at_end_of_test() away,
+        # which is 2m for Copter - four times the grab radius.  Restart
+        # the simulator so we begin where the clamp expects us: a failing
+        # run inherited an 0.59m offset and got "Clamp: missed vehicle".
+        self.reset_SITL_commandline()
+
         clamp_ch = 11
         self.set_parameters({
             "SIM_CLAMP_CH": clamp_ch,


### PR DESCRIPTION
### Summary

Clean up some starting conditions for various tests to make them relaibly pass after other tests

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

We state various assumptions for tests but aren't always giving them.

Ans sometimes they're not sufficient as there's state in the autopilot which hasn't cleared.

Fix them to make the tests more resilient to when they run and after what.
