### PR TITLE
Use float literal for CXOF pixel scaling

### DIFF
--- a/libraries/AP_OpticalFlow/AP_OpticalFlow_CXOF.cpp
+++ b/libraries/AP_OpticalFlow/AP_OpticalFlow_CXOF.cpp
@@ -45,7 +45,7 @@
 #define CXOF_HEADER         (uint8_t)0xFE
 #define CXOF_FOOTER         (uint8_t)0xAA
 #define CXOF_FRAME_LENGTH               9
-#define CXOF_PIXEL_SCALING      (1.76e-3)
+#define CXOF_PIXEL_SCALING      (1.76e-3f)
 #define CXOF_TIMEOUT_SEC             0.3f
 
 extern const AP_HAL::HAL& hal;


### PR DESCRIPTION
### Summary

<!-- Put a one or two line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [ ] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->

### Description
Change the CXOF pixel scaling constant from a double literal to an explicit float literal.

### Change
- Changed `1.76e-3` to `1.76e-3f` for `CXOF_PIXEL_SCALING`.

### Why
The CXOF driver performs float-based calculations, so using an explicit float literal avoids unnecessary double-precision conversion and keeps the constant consistent with the surrounding float calculations.
