### PR TITLE
autotest: allow a wider pitch tolerance in mount_test_body()

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -7713,8 +7713,13 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             p3=0, # stabilize pitch (unsupported)
         )
 
-    def test_mount_rc_targetting(self, pitch_rc_neutral=1500, do_rate_tests=True):
-        '''called in multipleplaces to make sure that mount RC targeting works'''
+    def test_mount_rc_targetting(self, pitch_rc_neutral=1500, do_rate_tests=True, pitch_tolerance=0.1):
+        '''called in multipleplaces to make sure that mount RC targeting works
+
+        pitch_tolerance defaults to the original tight 0.1deg check; backends whose
+        actuator has a coarser confirmed physical resolution (e.g. a rate-only
+        actuator closing an angle loop via a quantized speed command) may need to
+        pass a wider value'''
         if True:
             self.context_push()
             self.set_parameters({
@@ -7747,9 +7752,9 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             if expected_pitch != -11.25:
                 raise NotAchievedException("Calculation wrong - defaults changed?!")
             self.set_rc(12, rc12_in)
-            self.test_mount_pitch(-11.25, 0.1, mavutil.mavlink.MAV_MOUNT_MODE_RC_TARGETING)
+            self.test_mount_pitch(-11.25, pitch_tolerance, mavutil.mavlink.MAV_MOUNT_MODE_RC_TARGETING)
             self.set_rc(12, 1800)
-            self.test_mount_pitch(33.75, 0.1, mavutil.mavlink.MAV_MOUNT_MODE_RC_TARGETING)
+            self.test_mount_pitch(33.75, pitch_tolerance, mavutil.mavlink.MAV_MOUNT_MODE_RC_TARGETING)
             self.set_rc_from_map({
                 11: 1500,
                 12: 1500,
@@ -7765,11 +7770,11 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                     "MNT1_PITCH_MAX": 10,
                 })
                 self.set_rc(12, 1000)
-                self.test_mount_pitch(-90.00, 0.1, mavutil.mavlink.MAV_MOUNT_MODE_RC_TARGETING)
+                self.test_mount_pitch(-90.00, pitch_tolerance, mavutil.mavlink.MAV_MOUNT_MODE_RC_TARGETING)
                 self.set_rc(12, 2000)
-                self.test_mount_pitch(10.00, 0.1, mavutil.mavlink.MAV_MOUNT_MODE_RC_TARGETING)
+                self.test_mount_pitch(10.00, pitch_tolerance, mavutil.mavlink.MAV_MOUNT_MODE_RC_TARGETING)
                 self.set_rc(12, 1500)
-                self.test_mount_pitch(-40.00, 0.1, mavutil.mavlink.MAV_MOUNT_MODE_RC_TARGETING)
+                self.test_mount_pitch(-40.00, pitch_tolerance, mavutil.mavlink.MAV_MOUNT_MODE_RC_TARGETING)
             finally:
                 self.context_pop()
 
@@ -7804,7 +7809,8 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             self.set_rc(12, 1500)
             self.test_mount_pitch(0, 0.1, mavutil.mavlink.MAV_MOUNT_MODE_RC_TARGETING)
 
-    def mount_test_body(self, pitch_rc_neutral=1500, do_rate_tests=True, constrain_sysid_target=True, neutral_tol_deg=0):
+    def mount_test_body(self, pitch_rc_neutral=1500, do_rate_tests=True, constrain_sysid_target=True, neutral_tol_deg=0,
+                        rc_targetting_pitch_tolerance=0.1):
         '''Test Camera/Antenna Mount - assumes a camera is set up and ready to go'''
         if True:
             # make sure we're getting gimbal device attitude status
@@ -7895,10 +7901,11 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             self.test_mount_rc_targetting(
                 pitch_rc_neutral=pitch_rc_neutral,
                 do_rate_tests=do_rate_tests,
+                pitch_tolerance=rc_targetting_pitch_tolerance,
             )
 
             self.progress("Testing mount ROI behaviour")
-            self.test_mount_pitch(0, 0.1, mavutil.mavlink.MAV_MOUNT_MODE_RC_TARGETING)
+            self.test_mount_pitch(0, rc_targetting_pitch_tolerance, mavutil.mavlink.MAV_MOUNT_MODE_RC_TARGETING)
             start = self.mav.location()
             self.progress("start=%s" % str(start))
             (roi_lat, roi_lon) = mavextra.gps_offset(start.lat,


### PR DESCRIPTION
test_mount_rc_targetting() and mount_test_body() hardcoded a 0.1deg pitch tolerance for the RC-targeting checks. Threads a pitch_tolerance / rc_targetting_pitch_tolerance parameter through both instead (default 0.1deg, unchanged for every existing caller), so a backend whose actuator has a coarser confirmed physical resolution - e.g. a rate-only actuator closing an angle loop via a quantized speed command - can pass a wider, measurement-backed value instead of failing a tolerance the hardware cannot physically meet.

Split out of the SkyDroid gimbal driver PR (ArduPilot/ardupilot#34155) at Peter Barker's review suggestion - this parameter is generically useful and doesn't depend on anything SkyDroid-specific.

### Summary

Makes the pitch tolerance used by the shared mount RC-targeting autotest a parameter instead of a hardcoded `0.1deg`, unchanged by default.

### Classification & Testing (check all that apply and add your own)

- [ ] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

No test yet passes a non-default tolerance — that lands with #34155, the first real consumer. Ran the existing `MountTopotek` autotest (an unrelated backend, so exercises the unchanged `0.1deg` default through the new parameter's plumbing) — passes clean, confirming this is behaviour-preserving for every existing caller.

### Description

`test_mount_rc_targetting()` and `mount_test_body()` hardcoded a `0.1deg` tolerance on every pitch check in the RC-targeting test. That's fine for backends whose actuator can actually place an angle that precisely, but not every backend can: a rate-only actuator that closes an angle loop by sending a quantized speed command has a real physical floor below which a commanded correction rounds to zero, and that floor can be coarser than `0.1deg`.

Adds a `pitch_tolerance` parameter to `test_mount_rc_targetting()` and a `rc_targetting_pitch_tolerance` parameter to `mount_test_body()` (threaded through to the former), both defaulting to the existing `0.1deg` — no behaviour change for any current caller. A backend with a coarser, measurement-backed actuator resolution can now pass a wider value instead of either failing a tolerance the hardware can't physically meet, or the test being loosened for every backend.

Split out of #34155 (a new SkyDroid gimbal driver) at [Peter Barker's suggestion](https://github.com/ArduPilot/ardupilot/pull/34155#issuecomment-5391240637) that this parameter is generically useful on its own. That PR will rebase on top of this once merged, and will be the first real consumer passing a non-default value.

---
This PR was developed with AI assistance (Claude). All changes have been reviewed and tested by me, but not independently, only as part of #34155 