### PR TITLE
AP_Compass: IIS2MDC sensitivity, data-ready and register-recovery fixes

### DIFF
--- a/libraries/AP_Compass/AP_Compass_IIS2MDC.cpp
+++ b/libraries/AP_Compass/AP_Compass_IIS2MDC.cpp
@@ -137,7 +137,7 @@ void AP_Compass_IIS2MDC::timer()
         uint8_t tout1;
     } buffer;
 
-    const float range_scale = 100.f / 65.535f; // +/- 50,000 milligauss, 16bit
+    const float range_scale = 1.5f; // 1.5 mgauss/LSB
 
     uint8_t status = 0;
     if (!_dev->read_registers(IIS2MDC_ADDR_STATUS_REG, &status, 1)) {

--- a/libraries/AP_Compass/AP_Compass_IIS2MDC.cpp
+++ b/libraries/AP_Compass/AP_Compass_IIS2MDC.cpp
@@ -80,15 +80,17 @@ bool AP_Compass_IIS2MDC::init()
         return false;
     }
 
-    if (!_dev->write_register(IIS2MDC_ADDR_CFG_REG_A, MD_CONTINUOUS | ODR_100 | COMP_TEMP_EN)) {
+    _dev->setup_checked_registers(3);
+
+    if (!_dev->write_register(IIS2MDC_ADDR_CFG_REG_A, MD_CONTINUOUS | ODR_100 | COMP_TEMP_EN, true)) {
         return false;
     }
 
-    if (!_dev->write_register(IIS2MDC_ADDR_CFG_REG_B, OFF_CANC)) {
+    if (!_dev->write_register(IIS2MDC_ADDR_CFG_REG_B, OFF_CANC, true)) {
         return false;
     }
 
-    if (!_dev->write_register(IIS2MDC_ADDR_CFG_REG_C, BDU)) {
+    if (!_dev->write_register(IIS2MDC_ADDR_CFG_REG_C, BDU, true)) {
         return false;
     }
 
@@ -141,17 +143,18 @@ void AP_Compass_IIS2MDC::timer()
 
     uint8_t status = 0;
     if (!_dev->read_registers(IIS2MDC_ADDR_STATUS_REG, &status, 1)) {
-        return;
+        goto check_registers;
     }
 
     if (!(status & IIS2MDC_STATUS_REG_READY)) {
-        return;
+        goto check_registers;
     }
 
     if (!_dev->read_registers(IIS2MDC_ADDR_OUTX_L_REG, (uint8_t *) &buffer, sizeof(buffer))) {
-        return;
+        goto check_registers;
     }
 
+    {
     const int16_t x = ((buffer.xout1 << 8) | buffer.xout0);
     const int16_t y = ((buffer.yout1 << 8) | buffer.yout0);
     const int16_t z = -1 * ((buffer.zout1 << 8) | buffer.zout0);
@@ -159,6 +162,10 @@ void AP_Compass_IIS2MDC::timer()
     Vector3f field{ x * range_scale, y * range_scale, z * range_scale };
 
     accumulate_sample(field);
+    }
+
+check_registers:
+    _dev->check_next_register();
 }
 
 #endif //AP_COMPASS_IIS2MDC_ENABLED

--- a/libraries/AP_Compass/AP_Compass_IIS2MDC.cpp
+++ b/libraries/AP_Compass/AP_Compass_IIS2MDC.cpp
@@ -31,7 +31,7 @@
 
 // IIS2MDC Definitions
 #define IIS2MDC_WHO_AM_I         0b01000000
-#define IIS2MDC_STATUS_REG_READY 0b00001111
+#define IIS2MDC_STATUS_REG_READY 0b00001000  // ZYXDA, all three axes
 // CFG_REG_A
 #define COMP_TEMP_EN    (1 << 7)
 #define MD_CONTINUOUS   (0 << 0)

--- a/libraries/AP_Compass/AP_Compass_IIS2MDC.cpp
+++ b/libraries/AP_Compass/AP_Compass_IIS2MDC.cpp
@@ -128,6 +128,19 @@ bool AP_Compass_IIS2MDC::check_whoami()
 
 void AP_Compass_IIS2MDC::timer()
 {
+    _dev->check_next_register();
+
+    uint8_t status = 0;
+    if (!_dev->read_registers(IIS2MDC_ADDR_STATUS_REG, &status, 1)) {
+        return;
+    }
+
+    if (!(status & IIS2MDC_STATUS_REG_READY)) {
+        return;
+    }
+
+    // A burst read wraps around inside OUTX..OUTZ rather than running on into
+    // TEMP_OUT, so only the six axis bytes are worth asking for.
     struct PACKED {
         uint8_t xout0;
         uint8_t xout1;
@@ -135,26 +148,14 @@ void AP_Compass_IIS2MDC::timer()
         uint8_t yout1;
         uint8_t zout0;
         uint8_t zout1;
-        uint8_t tout0;
-        uint8_t tout1;
     } buffer;
+
+    if (!_dev->read_registers(IIS2MDC_ADDR_OUTX_L_REG, (uint8_t *) &buffer, sizeof(buffer))) {
+        return;
+    }
 
     const float range_scale = 1.5f; // 1.5 mgauss/LSB
 
-    uint8_t status = 0;
-    if (!_dev->read_registers(IIS2MDC_ADDR_STATUS_REG, &status, 1)) {
-        goto check_registers;
-    }
-
-    if (!(status & IIS2MDC_STATUS_REG_READY)) {
-        goto check_registers;
-    }
-
-    if (!_dev->read_registers(IIS2MDC_ADDR_OUTX_L_REG, (uint8_t *) &buffer, sizeof(buffer))) {
-        goto check_registers;
-    }
-
-    {
     const int16_t x = ((buffer.xout1 << 8) | buffer.xout0);
     const int16_t y = ((buffer.yout1 << 8) | buffer.yout0);
     const int16_t z = -1 * ((buffer.zout1 << 8) | buffer.zout0);
@@ -162,10 +163,6 @@ void AP_Compass_IIS2MDC::timer()
     Vector3f field{ x * range_scale, y * range_scale, z * range_scale };
 
     accumulate_sample(field);
-    }
-
-check_registers:
-    _dev->check_next_register();
 }
 
 #endif //AP_COMPASS_IIS2MDC_ENABLED


### PR DESCRIPTION
## Summary
The three uncontested fixes from #33780, cherry-picked with @andyp1per's authorship so they are not held up by the offset-cancellation disagreement there: 1.5 mgauss/LSB sensitivity (the old `100/65.535` read 1.7% high), a data-ready mask that waits for Zyxda instead of any single axis, and the three config registers registered as checked so a corrupted write is repaired rather than latched. Offset cancellation stays enabled.

## Problem
#33780 bundles those with disabling `OFF_CANC`, which is still being argued on data, and its register check is reached through three `goto`s. The driver also burst-reads eight bytes from `OUTX_L` for a temperature it never uses — and on this part the burst wraps around inside `OUTX..OUTZ` (a 10-byte read from `0x68` returns `8E FF B7 FE 03 FF 8E FF B7 FE`, with or without the auto-increment bit), so those bytes were only ever a second copy of `OUTX`.

## Solution
Andy's three commits as-is, plus one that runs `check_next_register()` before the sample so the early returns need no labels, and trims the read to the six axis bytes.

## Testing
Built ARK_PI6X copter. The wrap-around behaviour was measured on an IIS2MDC under PX4 (PX4/PX4-Autopilot#28336); this branch has not been run on hardware under ArduPilot.