### PR TITLE
GCS: clamp message interval to scheduler cap instead of rejecting

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3240,9 +3240,12 @@ MAV_RESULT GCS_MAVLINK::set_message_interval(uint32_t msg_id, int32_t interval_u
         interval_ms = interval_us / 1000;
     }
 #if AP_SCHEDULER_ENABLED
-    if (interval_ms != 0 && cap_message_interval(interval_ms) > interval_ms) {
-        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Requested rate for message ID %u too fast. Increase SCHED_LOOP_RATE", (unsigned int)msg_id);
-        return MAV_RESULT_DENIED;
+    if (interval_ms != 0) {
+        const uint16_t capped = cap_message_interval(interval_ms);
+        if (capped > interval_ms) {
+            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Rate for msg %u clamped to scheduler max (%u ms)", (unsigned int)msg_id, (unsigned int)capped);
+            interval_ms = capped;
+        }
     }
 #endif
     if (set_ap_message_interval(id, interval_ms)) {


### PR DESCRIPTION
## Summary

`set_message_interval` returned `MAV_RESULT_DENIED` when the requested rate
exceeded 0.8 * `SCHED_LOOP_RATE`. This broke drivers that request a fixed high
rate (like `AP_Mount_Gremsy`/`AP_Mount_MAVLink` requesting
`AUTOPILOT_STATE_FOR_GIMBAL_DEVICE` at 50Hz) on vehicles where the scheduler
loop rate defaults to a lower value.

The user sees: `"Requested rate for message ID 286 too fast. Increase SCHED_LOOP_RATE"`

## Fix

Instead of denying the request, clamp the interval to the scheduler's maximum
supported rate and accept. The driver gets the fastest rate the scheduler can
deliver, and a log message notes the clamping so the user knows the effective
rate differs from the requested one.

This means gimbal drivers work out of the box with default parameters instead
of requiring the user to manually increase `SCHED_LOOP_RATE`.

Fixes #31101
