### PR TITLE
AP_Motors: apply 6DOF upwards thrust limit on all frame classes

### DIFF
--- a/libraries/AP_Motors/AP_Motors6DOF.cpp
+++ b/libraries/AP_Motors/AP_Motors6DOF.cpp
@@ -282,6 +282,18 @@ float AP_Motors6DOF::get_current_limit_max_throttle()
     return 1.0f;
 }
 
+// clamp upwards thrust to the limit set by set_max_throttle()
+// Used to limit the motors output when surfaced to avoid sucking in air and wasting power
+float AP_Motors6DOF::apply_max_throttle(float throttle_thrust)
+{
+    if (throttle_thrust > _max_throttle) {
+        // set the limit flag so the vertical controller's integrators do not wind up
+        limit.throttle_upper = true;
+        return _max_throttle;
+    }
+    return throttle_thrust;
+}
+
 // output_armed - sends commands to the motors
 // includes new scaling stability patch
 // TODO pull code that is common to output_armed_not_stabilizing into helper functions
@@ -323,6 +335,8 @@ void AP_Motors6DOF::output_armed_stabilizing()
             throttle_thrust = _throttle_thrust_max;
             limit.throttle_upper = true;
         }
+
+        throttle_thrust = apply_max_throttle(throttle_thrust);
 
         // calculate roll, pitch and yaw for each motor
         for (i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
@@ -427,6 +441,8 @@ void AP_Motors6DOF::output_armed_stabilizing_vectored()
         limit.throttle_upper = true;
     }
 
+    throttle_thrust = apply_max_throttle(throttle_thrust);
+
     // calculate roll, pitch and yaw for each motor
     for (i=0; i<AP_MOTORS_MAX_NUM_MOTORS; i++) {
         if (motor_enabled[i]) {
@@ -510,7 +526,7 @@ void AP_Motors6DOF::output_armed_stabilizing_vectored_6dof()
         limit.throttle_upper = true;
     }
 
-    throttle_thrust = constrain_float(throttle_thrust, -1.0f, _max_throttle);
+    throttle_thrust = apply_max_throttle(throttle_thrust);
 
     // calculate roll, pitch and Throttle for each motor (only used by vertical thrusters)
     rpt_max = 1; //Initialized to 1 so that normalization will only occur if value is saturated

--- a/libraries/AP_Motors/AP_Motors6DOF.h
+++ b/libraries/AP_Motors/AP_Motors6DOF.h
@@ -65,6 +65,10 @@ protected:
     void output_armed_stabilizing_vectored();
     void output_armed_stabilizing_vectored_6dof();
 
+    // Clamp upwards thrust to the limit set by set_max_throttle()
+    // Used to limit the motors output when surfaced to avoid sucking in air and wasting power
+    float apply_max_throttle(float throttle_thrust);
+
     // Parameters
     AP_Int8             _motor_reverse[AP_MOTORS_MAX_NUM_MOTORS];
     AP_Float            _forwardVerticalCouplingFactor;


### PR DESCRIPTION
set_max_throttle() was only honoured by the vectored 6DOF mixer, so SURFACE_MAX_THR had no effect on the standard vectored or generic frames. 
Also raises limit.throttle_upper, so the vertical controller's integrators get anti-windup.

### Classification & Testing (check all that apply and add your own)

- [ ] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Tested on SITL, this is part of a larger change