### PR TITLE
Optimize uint64_div1000() on 64-bit

### DIFF
--- a/libraries/AP_Math/div1000.h
+++ b/libraries/AP_Math/div1000.h
@@ -1,3 +1,4 @@
+#pragma once
 #include <stdint.h>
 
 /*

--- a/libraries/AP_Math/div1000.h
+++ b/libraries/AP_Math/div1000.h
@@ -1,3 +1,5 @@
+#include <stdint.h>
+
 /*
   return 64 bit x / 1000
   faster than the normal gcc implementation using by about 3x

--- a/libraries/AP_Math/div1000.h
+++ b/libraries/AP_Math/div1000.h
@@ -3,12 +3,17 @@
 
 /*
   return 64 bit x / 1000
-  faster than the normal gcc implementation using by about 3x
-  With thanks to https://0x414b.com/2021/04/16/arm-division.html
-  and https://stackoverflow.com/questions/74765410/multiply-two-uint64-ts-and-store-result-to-uint64-t-doesnt-seem-to-work
 */
 static inline uint64_t uint64_div1000(uint64_t x)
 {
+#if defined(UINTPTR_MAX) && UINTPTR_MAX == UINT64_MAX
+    return x / 1000;
+#else
+    /*
+      faster than the normal gcc implementation using by about 3x
+      With thanks to https://0x414b.com/2021/04/16/arm-division.html
+      and https://stackoverflow.com/questions/74765410/multiply-two-uint64-ts-and-store-result-to-uint64-t-doesnt-seem-to-work
+    */
     x >>= 3U;
     uint64_t a_lo = (uint32_t)x;
     uint64_t a_hi = x >> 32;
@@ -26,4 +31,5 @@ static inline uint64_t uint64_div1000(uint64_t x)
     // 64-bit product + two 32-bit values
     uint64_t r = a_x_b_hi + (middle >> 32) + (b_x_a_mid >> 32);
     return r >> 4U;
+#endif
 }


### PR DESCRIPTION
### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer(also written)
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [X] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [X] Tested on hardware
- [ ] Logs attached__LP64__
- [ ] Logs available on request

### Description

Refactor the core of `uint64_div1000()` into an additional function, add tests, optimize it further on 64-bit platforms to speedup uint64_div1000. Roughly halves the instruction count on 64-bit targets. Cortex-A72 takes ~45% as long.

This may not be appropriate to upstream, as it switches out different implementations for 64-bit, and the main target of AP is 32-bit micros. I could probably also refactor the 32-bit path so that both routines can be unit-tested on 64-bit.

Saves ~256 bytes of codespace, but 64-bit targets don't really need it.