### PR TITLE
AP_OSD: remove unused font update counter

### DIFF
--- a/libraries/AP_OSD/AP_OSD_MAX7456.cpp
+++ b/libraries/AP_OSD/AP_OSD_MAX7456.cpp
@@ -157,7 +157,6 @@ bool AP_OSD_MAX7456::init()
 
 bool AP_OSD_MAX7456::update_font()
 {
-    uint8_t updated_chars = 0;
     last_font = get_font_num();
     FileData *fd = load_font_data(last_font);
 
@@ -182,7 +181,6 @@ bool AP_OSD_MAX7456::update_font()
                 delete fd;
                 return false;
             }
-            updated_chars++;
         }
     }
     delete fd;


### PR DESCRIPTION
### Summary

Removes an unused variable, which is a compilation failure on 

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Removes an unused variable.  This was a warning on clang for a long time IIRC.
