### PR TITLE
AP_HAL_SITL: allow any tcp serial port to pace the simulation

### DIFF
--- a/Tools/autotest/pysim/util.py
+++ b/Tools/autotest/pysim/util.py
@@ -725,8 +725,16 @@ def start_SITL(binary,
             cmd.extend(unix_domain_socket_serial_args())
             cmd.append("--rc-in-port=uds:APM-UDS-rcin")
         else:
-            # somewhere for MAVProxy to connect to:
-            cmd.append('--serial1=tcp:2')
+            # somewhere for MAVProxy to connect to.  "pace" holds the
+            # simulation back while this port's outbound queue is backed
+            # up, as always happens for serial0: without it a loaded
+            # machine can advance the simulation many seconds while
+            # MAVProxy is not scheduled, and the vehicle's own deadlines
+            # (e.g. the mission upload timeout) expire before MAVProxy
+            # has a chance to act.  The unix-domain-socket path above
+            # takes its arguments from unix_domain_socket_serial_args()
+            # and has no equivalent option.
+            cmd.append('--serial1=tcp:2:pace')
         if enable_fgview:
             cmd.append("--enable-fgview")
 

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -168,16 +168,26 @@ void SITL_State::wait_clock(uint64_t wait_time_usec)
     // up seeing traffic well into our past and hits time-out
     // conditions.
     if (speedup > 1 && hal.scheduler->in_main_thread()) {
-        while (true) {
-            HALSITL::UARTDriver *uart = (HALSITL::UARTDriver*)hal.serial(0);
-            const int queue_length = uart->get_system_outqueue_length();
-            // ::fprintf(stderr, "queue_length=%d\n", (signed)queue_length);
-            if (queue_length < uart->get_system_outqueue_limit()) {
-                break;
+        // serial0 is always paced; other ports opt in with the "pace"
+        // option (e.g. tcp:2:pace for a MAVProxy on 5762)
+        for (uint8_t i = 0; i < ARRAY_SIZE(_serial_path); i++) {
+            HALSITL::UARTDriver *uart = (HALSITL::UARTDriver*)hal.serial(i);
+            if (uart == nullptr) {
+                continue;
             }
-            _serial_0_outqueue_full_count++;
-            uart->handle_reading_from_device_to_readbuffer();
-            usleep(1000);
+            if (i != 0 && !uart->pacing()) {
+                continue;
+            }
+            while (true) {
+                const int queue_length = uart->get_system_outqueue_length();
+                // ::fprintf(stderr, "queue_length=%d\n", (signed)queue_length);
+                if (queue_length < uart->get_system_outqueue_limit()) {
+                    break;
+                }
+                _serial_0_outqueue_full_count++;
+                uart->handle_reading_from_device_to_readbuffer();
+                usleep(1000);
+            }
         }
     }
 }

--- a/libraries/AP_HAL_SITL/UARTDriver.cpp
+++ b/libraries/AP_HAL_SITL/UARTDriver.cpp
@@ -89,6 +89,7 @@ void UARTDriver::_begin(uint32_t baud, uint16_t rxSpace, uint16_t txSpace)
         /* parse type:args:flags string for path. 
            For example:
              tcp:5760:wait    // tcp listen on port 5760
+             tcp:2:wait,pace  // flags are a comma-separated list
              tcp:0:wait       // tcp listen on use base_port + 0
              uds:APM-UDS-serial0:wait
              tcpclient:192.168.2.15:5762
@@ -118,7 +119,25 @@ void UARTDriver::_begin(uint32_t baud, uint16_t rxSpace, uint16_t txSpace)
 #endif
         if (strcmp(devtype, "tcp") == 0) {
             uint16_t port = atoi(args1);
-            bool wait = (args2 && strcmp(args2, "wait") == 0);
+            // the flags field is a comma-separated option list, e.g.
+            // tcp:2:wait,pace:
+            //   wait: do not start the simulation until a client connects
+            //   pace: hold the simulation back while this port's
+            //         outbound queue is backed up, exactly as
+            //         wait_clock() always does for serial0, so a GCS
+            //         reading this port is never left processing
+            //         traffic from well in our past
+            bool wait = false;
+            char *optsave = nullptr;
+            for (char *opt = args2 ? strtok_r(args2, ",", &optsave) : nullptr;
+                 opt != nullptr;
+                 opt = strtok_r(nullptr, ",", &optsave)) {
+                if (strcmp(opt, "wait") == 0) {
+                    wait = true;
+                } else if (strcmp(opt, "pace") == 0) {
+                    _pace_sim = true;
+                }
+            }
             _tcp_start_connection(port, wait);
         } else if (strcmp(devtype, "uds") == 0) {
             if (args1 == nullptr || args1[0] == '\0') {

--- a/libraries/AP_HAL_SITL/UARTDriver.h
+++ b/libraries/AP_HAL_SITL/UARTDriver.h
@@ -33,6 +33,12 @@ public:
     ssize_t get_system_outqueue_length() const;
     ssize_t get_system_outqueue_limit() const;
 
+    // true if the simulation should be held back while this port's
+    // outbound queue is backed up, as wait_clock() always does for
+    // serial0; set with the "pace" option in the device string's
+    // comma-separated flags list, e.g. tcp:2:pace or tcp:2:wait,pace
+    bool pacing() const { return _pace_sim; }
+
     bool tx_pending() override {
         return false;
     }
@@ -41,6 +47,7 @@ public:
     uint32_t txspace() override;
 
     bool _unbuffered_writes;
+    bool _pace_sim;
 
     void set_flow_control(enum flow_control flow_control_setting) override;
     enum flow_control get_flow_control(void) override;


### PR DESCRIPTION
### Summary

Allows any port to get the same "SITL is blocked while there's a bunch of outbound traffic" patches as serial0

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change (except SITL)
- [x] No-binary change (well, SITL binaries change)
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

wait_clock() holds the simulation back while serial0's outbound TCP queue is backed up, so a GCS reading that port is never left processing traffic from well in the simulation's past.  Every other port advances regardless of whether its reader is keeping up.

MAVProxy connects to serial1, and in autotest that combination is a recurring failure class: on a machine busy running tests --parallel, the simulation advances many seconds while MAVProxy is not scheduled, and the vehicle's own deadlines - the eight-simulated-second mission upload timeout most visibly - expire before MAVProxy has had a chance to act:

    Got MISSION_ACK: TYPE_FENCE: OPERATION_CANCELLED
    AP: Fence upload timeout

Add a "pace" option so any tcp port can opt into serial0's behaviour (e.g. tcp:2:pace), and set it on autotest's serial1.
