### PR TITLE
Copter: keep CPU takeoff check without ESC telemetry

### DIFF
--- a/ArduCopter/takeoff_check.cpp
+++ b/ArduCopter/takeoff_check.cpp
@@ -7,13 +7,15 @@
 // detects if the vehicle should be allowed to takeoff or not and sets the motors.blocked flag
 void Copter::takeoff_check()
 {
-#if HAL_WITH_ESC_TELEM && FRAME_CONFIG != HELI_FRAME
+#if FRAME_CONFIG != HELI_FRAME
     // if motors have become unblocked return immediately
     // this ensures the motors can only be blocked immediately after arming
     uint32_t now_ms = AP_HAL::millis();
     if (!motors->get_spoolup_block()) {
         takeoff_check_warning_ms = now_ms;
+#if HAL_WITH_ESC_TELEM
         takeoff_check_state.warning_ms = now_ms;
+#endif
         return;
     }
 
@@ -26,7 +28,11 @@ void Copter::takeoff_check()
     }
 
     // Run the common motor checks (called early so it can clear its warning timer when disarmed)
+#if HAL_WITH_ESC_TELEM
     const bool motor_check_passed = motors_takeoff_check(g2.takeoff_rpm_min, g2.takeoff_rpm_max);
+#else
+    const bool motor_check_passed = true;
+#endif
 
     // Check system load
     float avg_load, peak_load;
@@ -51,5 +57,5 @@ void Copter::takeoff_check()
             gcs().send_text(MAV_SEVERITY_CRITICAL, "%s CPU overload (%4.1f%%)", prefix_str, avg_load);
         }
     }
-#endif
+#endif  // FRAME_CONFIG != HELI_FRAME
 }


### PR DESCRIPTION
<!-- Put a one or two line summary of what your PR does here -->
### Summary

Keep Copter's CPU-based pre-takeoff spool-up check enabled on non-heli builds without ESC telemetry. Only the ESC RPM check is gated by HAL_WITH_ESC_TELEM.

This fixes a spool-up lockup where the motor spool-up block could be set but never cleared on builds without ESC telemetry.
### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [X] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->
### Testing
`git diff --check`
`./waf configure --board sitl`
`./waf copter`
Compiled `ArduCopter/takeoff_check.cpp` with HAL_WITH_ESC_TELEM=0, AP_EXTENDED_ESC_TELEM_ENABLED=0, and FRAME_CONFIG=MULTICOPTER_FRAME

<!-- Describe the PR's content here -->
### Description

HAL_WITH_ESC_TELEM currently gates the entire Copter::takeoff_check() function. This unintentionally removes the CPU-based spool-up check and spool-up block handling from non-heli builds without ESC telemetry.

This change moves the HAL_WITH_ESC_TELEM guards to the ESC telemetry-specific code only. The CPU load check and spool-up block handling remain available regardless of ESC telemetry support.

When ESC telemetry is unavailable, the ESC RPM check is skipped and motor_check_passed defaults to true. The existing CPU load check continues to determine whether the spool-up block can be cleared.

Without this change, the spool-up block can remain set on builds without ESC telemetry, preventing the vehicle from progressing beyond ground idle. This restores the path that clears the block.

takeoff_check_state.warning_ms is also guarded because that state is only available when ESC telemetry is enabled.

Fixes #33399.
<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
