### PR TITLE
Logging: Populate MCU messages on Linux targets with Cpu freq and temperature

### DIFF
--- a/libraries/AP_HAL/AnalogIn.h
+++ b/libraries/AP_HAL/AnalogIn.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <inttypes.h>
+#include <math.h>
 
 #include "AP_HAL_Namespace.h"
 #include "AP_HAL_Boards.h"
@@ -54,12 +55,10 @@ public:
         CHANGED = 32,                     // Power status has changed since boot
     };
 
-#if HAL_WITH_MCU_MONITORING
-    virtual float mcu_temperature(void) { return 0; }
-    virtual float mcu_voltage(void) { return 0; }
-    virtual float mcu_voltage_max(void) { return 0; }
-    virtual float mcu_voltage_min(void) { return 0; }
-#endif
+    virtual float mcu_temperature(void) { return NAN; }
+    virtual float mcu_voltage(void) { return NAN; }
+    virtual float mcu_voltage_max(void) { return NAN; }
+    virtual float mcu_voltage_min(void) { return NAN; }
 };
 
 #define ANALOG_INPUT_BOARD_VCC 254

--- a/libraries/AP_HAL/Util.h
+++ b/libraries/AP_HAL/Util.h
@@ -155,6 +155,12 @@ public:
      */
     virtual uint32_t available_memory(void) { return 4096; }
 
+    // current CPU clock in MHz, if available
+    virtual bool get_cpu_frequency_mhz(uint16_t &freq_mhz) const { return false; }
+
+    // SoC/CPU temperature in degrees C, if available
+    virtual bool get_cpu_temperature_c(float &temp_c) const { return false; }
+
     // attempt to trap the processor, presumably to enter an attached debugger
     virtual bool trap() const { return false; }
 

--- a/libraries/AP_HAL/Util.h
+++ b/libraries/AP_HAL/Util.h
@@ -161,6 +161,9 @@ public:
     // SoC/CPU temperature in degrees C, if available
     virtual bool get_cpu_temperature_c(float &temp_c) const { return false; }
 
+    // true if the CPU/SoC is currently under-voltage, if available
+    virtual bool get_cpu_undervoltage(bool &undervolt) const { return false; }
+
     // attempt to trap the processor, presumably to enter an attached debugger
     virtual bool trap() const { return false; }
 

--- a/libraries/AP_HAL/board/linux.h
+++ b/libraries/AP_HAL/board/linux.h
@@ -163,3 +163,7 @@
 #ifndef HAL_LINUX_THERMAL_PATH
 #define HAL_LINUX_THERMAL_PATH "/sys/class/thermal/thermal_zone0/temp"
 #endif
+
+#ifndef HAL_LINUX_THROTTLED_PATH
+#define HAL_LINUX_THROTTLED_PATH "/sys/devices/platform/soc/soc:firmware/get_throttled"
+#endif

--- a/libraries/AP_HAL/board/linux.h
+++ b/libraries/AP_HAL/board/linux.h
@@ -155,3 +155,11 @@
 #ifndef HAL_LINUX_SERIALLED_ENABLED
 #define HAL_LINUX_SERIALLED_ENABLED 0
 #endif
+
+#ifndef HAL_LINUX_CPUFREQ_PATH
+#define HAL_LINUX_CPUFREQ_PATH "/sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq"
+#endif
+
+#ifndef HAL_LINUX_THERMAL_PATH
+#define HAL_LINUX_THERMAL_PATH "/sys/class/thermal/thermal_zone0/temp"
+#endif

--- a/libraries/AP_HAL_ChibiOS/Util.cpp
+++ b/libraries/AP_HAL_ChibiOS/Util.cpp
@@ -110,6 +110,26 @@ void Util::free_type(void *ptr, size_t size, AP_HAL::Util::Memory_Type mem_type)
 
 #endif // CH_CFG_USE_HEAP
 
+bool Util::get_cpu_frequency_mhz(uint16_t &freq_mhz) const
+{
+#if defined(STM32_SYS_CK)
+    freq_mhz = uint16_t(STM32_SYS_CK / 1000000U);
+#elif defined(STM32_HCLK)
+    freq_mhz = uint16_t(STM32_HCLK / 1000000U);
+#elif defined(HAL_EXPECTED_SYSCLOCK)
+    freq_mhz = uint16_t(HAL_EXPECTED_SYSCLOCK / 1000000U);
+#else
+    return false;
+#endif
+    return true;
+}
+
+bool Util::get_cpu_temperature_c(float &temp_c) const
+{
+    temp_c = hal.analogin->mcu_temperature();
+    return !isnan(temp_c);
+}
+
 /*
   get safety switch state
  */

--- a/libraries/AP_HAL_ChibiOS/Util.h
+++ b/libraries/AP_HAL_ChibiOS/Util.h
@@ -40,6 +40,9 @@ public:
 
     uint32_t available_memory() override;
 
+    bool get_cpu_frequency_mhz(uint16_t &freq_mhz) const override;
+    bool get_cpu_temperature_c(float &temp_c) const override;
+
     // get path to custom defaults file for AP_Param
     const char* get_custom_defaults_file() const override {
         return "@ROMFS/defaults.parm";

--- a/libraries/AP_HAL_Linux/Util.cpp
+++ b/libraries/AP_HAL_Linux/Util.cpp
@@ -1,6 +1,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/stat.h>
@@ -106,6 +107,29 @@ uint32_t Util::available_memory(void)
     return 256*1024;
 }
 
+bool Util::get_cpu_frequency_mhz(uint16_t &freq_mhz) const
+{
+    uint32_t freq_khz = 0;
+    if (read_file(HAL_LINUX_CPUFREQ_PATH, "%u", &freq_khz) < 1) {
+        return false;
+    }
+    if (freq_khz < 1000U) {
+        return false;
+    }
+    freq_mhz = uint16_t(freq_khz / 1000U);
+    return true;
+}
+
+bool Util::get_cpu_temperature_c(float &temp_c) const
+{
+    int32_t milli_c = 0;
+    if (read_file(HAL_LINUX_THERMAL_PATH, "%d", &milli_c) < 1) {
+        return false;
+    }
+    temp_c = milli_c / 1000.0f;
+    return true;
+}
+
 #ifndef HAL_LINUX_DEFAULT_SYSTEM_ID
 #define HAL_LINUX_DEFAULT_SYSTEM_ID "linux-unknown"
 #endif
@@ -184,7 +208,7 @@ int Util::write_file(const char *path, const char *fmt, ...)
     return ret;
 }
 
-int Util::read_file(const char *path, const char *fmt, ...)
+int Util::read_file(const char *path, const char *fmt, ...) const
 {
     errno = 0;
 

--- a/libraries/AP_HAL_Linux/Util.h
+++ b/libraries/AP_HAL_Linux/Util.h
@@ -68,6 +68,9 @@ public:
 
     uint32_t available_memory(void) override;
 
+    bool get_cpu_frequency_mhz(uint16_t &freq_mhz) const override;
+    bool get_cpu_temperature_c(float &temp_c) const override;
+
     bool get_system_id(char buf[50]) override;
     bool get_system_id_unformatted(uint8_t buf[], uint8_t &len) override;
 
@@ -83,7 +86,7 @@ public:
      * should not be used on hot path since it will open, read and close the
      * file for each call.
      */
-    int read_file(const char *path, const char *fmt, ...) FMT_SCANF(3, 4);
+    int read_file(const char *path, const char *fmt, ...) const FMT_SCANF(3, 4);
 
     int get_hw_arm32();
 

--- a/libraries/AP_Logger/LogFile.cpp
+++ b/libraries/AP_Logger/LogFile.cpp
@@ -399,20 +399,22 @@ void AP_Logger::Write_Power(void)
         safety_and_arm : safety_and_armed,
     };
     WriteBlock(&powr_pkt, sizeof(powr_pkt));
+#endif  // CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
 
-#if HAL_WITH_MCU_MONITORING
+    uint16_t freq_mhz = 0;
+    float temp_c = quiet_nanf();
+    hal.util->get_cpu_frequency_mhz(freq_mhz);
+    hal.util->get_cpu_temperature_c(temp_c);
     const struct log_MCU mcu_pkt{
         LOG_PACKET_HEADER_INIT(LOG_MCU_MSG),
-        time_us : now,
-        MCU_temp : hal.analogin->mcu_temperature(),
+        time_us : AP_HAL::micros64(),
+        MCU_temp : temp_c,
         MCU_voltage : hal.analogin->mcu_voltage(),
         MCU_voltage_min : hal.analogin->mcu_voltage_min(),
         MCU_voltage_max : hal.analogin->mcu_voltage_max(),
+        MCU_freq_mhz : freq_mhz,
     };
     WriteBlock(&mcu_pkt, sizeof(mcu_pkt));
-#endif
-
-#endif
 }
 
 void AP_Logger::Write_Radio(const mavlink_radio_t &packet)

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -360,6 +360,7 @@ struct PACKED log_MCU {
     float MCU_voltage;
     float MCU_voltage_min;
     float MCU_voltage_max;
+    uint16_t MCU_freq_mhz;
 };
 
 struct PACKED log_MAVLink_Command {
@@ -905,6 +906,7 @@ struct PACKED log_VER {
 // @Field: MVolt: Voltage
 // @Field: MVmin: Voltage min
 // @Field: MVmax: Voltage max
+// @Field: Freq: CPU clock frequency in MHz
 
 // @LoggerMessage: RAD
 // @Description: Telemetry radio statistics
@@ -1184,7 +1186,7 @@ LOG_STRUCTURE_FROM_PRECLAND \
     { LOG_POWR_MSG, sizeof(log_POWR), \
       "POWR","QffHHB","TimeUS,Vcc,VServo,Flags,AccFlags,Safety", "svv---", "F00---", true }, \
     { LOG_MCU_MSG, sizeof(log_MCU), \
-      "MCU","Qffff","TimeUS,MTemp,MVolt,MVmin,MVmax", "sOvvv", "F0000", true }, \
+      "MCU","QffffH","TimeUS,MTemp,MVolt,MVmin,MVmax,Freq", "sOvvv-", "F00000", true }, \
 LOG_STRUCTURE_FROM_MISSION \
     { LOG_MAVLINK_COMMAND_MSG, sizeof(log_MAVLink_Command), \
       "MAVC", "QBBBBBHffffiifBB","TimeUS,TS,TC,SS,SC,Fr,Cmd,P1,P2,P3,P4,X,Y,Z,Res,WL", "s---------------", "F---------------" }, \


### PR DESCRIPTION
### Summary

Adds a new LNX message, including cpu clock and temperature for linux targets.
Anything else we should add here?

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request
