### PR TITLE
AP_Arming: clarify throttle arming failure message as not zero

### DIFF
--- a/libraries/AP_Arming/AP_Arming.cpp
+++ b/libraries/AP_Arming/AP_Arming.cpp
@@ -868,7 +868,7 @@ bool AP_Arming::rc_arm_checks(AP_Arming::Method method)
         if (rc().arming_check_throttle()) {
             const RC_Channel *c = &rc().get_throttle_channel();
                 if (c->get_control_in() != 0) {
-                    check_failed(Check::RC, true, "%s (RC%d) is not neutral", "Throttle", c->ch());
+                    check_failed(Check::RC, true, "%s (RC%d) is not zero", "Throttle", c->ch());
                     check_passed = false;
                 }
             c = rc().find_channel_for_option(RC_Channel::AUX_FUNC::FWD_THR);


### PR DESCRIPTION
### Summary

Clarify the throttle arming check failure message from `"Throttle (RC%d) is not neutral"` to `"Throttle (RC%d) is not zero"`.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Tested and verified in SITL:
- When throttle stick is raised above zero / mid-stick (e.g. PWM 1500), attempting to arm correctly reports: `AP: Arm: Throttle (RC3) is not zero`.
- When throttle stick is lowered to minimum (PWM 1000), arming succeeds normally (`ARMED`).

After
<img width="506" height="497" alt="スクリーンショット 2026-08-22 15 31 04" src="https://github.com/user-attachments/assets/db7f3cf4-a61c-499b-8ee3-d6169318701f" />

### Description

In `libraries/AP_Arming/AP_Arming.cpp`, the throttle arming check verifies `c->get_control_in() == 0` (`// if throttle check is enabled, require zero input`).

However, the previous failure message reported `"%s (RC%d) is not neutral"`, which incorrectly implied that the pilot should center the throttle stick (e.g. 1500us/mid-stick), which is dangerous and still fails the check.

This change updates the failure message for the throttle channel to `"%s (RC%d) is not zero"` while keeping Roll/Pitch/Yaw as `"is not neutral"`, matching user intuition, the comment in the code, and the existing VTOL throttle check (`"VTOL Fwd Throttle is not zero"`).
