### PR TITLE
AP_Baro: bmp388 init cleanup

### DIFF
--- a/libraries/AP_Baro/AP_Baro_BMP388.cpp
+++ b/libraries/AP_Baro/AP_Baro_BMP388.cpp
@@ -109,8 +109,10 @@ bool AP_Baro_BMP388::init()
     dev->write_register(BMP388_REG_PWR_CTRL, 0x33, true);
 
     // read the calibration data
-    read_registers(BMP388_REG_CAL_P, (uint8_t *)&calib_p, sizeof(calib_p));
-    read_registers(BMP388_REG_CAL_T, (uint8_t *)&calib_t, sizeof(calib_t));
+    if (!read_registers(BMP388_REG_CAL_T, (uint8_t *)&calib_t, sizeof(calib_t)) ||
+        !read_registers(BMP388_REG_CAL_P, (uint8_t *)&calib_p, sizeof(calib_p))) {
+        return false;
+    }
 
     scale_calibration_data();
 

--- a/libraries/AP_Baro/AP_Baro_BMP388.cpp
+++ b/libraries/AP_Baro/AP_Baro_BMP388.cpp
@@ -143,14 +143,14 @@ void AP_Baro_BMP388::timer(void)
     // call.  Retrieve what we need from it beforehand to avoid a
     // warning.
     const uint8_t status = buf[0];
-    const uint32_t pressure_data = (buf[3] << 16) | (buf[2] << 8) | buf[1];
-    const uint32_t temperature_data = (buf[6] << 16) | (buf[5] << 8) | buf[4];
     if ((status & 0x20) != 0) {
         // we have pressure data
+        const uint32_t pressure_data = (buf[3] << 16) | (buf[2] << 8) | buf[1];
         update_pressure(pressure_data);
     }
     if ((status & 0x40) != 0) {
         // we have temperature data
+        const uint32_t temperature_data = (buf[6] << 16) | (buf[5] << 8) | buf[4];
         update_temperature(temperature_data);
     }
 

--- a/libraries/AP_Baro/AP_Baro_BMP388.cpp
+++ b/libraries/AP_Baro/AP_Baro_BMP388.cpp
@@ -105,9 +105,6 @@ bool AP_Baro_BMP388::init()
     }
     hal.scheduler->delay(10);
 
-    // normal mode, temp and pressure
-    dev->write_register(BMP388_REG_PWR_CTRL, 0x33, true);
-
     // read the calibration data
     if (!read_registers(BMP388_REG_CAL_T, (uint8_t *)&calib_t, sizeof(calib_t)) ||
         !read_registers(BMP388_REG_CAL_P, (uint8_t *)&calib_p, sizeof(calib_p))) {
@@ -119,7 +116,9 @@ bool AP_Baro_BMP388::init()
     dev->setup_checked_registers(4);
 
     // normal mode, temp and pressure
-    dev->write_register(BMP388_REG_PWR_CTRL, 0x33, true);
+    if (!dev->write_register(BMP388_REG_PWR_CTRL, 0x33, true)) {
+        return false;
+    }
 
     instance = _frontend.register_sensor();
 


### PR DESCRIPTION
### Summary

Improve robustness, clean up initialization, and optimize timer parsing in `AP_Baro_BMP388`.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Tested on hardware:
- Verified on **Holybro Pixhawk 6X** (dual BMP388 on I2C0 and I2C2).
- Both barometers initialize reliably, and real-time pressure telemetry (`SCALED_PRESSURE` and `SCALED_PRESSURE2`) streams healthy 1016.6 hPa data with smooth live waveforms.

<img width="645" height="694" alt="スクリーンショット 2026-08-22 20 45 31" src="https://github.com/user-attachments/assets/49f449d9-2e11-4b63-b96b-1c809654cb97" />
<img width="1725" height="1021" alt="スクリーンショット 2026-08-22 20 47 22" src="https://github.com/user-attachments/assets/d52d50a2-12b2-4f38-af4c-755c61591de3" />
<img width="1718" height="1022" alt="スクリーンショット 2026-08-22 20 47 50" src="https://github.com/user-attachments/assets/a20a0e6a-bd48-49a5-aad7-1b69f62ff9c8" />

### Description

This PR contains three cleanups for `AP_Baro_BMP388`:
1. **Check calibration read results**: `read_registers()` for `calib_t` (0x31) and `calib_p` (0x36) were ignoring return values. If bus communication failed, uninitialized data would be used in `scale_calibration_data()`. Added proper error return checks and reordered reads sequentially from `CAL_T` to `CAL_P`.
2. **Clean up and check `PWR_CTRL` write**: `write_register(BMP388_REG_PWR_CTRL, 0x33, true)` was called before `setup_checked_registers(4)` and then called again after. Following Bosch SensorAPI reference initialization, NVM calibration data is read in sleep mode after soft reset, and `PWR_CTRL` is configured after `setup_checked_registers()` with proper return value checking.
3. **Localize data unpacking scope in `timer()`**: Moved `pressure_data` and `temperature_data` unpacking inside their respective `(status & 0x20)` and `(status & 0x40)` status checks to avoid unnecessary bitshift operations when data is not ready and to restrict variable scope.

This PR was prepared with AI assistance.
