### PR TITLE
Tradheli: improve swashplate collective and cyclic pitch logging

### DIFF
--- a/libraries/AP_Motors/AP_MotorsHeli.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli.cpp
@@ -152,6 +152,15 @@ const AP_Param::GroupInfo AP_MotorsHeli::var_info[] = {
     // @Path: ../AC_Autorotation/RSC_Autorotation.cpp
     AP_SUBGROUPINFO(_main_rotor.autorotation, "RSC_AROT_", 33, AP_MotorsHeli, RSC_Autorotation),
 
+    // @Param: CYC_ANG_MAX
+    // @DisplayName: Cyclic Blade Pitch Angle Maximum
+    // @Description: Maximum cyclic blade pitch angle in deg that corresponds to the setting for maximum cyclic pitch (H_CYC_MAX).
+    // @Range: 5 20
+    // @Units: deg
+    // @Increment: 0.1
+    // @User: Standard
+    AP_GROUPINFO("CYC_ANG_MAX", 34, AP_MotorsHeli, _cyclic_max_deg, AP_MOTORS_HELI_CYCLIC_MAX_DEG),
+
     AP_GROUPEND
 };
 
@@ -605,17 +614,6 @@ void AP_MotorsHeli::set_rotor_runup_complete(bool new_value)
 #endif
     _heliflags.rotor_runup_complete = new_value;
 }
-
-#if HAL_LOGGING_ENABLED
-// Returns the scaling value required to convert the collective angle parameters into the cyclic-output-to-angle conversion
-float AP_MotorsHeli::get_cyclic_angle_scaler(void) const {
-    // We want to use the collective min-max to angle relationship to calculate the cyclic input to angle relationship
-    // First we scale the collective angle range by it's min-max output. Recall that we assume that the maximum possible
-    // collective range is 1000, hence the *1e-3.
-    // The factor 2.0 accounts for the fact that we scale the servo outputs from 0 ~ 1 to -1 ~ 1
-    return ((float)(_collective_max-_collective_min))*1e-3 * (_collective_max_deg.get() - _collective_min_deg.get()) * 2.0;
-}
-#endif
 
 // Helper function for param conversions to be done in motors class
 void AP_MotorsHeli::heli_motors_param_conversions(void)

--- a/libraries/AP_Motors/AP_MotorsHeli.h
+++ b/libraries/AP_Motors/AP_MotorsHeli.h
@@ -25,7 +25,7 @@
 #define AP_MOTORS_HELI_COLLECTIVE_MIN_DEG      -90.0f // minimum collective blade pitch angle in deg
 #define AP_MOTORS_HELI_COLLECTIVE_MAX_DEG       90.0f // maximum collective blade pitch angle in deg
 #define AP_MOTORS_HELI_COLLECTIVE_LAND_MIN      -2.0f // minimum landed collective blade pitch angle in deg for modes using althold
-
+#define AP_MOTORS_HELI_CYCLIC_MAX_DEG           5.0f // maximum cyclic blade pitch angle in deg
 
 // rsc function output channels.
 #define AP_MOTORS_HELI_RSC                      CH_8
@@ -225,11 +225,6 @@ protected:
     // Update _heliflags.rotor_runup_complete value writing log event on state change
     void set_rotor_runup_complete(bool new_value);
 
-#if HAL_LOGGING_ENABLED
-    // Returns the scaling value required to convert the collective angle parameters into the cyclic-output-to-angle conversion for blade angle logging
-    float get_cyclic_angle_scaler(void) const;
-#endif
-
     // enum values for HOVER_LEARN parameter
     enum HoverLearn {
         HOVER_LEARN_DISABLED = 0,
@@ -263,7 +258,7 @@ protected:
     AP_Float        _collective_land_min_deg;   // Minimum Landed collective blade pitch in degrees for non-manual collective modes (i.e. modes that use altitude hold)
     AP_Float        _collective_max_deg;        // Maximum collective blade pitch angle in deg that corresponds to the PWM set for maximum collective pitch (H_COL_MAX)
     AP_Float        _collective_min_deg;        // Minimum collective blade pitch angle in deg that corresponds to the PWM set for minimum collective pitch (H_COL_MIN)
-
+    AP_Float        _cyclic_max_deg;            // Maximum cyclic blade pitch angle in deg that corresponds to the setting for maximum cyclic pitch (H_CYC_MAX)
     // internal variables
     float           _collective_zero_thrust_pct;      // collective zero thrutst parameter value converted to 0 ~ 1 range
     float           _collective_land_min_pct;      // collective land min parameter value converted to 0 ~ 1 range

--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -614,8 +614,8 @@ void AP_MotorsHeli_Dual::heli_motors_param_conversions(void)
 void AP_MotorsHeli_Dual::Log_Write(void)
 {
     // write swashplate log
-    _swashplate1.write_log(get_cyclic_angle_scaler(), _collective_min_deg.get(), _collective_max_deg.get(), _collective_min.get(), _collective_max.get());
-    _swashplate2.write_log(get_cyclic_angle_scaler(), _collective_min_deg.get(), _collective_max_deg.get(), _collective2_min.get(), _collective2_max.get());
+    _swashplate1.write_log(_collective_min_deg.get(), _collective_max_deg.get(), _cyclic_max_deg.get(), _collective_min.get(), _collective_max.get(), _cyclic_max.get());
+    _swashplate2.write_log(_collective_min_deg.get(), _collective_max_deg.get(), _cyclic_max_deg.get(), _collective2_min.get(), _collective2_max.get(), _cyclic_max.get());
 
     // write RSC log
     _main_rotor.write_log();

--- a/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Single.cpp
@@ -682,11 +682,7 @@ bool AP_MotorsHeli_Single::use_tail_RSC() const
 void AP_MotorsHeli_Single::Log_Write(void)
 {
     // Write swash plate logging
-    // For single heli we have to apply an additional cyclic scaler of sqrt(2.0) because the
-    // definition of when we achieve _cyclic_max is different to dual heli. In single, _cyclic_max
-    // is limited at sqrt(2.0), in dual it is limited at 1.0
-    float cyclic_angle_scaler = get_cyclic_angle_scaler() * sqrtf(2.0);
-    _swashplate.write_log(cyclic_angle_scaler, _collective_min_deg.get(), _collective_max_deg.get(), _collective_min.get(), _collective_max.get());
+    _swashplate.write_log(_collective_min_deg.get(), _collective_max_deg.get(), _cyclic_max_deg.get(), _collective_min.get(), _collective_max.get(), _cyclic_max.get());
 
     // Write RSC logging
     _main_rotor.write_log();

--- a/libraries/AP_Motors/AP_MotorsHeli_Swash.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Swash.cpp
@@ -17,6 +17,8 @@
 #include <AP_HAL/AP_HAL.h>
 #include <SRV_Channel/SRV_Channel.h>
 #include <AP_Logger/AP_Logger.h>
+#include <AP_Math/matrix3.h>
+#include <GCS_MAVLink/GCS.h>
 
 #include "AP_MotorsHeli_Swash.h"
 
@@ -107,6 +109,14 @@ void AP_MotorsHeli_Swash::configure()
     enable.set(_swash_type == SWASHPLATE_TYPE_H3);
 
     calculate_roll_pitch_collective_factors();
+
+    // Calculate the swash to servo matrix and its inverse. The 0.45 factor was used in calculating the servo output.
+    // The 0.45 factor is removed to calculate the swashplate inputs from the servo outputs directly for logging.
+    _swash_to_servo_matrix = Matrix3f(_collectiveFactor[0], _rollFactor[0], _pitchFactor[0],
+                                      _collectiveFactor[1], _rollFactor[1], _pitchFactor[1],
+                                      _collectiveFactor[2], _rollFactor[2], _pitchFactor[2]);
+    _valid_swash_conv_inverse = _swash_to_servo_matrix.inverse(_servo_to_swash_matrix);
+
 }
 
 // CCPM Mixers - calculate mixing scale factors by swashplate type
@@ -289,6 +299,13 @@ void AP_MotorsHeli_Swash::rc_write(uint8_t chan, float swash_in)
     SRV_Channels::set_output_pwm_trimmed(function, pwm);
 }
 
+float AP_MotorsHeli_Swash::get_actual_servo_input(uint8_t chan) const
+{
+    SRV_Channel::Function function = SRV_Channels::get_motor_function(chan);
+    uint16_t pwm = SRV_Channels::get_output_pwm_trimmed(function);
+    return (float)(pwm - 1500) / 500.0f;
+}
+
 // Get function output mask
 uint32_t AP_MotorsHeli_Swash::get_output_mask() const
 {
@@ -303,34 +320,50 @@ uint32_t AP_MotorsHeli_Swash::get_output_mask() const
 
 #if HAL_LOGGING_ENABLED
 // Write SWSH log for this instance of swashplate
-void AP_MotorsHeli_Swash::write_log(float cyclic_scaler, float col_ang_min, float col_ang_max, int16_t col_min, int16_t col_max) const
+void AP_MotorsHeli_Swash::write_log(float col_ang_min, float col_ang_max, float cyc_ang_max, int16_t col_min, int16_t col_max, int16_t cyc_max) const
 {
-    // Calculate the collective contribution to blade pitch angle
-    // Swashplate receives the scaled collective value based on the col_min and col_max params. We have to reverse the scaling here to do the angle calculation.
-    float collective_scalar = ((float)(col_max-col_min))*1e-3;
-    collective_scalar = MAX(collective_scalar, 1e-3);
-    float _collective_input = (_collective_input_scaled - (float)(col_min - 1000)*1e-3) / collective_scalar;
-    float col = (col_ang_max - col_ang_min) * _collective_input + col_ang_min;
 
-    // Calculate the cyclic contribution to blade pitch angle
-    float tcyc = norm(_roll_input, _pitch_input) * cyclic_scaler;
-    float pcyc = _pitch_input * cyclic_scaler;
-    float rcyc = _roll_input * cyclic_scaler;
+    // determine collective and cyclic blade pitch angle based on the swashplate output values.
+    float col_ang_per_pwm = (col_ang_max - col_ang_min)  / ((float)(col_max - col_min) * 1e-3);
+    float cyc_ang_per_pwm = cyc_ang_max / ((float)cyc_max / 4500.0f);
+    Vector3f servo_vector;
+    // only use first three servos for swashplate output calculations, even if a fourth servo is used for a four-servo swashplate.
+    for (uint8_t i = 0; i < 3; i++) {
+        if (_enabled[i]) {
+            // convert servo output from -1 to 1 to 0 to 1.
+            servo_vector[i] = (0.5f * (get_actual_servo_input(_motor_num[i]) + 1.0f));
+        }
+    }
+    // If the swash to servo matrix has a valid inverse, then convert the servo output to swashplate collective and cyclic and log them.
+    if (_valid_swash_conv_inverse) {
+        // convert servo output to swashplate output using the inverse of the swash to servo matrix.
+        Vector3f swash_vector = _servo_to_swash_matrix * servo_vector;
+        float col = swash_vector.x;
+        if (_collective_direction == COLLECTIVE_DIRECTION_REVERSED) {
+            col = col_ang_per_pwm - (col + (col_min - 1000) * 1e-3) * col_ang_per_pwm + col_ang_min;
+        } else {
+            col = (col - (col_min - 1000) * 1e-3) * col_ang_per_pwm + col_ang_min;
+        }
+        // convert swashplate cyclic output to blade pitch angle contribution from cyclic
+        float rcyc = cyc_ang_per_pwm * swash_vector.y;
+        float pcyc = cyc_ang_per_pwm * swash_vector.z;
+        float tcyc = norm(rcyc, pcyc);
 
-    // @LoggerMessage: SWSH
-    // @Description: Helicopter swashplate logging
-    // @Field: TimeUS: Time since system startup
-    // @Field: I: Swashplate instance
-    // @Field: Col: Blade pitch angle contribution from collective
-    // @Field: TCyc: Total blade pitch angle contribution from cyclic
-    // @Field: PCyc: Blade pitch angle contribution from pitch cyclic
-    // @Field: RCyc: Blade pitch angle contribution from roll cyclic
-    AP::logger().WriteStreaming("SWSH", "TimeUS,I,Col,TCyc,PCyc,RCyc", "s#dddd", "F-0000", "QBffff",
-                                AP_HAL::micros64(),
-                                _instance,
-                                col,
-                                tcyc,
-                                pcyc,
-                                rcyc);
+        // @LoggerMessage: SWSH
+        // @Description: Helicopter swashplate logging
+        // @Field: TimeUS: Time since system startup
+        // @Field: I: Swashplate instance
+        // @Field: Col: Blade pitch angle contribution from collective
+        // @Field: TCyc: Total blade pitch angle contribution from cyclic
+        // @Field: PCyc: Blade pitch angle contribution from pitch cyclic
+        // @Field: RCyc: Blade pitch angle contribution from roll cyclic
+        AP::logger().WriteStreaming("SWSH", "TimeUS,I,Col,TCyc,PCyc,RCyc", "s#dddd", "F-0000", "QBffff",
+                                    AP_HAL::micros64(),
+                                    _instance,
+                                    col,
+                                    tcyc,
+                                    pcyc,
+                                    rcyc);
+    }
 }
 #endif

--- a/libraries/AP_Motors/AP_MotorsHeli_Swash.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_Swash.h
@@ -42,7 +42,7 @@ public:
 
 #if HAL_LOGGING_ENABLED
     // Write SWSH log for this instance of swashplate
-    void write_log(float cyclic_scaler, float col_ang_min, float col_ang_max, int16_t col_min, int16_t col_max) const;
+    void write_log(float col_ang_min, float col_ang_max, float cyc_ang_max, int16_t col_min, int16_t col_max, int16_t cyc_max) const;
 #endif
 
     // var_info
@@ -62,6 +62,9 @@ private:
 
     // write to a swash servo. output value is pwm
     void rc_write(uint8_t chan, float swash_in);
+
+    float get_actual_servo_input(uint8_t chan) const;
+
 
     enum CollectiveDirection {
         COLLECTIVE_DIRECTION_NORMAL = 0,
@@ -88,6 +91,11 @@ private:
     float _roll_input;
     float _pitch_input;
     float _collective_input_scaled;
+    Matrix3f _servo_to_swash_matrix;  // Matrix to convert servo frame to swash frame
+    Matrix3f _swash_to_servo_matrix;  // Matrix to convert swash frame to servo frame
+    Vector3f _swash_vector;            // Swash vector in swash frame
+    Vector3f _servo_vector;            // Servo vector in servo frame
+    bool _valid_swash_conv_inverse;    // True if the swash to servo matrix has a valid inverse
 
     // parameters
     AP_Int8  _swashplate_type;                   // Swash Type Setting

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -469,6 +469,9 @@ public:
     // set output for all channels matching the given function type, allow radio_trim to center servo
     static void set_output_pwm_trimmed(SRV_Channel::Function function, int16_t value);
 
+    // get the input for a channel function from the pwm value of the first matching channel
+    static uint16_t get_output_pwm_trimmed(SRV_Channel::Function function);
+
     // set and save the trim for a function channel to the output value
     static void set_trim_to_servo_out_for(SRV_Channel::Function function);
 

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -388,6 +388,26 @@ SRV_Channels::set_output_pwm_trimmed(SRV_Channel::Function function, int16_t val
     }
 }
 
+
+// get the input for a channel function from the pwm value of the first matching channel
+uint16_t SRV_Channels::get_output_pwm_trimmed(SRV_Channel::Function function)
+{
+    uint8_t chan;
+    if (!find_channel(function, chan)) {
+        return 0;
+    }
+    uint16_t value = 0;
+    if (SRV_Channel::valid_function(function)) {
+        uint16_t value2 = channels[chan].get_output_pwm();
+        if (channels[chan].get_reversed()) {
+            value = 1500 - value2 + channels[chan].get_trim();
+        } else {
+            value = value2 + 1500 - channels[chan].get_trim();
+        }
+    }
+    return value;
+}
+
 /*
   set and save the trim value to current output for all channels matching
   the given function type


### PR DESCRIPTION
### Summary

This PR changes the way swashplate collective and cyclic blade pitch is calculated.  The current implementation has been shown to have errors in the estimation.  The new method fixes this issue

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Removes previous calculation of swashplate collective and cyclic pitch for logging
Add improved method for calculation of swashplate collective and cyclic pitch for logging.  This method uses a transformation matrix from the calculations to determine the servo outputs from the requested motor class inputs.  It takes the transformation matrix and inverts it to take the servo outputs and determine the swashplate collective and cyclic angles.  There are no scalings required between single and dual heli since it uses the transformation matrix used to determine the servo outputs.

Requires more testing on different swashplate types mainly 4 servo swashplates.

