### PR TITLE
Plane standby mode

### DIFF
--- a/ArduPlane/Plane.cpp
+++ b/ArduPlane/Plane.cpp
@@ -87,6 +87,7 @@ const AP_Scheduler::Task Plane::scheduler_tasks[] = {
     SCHED_TASK_CLASS(AP_ServoRelayEvents, &plane.ServoRelayEvents, update_events, 50, 150,  63),
 #endif
     SCHED_TASK_CLASS(AP_BattMonitor, &plane.battery, read,   10, 300,  66),
+    SCHED_TASK(standby_update,        100,     75,  69),
 #if AP_RANGEFINDER_ENABLED
     SCHED_TASK(read_rangefinder,       50,    100, 78),
 #endif

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -347,6 +347,14 @@ private:
     // This is used to enable the inverted flight feature
     bool inverted_flight;
 
+    // true when this flight controller is a "ride along" in a system
+    // with multiple flight controllers running in parallel, and is not
+    // the controller in command. While set, all of the control loops
+    // keep running at full rate but their accumulated state is
+    // continually flushed, and the checks which compare commanded
+    // against sensed motion are suppressed. See standby.cpp
+    bool standby_active;
+
     // last time we ran roll/pitch stabilization
     uint32_t last_stabilize_ms;
 
@@ -1203,6 +1211,9 @@ private:
     void parachute_release();
     bool parachute_manual_release();
 #endif
+
+    // standby.cpp
+    void standby_update();
 
     // soaring.cpp
 #if HAL_SOARING_ENABLED

--- a/ArduPlane/RC_Channel_Plane.cpp
+++ b/ArduPlane/RC_Channel_Plane.cpp
@@ -196,6 +196,7 @@ void RC_Channel_Plane::init_aux_function(const RC_Channel::AUX_FUNC ch_option,
 #endif
     case AUX_FUNC::TER_DISABLE:
     case AUX_FUNC::CROW_SELECT:
+    case AUX_FUNC::STANDBY:
 #if AP_ICENGINE_ENABLED
     case AUX_FUNC::ICE_START_STOP:
 #endif
@@ -495,6 +496,22 @@ bool RC_Channel_Plane::do_aux_function(const AuxFuncTrigger &trigger)
         break;
 
 #endif
+
+    case AUX_FUNC::STANDBY: {
+        switch (ch_flag) {
+        case AuxSwitchPos::HIGH:
+            plane.standby_active = true;
+            LOGGER_WRITE_EVENT(LogEvent::STANDBY_ENABLE);
+            gcs().send_text(MAV_SEVERITY_INFO, "Stand By Enabled");
+            break;
+        default:
+            plane.standby_active = false;
+            LOGGER_WRITE_EVENT(LogEvent::STANDBY_DISABLE);
+            gcs().send_text(MAV_SEVERITY_INFO, "Stand By Disabled");
+            break;
+        }
+        break;
+    }
 
     default:
         return RC_Channel::do_aux_function(trigger);

--- a/ArduPlane/is_flying.cpp
+++ b/ArduPlane/is_flying.cpp
@@ -210,6 +210,16 @@ bool Plane::is_flying(void)
  */
 void Plane::crash_detection_update(void)
 {
+    if (standby_active) {
+        // exit immediately if in standby. A ride-along controller is
+        // not commanding the aircraft, so the comparison of its own
+        // commands against sensed motion is meaningless and must never
+        // be allowed to disarm the vehicle
+        crash_state.debounce_timer_ms = 0;
+        crash_state.is_crashed = false;
+        return;
+    }
+
     if (control_mode != &mode_auto || !aparm.crash_detection_enable)
     {
         // crash detection is only available in AUTO mode

--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -101,6 +101,10 @@ public:
     // Reset rate and steering and TECS controllers
     void reset_controllers();
 
+    // drop any navigation state this mode has accumulated. Called at
+    // 100Hz while standby is active, see standby.cpp
+    virtual void standby_reset() {}
+
     //
     // methods that sub classes should override to affect movement of the vehicle in this mode
     //
@@ -680,6 +684,8 @@ public:
     void navigate() override;
 
     bool get_target_heading_cd(int32_t &target_heading) const;
+
+    void standby_reset() override;
 
     bool does_auto_throttle() const override { return true; }
 

--- a/ArduPlane/mode_cruise.cpp
+++ b/ArduPlane/mode_cruise.cpp
@@ -95,3 +95,17 @@ bool ModeCruise::get_target_heading_cd(int32_t &target_heading) const
     target_heading = locked_heading_cd;
     return locked_heading;
 }
+
+/*
+  while standing by we are not the controller in command, so don't hold
+  a locked heading. The locked track is anchored at the position where
+  the lock was taken, and would otherwise accumulate cross-track error
+  while another controller flies the aircraft, giving a large roll
+  demand at takeover. The heading re-locks half a second after standby
+  is released.
+ */
+void ModeCruise::standby_reset()
+{
+    locked_heading = false;
+    lock_timer_ms = 0;
+}

--- a/ArduPlane/parachute.cpp
+++ b/ArduPlane/parachute.cpp
@@ -7,6 +7,12 @@
 void Plane::parachute_check()
 {
 #if HAL_PARACHUTE_ENABLED
+    if (standby_active) {
+        // exit immediately if in standby. The sink rate check compares
+        // this controller's intent against sensed motion, which is
+        // meaningless while another controller is flying the aircraft
+        return;
+    }
     parachute.update();
     parachute.check_sink_rate();
 #endif

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -1064,6 +1064,11 @@ void Plane::servos_output(void)
 }
 
 void Plane::update_throttle_hover() {
+    if (standby_active) {
+        // don't learn the hover throttle while riding along: this
+        // controller is not driving the motors
+        return;
+    }
     // update hover throttle at 100Hz
 #if HAL_QUADPLANE_ENABLED
     quadplane.update_throttle_hover();
@@ -1077,6 +1082,11 @@ void Plane::update_throttle_hover() {
  */
 void Plane::servos_auto_trim(void)
 {
+    if (standby_active) {
+        // the rate controller I terms are being continually flushed
+        // while in standby, so they carry no trim information
+        return;
+    }
     // only in auto modes and FBWA
     if (!control_mode->does_auto_throttle() && control_mode != &mode_fbwa) {
         return;

--- a/ArduPlane/standby.cpp
+++ b/ArduPlane/standby.cpp
@@ -1,0 +1,89 @@
+#include "Plane.h"
+
+/*
+  Stand-By mode, for use with multiple flight controllers running in
+  parallel on one airframe. Only one of them is the controller in
+  command (CIC); its outputs reach the servos through an external
+  multiplexer. The others "ride along": they sense the same flight but
+  do not command it.
+
+  A ride-along controller accumulates error, because the aircraft is
+  doing what another controller commands rather than what it commands.
+  On a fixed wing a large part of the trim is carried in the rate
+  controller I terms and in the TECS integrators, so a stale ride-along
+  controller would command a large control surface step the moment it
+  is promoted to CIC. Its self monitoring logic, which compares its own
+  commands against sensed motion, would also false trigger.
+
+  Standby solves both with a single flag. While it is set, the control
+  loops keep running at full rate - only the accumulated state is
+  flushed - so the controller is always "fresh" and can take command
+  with a minimal transient.
+
+  This is the fixed wing equivalent of ArduCopter/standby.cpp
+ */
+
+/*
+  run standby functions at approximately 100Hz to limit maximum
+  variable build up.
+
+  When standby is active:
+      the roll, pitch, yaw and steering rate controller I terms are
+          continually reset
+      the TECS throttle and energy balance integrators are reset
+      the L1 cross-track integrator is reset
+      the altitude target tracks the current altitude
+      the flight mode drops any navigation state of its own
+      the VTOL attitude and position controllers are reset
+      crash detection, parachute release, hover throttle learning and
+          servo auto trim are disabled
+ */
+void Plane::standby_update()
+{
+    if (!standby_active) {
+        return;
+    }
+
+    // rate controller integrators. On a fixed wing these carry much of
+    // the trim, so they are the largest single source of a takeover
+    // transient
+    rollController.reset_I();
+    pitchController.reset_I();
+    yawController.reset_I();
+    steerController.reset_I();
+
+    // don't hold a ground course that we are not actually steering
+    steer_state.locked_course = false;
+    steer_state.locked_course_err = 0;
+
+    // flush the TECS integrators. Deliberately NOT TECS_controller.reset():
+    // a full reset also re-anchors the pitch demand rate limiter and the
+    // pitch crossover filters to the current pitch every cycle, which leaves
+    // the speed/height loop with no reference and produces an undamped
+    // phugoid. The height demand is pinned by set_target_altitude_current().
+    TECS_controller.reset_throttle_I();
+    TECS_controller.reset_pitch_I();
+
+    // flush the L1 cross-track integrator so that no lateral
+    // correction is stored up
+    nav_controller->standby_reset();
+
+    // keep the height demand glued to the current altitude so taking
+    // command does not command a climb or dive to recover an old
+    // target
+    set_target_altitude_current();
+
+    // let the flight mode drop any accumulated navigation state of its
+    // own, such as the CRUISE locked heading
+    control_mode->standby_reset();
+
+#if HAL_QUADPLANE_ENABLED
+    if (quadplane.available()) {
+        // the VTOL controllers accumulate state in exactly the same way
+        // as they do on copter
+        quadplane.attitude_control->reset_rate_controller_I_terms();
+        quadplane.attitude_control->reset_yaw_target_and_rate();
+        quadplane.pos_control->NED_standby_reset();
+    }
+#endif
+}

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -1513,6 +1513,134 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.set_rc(9, 2000)
         self.wait_mode('FBWA')
 
+    def Standby(self):
+        '''test standby (ride-along) support for redundant flight controllers'''
+        standby_aux_function = 76
+        standby_enable_event = 74   # LogEvent::STANDBY_ENABLE
+        self.set_parameters({
+            "RC7_OPTION": standby_aux_function,
+            # a disturbance source, so the controllers have something to
+            # wind up against:
+            "SIM_WIND_SPD": 8,
+            "SIM_WIND_DIR": 45,
+        })
+
+        self.wait_ready_to_arm()
+        self.takeoff(alt=100)
+        self.change_mode('LOITER')
+
+        self.progress("Letting the controllers wind up in normal flight")
+        self.delay_sim_time(20, "winding up the controllers")
+        normal_flight_text = "normal-flight"
+        self.send_statustext(normal_flight_text)
+        self.delay_sim_time(15, "sampling normal flight")
+
+        self.progress("Engaging standby")
+        self.context_collect('STATUSTEXT')
+        self.set_rc(7, 2000)
+        self.wait_statustext("Stand By Enabled", check_context=True)
+        self.context_stop_collecting('STATUSTEXT')
+        standby_text = "standby-engaged"
+        self.send_statustext(standby_text)
+        self.delay_sim_time(20, "sampling while standing by")
+
+        self.progress("Releasing standby")
+        self.context_collect('STATUSTEXT')
+        self.set_rc(7, 1000)
+        self.wait_statustext("Stand By Disabled", check_context=True)
+        self.context_stop_collecting('STATUSTEXT')
+        standby_released_text = "standby-released"
+        self.send_statustext(standby_released_text)
+        self.delay_sim_time(10, "settling after standby release")
+
+        log_filepath = self.current_onboard_log_filepath()
+        # terminate in-flight, both to close the log and so that the
+        # checks below aren't fooled by the flying-home data:
+        self.reboot_sitl(force=True)
+
+        self.progress("Inspecting the onboard log")
+        dfreader = self.dfreader_for_path(log_filepath)
+
+        # NOTE: DFReader caches the message-type filter from the first
+        # recv_match() call, so this single scan has to ask for everything it
+        # will ever want up front.
+        scan_types = ['MSG', 'EV', 'RCOU', 'PIDR', 'PIDP']
+        markers = {
+            "SRC=250/250:" + normal_flight_text: 'normal',
+            "SRC=250/250:" + standby_text: 'standby',
+            "SRC=250/250:" + standby_released_text: 'after',
+        }
+
+        def new_window():
+            return {'max_i': {}, 'count': {}, 'rcou': {}, 'events': []}
+
+        windows = {}
+        current = None
+        while True:
+            m = dfreader.recv_match(type=scan_types)
+            if m is None:
+                break
+            mtype = m.get_type()
+            if mtype == 'MSG':
+                name = markers.get(m.Message)
+                if name is not None:
+                    current = name
+                    windows.setdefault(current, new_window())
+                continue
+            if current is None:
+                continue
+            w = windows[current]
+            if mtype == 'EV':
+                w['events'].append(m.Id)
+            elif mtype == 'RCOU':
+                for chan in 'C1', 'C2':
+                    value = getattr(m, chan)
+                    (lo, hi) = w['rcou'].get(chan, (value, value))
+                    w['rcou'][chan] = (min(lo, value), max(hi, value))
+            else:
+                w['max_i'][mtype] = max(w['max_i'].get(mtype, 0), abs(m.I))
+                w['count'][mtype] = w['count'].get(mtype, 0) + 1
+
+        for name in 'normal', 'standby':
+            if name not in windows:
+                raise NotAchievedException("No %s window found in log" % name)
+        normal = windows['normal']
+        standby = windows['standby']
+        self.progress("normal-flight  max|I|=%s rcou=%s" % (str(normal['max_i']), str(normal['rcou'])))
+        self.progress("during-standby max|I|=%s rcou=%s" % (str(standby['max_i']), str(standby['rcou'])))
+
+        # the enable event is logged between the normal-flight marker and the
+        # standby-engaged marker:
+        if standby_enable_event not in normal['events']:
+            raise NotAchievedException("Did not see STANDBY_ENABLE event in log")
+
+        for pid in 'PIDR', 'PIDP':
+            if standby['count'].get(pid, 0) < 50:
+                raise NotAchievedException("Too few %s messages while in standby (%u)" %
+                                           (pid, standby['count'].get(pid, 0)))
+            # the controllers keep running while in standby, so the I term is
+            # not exactly zero - but it can only ever hold a single scheduler
+            # period of integration:
+            if standby['max_i'][pid] > 0.1:
+                raise NotAchievedException("%s I term not flushed while in standby (%f)" %
+                                           (pid, standby['max_i'][pid]))
+            # ...and it must be much smaller than what normal flight builds up,
+            # otherwise this test is not proving anything:
+            if normal['max_i'].get(pid, 0) < 3 * standby['max_i'][pid]:
+                raise NotAchievedException(
+                    "%s I term did not wind up in normal flight (%f vs %f in standby)" %
+                    (pid, normal['max_i'].get(pid, 0), standby['max_i'][pid]))
+
+        # standby flushes accumulated state, it does not stop the control
+        # loops, so the surfaces must still be moving:
+        for chan in 'C1', 'C2':
+            if chan not in standby['rcou']:
+                raise NotAchievedException("No RCOU %s while in standby" % chan)
+            (lo, hi) = standby['rcou'][chan]
+            if hi - lo < 5:
+                raise NotAchievedException("Servo %s did not move while in standby (%u..%u)" %
+                                           (chan, lo, hi))
+
     def FenceStatic(self):
         '''Test Basic Fence Functionality'''
         self.progress("Checking for bizarre healthy-when-not-present-or-enabled")
@@ -9008,6 +9136,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.NoArmWithoutMissionItems,
             self.RudderArmedTakeoffRequiresNeutralThrottle,
             self.MODE_SWITCH_RESET,
+            self.Standby,
             self.ExternalPositionEstimate,
             self.SagetechMXS,
             self.MAV_CMD_GUIDED_CHANGE_ALTITUDE,

--- a/libraries/AP_L1_Control/AP_L1_Control.h
+++ b/libraries/AP_L1_Control/AP_L1_Control.h
@@ -74,6 +74,13 @@ public:
         _reverse = reverse;
     }
 
+    // flush the cross-track integrator. Used by standby mode so that no
+    // lateral correction is stored up while another flight controller is
+    // flying the aircraft
+    void standby_reset(void) override {
+        _L1_xtrack_i = 0;
+    }
+
 private:
     // reference to the AHRS object
     AP_AHRS &_ahrs;

--- a/libraries/AP_Navigation/AP_Navigation.h
+++ b/libraries/AP_Navigation/AP_Navigation.h
@@ -116,6 +116,14 @@ public:
 
     virtual void set_reverse(bool reverse) = 0;
 
+    // flush any error that the controller has accumulated over time
+    // (for example a cross-track integrator). This is used by standby
+    // mode, where this flight controller is running in parallel with
+    // another one which is actually flying the aircraft, so any stored
+    // up correction is meaningless and would produce a transient when
+    // this controller takes command.
+    virtual void standby_reset(void) {}
+
     // add new navigation controllers to this enum. Users can then
     // select which navigation controller to use by setting the
     // NAV_CONTROLLER parameter

--- a/libraries/AP_Scripting/examples/plane_standby_guard.lua
+++ b/libraries/AP_Scripting/examples/plane_standby_guard.lua
@@ -1,0 +1,149 @@
+--[[
+   Stand-By guard for a redundant ("ride along") flight controller.
+
+   Install this ONLY on a flight controller that is meant to boot as the backup.
+
+   It closes two gaps in the RC-switch path to AUX_FUNC STANDBY (76):
+
+   1. Boot state. RC_Channel::init_aux() runs before any RC input exists and,
+      when it cannot read a valid switch position, defaults it to LOW - which
+      *releases* standby. A backup controller therefore boots believing it is
+      the controller in command.
+
+   2. A standby signal that is present but meaningless. RC_Channels::read_aux_all()
+      does nothing at all while there is no valid RC input, and a channel floating
+      at mid-stick reads as MIDDLE, which the vehicle handler treats the same as
+      "released". Either way the unit quietly ends up out of standby with nothing
+      reporting it.
+
+   This script mirrors the supervisor's channel onto the flag itself, so that the
+   only way to be out of standby is for the channel to be readable AND
+   unambiguously low:
+
+       channel clearly high (>1800us)  -> standby asserted
+       channel clearly low  (<1200us)  -> standby released
+       anything else, no RC input,
+       or no channel configured        -> standby asserted, and say so
+
+   Mirroring rather than merely defaulting matters: if the guard asserted standby
+   while RC was invalid and RC then returned already sitting low, the aux path
+   would see no *change* of switch position and would never run, leaving the
+   vehicle stuck in standby. Driving the flag to match the channel avoids that.
+--]]
+
+local PARAM_TABLE_KEY = 82
+local PARAM_TABLE_PREFIX = "STBY_"
+
+local AUX_FUNC_STANDBY = 76
+local AUX_LOW = 0
+local AUX_HIGH = 2
+
+local PWM_HIGH = 1800
+local PWM_LOW = 1200
+local PWM_MIN = 800     -- matches RC_MIN_LIMIT_PWM in RC_Channel.cpp
+local PWM_MAX = 2200    -- matches RC_MAX_LIMIT_PWM
+
+local UPDATE_MS = 200
+local SEVERITY_INFO = 6
+local SEVERITY_WARNING = 4
+
+assert(param:add_table(PARAM_TABLE_KEY, PARAM_TABLE_PREFIX, 1),
+       "StandbyGuard: could not add param table")
+
+--[[
+  // @Param: STBY_GUARD
+  // @DisplayName: Standby guard enable
+  // @Description: Mirror the RCx_OPTION=76 channel onto the standby flag, asserting standby at boot and whenever that channel is missing, unreadable or ambiguous. Enable on a backup flight controller only; set to 0 on the controller that boots in command.
+  // @Values: 0:Disabled,1:Enabled
+--]]
+assert(param:add_param(PARAM_TABLE_KEY, 1, "GUARD", 1),
+       "StandbyGuard: could not add STBY_GUARD")
+
+local guard_enable = Parameter()
+assert(guard_enable:init("STBY_GUARD"), "StandbyGuard: STBY_GUARD missing")
+
+local standby_ch = nil
+local last_reason = nil
+
+-- find the channel carrying the standby function, so no second parameter is
+-- needed and the two can never be configured inconsistently
+local function find_standby_channel()
+   for i = 1, 16 do
+      local opt = param:get(string.format("RC%u_OPTION", i))
+      if opt ~= nil and math.floor(opt) == AUX_FUNC_STANDBY then
+         return i
+      end
+   end
+   return nil
+end
+
+-- decide what the flag should be, and why. returns want_standby, reason
+-- reason is nil when the supervisor's channel is being followed normally
+local function decide()
+   if standby_ch == nil then
+      standby_ch = find_standby_channel()
+      if standby_ch == nil then
+         return true, "no RCx_OPTION=76 channel configured"
+      end
+      gcs:send_text(SEVERITY_INFO,
+                    string.format("StandbyGuard: watching RC%u", standby_ch))
+   end
+
+   -- this is the same gate RC_Channels::read_aux_all() uses; while it is false
+   -- the aux function cannot run at all
+   if not rc:has_valid_input() then
+      return true, "no valid RC input"
+   end
+
+   local pwm = rc:get_pwm(standby_ch)
+   if pwm == nil or pwm <= PWM_MIN or pwm >= PWM_MAX then
+      return true, "standby channel unreadable"
+   end
+   if pwm >= PWM_HIGH then
+      return true, nil
+   end
+   if pwm <= PWM_LOW then
+      return false, nil
+   end
+   -- keep under the 50-character MAVLink statustext limit
+   return true, string.format("standby ch %uus: ambiguous", pwm)
+end
+
+function update()
+   if guard_enable:get() ~= 1 then
+      return update, 1000
+   end
+
+   local want_standby, reason = decide()
+
+   if reason ~= last_reason then
+      if reason ~= nil then
+         gcs:send_text(SEVERITY_WARNING, "StandbyGuard: " .. reason)
+      else
+         gcs:send_text(SEVERITY_INFO, "StandbyGuard: following RC normally")
+      end
+      last_reason = reason
+   end
+
+   -- only touch the flag when the effective state differs, so we neither spam
+   -- the log nor fight the supervisor's own switch handling
+   local cached = rc:get_aux_cached(AUX_FUNC_STANDBY)
+   local want_pos = want_standby and AUX_HIGH or AUX_LOW
+   if cached == nil or cached ~= want_pos then
+      rc:run_aux_function(AUX_FUNC_STANDBY, want_pos)
+   end
+
+   return update, UPDATE_MS
+end
+
+-- Boot state: assert standby before any RC has been seen, so the window between
+-- power-up and the first debounced switch reading is spent in standby rather
+-- than in command.
+if guard_enable:get() == 1 then
+   rc:run_aux_function(AUX_FUNC_STANDBY, AUX_HIGH)
+   gcs:send_text(SEVERITY_WARNING, "StandbyGuard: asserted standby at boot")
+else
+   gcs:send_text(SEVERITY_INFO, "StandbyGuard: disabled (STBY_GUARD=0)")
+end
+
+return update, UPDATE_MS


### PR DESCRIPTION
### Summary

Ports ArduCopter's Stand-By feature ([#12441](https://github.com/ArduPilot/ardupilot/pull/12441)) to fixed wing: a single flag, set by `AUX_FUNC::STANDBY` (76), that continuously flushes accumulated controller state on a flight controller which is running in parallel with — but not commanding — the aircraft, so that it can take command with a minimal transient.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

**Testing**

A new autotest, `test.Plane.Standby`, is included. It takes off, loiters at 100 m in 8 m/s wind, asserts standby from the RC aux switch, and checks from the onboard log that the rate-controller I terms stay flushed, that the `STANDBY_ENABLE` event is recorded, and that the servo outputs keep moving — standby flushes accumulated state, it must not stop the control loops.

Measured over the standby window, against the same flight before standby was asserted:

| | normal flight | during standby |
|---|---|---|
| max \|`PIDR.I`\| | 0.440 | **0.008** |
| max \|`PIDP.I`\| | 4.837 | **0.025** |
| aileron travel | 12 µs | 17 µs |
| elevator travel | 33 µs | 67 µs |

The servos move *more* while standing by, which is expected: with the integrators flushed, P and FF carry the load the I term was carrying.

Separately, a scripted MAVLink session commands a climb to 130 m **while standby is asserted**. Peak `NAV_CONTROLLER_OUTPUT.alt_error` over the next 60 s was **0.04 m** — the commanded climb never becomes an altitude error, because the target is re-pinned to the current altitude every cycle. The moment standby is released the real target reappears and the aircraft converges on it. The vehicle stayed armed throughout and no crash detection or parachute action fired.

A second autotest, `StandbyParachute`, covers the parachute sink rate debounce: it dives until the sink exceeds `CHUTE_CRT_SINK` while standing by, releases standby *while still sinking fast*, and requires the release to wait out the one second debounce rather than firing on the first cycle. Measured 0.6 s to release against the naive implementation and 1.8 s with the debounce re-armed; it was confirmed to fail against the old code before being kept.

Regression run against current master, all passing: `StandbyParachute`, `Standby`, `MainFlight`, `AuxModeSwitch`, `MAV_CMD_DO_AUX_FUNCTION`, `Parachute`, `ParachuteSinkRate`, `LOITER`, `TakeoffTakeoff1`, plus `Standby` run in sequence with its neighbours in `tests1b` to confirm it leaves no state behind.

The scripting example was exercised separately in SITL across five fault cases: boot with no RC, channel high, channel low, channel floating at mid-stick, and RC lost in flight.

The altitude figures above come from a separate scripted benchmark: zero wind, straight and level in CRUISE, three repeats per variant, measuring both the drift while standing by and the transient after release, since those trade off against each other.

Not tested on hardware. Logs available on request.

### Description

Stand-By supports running two or more flight controllers in parallel on one airframe, where only one is the controller in command (CIC) and the others "ride along" behind an external output multiplexer. ArduPilot does not switch the outputs; that, and the arbitration, remain the job of an external supervisor. This PR provides only the vehicle-side flag, exactly as #12441 does for Copter.

The problem it solves is that a ride-along controller's corrective output has no effect on the aircraft. Any disagreement between it and the CIC — a degree of AHRS trim difference is enough — therefore integrates without ever being nulled, up to `IMAX`, instead of converging. On a fixed wing much of the trim is carried in the rate controller and TECS integrators, so a stale unit would command a large control surface step the instant it is promoted. Its self-monitoring, which compares its own commands against sensed motion, would also false-trigger.

While the flag is set, a 100 Hz scheduler task flushes accumulated state, with every control loop still running at full rate:

- roll, pitch, yaw and steering rate controller I terms, and the ground-steering locked course
- the TECS throttle and energy-balance integrators
- the L1 cross-track integrator
- the altitude target, which follows the current altitude through a clamped first order lag
- navigation references a mode captures from `current_loc` on entry, via a new `Mode::standby_reset()` hook: the LOITER and CIRCLE centres and the accumulated loiter angle, the CRUISE locked heading, and the RTL cross-track origin
- the VTOL attitude and position controllers on quadplanes

and the checks that compare commanded against sensed motion are suppressed: crash detection, the parachute sink rate check, quadplane hover-throttle learning and servo auto-trim. Battery, RC and geofence failsafes are deliberately left active, since they are based on reality both controllers share.

No new flight mode, no new parameter, no new log message — `AUX_FUNC::STANDBY` and `LogEvent::STANDBY_ENABLE`/`STANDBY_DISABLE` already exist. Because the aux function is also reachable over MAVLink (`MAV_CMD_DO_AUX_FUNCTION`), a companion computer can drive it without any RC involvement.

**Notes for reviewers**

Two places where the obvious implementation turned out to be wrong, both found in SITL:

1. **`TECS_controller.reset()` is deliberately not used.** A full reset re-runs `_initialise_states()`, which also re-anchors `_last_pitch_dem` and both pitch crossover filters to the *current* pitch attitude. Doing that every cycle leaves the speed/height loop with no reference to pull back to; the aircraft entered an undamped phugoid, `NavPitch` cycling 0°→24° with a ~30 s period and climbing 358 m in 100 s. Only the integrators are flushed, via the existing `reset_throttle_I()` and `reset_pitch_I()`; the height demand is pinned separately by `set_target_altitude_current()`.

2. **`AP_Navigation::set_data_is_stale()` is not sufficient** to flush L1. It only marks the bearing data stale and leaves `_L1_xtrack_i` untouched, hence the new `standby_reset()` on the navigation interface.

3. **The parachute needs more than an early return.** `set_sink_rate()` is fed from `update_alt()`, which keeps running while standing by, so `AP_Parachute`'s `_sink_time_ms` latches there and stays latched; the one second debounce in `check_sink_rate()` would then be long expired the moment standby is released, firing the parachute immediately, and `_release_initiated` is never cleared so that is not recoverable in flight. A sub-critical sink rate is fed instead, which re-arms the debounce. `parachute.update()` deliberately keeps running, since suspending it would collapse a release commanded over RC or MAVLink into a single ~100 ms output pulse. Thanks to @IamPete1 for spotting this.

**Altitude behaviour while standing by.** Flushing the energy controller integrators costs altitude hold, so the aircraft drifts for as long as standby is asserted. This only matters if a unit is promoted while standby is still asserted — attitude stabilisation is unaffected — but it is worth minimising.

Pinning the target exactly to the current altitude, which is the obvious implementation and what `AC_PosControl::NED_standby_reset()` effectively does on Copter, makes the height error zero by construction and therefore leaves no restoring force at all. This PR instead follows the current altitude through a first order lag, which leaves a small error proportional to the drift rate for TECS to work against, and clamps that lag so a fast climb commanded by the other controller cannot leave a large stale target behind. The clamp matters because the lag is the aircraft's rate of altitude change multiplied by the time constant, and while standing by that rate is set by the controller in command, not by this one.

Measured straight and level with no wind, over a 90 s standby window, three runs per variant (run-to-run spread was under 0.05 m/s):

| | drift | vs exact pin | worst case stale target |
|---|---|---|---|
| exact pin | 0.905 m/s | — | none |
| lag, τ = 3 s | 0.493 m/s | −46% | 3 s × altitude rate |
| lag, τ = 10 s | 0.257 m/s | −72% | 10 s × altitude rate |
| **lag τ = 10 s, clamped to 5 m** | **0.274 m/s** | **−70%** | **5 m** |

The transient when standby is released was unchanged at 1.3–1.4 m peak altitude error in every case.

A residual drift of order 0.3 m/s remains and is inherent. It shrinks further with ordinary trimming — moving level flight trim out of the flushed integrators and into the unflushed feedforwards, `PTCH_TRIM_DEG` and `TRIM_THROTTLE`, measured 0.905 → 0.586 m/s on its own — so a well trimmed airframe does better than the figures above.

The time constant and clamp are compile time constants rather than parameters, to keep the promise of no new parameters; happy to expose them if reviewers would prefer.


**Scripting example.** `plane_standby_guard.lua` is included because the RC aux path fails *open* for a safety-relevant function. `RC_Channel::init_aux()` defaults an unreadable switch to `LOW`, which releases standby, so a backup unit boots believing it is in command; and `read_aux_all()` does nothing at all while there is no valid RC input, so a standby signal that is never present means the function simply never runs, silently. The script mirrors the channel onto the flag so that the only way to be out of standby is for the channel to be readable and unambiguously low. If maintainers would rather see this addressed in the core aux-function handling than in an example script, I am happy to take that direction instead.
