### PR TITLE
Make requesting the terrain at 0,0 an internal error

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -1714,6 +1714,37 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.wait_mode("RTL")
         self.wait_rtl_complete()
 
+    def TerrainTakeoffNoLatLon(self):
+        '''arm with a terrain-frame takeoff which has no lat/lon (issue 34016)'''
+        # start with no terrain data on board, so it must all be
+        # fetched from the GCS:
+        self.remove_ardupilot_terrain_cache()
+        self.reboot_sitl()
+
+        self.install_terrain_handlers_context()
+
+        # a takeoff to 20m above terrain with no lat/lon, followed by
+        # an RTL, also in the terrain frame.  Nothing in this mission
+        # has a location.  ArduPilot does not report the RTL's frame
+        # back on download, so upload without the usual readback
+        # comparison.
+        items = self.create_simple_relhome_mission([
+            (mavutil.mavlink.MAV_CMD_NAV_TAKEOFF, 0, 0, 20, {
+                "frame": mavutil.mavlink.MAV_FRAME_GLOBAL_TERRAIN_ALT,
+            }),
+            (mavutil.mavlink.MAV_CMD_NAV_RETURN_TO_LAUNCH, 0, 0, 0, {
+                "frame": mavutil.mavlink.MAV_FRAME_GLOBAL_TERRAIN_ALT,
+            }),
+        ])
+        self.upload_using_mission_protocol(mavutil.mavlink.MAV_MISSION_TYPE_MISSION, items)
+
+        # allow arming in AUTO, and start the mission's takeoff
+        # command before we arm, as a GCS user would:
+        self.set_parameter('AUTO_OPTIONS', 3)
+        self.change_mode('AUTO')
+
+        self.wait_ready_to_arm(timeout=200)
+
     def CustomController(self, timeout=300):
         '''Test Custom Controller'''
         self.progress("Configure custom controller parameters")
@@ -16071,6 +16102,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
              self.ThrottleFailsafePassthrough,
              self.GCSFailsafe,
              self.TerrainFailsafe,
+             self.TerrainTakeoffNoLatLon,
              self.CustomController,
              self.WPArcs,
              self.WPArcs2,

--- a/libraries/AP_Terrain/AP_Terrain.cpp
+++ b/libraries/AP_Terrain/AP_Terrain.cpp
@@ -26,6 +26,7 @@
 #include <AP_AHRS/AP_AHRS.h>
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 #include <AP_Filesystem/AP_Filesystem.h>
+#include <AP_InternalError/AP_InternalError.h>
 #include <AP_Rally/AP_Rally.h>
 
 extern const AP_HAL::HAL& hal;
@@ -115,6 +116,13 @@ AP_Terrain::AP_Terrain() :
 bool AP_Terrain::height_amsl(const Location &loc, float &height, bool corrected)
 {
     if (!allocate()) {
+        return false;
+    }
+
+    // a lat/lng of 0,0 indicates an uninitialised location; callers
+    // should never ask for terrain height there
+    if (loc.lat == 0 && loc.lng == 0) {
+        INTERNAL_ERROR(AP_InternalError::error_t::invalid_arg_or_result);
         return false;
     }
 

--- a/libraries/AP_Terrain/AP_Terrain.cpp
+++ b/libraries/AP_Terrain/AP_Terrain.cpp
@@ -198,6 +198,10 @@ bool AP_Terrain::height_amsl(const Location &loc, float &height, bool corrected)
 bool AP_Terrain::height_terrain_difference_home(float &terrain_difference, bool extrapolate)
 {
     const AP_AHRS &ahrs = AP::ahrs();
+    if (!ahrs.home_is_set()) {
+        // we don't know where home is
+        return false;
+    }
 
     float height_home, height_loc;
     if (!height_amsl(ahrs.get_home(), height_home)) {
@@ -296,6 +300,9 @@ bool AP_Terrain::height_relative_home_equivalent(float terrain_altitude,
       adjust for height of home above terrain height at home
      */
     const AP_AHRS &ahrs = AP::ahrs();
+    if (!ahrs.home_is_set()) {
+        return false;
+    }
     const auto &home = ahrs.get_home();
     int32_t home_height_amsl_cm = 0;
     UNUSED_RESULT(home.get_alt_cm(Location::AltFrame::ABSOLUTE, home_height_amsl_cm));
@@ -368,7 +375,9 @@ void AP_Terrain::update(void)
 
     // try to ensure the home location is populated
     float height;
-    height_amsl(ahrs.get_home(), height);
+    if (ahrs.home_is_set()) {
+        height_amsl(ahrs.get_home(), height);
+    }
 
     // update the cached current location height
     Location loc;

--- a/libraries/AP_Terrain/TerrainGCS.cpp
+++ b/libraries/AP_Terrain/TerrainGCS.cpp
@@ -235,7 +235,10 @@ void AP_Terrain::send_terrain_report(GCS_MAVLINK &link, const Location &loc, boo
 
     float terrain_height = 0;
     uint16_t spacing = 0;
-    if (height_amsl(loc, terrain_height)) {
+    // loc may be zero if we do not know where we are, or if the GCS
+    // sent us a TERRAIN_CHECK for lat/lng 0,0
+    const bool have_loc = (loc.lat != 0 || loc.lng != 0);
+    if (have_loc && height_amsl(loc, terrain_height)) {
         // non-zero spacing indicates we have data
         spacing = grid_spacing;
     } else if (extrapolate && have_current_loc_height) {


### PR DESCRIPTION
### Summary

Makes it clear when we ask for terrain we never should

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Makes requesting terrain at 0,0 an internal error.
