### PR TITLE
RC_Channel: defer aux initialization until backends exist

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -8198,6 +8198,85 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             minimum_duration=5,
         ).run()
 
+    def MountAuxFunctionAtBoot(self):
+        '''test a mount aux switch position is applied when the mount is initialised'''
+        # this is the defect which prompted the aux initialisation
+        # split: rc().init() runs the aux functions before the vehicle
+        # has created the mount backends, so the mount functions reach
+        # AP_Mount's null-instance early return and are lost.  a
+        # switch which was already in the retract position when the
+        # vehicle booted must retract the mount without the pilot
+        # having to move it.
+        self.setup_servo_mount()
+        # a pitch angle no other mount mode produces, and inside the
+        # pitch limits set below so that it is not constrained away
+        retract_pitch = -80
+        self.set_parameters({
+            "RC7_OPTION": 27,       # AUX_FUNC::RETRACT_MOUNT1
+            "RC7_REVERSED": 1,      # so that 1000us is the retract position
+            # ALLOW_SWITCH_REV (128) added to the ARMING_CHECK_THROTTLE
+            # (32) default rather than replacing it; this test does not
+            # arm, but a copy of this block in a test which does would
+            # silently lose the throttle check
+            "RC_OPTIONS": 160,
+            "MNT1_RETRACT_Y": retract_pitch,
+            "MNT1_PITCH_MIN": -90,
+            "MNT1_PITCH_MAX": 45,
+            "LOG_DISARMED": 1,      # the mount's first update is long before arming
+        })
+        # the retract position is 1000us on this reversed channel, which
+        # is also what SITL serves for channel 7 until the first RC
+        # datagram arrives (AP_RCProtocol_UDP::set_default_pwm_input_values()),
+        # so the switch reads the same either way; asking for a value
+        # SITL does not default to makes the boot read a race against
+        # that first datagram
+        self.set_rc(7, 1000)
+        self.context_collect('STATUSTEXT')
+        self.reboot_sitl()
+        self.delay_sim_time(5, reason="mount logging after boot")
+
+        # the mount is logged at 10Hz from the start of the main loop,
+        # so its first MNT message is the earliest state we can see
+        dfreader = self.dfreader_for_current_onboard_log()
+        samples = []
+        while len(samples) < 20:
+            m = dfreader.recv_match(type='MNT')
+            if m is None:
+                break
+            samples.append((m.TimeUS, m.Mode, m.Pitch))
+        if len(samples) == 0:
+            raise NotAchievedException("no MNT messages logged")
+        self.progress("MNT (TimeUS, Mode, Pitch): %s" % str(samples))
+
+        retract = mavutil.mavlink.MAV_MOUNT_MODE_RETRACT
+        first_retract = None
+        for (t, mode, pitch) in samples:
+            if mode == retract:
+                first_retract = t
+                break
+        if samples[0][1] != retract:
+            raise NotAchievedException(
+                "mount not retracted in its first logged sample: Mode=%u at TimeUS=%u, first RETRACT at %s" %
+                (samples[0][1], samples[0][0], str(first_retract)))
+
+        # the mode says the retract was selected; the logged pitch says
+        # it was applied.  MNT.Pitch is the servo mount's demanded
+        # angle, and retract does no stabilisation
+        # (AP_Mount_Servo::update_angle_outputs()), so it is
+        # MNT1_RETRACT_Y itself
+        if abs(samples[0][2] - retract_pitch) > 1:
+            raise NotAchievedException(
+                "mount at pitch %f, not the retract angle %f, in its first logged sample" %
+                (samples[0][2], retract_pitch))
+
+        # and it must be initialisation which retracted it, not the
+        # first debounced RC read a debounce interval later - read_aux()
+        # announces each function it runs
+        for m in self.context_collection('STATUSTEXT'):
+            if "RetractMount1" in m.text:
+                raise NotAchievedException(
+                    "switch applied by the debounced read, not by initialisation (%s)" % m.text)
+
     def MountPOIFromAuxFunction(self):
         '''test we can lock onto a lat/lng/alt with the flick of a switch'''
         self.install_terrain_handlers_context()
@@ -16368,6 +16447,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
              self.MAV_CMD_DO_GIMBAL_MANAGER_CONFIGURE,
              self.AutoYawDO_MOUNT_CONTROL,
              self.MountPOIFromAuxFunction,
+             self.MountAuxFunctionAtBoot,
              self.MAV_CMD_DO_SET_ROI_WPNEXT_OFFSET,
              self.Button,
              self.ShipTakeoff,

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -1422,6 +1422,105 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             wipe=False,
         )
 
+    def ICEngineStartChanMinAtBoot(self):
+        '''Test ICE_STARTCHN_MIN is applied to the boot switch position'''
+        rc_engine_start_chan = 11
+        self.setup_ICEngine_vehicle()
+
+        self.start_subtest("A reversed switch below the minimum must not start the engine")
+        # ICE_STARTCHN_MIN rejects PWM below it, but the switch
+        # position is not a function of PWM alone: a reversed channel
+        # with RC_OPTIONS bit 7 set reads a low PWM as HIGH.  the
+        # position the aux function is initialised with must be
+        # filtered the same way the RC path filters it.
+        self.set_parameters({
+            "ICE_STARTCHN_MIN": 1200,
+            "RC_OPTIONS": 1 << 7,     # ALLOW_SWITCH_REV
+            "RC11_REVERSED": 1,
+        })
+        self.set_rc(rc_engine_start_chan, 1000)
+        self.reboot_sitl()
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+        self.wait_rpm(1, 0, 0, minimum_duration=10, timeout=20)
+        self.disarm_vehicle(force=True)
+
+        self.start_subtest("A switch below the minimum must not permit a commanded start")
+        # and rejecting the initialisation is not enough on its own:
+        # AP_ICEngine::aux_pos defaults to MIDDLE, which permits a
+        # commanded start, so a rejected initialisation has to leave
+        # it at LOW
+        self.set_parameters({
+            "ICE_STARTCHN_MIN": 1300,
+            "RC_OPTIONS": 0,
+            "RC11_REVERSED": 0,
+        })
+        self.set_rc(rc_engine_start_chan, 1250)
+        self.reboot_sitl()
+        self.wait_ready_to_arm()
+        self.change_mode('MANUAL')
+        self.arm_vehicle()
+        self.context_collect('STATUSTEXT')
+        self.run_cmd(
+            mavutil.mavlink.MAV_CMD_DO_ENGINE_CONTROL,
+            p1=1,
+            want_result=mavutil.mavlink.MAV_RESULT_FAILED,
+        )
+        self.wait_statustext("start control disabled", check_context=True)
+        self.context_stop_collecting('STATUSTEXT')
+        self.wait_rpm(1, 0, 0, minimum_duration=1)
+        self.disarm_vehicle(force=True)
+
+        self.start_subtest("A switch above the minimum must start the engine from the boot position")
+        # the subtests above are negative assertions, so this is the
+        # control that the floor is not simply blocking everything.
+        #
+        # it is deliberately not a check that the *boot* position was
+        # read live, which cannot be asserted from here: the whole
+        # point of applying the same floor to both paths is that a
+        # defaulted boot position followed by the first debounced RC
+        # read reaches the same aux_pos as a live boot position, so no
+        # observable vehicle state distinguishes them.  The live path
+        # is pinned instead by RCChannel.AuxFunctionBootPosition in
+        # libraries/RC_Channel/tests/test_aux_boot_position.cpp.
+        self.set_parameters({
+            "ICE_STARTCHN_MIN": 1200,
+        })
+        self.set_rc(rc_engine_start_chan, 2000)
+        self.reboot_sitl()
+        self.wait_ready_to_arm()
+        self.context_collect('STATUSTEXT')
+        self.arm_vehicle()
+        self.wait_statustext("Starting engine", check_context=True)
+        self.context_stop_collecting('STATUSTEXT')
+        self.wait_rpm(1, 300, 400, minimum_duration=1)
+        # the floor has to come off before the switch can stop the
+        # engine again: rejecting a stop request from a PWM below it
+        # is what ICE_STARTCHN_MIN is for
+        self.set_parameter("ICE_STARTCHN_MIN", 0)
+        self.set_rc(rc_engine_start_chan, 1000)
+        self.wait_rpm(1, 0, 0, minimum_duration=1)
+        self.disarm_vehicle(force=True)
+        self.reboot_sitl()
+
+    def AuxFunctionBootRetry(self):
+        '''Test an aux function that declines at boot is retried'''
+        # AVOID_ADSB's handler declines while ADSB is not yet healthy,
+        # which at the end of AP_Vehicle::setup() it normally is not:
+        # AP_ADSB::init() is reached from a scheduled task that does
+        # not run until the main loop starts.  the boot dispatch must
+        # therefore not be recorded as applied, or the debounced read
+        # that would apply it once ADSB comes up never fires.
+        self.set_parameters({
+            "RC12_OPTION": 38,    # AUX_FUNC::AVOID_ADSB
+            "ADSB_TYPE": 1,
+            "AVD_ENABLE": 0,
+        })
+        self.set_rc(12, 2000)     # switch held HIGH across the reboot
+        self.reboot_sitl()
+        self.wait_ready_to_arm()
+        self.wait_parameter_value("AVD_ENABLE", 1, timeout=30)
+
     def ICEngine(self):
         '''Test ICE Engine support'''
         rc_engine_start_chan = 11
@@ -3826,6 +3925,8 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             self.Tailsitter,
             self.CopterTailsitter,
             self.ICEngine,
+            self.ICEngineStartChanMinAtBoot,
+            self.AuxFunctionBootRetry,
             self.ICEngineMission,
             self.ICEngineRPMGovernor,
             self.MAV_CMD_DO_ENGINE_CONTROL,

--- a/libraries/AP_ICEngine/AP_ICEngine.cpp
+++ b/libraries/AP_ICEngine/AP_ICEngine.cpp
@@ -283,10 +283,25 @@ void AP_ICEngine::param_conversion()
 // Handle incoming aux function
 void AP_ICEngine::do_aux_function(const RC_Channel::AuxFuncTrigger &trigger)
 {
-    // If triggered from RC apply start chan min
-    if (trigger.source == RC_Channel::AuxFuncTrigger::Source::RC) {
+    // apply the start channel minimum PWM to the initialisation
+    // dispatch as well as to RC.  the switch position is derived from
+    // the PWM but is not a function of it alone - a reversed channel
+    // with RC_OPTIONS bit 7 set reads a low PWM as HIGH - so a boot
+    // position which the RC path would have rejected can otherwise
+    // request an engine start
+    const bool source_is_rc = trigger.source == RC_Channel::AuxFuncTrigger::Source::RC;
+    if (source_is_rc || trigger.source == RC_Channel::AuxFuncTrigger::Source::INIT) {
         RC_Channel *chan = rc().channel(trigger.source_index);
         if ((chan != nullptr) && (chan->get_radio_in() < start_chan_min_pwm)) {
+            if (!source_is_rc) {
+                // aux_pos defaults to MIDDLE, which permits a
+                // commanded start; a rejected initialisation must
+                // leave it at the LOW that initialisation has always
+                // established, or a DO_ENGINE_CONTROL or mission
+                // engine start would be accepted where it was not
+                // before
+                aux_pos = RC_Channel::AuxSwitchPos::LOW;
+            }
             return;
         }
     }

--- a/libraries/AP_Vehicle/AP_Vehicle.cpp
+++ b/libraries/AP_Vehicle/AP_Vehicle.cpp
@@ -15,6 +15,7 @@
 #include <SRV_Channel/SRV_Channel.h>
 #include <AP_Motors/AP_Motors.h>
 #include <AR_Motors/AP_MotorsUGV.h>
+#include <RC_Channel/RC_Channel.h>
 #include <AP_CheckFirmware/AP_CheckFirmware.h>
 #include <GCS_MAVLink/GCS.h>
 #if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
@@ -442,10 +443,6 @@ void AP_Vehicle::setup()
     // init_ardupilot is where the vehicle does most of its initialisation.
     init_ardupilot();
 
-#if AP_SCRIPTING_ENABLED
-    scripting.init();
-#endif // AP_SCRIPTING_ENABLED
-
 #if AP_AIRSPEED_ENABLED
     airspeed.init();
     if (airspeed.enabled()) {
@@ -548,6 +545,23 @@ void AP_Vehicle::setup()
 #if AP_ARMING_ENABLED
     AP::arming().init();
 #endif
+
+    // auxiliary functions may depend on backends created during vehicle and
+    // library initialisation; the functions which gate the vehicle from boot
+    // have already been initialised in RC_Channels::init(). Not all
+    // AP_Vehicle subclasses have an RC_Channels singleton (e.g.
+    // Tools/Replay), so guard the call.
+#if AP_RC_CHANNEL_ENABLED
+    if (RC_Channels *rc_channels = RC_Channels::get_singleton()) {
+        rc_channels->init_aux();
+    }
+#endif // AP_RC_CHANNEL_ENABLED
+
+#if AP_SCRIPTING_ENABLED
+    // scripting can read aux function state (e.g. get_emergency_stop()),
+    // so must not start until aux initialisation above has completed
+    scripting.init();
+#endif // AP_SCRIPTING_ENABLED
 
     // invalidate count in case an enable parameter changed during
     // initialisation

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -1086,32 +1086,37 @@ void RC_Channel::do_aux_function_armdisarm(const AuxSwitchPos ch_flag)
 }
 
 #if AP_ADSB_AVOIDANCE_ENABLED
-void RC_Channel::do_aux_function_avoid_adsb(const AuxSwitchPos ch_flag)
+// returns false if the function could not be applied, so that the
+// caller can leave it to be retried.  ADSB health depends on runtime
+// discovery rather than on the backend merely existing, so this is
+// normally still declining at the end of AP_Vehicle::setup()
+bool RC_Channel::do_aux_function_avoid_adsb(const AuxSwitchPos ch_flag)
 {
     AP_Avoidance *avoidance = AP::ap_avoidance();
     if (avoidance == nullptr) {
-        return;
+        return false;
     }
     if (ch_flag == AuxSwitchPos::HIGH) {
         AP_ADSB *adsb = AP::ADSB();
         if (adsb == nullptr) {
-            return;
+            return false;
         }
         // try to enable AP_Avoidance
         if (!adsb->enabled() || !adsb->healthy()) {
             GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "ADSB not available");
-            return;
+            return false;
         }
         avoidance->enable();
         LOGGER_WRITE_EVENT(LogEvent::AVOIDANCE_ADSB_ENABLE);
         GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "ADSB Avoidance Enabled");
-        return;
+        return true;
     }
 
     // disable AP_Avoidance
     avoidance->disable();
     LOGGER_WRITE_EVENT(LogEvent::AVOIDANCE_ADSB_DISABLE);
     GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "ADSB Avoidance Disabled");
+    return true;
 }
 #endif  // AP_ADSB_AVOIDANCE_ENABLED
 
@@ -1472,6 +1477,26 @@ bool RC_Channel::run_aux_function(AUX_FUNC ch_option, AuxSwitchPos pos, AuxFuncT
 
     const bool ret = do_aux_function(trigger);
 
+    if (source == AuxFuncTrigger::Source::INIT &&
+        init_position_is_live &&
+        ret &&
+        ch_option == (AUX_FUNC)option.get()) {
+        // record the position the function was applied for, so that
+        // the first debounced read_aux() does not apply it again for
+        // a switch which has not moved.  the conditions above each
+        // mark an application that read is still owed: a defaulted
+        // position (the pilot's real one is not yet known), a
+        // function which is no longer the
+        // channel's (switch_state is per-channel, not per-function,
+        // so recording would suppress the only thing that would ever
+        // apply the replacement), and a handler reporting that it
+        // could not apply the function, so that it is retried - only
+        // handlers propagating a real result discriminate there, the
+        // rest returning true for any recognised function.
+        switch_state.current_position = (int8_t)pos;
+        switch_state.debounce_position = (int8_t)pos;
+    }
+
 #if HAL_LOGGING_ENABLED
     // @LoggerMessage: AUXF
     // @Description: Auxiliary function invocation information
@@ -1571,8 +1596,7 @@ bool RC_Channel::do_aux_function(const AuxFuncTrigger &trigger)
 
 #if AP_ADSB_AVOIDANCE_ENABLED
     case AUX_FUNC::AVOID_ADSB:
-        do_aux_function_avoid_adsb(ch_flag);
-        break;
+        return do_aux_function_avoid_adsb(ch_flag);
 #endif  // AP_ADSB_AVOIDANCE_ENABLED
 
     case AUX_FUNC::FFT_NOTCH_TUNE:
@@ -2048,14 +2072,119 @@ bool RC_Channel::do_aux_function(const AuxFuncTrigger &trigger)
     return true;
 }
 
-void RC_Channel::init_aux()
+// returns true if the auxiliary function must be initialised in
+// RC_Channels::init(), before the vehicle and library backends have
+// been created.  These functions have no backend dependency of their
+// own, and deferring them would change behaviour: ARM_EMERGENCY_STOP
+// and RC_OVERRIDE_ENABLE establish their gate from the LOW position
+// this early phase applies, and nothing re-establishes it afterwards,
+// so the vehicle would be ungated for the whole of startup.
+// MOTOR_ESTOP gates on HIGH rather than LOW and so establishes
+// nothing at boot, where the switch is not yet readable; it is kept
+// here to leave it byte-identical to master rather than to move it
+// into the late phase's live read.  Everything else is initialised
+// late, once the backend its handler needs exists.  No
+// vehicle-specific auxiliary function currently needs early
+// initialisation, but this is virtual so that a vehicle subclass can
+// classify one of its own without editing the base class.
+bool RC_Channel::init_aux_function_early(AUX_FUNC func) const
 {
-    AuxSwitchPos position;
-    if (!read_3pos_switch(position)) {
-        position = AuxSwitchPos::LOW;
+    switch (func) {
+#if AP_ARMING_ENABLED
+    case AUX_FUNC::ARM_EMERGENCY_STOP:
+#endif
+    case AUX_FUNC::MOTOR_ESTOP:
+    case AUX_FUNC::RC_OVERRIDE_ENABLE:
+        return true;
+    default:
+        return false;
+    }
+}
+
+// returns the switch position an auxiliary function should be
+// initialised with.  position_is_live is set true only if the
+// position returned was read from the channel rather than defaulted.
+RC_Channel::AuxSwitchPos RC_Channel::initial_aux_switch_position(AUX_FUNC func, bool &position_is_live)
+{
+    position_is_live = false;
+
+    // functions such as ARM_EMERGENCY_STOP must not be triggered by
+    // whatever position the switch happens to be in the first time we
+    // read it (e.g. the pilot's transmitter was left with the arm
+    // switch high); default those to a safe position rather than
+    // acting on a possibly-live read here.  The scheduled read_aux()
+    // path is responsible for picking up the pilot's actual switch
+    // position once it has been safely observed.
+    AuxSwitchPos position = AuxSwitchPos::LOW;
+    if (!init_position_on_first_radio_read(func)) {
+        position_is_live = read_3pos_switch(position);
+        if (!position_is_live) {
+            position = AuxSwitchPos::LOW;
+        }
     }
 
-    init_aux_function((AUX_FUNC)option.get(), position);
+    return position;
+}
+
+// set while init_aux_function_at_boot() is initialising a function
+// from a switch position which was really read rather than defaulted.
+// initialisation is sequential and single-threaded, so a single flag
+// serves every channel and costs no per-channel storage.
+bool RC_Channel::init_position_is_live;
+
+// initialise a single auxiliary function; common to both
+// initialisation phases
+void RC_Channel::init_aux_function_at_boot(const AUX_FUNC func)
+{
+    bool position_is_live;
+    const AuxSwitchPos position = initial_aux_switch_position(func, position_is_live);
+
+    // init_aux_function() deliberately applies only some of the
+    // functions, leaving the rest to the first debounced read_aux().
+    // the initial position is therefore recorded by
+    // run_aux_function(), which is reached only for the functions
+    // which really were applied; recording it here would suppress
+    // that first read for all of the others.  see the comment there.
+    init_position_is_live = position_is_live;
+    init_aux_function(func, position);
+    init_position_is_live = false;
+}
+
+// initialise the auxiliary functions which must be gated from boot;
+// called from RC_Channels::init()
+void RC_Channel::init_aux_early()
+{
+    // latch the function for both phases.  MAVLink is serviced between
+    // them by AP_Vehicle::scheduler_delay_callback(), so re-reading
+    // option in the second phase would let a mid-boot PARAM_SET slip
+    // through the partition: changing an RCx_OPTION from a late
+    // function to an early one in that window would have the early
+    // phase skip the old value and the late phase skip the new one,
+    // leaving the channel initialised not at all.
+    init_aux_func = (AUX_FUNC)option.get();
+
+    if (!init_aux_function_early(init_aux_func)) {
+        // initialised later, once the backends exist
+        return;
+    }
+
+    init_aux_function_at_boot(init_aux_func);
+}
+
+// initialise the auxiliary functions which depend on backends created
+// during vehicle and library initialisation; called from
+// AP_Vehicle::setup()
+void RC_Channel::init_aux()
+{
+    // the function latched by init_aux_early(), not a fresh read of
+    // option; see the comment there
+    const AUX_FUNC func = init_aux_func;
+    if (init_aux_function_early(func)) {
+        // already initialised in RC_Channels::init()
+        return;
+    }
+
+    init_aux_function_at_boot(func);
 }
 
 // read_3pos_switch

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -127,6 +127,7 @@ public:
     AP_Int16    option; // e.g. activate EPM gripper / enable fence
 
     // auxiliary switch support
+    void init_aux_early();
     void init_aux();
     bool read_aux();
 
@@ -496,11 +497,18 @@ protected:
 
     __INITFUNC__ virtual void init_aux_function(AUX_FUNC ch_option, AuxSwitchPos);
 
+    // returns true if the auxiliary function must be initialised
+    // before the vehicle and library backends have been created; the
+    // definition in RC_Channel.cpp carries the rationale and the
+    // current set.  virtual so that a vehicle subclass can classify
+    // its own auxiliary functions as early.
+    virtual bool init_aux_function_early(AUX_FUNC func) const;
+
     // virtual function to be overridden my subclasses
     virtual bool do_aux_function(const AuxFuncTrigger &trigger);
 
     void do_aux_function_armdisarm(const AuxSwitchPos ch_flag);
-    void do_aux_function_avoid_adsb(const AuxSwitchPos ch_flag);
+    bool do_aux_function_avoid_adsb(const AuxSwitchPos ch_flag);
     void do_aux_function_avoid_proximity(const AuxSwitchPos ch_flag);
     void do_aux_function_camera_trigger(const AuxSwitchPos ch_flag);
     bool do_aux_function_record_video(const AuxSwitchPos ch_flag);
@@ -587,6 +595,27 @@ private:
     // switch high!
     bool init_position_on_first_radio_read(AUX_FUNC func) const;
 
+    // the auxiliary function to initialise, latched by init_aux_early()
+    // and reused by init_aux().  MAVLink is serviced between the two
+    // phases by AP_Vehicle::scheduler_delay_callback(), so re-reading
+    // option in the second phase would let a PARAM_SET slip through the
+    // partition; see RC_Channel::init_aux_early().
+    AUX_FUNC init_aux_func;
+
+    // returns the switch position an auxiliary function should be
+    // initialised with; position_is_live is set true only if that
+    // position was read from the channel rather than defaulted
+    AuxSwitchPos initial_aux_switch_position(AUX_FUNC func, bool &position_is_live);
+
+    // initialise a single auxiliary function; common to both
+    // initialisation phases
+    void init_aux_function_at_boot(AUX_FUNC func);
+
+    // true while init_aux_function_at_boot() is initialising a
+    // function from a position which was really read rather than
+    // defaulted; consumed by run_aux_function()
+    static bool init_position_is_live;
+
 #if AP_RC_CHANNEL_AUX_FUNCTION_STRINGS_ENABLED
     // Structure to lookup switch change announcements
     struct LookupTable{
@@ -610,6 +639,10 @@ public:
     RC_Channels(void);
 
     __INITFUNC__ void init(void);
+
+    // initialise the configured auxiliary functions which depend on
+    // backends created during vehicle and library initialisation
+    void init_aux();
 
     // get singleton instance
     static RC_Channels *get_singleton() {
@@ -647,7 +680,6 @@ public:
     bool duplicate_options_exist();
     void convert_options(const RC_Channel::AUX_FUNC old_option, const RC_Channel::AUX_FUNC new_option);
 
-    void init_aux_all();
     void read_aux_all();
 
     // mode switch handling
@@ -792,6 +824,10 @@ protected:
     bool throttle_moved_since_override_start() const;
 
 private:
+    // initialise the configured auxiliary functions which must be
+    // gated from boot; see RC_Channel::init_aux_function_early()
+    void init_aux_early();
+
     static RC_Channels *_singleton;
     // this static arrangement is to avoid static pointers in AP_Param tables
     static RC_Channel *channels;

--- a/libraries/RC_Channel/RC_Channels.cpp
+++ b/libraries/RC_Channel/RC_Channels.cpp
@@ -59,7 +59,31 @@ void RC_Channels::init(void)
         channel(i)->ch_in = i;
     }
 
-    init_aux_all();
+    init_aux_early();
+
+    reset_mode_switch();
+}
+
+void RC_Channels::init_aux_early()
+{
+    for (uint8_t i=0; i<NUM_RC_CHANNELS; i++) {
+        RC_Channel *c = channel(i);
+        if (c == nullptr) {
+            continue;
+        }
+        c->init_aux_early();
+    }
+}
+
+void RC_Channels::init_aux()
+{
+    for (uint8_t i=0; i<NUM_RC_CHANNELS; i++) {
+        RC_Channel *c = channel(i);
+        if (c == nullptr) {
+            continue;
+        }
+        c->init_aux();
+    }
 }
 
 bool RC_Channels::has_valid_input() const
@@ -237,18 +261,6 @@ void RC_Channels::read_aux_all()
         AP::logger().Write_RCIN();
     }
 #endif
-}
-
-void RC_Channels::init_aux_all()
-{
-    for (uint8_t i=0; i<NUM_RC_CHANNELS; i++) {
-        RC_Channel *c = channel(i);
-        if (c == nullptr) {
-            continue;
-        }
-        c->init_aux();
-    }
-    reset_mode_switch();
 }
 
 //

--- a/libraries/RC_Channel/tests/test_aux_boot_position.cpp
+++ b/libraries/RC_Channel/tests/test_aux_boot_position.cpp
@@ -1,0 +1,268 @@
+// covers what RC_Channel does with the switch position an auxiliary
+// function is initialised from.  unlike test_aux_initialisation.cpp,
+// which mocks init_aux_function() to observe the phase split, this
+// exercises the real RC_Channel::init_aux_function() and the real
+// debounce path, because what is under test is precisely the
+// interaction between the two: a function applied at boot must not be
+// applied a second time by the first debounced read, and a function
+// which was *not* applied at boot must still be applied by it.
+
+#include <AP_gtest.h>
+#include <AP_HAL/AP_HAL.h>
+#include <RC_Channel/RC_Channel.h>
+#include <AP_Logger/AP_Logger.h>
+
+const AP_HAL::HAL& hal = AP_HAL::get_HAL();
+
+class RC_Channel_Test : public RC_Channel
+{
+public:
+    // run_aux_function() dispatches through do_aux_function(), so
+    // counting there counts every application of the function,
+    // whether it came from initialisation or from a debounced read
+    uint8_t dispatches;
+    AuxSwitchPos last_pos;
+    AUX_FUNC last_func;
+    AuxFuncTrigger::Source last_source;
+    // what do_aux_function() reports back; a handler which could not
+    // apply the function returns false
+    bool dispatch_succeeds;
+
+    RC_Channel_Test() :
+        dispatches(0),
+        last_pos(AuxSwitchPos::LOW),
+        last_func(AUX_FUNC::DO_NOTHING),
+        last_source(AuxFuncTrigger::Source::INIT),
+        dispatch_succeeds(true)
+    {
+    }
+
+protected:
+    bool do_aux_function(const AuxFuncTrigger &trigger) override
+    {
+        dispatches++;
+        last_pos = trigger.pos;
+        last_func = trigger.func;
+        last_source = trigger.source;
+        return dispatch_succeeds;
+    }
+};
+
+class RC_Channels_Test : public RC_Channels
+{
+public:
+    RC_Channel_Test obj_channels[NUM_RC_CHANNELS];
+
+    RC_Channel_Test *channel(const uint8_t chan) override
+    {
+        if (chan >= NUM_RC_CHANNELS) {
+            return nullptr;
+        }
+        return &obj_channels[chan];
+    }
+
+    const RC_Channel_Test *channel(const uint8_t chan) const override
+    {
+        if (chan >= NUM_RC_CHANNELS) {
+            return nullptr;
+        }
+        return &obj_channels[chan];
+    }
+
+protected:
+    int8_t flight_mode_channel_number() const override
+    {
+        return 5;
+    }
+};
+
+#define RC_CHANNELS_SUBCLASS RC_Channels_Test
+#define RC_CHANNEL_SUBCLASS RC_Channel_Test
+
+#include <RC_Channel/RC_Channels_VarInfo.h>
+
+// run_aux_function() logs the invocation.  file scope rather than
+// automatic storage: AP_Logger::Write() walks backends[0.._next_backend),
+// and an AP_Logger on the stack has an indeterminate _next_backend.
+// zero-initialised in BSS it has no backends and the write is a no-op.
+static AP_Logger logger;
+
+// RC_Channels is a singleton and panics if a second instance is
+// constructed, so the tests in this file share one file-scope
+// instance rather than each declaring their own
+static RC_Channels_Test rc_channels;
+
+// step past the switch debounce window, calling read_aux() as the
+// scheduled RC_Channels::read_aux() would
+static void read_aux_through_debounce(RC_Channel_Test *c)
+{
+    for (uint8_t i=0; i<5; i++) {
+        c->read_aux();
+        hal.scheduler->delay(60);
+    }
+}
+
+TEST(RCChannel, AuxFunctionBootPosition)
+{
+    for (uint8_t i=0; i<NUM_RC_CHANNELS; i++) {
+        rc_channels.channel(i)->set_radio_in(0);
+    }
+
+    // AHRS_TYPE is one of the functions RC_Channel::init_aux_function()
+    // applies explicitly.  the switch is readable here, which is what
+    // the deferred late phase can now find on Plane, where
+    // failsafe_check() reads RC while the main loop is stalled
+    // through setup().  the functions used in this file are ones with
+    // no entry in RC_Channel's aux-function name table, so that
+    // read_aux() does not announce them: there is no GCS singleton
+    // here to announce them to
+    RC_Channel_Test *applied = rc_channels.channel(8);
+    applied->option.set(int16_t(RC_Channel::AUX_FUNC::AHRS_TYPE));
+    applied->set_radio_in(1900);
+
+    // EKF_SOURCE_SET is in the group init_aux_function() deliberately
+    // does not apply, precisely so that the first debounced read_aux()
+    // applies it
+    RC_Channel_Test *not_applied = rc_channels.channel(9);
+    not_applied->option.set(int16_t(RC_Channel::AUX_FUNC::EKF_SOURCE_SET));
+    not_applied->set_radio_in(1900);
+
+    // a third switch is moved between initialisation and the first
+    // read, which must still be picked up
+    RC_Channel_Test *moved = rc_channels.channel(10);
+    moved->option.set(int16_t(RC_Channel::AUX_FUNC::AHRS_TYPE));
+    moved->set_radio_in(1900);
+
+    rc_channels.init();
+    rc_channels.init_aux();
+
+    EXPECT_EQ(1, applied->dispatches);
+    EXPECT_EQ(RC_Channel::AuxSwitchPos::HIGH, applied->last_pos);
+    EXPECT_EQ(RC_Channel::AuxFuncTrigger::Source::INIT, applied->last_source);
+
+    EXPECT_EQ(0, not_applied->dispatches);
+
+    // a function applied from a live boot position is not applied a
+    // second time by the first debounced read of a switch which has
+    // not moved
+    read_aux_through_debounce(applied);
+    EXPECT_EQ(1, applied->dispatches);
+
+    // whereas a function which initialisation did not apply is still
+    // applied by that read
+    read_aux_through_debounce(not_applied);
+    EXPECT_EQ(1, not_applied->dispatches);
+    EXPECT_EQ(RC_Channel::AuxSwitchPos::HIGH, not_applied->last_pos);
+    EXPECT_EQ(RC_Channel::AuxFuncTrigger::Source::RC, not_applied->last_source);
+
+    // and recording the boot position does not swallow a genuine
+    // change: this switch was HIGH at initialisation and is LOW by the
+    // time it is read
+    EXPECT_EQ(1, moved->dispatches);
+    moved->set_radio_in(1000);
+    read_aux_through_debounce(moved);
+    EXPECT_EQ(2, moved->dispatches);
+    EXPECT_EQ(RC_Channel::AuxSwitchPos::LOW, moved->last_pos);
+    EXPECT_EQ(RC_Channel::AuxFuncTrigger::Source::RC, moved->last_source);
+}
+
+// the same two functions, but with the switch unreadable at
+// initialisation - the usual case, and the only one on vehicles whose
+// timer failsafe does not read RC.  the boot position is defaulted
+// rather than read, so it must not be recorded: the pilot's real
+// position has to be acted upon once RC comes up.
+TEST(RCChannel, AuxFunctionDefaultedBootPosition)
+{
+    RC_Channel_Test *applied = rc_channels.channel(11);
+    applied->option.set(int16_t(RC_Channel::AUX_FUNC::AHRS_TYPE));
+    applied->set_radio_in(0);  // unreadable
+
+    applied->init_aux_early();
+    applied->init_aux();
+
+    // initialised, from the defaulted LOW position
+    EXPECT_EQ(1, applied->dispatches);
+    EXPECT_EQ(RC_Channel::AuxSwitchPos::LOW, applied->last_pos);
+
+    // RC comes up with the switch HIGH; the defaulted position was not
+    // recorded, so this is seen as a change and applied
+    applied->set_radio_in(1900);
+    read_aux_through_debounce(applied);
+    EXPECT_EQ(2, applied->dispatches);
+    EXPECT_EQ(RC_Channel::AuxSwitchPos::HIGH, applied->last_pos);
+    EXPECT_EQ(RC_Channel::AuxFuncTrigger::Source::RC, applied->last_source);
+
+    // and the case that distinguishes a defaulted position from a
+    // read one: RC comes up with the switch in the same LOW position
+    // that initialisation defaulted to.  the function is applied
+    // again, because that first application was against a position
+    // nobody had actually read.  recording defaulted positions would
+    // swallow this
+    RC_Channel_Test *unread_then_low = rc_channels.channel(12);
+    unread_then_low->option.set(int16_t(RC_Channel::AUX_FUNC::AHRS_TYPE));
+    unread_then_low->set_radio_in(0);
+
+    unread_then_low->init_aux_early();
+    unread_then_low->init_aux();
+    EXPECT_EQ(1, unread_then_low->dispatches);
+    EXPECT_EQ(RC_Channel::AuxSwitchPos::LOW, unread_then_low->last_pos);
+
+    unread_then_low->set_radio_in(1000);
+    read_aux_through_debounce(unread_then_low);
+    EXPECT_EQ(2, unread_then_low->dispatches);
+    EXPECT_EQ(RC_Channel::AuxSwitchPos::LOW, unread_then_low->last_pos);
+    EXPECT_EQ(RC_Channel::AuxFuncTrigger::Source::RC, unread_then_low->last_source);
+}
+
+// three cases where the first debounced read is still owed an
+// application, so the boot position must not be recorded even though
+// it was read live and the function was one initialisation applies
+TEST(RCChannel, AuxFunctionBootPositionNotRecorded)
+{
+    // the channel's function is changed by a GCS between the two
+    // initialisation phases.  init_aux_early() latches the function
+    // for both phases deliberately, so the late phase applies the
+    // latched one - but switch_state is per-channel, not
+    // per-function, so recording its position would suppress the read
+    // which is the only thing that will ever apply the replacement
+    RC_Channel_Test *option_changed = rc_channels.channel(13);
+    option_changed->option.set(int16_t(RC_Channel::AUX_FUNC::AHRS_TYPE));
+    option_changed->set_radio_in(1900);
+
+    option_changed->init_aux_early();
+    // MAVLink is serviced between the phases by
+    // AP_Vehicle::scheduler_delay_callback(), so a PARAM_SET can land
+    // here
+    option_changed->option.set(int16_t(RC_Channel::AUX_FUNC::EKF_SOURCE_SET));
+    option_changed->init_aux();
+
+    // the latched function was applied, as the latch intends
+    EXPECT_EQ(1, option_changed->dispatches);
+    EXPECT_EQ(RC_Channel::AUX_FUNC::AHRS_TYPE, option_changed->last_func);
+
+    // and the channel's new function is still applied by the first
+    // debounced read
+    read_aux_through_debounce(option_changed);
+    EXPECT_EQ(2, option_changed->dispatches);
+    EXPECT_EQ(RC_Channel::AUX_FUNC::EKF_SOURCE_SET, option_changed->last_func);
+    EXPECT_EQ(RC_Channel::AuxFuncTrigger::Source::RC, option_changed->last_source);
+
+    // a handler which could not apply the function at boot - e.g. a
+    // MAVLink camera which has not finished discovery - is retried by
+    // the first debounced read rather than left unapplied
+    RC_Channel_Test *dispatch_failed = rc_channels.channel(14);
+    dispatch_failed->option.set(int16_t(RC_Channel::AUX_FUNC::AHRS_TYPE));
+    dispatch_failed->set_radio_in(1900);
+    dispatch_failed->dispatch_succeeds = false;
+
+    dispatch_failed->init_aux_early();
+    dispatch_failed->init_aux();
+    EXPECT_EQ(1, dispatch_failed->dispatches);
+
+    dispatch_failed->dispatch_succeeds = true;
+    read_aux_through_debounce(dispatch_failed);
+    EXPECT_EQ(2, dispatch_failed->dispatches);
+    EXPECT_EQ(RC_Channel::AuxFuncTrigger::Source::RC, dispatch_failed->last_source);
+}
+
+AP_GTEST_MAIN()

--- a/libraries/RC_Channel/tests/test_aux_early_gating.cpp
+++ b/libraries/RC_Channel/tests/test_aux_early_gating.cpp
@@ -1,0 +1,97 @@
+// pins the property the early-initialisation allowlist exists for:
+// that RC_Channels::init() alone - before any backend exists, and
+// before the deferred RC_Channels::init_aux() runs - leaves the
+// vehicle gated.  Nothing here is mocked: the other two test files
+// override init_aux_function() and do_aux_function() respectively to
+// observe dispatch, which means neither of them would notice a
+// function being moved out of init_aux_function_early() and the gate
+// silently not being established.
+
+#include <AP_gtest.h>
+#include <AP_HAL/AP_HAL.h>
+#include <RC_Channel/RC_Channel.h>
+#include <SRV_Channel/SRV_Channel.h>
+#include <AP_Logger/AP_Logger.h>
+
+const AP_HAL::HAL& hal = AP_HAL::get_HAL();
+
+class RC_Channel_Test : public RC_Channel
+{
+};
+
+class RC_Channels_Test : public RC_Channels
+{
+public:
+    RC_Channel_Test obj_channels[NUM_RC_CHANNELS];
+
+    RC_Channel_Test *channel(const uint8_t chan) override
+    {
+        if (chan >= NUM_RC_CHANNELS) {
+            return nullptr;
+        }
+        return &obj_channels[chan];
+    }
+
+    const RC_Channel_Test *channel(const uint8_t chan) const override
+    {
+        if (chan >= NUM_RC_CHANNELS) {
+            return nullptr;
+        }
+        return &obj_channels[chan];
+    }
+
+protected:
+    int8_t flight_mode_channel_number() const override
+    {
+        return 5;
+    }
+};
+
+#define RC_CHANNELS_SUBCLASS RC_Channels_Test
+#define RC_CHANNEL_SUBCLASS RC_Channel_Test
+
+#include <RC_Channel/RC_Channels_VarInfo.h>
+
+// run_aux_function() logs the invocation; file scope so that it is
+// zero-initialised and Write() finds no backends to walk
+static AP_Logger logger;
+
+static RC_Channels_Test rc_channels;
+
+TEST(RCChannel, AuxFunctionEarlyGating)
+{
+    for (uint8_t i=0; i<NUM_RC_CHANNELS; i++) {
+        rc_channels.channel(i)->set_radio_in(0);
+    }
+
+    // a transmitter left with the arm switch physically HIGH at boot
+    RC_Channel_Test *arm_estop = rc_channels.channel(3);
+    arm_estop->option.set(int16_t(RC_Channel::AUX_FUNC::ARM_EMERGENCY_STOP));
+    arm_estop->set_radio_in(1900);
+
+    // RC is not readable this early on any vehicle, which is the
+    // position this function's gate is established from
+    RC_Channel_Test *rc_override = rc_channels.channel(7);
+    rc_override->option.set(int16_t(RC_Channel::AUX_FUNC::RC_OVERRIDE_ENABLE));
+
+    // SRV_Channels::emergency_stop is a zero-init static and
+    // _gcs_overrides_enabled defaults true, so neither is gated until
+    // the aux function establishes it
+    EXPECT_FALSE(SRV_Channels::get_emergency_stop());
+    EXPECT_TRUE(rc_channels.gcs_overrides_enabled());
+
+    // RC_Channels::init() only.  RC_Channels::init_aux() is
+    // deliberately not called: these functions must be gated by the
+    // end of this call, not by the end of AP_Vehicle::setup()
+    rc_channels.init();
+
+    // engaged despite the switch being physically HIGH: the pilot's
+    // real position is picked up later, by the debounced,
+    // first-read-guarded read_aux() path
+    EXPECT_TRUE(SRV_Channels::get_emergency_stop());
+
+    // GCS RC overrides are gated for a user who put them behind a switch
+    EXPECT_FALSE(rc_channels.gcs_overrides_enabled());
+}
+
+AP_GTEST_MAIN()

--- a/libraries/RC_Channel/tests/test_aux_initialisation.cpp
+++ b/libraries/RC_Channel/tests/test_aux_initialisation.cpp
@@ -1,0 +1,221 @@
+#include <AP_gtest.h>
+#include <AP_HAL/AP_HAL.h>
+#include <RC_Channel/RC_Channel.h>
+
+const AP_HAL::HAL& hal = AP_HAL::get_HAL();
+
+class RC_Channel_Test : public RC_Channel
+{
+public:
+    // each test channel carries a single RCx_OPTION, so recording the
+    // most recent initialisation is enough to describe it
+    uint8_t init_count;
+    AUX_FUNC init_func;
+    AuxSwitchPos init_position;
+
+    RC_Channel_Test() :
+        init_count(0),
+        init_func(AUX_FUNC::DO_NOTHING),
+        init_position(AuxSwitchPos::LOW)
+    {
+    }
+
+protected:
+    // a vehicle subclass classifying one of its own functions as
+    // early, in the way a vehicle would: by delegating to the base
+    // list rather than re-enumerating it.  no vehicle needs this
+    // today, which is why it is exercised here
+    bool init_aux_function_early(const AUX_FUNC func) const override
+    {
+        if (func == AUX_FUNC::MISSION_RESET) {
+            return true;
+        }
+        return RC_Channel::init_aux_function_early(func);
+    }
+
+    void init_aux_function(const AUX_FUNC ch_option, const AuxSwitchPos ch_flag) override
+    {
+        init_count++;
+        init_func = ch_option;
+        init_position = ch_flag;
+    }
+};
+
+class RC_Channels_Test : public RC_Channels
+{
+public:
+    RC_Channel_Test obj_channels[NUM_RC_CHANNELS];
+
+    RC_Channel_Test *channel(const uint8_t chan) override
+    {
+        if (chan >= NUM_RC_CHANNELS) {
+            return nullptr;
+        }
+        return &obj_channels[chan];
+    }
+
+    const RC_Channel_Test *channel(const uint8_t chan) const override
+    {
+        if (chan >= NUM_RC_CHANNELS) {
+            return nullptr;
+        }
+        return &obj_channels[chan];
+    }
+
+protected:
+    int8_t flight_mode_channel_number() const override
+    {
+        return 5;
+    }
+};
+
+#define RC_CHANNELS_SUBCLASS RC_Channels_Test
+#define RC_CHANNEL_SUBCLASS RC_Channel_Test
+
+#include <RC_Channel/RC_Channels_VarInfo.h>
+
+// RC_Channels is a singleton (it panics if a second instance is
+// constructed while one already exists, and nothing clears the
+// singleton pointer on destruction), so all scenarios needing an
+// RC_Channels_Test instance share this single test body rather than
+// each getting their own local instance.
+TEST(RCChannel, AuxFunctionInitialisationPhases)
+{
+    RC_Channels_Test rc_channels;
+
+    // channel index 4 is reserved by
+    // RC_Channels_Test::flight_mode_channel_number() (returning the
+    // 1-indexed channel number 5) via channel(num - 1); the remaining
+    // indices used here are arbitrary.
+
+    // RC_Channel does not zero radio_in and rc_channels here is
+    // automatic storage, so seed every channel rather than leaving the
+    // ones this test does not configure to be read indeterminate: both
+    // initialisation phases sweep all NUM_RC_CHANNELS channels, and
+    // reset_mode_switch() reads the flight-mode channel.  0 is below
+    // RC_MIN_LIMIT_PWM, so it makes those reads fail deterministically.
+    for (uint8_t i=0; i<NUM_RC_CHANNELS; i++) {
+        rc_channels.channel(i)->set_radio_in(0);
+    }
+
+    // MOTOR_ESTOP gates the outputs from boot and has no backend
+    // dependency, so it is initialised early, from the live switch.
+    RC_Channel_Test *motor_estop_channel = rc_channels.channel(6);
+    motor_estop_channel->option.set(int16_t(RC_Channel::AUX_FUNC::MOTOR_ESTOP));
+    motor_estop_channel->set_radio_in(1900);
+
+    // ARM_EMERGENCY_STOP is initialised early too, so that
+    // emergency-stop is engaged for the whole of startup.
+    RC_Channel_Test *arm_estop_channel = rc_channels.channel(3);
+    arm_estop_channel->option.set(int16_t(RC_Channel::AUX_FUNC::ARM_EMERGENCY_STOP));
+    arm_estop_channel->set_radio_in(1900);  // switch physically HIGH at boot
+
+    // RC_OVERRIDE_ENABLE gates GCS overrides from boot.
+    RC_Channel_Test *rc_override_channel = rc_channels.channel(7);
+    rc_override_channel->option.set(int16_t(RC_Channel::AUX_FUNC::RC_OVERRIDE_ENABLE));
+    rc_override_channel->set_radio_in(1900);
+
+    // FENCE acts on a backend created during vehicle initialisation,
+    // so it must not be initialised until that backend exists.
+    RC_Channel_Test *fence_channel = rc_channels.channel(8);
+    fence_channel->option.set(int16_t(RC_Channel::AUX_FUNC::FENCE));
+    fence_channel->set_radio_in(1900);
+
+    // a second late function, but with RC not readable, which is the
+    // usual state at RC_Channels::init(); its switch position is
+    // defaulted rather than read
+    RC_Channel_Test *unreadable_channel = rc_channels.channel(10);
+    unreadable_channel->option.set(int16_t(RC_Channel::AUX_FUNC::FENCE));
+
+    // a function the subclass has classified as early, which the base
+    // class classifies as late
+    RC_Channel_Test *subclass_early_channel = rc_channels.channel(11);
+    subclass_early_channel->option.set(int16_t(RC_Channel::AUX_FUNC::MISSION_RESET));
+    subclass_early_channel->set_radio_in(1900);
+
+    rc_channels.init();
+
+    // the subclass's own early function is initialised by the early
+    // phase, without the subclass having had to re-enumerate the base
+    // list to get there
+    EXPECT_EQ(1, subclass_early_channel->init_count);
+    EXPECT_EQ(RC_Channel::AUX_FUNC::MISSION_RESET, subclass_early_channel->init_func);
+    EXPECT_EQ(RC_Channel::AuxSwitchPos::HIGH, subclass_early_channel->init_position);
+
+    // MOTOR_ESTOP is safe to initialise against the live switch position.
+    EXPECT_EQ(1, motor_estop_channel->init_count);
+    EXPECT_EQ(RC_Channel::AUX_FUNC::MOTOR_ESTOP, motor_estop_channel->init_func);
+    EXPECT_EQ(RC_Channel::AuxSwitchPos::HIGH, motor_estop_channel->init_position);
+
+    // ARM_EMERGENCY_STOP must never be initialised against a live
+    // switch position: a transmitter left with the switch physically
+    // HIGH at boot must not clear emergency-stop / request arming
+    // during init. It is still initialised (to the safe LOW /
+    // e-stop-engaged position); the pilot's actual switch position is
+    // picked up later via the debounced, first-read-guarded read_aux()
+    // path.
+    EXPECT_EQ(1, arm_estop_channel->init_count);
+    EXPECT_EQ(RC_Channel::AUX_FUNC::ARM_EMERGENCY_STOP, arm_estop_channel->init_func);
+    EXPECT_EQ(RC_Channel::AuxSwitchPos::LOW, arm_estop_channel->init_position);
+
+    EXPECT_EQ(1, rc_override_channel->init_count);
+    EXPECT_EQ(RC_Channel::AUX_FUNC::RC_OVERRIDE_ENABLE, rc_override_channel->init_func);
+    EXPECT_EQ(RC_Channel::AuxSwitchPos::HIGH, rc_override_channel->init_position);
+
+    // the backend-dependent function has not been initialised yet
+    EXPECT_EQ(0, fence_channel->init_count);
+
+    rc_channels.init_aux();
+
+    // the backend-dependent function is initialised now that the
+    // backends exist
+    EXPECT_EQ(1, fence_channel->init_count);
+    EXPECT_EQ(RC_Channel::AUX_FUNC::FENCE, fence_channel->init_func);
+    EXPECT_EQ(RC_Channel::AuxSwitchPos::HIGH, fence_channel->init_position);
+
+    // a late function whose switch could not be read is still
+    // initialised, to the defaulted LOW position; the pilot's real
+    // position is picked up by read_aux() once RC becomes readable
+    EXPECT_EQ(1, unreadable_channel->init_count);
+    EXPECT_EQ(RC_Channel::AUX_FUNC::FENCE, unreadable_channel->init_func);
+    EXPECT_EQ(RC_Channel::AuxSwitchPos::LOW, unreadable_channel->init_position);
+
+    // and not a second time by the late phase
+    EXPECT_EQ(1, subclass_early_channel->init_count);
+
+    // the early functions are not initialised a second time; in
+    // particular ARM_EMERGENCY_STOP must not be re-read here, where
+    // RC is likely to be live
+    EXPECT_EQ(1, motor_estop_channel->init_count);
+    EXPECT_EQ(1, arm_estop_channel->init_count);
+    EXPECT_EQ(1, rc_override_channel->init_count);
+    EXPECT_EQ(RC_Channel::AuxSwitchPos::LOW, arm_estop_channel->init_position);
+
+    // the function is latched by the first phase, so a mid-boot
+    // PARAM_SET arriving between the two phases cannot slip through the
+    // partition and leave a channel initialised not at all.  MAVLink is
+    // serviced between them by AP_Vehicle::scheduler_delay_callback().
+    // this channel carried no RCx_OPTION above, so the sweeps already
+    // run have initialised it as DO_NOTHING; count from there
+    RC_Channel_Test *late_to_early_channel = rc_channels.channel(9);
+    const uint8_t init_count_before = late_to_early_channel->init_count;
+
+    late_to_early_channel->option.set(int16_t(RC_Channel::AUX_FUNC::FENCE));
+    late_to_early_channel->set_radio_in(1900);
+    late_to_early_channel->init_aux_early();
+
+    // a late function is not initialised by the early phase
+    EXPECT_EQ(init_count_before, late_to_early_channel->init_count);
+
+    // the GCS changes the option from a late function to an early one
+    // after the early phase has run
+    late_to_early_channel->option.set(int16_t(RC_Channel::AUX_FUNC::MOTOR_ESTOP));
+    late_to_early_channel->init_aux();
+
+    // the late phase still initialises the function the early phase
+    // latched, rather than skipping the channel entirely
+    EXPECT_EQ(init_count_before + 1, late_to_early_channel->init_count);
+    EXPECT_EQ(RC_Channel::AUX_FUNC::FENCE, late_to_early_channel->init_func);
+}
+
+AP_GTEST_MAIN()

--- a/libraries/RC_Channel/tests/wscript
+++ b/libraries/RC_Channel/tests/wscript
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+def build(bld):
+    bld.ap_find_tests(
+        use='ap',
+    )


### PR DESCRIPTION
### Summary

Defer RC auxiliary-function initialization until vehicle and library backends have been created, while keeping the small set of functions that gate the vehicle from boot in `RC_Channels::init()`. This is a long standing bug impacting several subsystems. Currently switch inits can occur before the backend exists and silently fail due to nullptr checks.

### Classification & Testing (check all that apply and add your own)

- [ ] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Testing performed:

- `./waf --targets tests/test_aux_initialisation`
- `build/sitl/tests/test_aux_initialisation`
- `./waf copter plane rover replay`
- `./waf --targets examples/RC_Channel,examples/AC_PID_test`
- `./waf --targets tests/test_aux_boot_position tests/test_aux_early_gating` and both binaries
- `valgrind build/sitl/tests/test_aux_initialisation` and `valgrind build/sitl/tests/test_aux_boot_position` - `0 errors from 0 contexts` (11, from the late phase's sweep of channels the test had not given a `radio_in`, before every channel was seeded)
- `Tools/autotest/autotest.py test.Copter.AuxSwitchOptions test.Copter.AuxFunctionsInMission test.Copter.MountPOIFromAuxFunction` - all pass
- `Tools/autotest/autotest.py test.QuadPlane.ICEngine test.QuadPlane.ICEngineMission test.QuadPlane.MAV_CMD_DO_ENGINE_CONTROL test.QuadPlane.ICEngineStartChanMinAtBoot` - all pass; the new test fails on the un-fixed engine (RPM reaches 70 with no command given, and `DO_ENGINE_CONTROL` returns `ACCEPTED` where it should be `FAILED`)
- SITL Copter with `RC9_OPTION=165` (`ARM_EMERGENCY_STOP`): arming is refused with `Arm: Motors Emergency Stopped`, confirming emergency-stop is engaged from boot. Same build without the switch configured arms normally.
- SITL Copter and `Tools/Replay` both run through `AP_Vehicle::setup()` without the null-deref that an unguarded `rc()` accessor introduced
- `Tools/scripts/check_branch_conventions.py --base-branch upstream/master`
- `git diff --check upstream/master...HEAD`

### Description

Some RC auxiliary functions depend on backends created during vehicle and library initialization. Calling `init_aux_all()` directly from `RC_Channels::init()` therefore applies the initial switch state before those dependencies exist, where it silently fails against a null backend.

**The concrete example.** On Copter, `rc().init()` is `ArduCopter/system.cpp:68`, while `camera_mount.init()` is `:113` and `camera.init()` is `:118` — both of which allocate their backends (`NEW_NOTHROW`) inside those calls. So the explicit-init mount functions (`RETRACT_MOUNT1/2`, `MOUNT_YAW_LOCK`, `MOUNT_RP_LOCK`, `MOUNT_POI_LOCK`) reach `AP_Mount::set_mode()`, which returns early on a null `get_instance()`, and the camera ones (`CAMERA_REC_VIDEO`, `CAMERA_ZOOM`, `CAMERA_MANUAL_FOCUS`, `CAMERA_AUTO_FOCUS`, `CAMERA_LENS`) reach the primary-instance overloads — `do_aux_function_record_video()` calls `AP_Camera::record_video(bool)`, which returns `false` on `primary == nullptr` (`AP_Camera.cpp:183`). A guaranteed silent no-op, 45–50 lines before the backend exists. See also https://discuss.ardupilot.org/t/copter-4-7-1-beta1-released-for-beta-testing/145262/3

**Scope of the fix.** `debounce_position` and `current_position` both default to `-1`, and `read_aux()` seeds-without-executing only for the `init_position_on_first_radio_read()` set — so for the mount/camera functions above, the first debounced RC read already re-fires them against live backends. What this genuinely fixes is (a) the window before the first valid RC read and (b) installations where RC never becomes valid — with the caveat in *Where the switch still cannot be read* below, which bounds what (b) is worth. That re-fire is now suppressed where the deferred phase managed a live read of its own - see *The late phase reads the switch* below.

### Two-phase initialization

Aux initialization is now split, with the split stated in code rather than falling out of which call site won:

- **`RC_Channels::init_aux_early()`**, still called from `RC_Channels::init()`, initializes the functions that establish a safe or gated state at boot and have no backend dependency of their own: `ARM_EMERGENCY_STOP`, `MOTOR_ESTOP` and `RC_OVERRIDE_ENABLE`. `RC_Channel::init_aux_function_early()` is the allowlist.
- **`RC_Channels::init_aux()`**, called near the end of `AP_Vehicle::setup()` after backend initialization, initializes everything else.

Deferring the first group would have been a real regression, because nothing re-establishes their state afterwards:

- `SRV_Channels::emergency_stop` is a plain zero-init static (`SRV_Channels.cpp:53`), so `false` at boot. With `RCx_OPTION=165` the `LOW` branch is what asserts it (`RC_Channel.cpp`, `set_emergency_stop(true)`), and `read_aux()` *seeds without executing* for exactly this function set — so had the assertion moved to the end of `setup()`, the interlock would have been disengaged across the whole startup window (through `AP::arming().init()`, with MAVLink live via `scheduler_delay_callback()`), and would not have been re-asserted until the pilot moved the switch. `AP_Arming::estop_checks()` and `arm_checks()` both key off `get_emergency_stop()`.
- `_gcs_overrides_enabled` defaults to **`true`** (`RC_Channel.h:819`), and `RC_OVERRIDE_ENABLE`'s `LOW` branch is what clears it. Deferring it would have left GCS RC overrides ungated (`RC_Channel::set_override()` returns early only when disabled) for the whole of startup for a user who deliberately gated them behind a switch.

Keeping these three early is byte-for-byte the master behaviour for them, so no new analysis of their handlers is required.

No vehicle-specific auxiliary function currently needs early initialization. I checked the three vehicle overrides: Plane's `REVERSE_THROTTLE` handler is order-sensitive but self-contained — it sets `plane.have_reverse_throttle_rc_option` **and** calls `channel_throttle->set_range(100)` itself, and the only other `set_control_channels()` caller is `Plane::one_second_loop()` (`ArduPlane/Plane.cpp:365`), which runs after `setup()` returns; Copter's `MOTOR_INTERLOCK` only sets `copter.ap.motor_interlock_switch`, whose zero-init value is the conservative one, so deferring it is if anything safer; Rover's only init-executed function is `SAILBOAT_MOTOR_3POS`. `RC_Channel::init_aux_function_early()` is `virtual` and `protected` so that one can: a vehicle may classify a function of its own as early either by overriding outright or by delegating to the base implementation, without re-enumerating the base allowlist.

### Other behaviour notes

`scripting.init()` now runs after aux initialization rather than ~25 subsystem inits earlier, so a script with a raised `SCR_THD_PRIORITY` cannot read aux state such as `get_emergency_stop()` before it is initialized.

Functions that must not act on whatever position a switch happens to be in the first time it is read — `ARM_EMERGENCY_STOP` and the rest of `init_position_on_first_radio_read()`'s set — are initialized to the safe LOW position instead of the live read, since deferred init means RC input may already be live. The scheduled `read_aux()` path remains responsible for picking up the pilot's actual switch position once it has been safely observed.

The deferred group's initial switch position is now applied near the end of `AP_Vehicle::setup()`, after backend and motor/ESC initialization — `FENCE`, `GPS_DISABLE`, `AVOID_PROXIMITY`, `AVOID_ADSB`, the mount/camera functions and the rest of the explicit-init list. Outputs remain safed and arming still requires explicit pilot or GCS action, and the functions which gate the vehicle are no longer among those deferred, but reviewers should note this small additional initialization window.

### The late phase reads the switch

`RC_Channel::init_aux()` determines its initial switch position the same way `RC_Channels::init()` did, with a live `read_3pos_switch()`. Running at the end of `AP_Vehicle::setup()` rather than the start, that read can now succeed where it previously failed and the position was defaulted to `LOW`. Which way it goes is per-vehicle, and two separate routes read RC during setup:

| | reads RC during `setup()` | late read |
|---|---|---|
| Plane / QuadPlane | `Plane::failsafe_check()` calls `rc().read_input()` once the main loop has stalled 200 ms, i.e. for the whole of `setup()` (`ArduPlane/failsafe.cpp:44,48`) | **succeeds** |
| Copter, multirotor | `esc_calibration_startup_check()` (`ArduCopter/system.cpp:74`, immediately after `rc().init()`) polls `read_radio()` for up to 2 s waiting for first RC input | **succeeds** |
| Copter, TradHeli or brushed PWM | that poll is skipped (`#if FRAME_CONFIG != HELI_FRAME`, and an early return for brushed motors, `esc_calibration.cpp:12-17`) | fails, defaulted |
| Rover, Sub, Blimp, Tracker | nothing reads RC during setup | fails, defaulted |

and on any vehicle with no working RC at all it fails regardless. So the live-read consequences below apply to Plane **and to multirotor Copter**, not to Plane alone.

> [!WARNING]
> **Known open defect at this head, for the dev call rather than for this description to resolve.** That boot read is not gated on RC input being *valid*, where the scheduled `RC_Channels::read_aux_all()` path refuses to act on auxiliary functions at all when it is not (`RC_Channels.cpp:243-248`). A receiver in failsafe still streams frames with in-range PWM, so its failsafe positions are read and applied as though the pilot had selected them. Reproduced on QuadPlane as an **engine start from a receiver in failsafe, while disarmed** (`ICE_OPTIONS=0`, `THR_FAILSAFE=1`, `THR_FS_VALUE=1100`, throttle 1000, engine switch 2000 → RPM 350 across a reboot; the merge base gives RPM 0).
>
> The obvious gate does not work: `has_valid_input()` is false on **every** Plane boot regardless of RC, because `Plane::rc_failsafe_active()` keys off `failsafe.last_valid_rc_ms`, written only inside the scheduled `Plane::read_radio()` (`ArduPlane/radio.cpp:132`), which has not run when `init_aux()` does — while on multirotor Copter it is true only because `copter.failsafe.radio` is zero-initialised. Neither vehicle has validated its RC at that point; they report opposite defaults. Gating on it would disable the live read entirely on Plane while leaving Copter exposed.
>
> Resolving this is a design decision, and the leading option — dropping the live read from the late phase altogether — would remove the `AP_ICEngine` commit and the boot-position recording along with it, and would materially shrink this PR. See [the discussion here](https://github.com/ArduPilot/ardupilot/pull/34166#issuecomment-5576690874). The reproduction exists as a working autotest and will be pushed with whichever fix is chosen.

That has one consequence beyond the ordering fix, addressed here rather than left to fall out.

**A switch held HIGH at boot would otherwise be applied twice.** Neither master's `init_aux()` nor this PR's touches `switch_state`, and `current_position` starts at `-1`, so the first debounced `read_aux()` re-runs the function. On master the pair was a defaulted `LOW` at init and then a live `HIGH` once RC came up - a genuine change, correctly acted on. With a successful late read the pair becomes `HIGH` then `HIGH`, running the function twice for a switch that never moved; on a mount that is visible, since `set_poi_lock()` re-saves `saved_mount_mode`, and `do_aux_function_mission_reset()` would reset the mission twice. This is a latent bug in master's `init_aux()` too - it reads the switch live and does not touch `switch_state` either - and deferring the phase is what makes it reachable.

`RC_Channel::run_aux_function()` therefore records `current_position`/`debounce_position` for its `Source::INIT` dispatch, so `debounce_completed()` suppresses the duplicate. Four conditions, each of which keeps an application that the first debounced read is still owed:

- **Only for a position that was really read.** A defaulted position is deliberately not recorded, so the pilot's real position is still acted upon by `read_aux()` once RC comes up, exactly as on master. `RC_Channel::init_aux_function_at_boot()` carries that fact into the dispatch.
- **Only for functions initialisation actually applied.** `init_aux_function()`'s first case group is the "do not need to be initialised" set, which falls through to a bare `break` precisely so that the first debounced `read_aux()` applies it - `RELAY`-`RELAY6`, `GRIPPER`, `LANDING_GEAR`, `EKF_SOURCE_SET`, `SCRIPTING_1`-`16` and the rest. Recording a position for those would suppress that read and the output would never follow the switch until the pilot toggled it. Doing the recording in `run_aux_function()` rather than in the caller is what draws that line, since it is reached only for the functions that were applied. (Rover applies `SAILBOAT_MOTOR_3POS` without going through `run_aux_function()`, so it keeps the old behaviour; it cannot reach a live boot position anyway.)
- **Only when the application succeeded.** `do_aux_function()` returning false means the function did not take - `AP_Camera_MAVLinkCamV2` rejects commands until camera discovery completes, for instance - so the position is not recorded and the first debounced read retries it.
- **Only while the function is still the channel's.** `init_aux_early()` latches the function for both phases deliberately, but `switch_state` is per-channel rather than per-function. A `PARAM_SET` arriving in the window between the phases - MAVLink is serviced there by `scheduler_delay_callback()` - leaves the late phase applying the latched function; recording its position would suppress the read which is the only thing that would ever apply the replacement, so an `RCx_OPTION` changed during boot would silently never take effect.

**`ICE_START_STOP` needs the same treatment on the other side of the interface,** which is what the `AP_ICEngine` commit does. `AP_ICEngine::do_aux_function()` applied the `ICE_STARTCHN_MIN` floor only to `Source::RC`. That did not matter while the initialisation dispatch always carried a fabricated `LOW`; with a live boot position it does, because the switch position is not a function of the PWM alone. A reversed channel with `RC_OPTIONS` bit 7 set reads a low PWM as `HIGH`, so a boot position the RC path would have filtered can reach `should_run = true` and start the engine with no command given. Rejecting the dispatch is necessary but not sufficient: `aux_pos` defaults to `MIDDLE`, which permits a commanded start, so a rejected initialisation also has to leave it at the `LOW` that initialisation has always established, or a `DO_ENGINE_CONTROL` or mission engine-start item would be accepted where it previously was not. Both are covered by `QuadPlane.ICEngineStartChanMinAtBoot`, and each fails independently if its half of the fix is removed.

This only diverges from master where `ICE_STARTCHN_MIN` is non-zero; it defaults to 0, which leaves the floor inactive out of the box.

### Where the switch still cannot be read, the defaulted LOW now reaches a live backend

The other side of the same coin, and the reason the row above matters in both directions. When `read_3pos_switch()` fails, `initial_aux_switch_position()` returns `LOW` and the late phase dispatches it, exactly as `RC_Channels::init()` did on master. What has changed is where that dispatch lands: on master it hit a **null** backend and no-op'd; now the backend exists, so any deferred function whose `LOW` branch is an action rather than a neutral state performs that action at boot. `CAMERA_ZOOM` `LOW` issues a continuous zoom-out rate command, `CAMERA_MANUAL_FOCUS` a continuous focus-in, `RETRACT_MOUNT1` calls `AP_Mount::set_mode_to_default()`, `MOUNT_POI_LOCK` calls `clear_poi_lock()` and emits a "POI: Cleared" statustext, and `RUNCAM_CONTROL` calls `stop_recording()`.

**This is deliberate, not an oversight, and it is the intended consequence of the change** — the whole complaint being fixed is that these initialisations silently failed against a null backend. Where RC does become valid the first debounced `read_aux()` corrects it about 200 ms later, since a defaulted position is not recorded and so that read still fires; `RCChannel.AuxFunctionDefaultedBootPosition` pins exactly that. Where RC never becomes valid, the defaulted `LOW` stands.

Who is newly affected, precisely: **TradHeli and brushed-PWM Copter frames**, **Sub** (whose `camera_mount.init()` at `ArduSub/system.cpp:91` is after `rc().init()` at `:52`, and which deliberately sets `RC_TARGETING` at `:95`), and any vehicle flying without working RC. **Rover is not affected** — its `camera_mount.init()` (`:84`) and `camera.init()` (`:89`) already run before `rc().init()` (`:139`), so master already delivered that defaulted `LOW` into live backends there.

The alternative is to skip the late dispatch entirely when the position was defaulted. That is worth stating because it is *not* simply "restore master": master does perform this dispatch, and skipping it would also remove the boot `LOW` for Rover and for every late function whose backend was never null, so it is its own behaviour change rather than the absence of one. Raising it here so the choice is explicit rather than implicit.

The new call site is guarded two ways: on the `RC_Channels` singleton being present, because `Tools/Replay`'s `ReplayVehicle` inherits the `final` `AP_Vehicle::setup()` but never constructs one; and on `AP_RC_CHANNEL_ENABLED`, since `RC_Channel.h` wraps the whole class in it. (There is no `AP::rc()` in tree — only the free `rc()`, which dereferences the singleton unchecked, so the null guard is required rather than stylistic.)

`tests/test_aux_boot_position.cpp` covers the boot position against the *real* `RC_Channel::init_aux_function()` and the real debounce path, because what is under test is the interaction between the two: a function applied from a live boot position is not applied again by the first debounced read; a function initialisation did not apply still is; a switch that genuinely moves between the two is still picked up; a defaulted boot position is re-applied when RC comes up in that same position, since nobody had read it; a failed application is retried; and an `RCx_OPTION` changed between the phases still takes effect. Each of those fails if the corresponding condition is removed.

`tests/test_aux_early_gating.cpp` mocks nothing at all, and pins the property the early allowlist exists for: after `RC_Channels::init()` alone, with no backend created and `init_aux()` not yet called, `SRV_Channels::get_emergency_stop()` is true for a channel carrying `ARM_EMERGENCY_STOP` (even with the switch physically HIGH) and `gcs_overrides_enabled()` is false for one carrying `RC_OVERRIDE_ENABLE`. Moving either function out of `init_aux_function_early()` turns it red; the other two test files mock `init_aux_function()` and `do_aux_function()` respectively, so neither of them would notice.

`tests/test_aux_initialisation.cpp` covers the phase split, and its test channel overrides `init_aux_function_early()` the way a vehicle subclass would — by delegating to the base list rather than re-enumerating it — to check that a subclass's own early function is initialised by the early phase: the boot-gating functions are initialized during `RC_Channels::init()` and not a second time afterwards, a backend-dependent function (`FENCE`) is not initialized until `RC_Channels::init_aux()`, `MOTOR_ESTOP` is initialized from its live boot position, and `ARM_EMERGENCY_STOP` is initialized LOW even with its switch physically HIGH at boot.

This contribution was developed with Codex and Claude AI assistance. The AI helped analyze the initialization ordering, implement the targeted changes and regression test, and prepare the PR description.





