### PR TITLE
Copter: refactor SmartRTL fallback methods

### DIFF
--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -826,6 +826,7 @@ private:
     void gpsglitch_check();
     void failsafe_deadreckon_check();
     void set_mode_RTL_or_land_with_pause(ModeReason reason);
+    void set_mode_SmartRTL_or_fallback(const char *action_str, ModeReason reason, bool fallback_to_rtl);
     void set_mode_SmartRTL_or_RTL(ModeReason reason);
     void set_mode_SmartRTL_or_land_with_pause(ModeReason reason);
     void set_mode_auto_do_land_start_or_RTL(ModeReason reason);

--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -399,35 +399,36 @@ void Copter::set_mode_RTL_or_land_with_pause(ModeReason reason)
     set_mode_land_with_pause(reason);
 }
 
-// set_mode_SmartRTL_or_land_with_pause - sets mode to SMART_RTL if possible or LAND with 4 second delay before descent starts
-// this is always called from a failsafe so we trigger notification to pilot
-void Copter::set_mode_SmartRTL_or_land_with_pause(ModeReason reason)
+// set_mode_SmartRTL_or_fallback - attempts to switch to SmartRTL, if failed sends warning with action_str and executes fallback
+void Copter::set_mode_SmartRTL_or_fallback(const char *action_str, ModeReason reason, bool fallback_to_rtl)
 {
 #if MODE_SMARTRTL_ENABLED
-    // attempt to switch to SMART_RTL, if this failed then switch to Land
+    // attempt to switch to SMART_RTL, if this succeeded trigger notification to pilot
     if (set_mode(Mode::Number::SMART_RTL, reason)) {
         AP_Notify::events.failsafe_mode_change = 1;
         return;
     }
 #endif
-    gcs().send_text(MAV_SEVERITY_WARNING, "SmartRTL Unavailable, Using Land Mode");
-    set_mode_land_with_pause(reason);
+    GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "SmartRTL Unavailable, %s", action_str);
+    if (fallback_to_rtl) {
+        set_mode_RTL_or_land_with_pause(reason);
+    } else {
+        set_mode_land_with_pause(reason);
+    }
+}
+
+// set_mode_SmartRTL_or_land_with_pause - sets mode to SMART_RTL if possible or LAND with 4 second delay before descent starts
+// this is always called from a failsafe so we trigger notification to pilot
+void Copter::set_mode_SmartRTL_or_land_with_pause(ModeReason reason)
+{
+    set_mode_SmartRTL_or_fallback("Using Land Mode", reason, false);
 }
 
 // set_mode_SmartRTL_or_RTL - sets mode to SMART_RTL if possible or RTL if possible or LAND with 4 second delay before descent starts
 // this is always called from a failsafe so we trigger notification to pilot
 void Copter::set_mode_SmartRTL_or_RTL(ModeReason reason)
 {
-#if MODE_SMARTRTL_ENABLED
-    // attempt to switch to SmartRTL, if this failed then attempt to RTL
-    // if that fails, then land
-    if (set_mode(Mode::Number::SMART_RTL, reason)) {
-        AP_Notify::events.failsafe_mode_change = 1;
-        return;
-    }
-#endif
-    gcs().send_text(MAV_SEVERITY_WARNING, "SmartRTL Unavailable, Trying RTL Mode");
-    set_mode_RTL_or_land_with_pause(reason);
+    set_mode_SmartRTL_or_fallback("Trying RTL Mode", reason, true);
 }
 
 // Sets mode to Auto and jumps to DO_LAND_START, as set with AUTO_RTL param
@@ -441,7 +442,7 @@ void Copter::set_mode_auto_do_land_start_or_RTL(ModeReason reason)
     }
 #endif
 
-    gcs().send_text(MAV_SEVERITY_WARNING, "Trying RTL Mode");
+    GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Trying RTL Mode");
     set_mode_RTL_or_land_with_pause(reason);
 }
 


### PR DESCRIPTION
### Summary

Refactor `set_mode_SmartRTL_or_land_with_pause` and `set_mode_SmartRTL_or_RTL` into a common helper `set_mode_SmartRTL_or_fallback` to reduce code duplication, unify GCS warning formatting, and adhere to coding guidelines.

Binary size comparison (CubeOrangePlus):
- Flash: 1713508 -> 1713468 (-40 bytes)
- RAM: No change

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Verified with:
1. SITL Autotests:
   ```bash
   Tools/autotest/autotest.py test.Copter.ThrottleFailsafe test.Copter.GCSFailsafe
   ```
   Result: `PASSED`
2. Manual SITL testing:
   - Verified `AP: SmartRTL Unavailable, Trying RTL Mode` warning and fallback transition on RC failure (`FS_THR_ENABLE=4`).
   - Verified `AP: SmartRTL Unavailable, Using Land Mode` warning and fallback transition on RC failure (`FS_THR_ENABLE=5`).

Trying RTL Mode
<img width="716" height="641" alt="スクリーンショット 2026-08-22 8 01 37" src="https://github.com/user-attachments/assets/fe0275be-9946-4e18-ac11-be096fd696a7" />

Using Land Mode
<img width="745" height="651" alt="スクリーンショット 2026-08-22 8 08 35" src="https://github.com/user-attachments/assets/f8e7c557-a9fd-4612-a0ca-a19d2f670bb2" />

after
BUILD SUMMARY
Build directory: /home/mura/work2/ardupilot-smartrtl-fallback/build/CubeOrangePlus
Target          Text (B)  Data (B)  BSS (B)  Total Flash Used (B)  Free Flash (B)  External Flash Used (B)

bin/arducopter   1708848      4620   142580               1713468          252612  Not Applicable         

before
BUILD SUMMARY
Build directory: /home/mura/work2/ardupilot-smartrtl-fallback/build/CubeOrangePlus
Target          Text (B)  Data (B)  BSS (B)  Total Flash Used (B)  Free Flash (B)  External Flash Used (B)

bin/arducopter   1708888      4620   142580               1713508          252572  Not Applicable         

### Description

`set_mode_SmartRTL_or_land_with_pause` and `set_mode_SmartRTL_or_RTL` shared identical `#if MODE_SMARTRTL_ENABLED` logic, pilot notification handling, and GCS warning prefixes.

This PR introduces a private helper `set_mode_SmartRTL_or_fallback(const char *action_str, ModeReason reason, bool fallback_to_rtl)` that:
- Eliminates the duplicate `#if MODE_SMARTRTL_ENABLED` block
- Reuses the format string `"SmartRTL Unavailable, %s"` with `"Using Land Mode"` and `"Trying RTL Mode"`
- Modernizes GCS message sending to use `GCS_SEND_TEXT`

This PR was prepared with AI assistance.
