### PR TITLE
Add MAVLink buffers for lua scripting

### DIFF
--- a/libraries/AP_Scripting/AP_Scripting.cpp
+++ b/libraries/AP_Scripting/AP_Scripting.cpp
@@ -12,8 +12,8 @@
    You should have received a copy of the GNU General Public License
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 #include "AP_Scripting_config.h"
+
 
 #if AP_SCRIPTING_ENABLED
 
@@ -475,22 +475,14 @@ void AP_Scripting::restart_all()
 
 #if HAL_GCS_ENABLED
 void AP_Scripting::handle_message(const mavlink_message_t &msg, const mavlink_channel_t chan) {
-    if (mavlink_data.rx_buffer == nullptr) {
+    if (mavlink_data.buffer_list == nullptr) {
         return;
     }
 
     struct mavlink_msg data {msg, chan, AP_HAL::millis()};
 
     WITH_SEMAPHORE(mavlink_data.sem);
-    for (uint16_t i = 0; i < mavlink_data.accept_msg_ids_size; i++) {
-        if (mavlink_data.accept_msg_ids[i] == UINT32_MAX) {
-            return;
-        }
-        if (mavlink_data.accept_msg_ids[i] == msg.msgid) {
-            mavlink_data.rx_buffer->push(data);
-            return;
-        }
-    }
+    mavlink_data.buffer_list->handle_msg(data);
 }
 
 bool AP_Scripting::is_handling_command(uint16_t cmd_id)

--- a/libraries/AP_Scripting/AP_Scripting.cpp
+++ b/libraries/AP_Scripting/AP_Scripting.cpp
@@ -18,6 +18,7 @@
 #if AP_SCRIPTING_ENABLED
 
 #include <AP_Scripting/AP_Scripting.h>
+#include "AP_Scripting/AP_Scripting_MAVLink.h"
 #include <AP_RCTelemetry/AP_CRSF_Telem.h>
 #include <AP_HAL/AP_HAL.h>
 #include <GCS_MAVLink/GCS.h>

--- a/libraries/AP_Scripting/AP_Scripting.cpp
+++ b/libraries/AP_Scripting/AP_Scripting.cpp
@@ -369,6 +369,15 @@ void AP_Scripting::thread(void) {
             }
         }
 
+        {
+            WITH_SEMAPHORE(mavlink_data.sem);
+            while (mavlink_data.buffer_list != nullptr) {
+                ScriptingMAVLinkBuffer *next_item = mavlink_data.buffer_list->next;
+                delete mavlink_data.buffer_list;
+                mavlink_data.buffer_list = next_item;
+            }
+        }
+
         bool cleared = false;
         while(true) {
             // 1hz check if we should restart

--- a/libraries/AP_Scripting/AP_Scripting.h
+++ b/libraries/AP_Scripting/AP_Scripting.h
@@ -130,12 +130,6 @@ public:
     SocketAPM *_net_sockets[SCRIPTING_MAX_NUM_NET_SOCKET];
 #endif
 
-    struct mavlink_msg {
-        mavlink_message_t msg;
-        mavlink_channel_t chan;
-        uint32_t timestamp_ms;
-    };
-
     struct mavlink {
         ScriptingMAVLinkBuffer *buffer_list;
         HAL_Semaphore sem;

--- a/libraries/AP_Scripting/AP_Scripting.h
+++ b/libraries/AP_Scripting/AP_Scripting.h
@@ -46,6 +46,8 @@ class SocketAPM;
 #include "AP_Scripting_SerialDevice.h"
 #endif
 
+class ScriptingMAVLinkBuffer;
+
 class AP_Scripting
 {
 public:

--- a/libraries/AP_Scripting/AP_Scripting.h
+++ b/libraries/AP_Scripting/AP_Scripting.h
@@ -14,6 +14,7 @@
  */
 #pragma once
 
+#include "AP_Scripting/AP_Scripting_MAVLink.h"
 #include "AP_Scripting/AP_Scripting_config.h"
 
 #if AP_SCRIPTING_ENABLED
@@ -136,9 +137,7 @@ public:
     };
 
     struct mavlink {
-        ObjectBuffer<struct mavlink_msg> *rx_buffer;
-        uint32_t *accept_msg_ids;
-        uint16_t accept_msg_ids_size;
+        ScriptingMAVLinkBuffer *buffer_list;
         HAL_Semaphore sem;
     } mavlink_data;
 

--- a/libraries/AP_Scripting/AP_Scripting_MAVLink.cpp
+++ b/libraries/AP_Scripting/AP_Scripting_MAVLink.cpp
@@ -38,15 +38,6 @@ void ScriptingMAVLinkBuffer::handle_msg(mavlink_msg &msg) {
         }
     }
 
-    uint32_t id = msg.msg.msgid;
-    bool valid = false;
-    for(uint32_t i = 0; i < num_accepted_msgs; i++) {
-        if(id == accept_msg_ids[i]) {
-            valid = true;
-            break;
-        }
-    }
-
     if(valid) buffer.push(msg);
 
     if (next != nullptr) {
@@ -75,20 +66,6 @@ bool ScriptingMAVLinkBuffer::add_accepted_id(uint32_t id) {
     if(next_accepted_pos < num_accepted_msgs) {
         accept_msg_ids[next_accepted_pos] = id;
         next_accepted_pos++;
-        return true;
-    }
-
-    return false;
-}
-
-bool ScriptingMAVLinkBuffer::add_accepted_id(uint32_t id) {
-    for(uint32_t i = 0; i <= last_accepted_pos; i++) {
-        if(accept_msg_ids[i] == id) return true;
-    }
-
-    if(last_accepted_pos + 1 < num_accepted_msgs) {
-        last_accepted_pos++;
-        accept_msg_ids[last_accepted_pos] = id;
         return true;
     }
 

--- a/libraries/AP_Scripting/AP_Scripting_MAVLink.cpp
+++ b/libraries/AP_Scripting/AP_Scripting_MAVLink.cpp
@@ -1,0 +1,73 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  Scripting MAVLinkBuffer class, for easy scripting MAVLink support
+ */
+
+#include "AP_Scripting/AP_Scripting_MAVLink.h"
+#include "AP_HAL/Semaphores.h"
+#include <cstdint>
+
+// read a message from the buffer
+bool ScriptingMAVLinkBuffer::read_msg(mavlink_msg &msg) {
+    return buffer.pop(msg);
+}
+
+// handler for incoming messages, add to buffers
+void ScriptingMAVLinkBuffer::handle_msg(mavlink_msg &msg) {
+    WITH_SEMAPHORE(sem);
+
+    uint32_t id = msg.msg.msgid;
+    bool valid = false;
+    for(uint32_t i = 0; i < next_accepted_pos; i++) {
+        if(id == accept_msg_ids[i]) {
+            valid = true;
+            break;
+        }
+    }
+
+    if(valid) buffer.push(msg);
+
+    if (next != nullptr) {
+        next->handle_msg(msg);
+    }
+}
+
+// add a new buffer to this list
+void ScriptingMAVLinkBuffer::add_buffer(ScriptingMAVLinkBuffer* new_buff) {
+    WITH_SEMAPHORE(sem);
+    if (next == nullptr) {
+        next = new_buff;
+        return;
+    }
+
+    next->add_buffer(new_buff);
+}
+
+bool ScriptingMAVLinkBuffer::add_accepted_id(uint32_t id) {
+    WITH_SEMAPHORE(sem);
+
+    for(uint32_t i = 0; i < next_accepted_pos; i++) {
+        if(accept_msg_ids[i] == id) return true;
+    }
+
+    if(next_accepted_pos < num_accepted_msgs) {
+        accept_msg_ids[next_accepted_pos] = id;
+        next_accepted_pos++;
+        return true;
+    }
+
+    return false;
+}

--- a/libraries/AP_Scripting/AP_Scripting_MAVLink.cpp
+++ b/libraries/AP_Scripting/AP_Scripting_MAVLink.cpp
@@ -38,6 +38,15 @@ void ScriptingMAVLinkBuffer::handle_msg(mavlink_msg &msg) {
         }
     }
 
+    uint32_t id = msg.msg.msgid;
+    bool valid = false;
+    for(uint32_t i = 0; i < num_accepted_msgs; i++) {
+        if(id == accept_msg_ids[i]) {
+            valid = true;
+            break;
+        }
+    }
+
     if(valid) buffer.push(msg);
 
     if (next != nullptr) {
@@ -66,6 +75,20 @@ bool ScriptingMAVLinkBuffer::add_accepted_id(uint32_t id) {
     if(next_accepted_pos < num_accepted_msgs) {
         accept_msg_ids[next_accepted_pos] = id;
         next_accepted_pos++;
+        return true;
+    }
+
+    return false;
+}
+
+bool ScriptingMAVLinkBuffer::add_accepted_id(uint32_t id) {
+    for(uint32_t i = 0; i <= last_accepted_pos; i++) {
+        if(accept_msg_ids[i] == id) return true;
+    }
+
+    if(last_accepted_pos + 1 < num_accepted_msgs) {
+        last_accepted_pos++;
+        accept_msg_ids[last_accepted_pos] = id;
         return true;
     }
 

--- a/libraries/AP_Scripting/AP_Scripting_MAVLink.h
+++ b/libraries/AP_Scripting/AP_Scripting_MAVLink.h
@@ -33,8 +33,8 @@
 #include <AP_CANManager/AP_CANSensor.h>
 
 class ScriptingMAVLinkBuffer {
-public: ScriptingMAVLinkBuffer(uint32_t buffer_size):
-        buffer(buffer_size)
+public: ScriptingMAVLinkBuffer(uint32_t buffer_size, uint32_t num_msgs):
+        buffer(buffer_size), accept_msg_ids(NEW_NOTHROW uint32_t[num_msgs]), num_accepted_msgs(num_msgs)
     {};
 
     // read a messages from the buffer
@@ -47,11 +47,15 @@ public: ScriptingMAVLinkBuffer(uint32_t buffer_size):
     void add_buffer(ScriptingMAVLinkBuffer* new_buff);
 
     // Add a filter to this buffer
-    // bool add_filter(uint32_t mask, uint32_t value);
+    bool add_accepted_id(uint32_t id);
 
 private:
 
     ObjectBuffer<AP_Scripting::mavlink_msg> buffer;
+
+    uint32_t* accept_msg_ids;
+    uint32_t num_accepted_msgs;
+    uint32_t last_accepted_pos = -1;
 
     ScriptingMAVLinkBuffer *next;
 

--- a/libraries/AP_Scripting/AP_Scripting_MAVLink.h
+++ b/libraries/AP_Scripting/AP_Scripting_MAVLink.h
@@ -14,34 +14,38 @@
  */
 /*
   Scripting MAVLink class, for easy scripting MAVLink support
- */
- 
+*/
+
 #pragma once
 
 #include "AP_Scripting/AP_Scripting.h"
+#include <GCS_MAVLink/GCS_MAVLink.h>
 #include <AP_HAL/AP_HAL.h>
 
-//#if defined(HAL_BUILD_AP_PERIPH)
-//    // Must have at least two CAN ports on Periph
-//    #define AP_SCRIPTING_CAN_SENSOR_ENABLED (HAL_MAX_CAN_PROTOCOL_DRIVERS > 1)
-//#else
-//    #define AP_SCRIPTING_CAN_SENSOR_ENABLED HAL_MAX_CAN_PROTOCOL_DRIVERS
-//#endif
-
-//#if AP_SCRIPTING_CAN_SENSOR_ENABLED
-
-#include <AP_CANManager/AP_CANSensor.h>
+struct mavlink_msg {
+    mavlink_message_t msg;
+    mavlink_channel_t chan;
+    uint32_t timestamp_ms;
+};
 
 class ScriptingMAVLinkBuffer {
+friend class AP_Scripting;
+
 public: ScriptingMAVLinkBuffer(uint32_t buffer_size, uint32_t num_msgs):
         buffer(buffer_size), accept_msg_ids(NEW_NOTHROW uint32_t[num_msgs]), num_accepted_msgs(num_msgs)
     {};
 
+    ~ScriptingMAVLinkBuffer() {
+        delete[] accept_msg_ids;
+    }
+
+    bool init_ok() const { return accept_msg_ids != nullptr; }
+
     // read a messages from the buffer
-    bool read_msg(AP_Scripting::mavlink_msg &msg);
+    bool read_msg(mavlink_msg &msg);
 
     // recursively add messages to buffer
-    void handle_msg(AP_Scripting::mavlink_msg &msg);
+    void handle_msg(mavlink_msg &msg);
 
     // recursively add new buffer
     void add_buffer(ScriptingMAVLinkBuffer* new_buff);
@@ -51,24 +55,15 @@ public: ScriptingMAVLinkBuffer(uint32_t buffer_size, uint32_t num_msgs):
 
 private:
 
-    ObjectBuffer<AP_Scripting::mavlink_msg> buffer;
+    ObjectBuffer<mavlink_msg> buffer;
 
     uint32_t* accept_msg_ids;
     uint32_t num_accepted_msgs;
-    uint32_t last_accepted_pos = -1;
+    uint32_t next_accepted_pos = 0;
 
-    ScriptingMAVLinkBuffer *next;
+    ScriptingMAVLinkBuffer *next = nullptr;
 
     HAL_Semaphore sem;
 
-    /*
-    struct {
-        uint32_t mask;
-        uint32_t value;
-    } filter[8];
-    uint8_t num_filters;
-    */
-
 };
 
-//#endif // AP_SCRIPTING_CAN_SENSOR_ENABLED

--- a/libraries/AP_Scripting/AP_Scripting_MAVLink.h
+++ b/libraries/AP_Scripting/AP_Scripting_MAVLink.h
@@ -1,0 +1,70 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+  Scripting MAVLink class, for easy scripting MAVLink support
+ */
+ 
+#pragma once
+
+#include "AP_Scripting/AP_Scripting.h"
+#include <AP_HAL/AP_HAL.h>
+
+//#if defined(HAL_BUILD_AP_PERIPH)
+//    // Must have at least two CAN ports on Periph
+//    #define AP_SCRIPTING_CAN_SENSOR_ENABLED (HAL_MAX_CAN_PROTOCOL_DRIVERS > 1)
+//#else
+//    #define AP_SCRIPTING_CAN_SENSOR_ENABLED HAL_MAX_CAN_PROTOCOL_DRIVERS
+//#endif
+
+//#if AP_SCRIPTING_CAN_SENSOR_ENABLED
+
+#include <AP_CANManager/AP_CANSensor.h>
+
+class ScriptingMAVLinkBuffer {
+public: ScriptingMAVLinkBuffer(uint32_t buffer_size):
+        buffer(buffer_size)
+    {};
+
+    // read a messages from the buffer
+    bool read_msg(AP_Scripting::mavlink_msg &msg);
+
+    // recursively add messages to buffer
+    void handle_msg(AP_Scripting::mavlink_msg &msg);
+
+    // recursively add new buffer
+    void add_buffer(ScriptingMAVLinkBuffer* new_buff);
+
+    // Add a filter to this buffer
+    // bool add_filter(uint32_t mask, uint32_t value);
+
+private:
+
+    ObjectBuffer<AP_Scripting::mavlink_msg> buffer;
+
+    ScriptingMAVLinkBuffer *next;
+
+    HAL_Semaphore sem;
+
+    /*
+    struct {
+        uint32_t mask;
+        uint32_t value;
+    } filter[8];
+    uint8_t num_filters;
+    */
+
+};
+
+//#endif // AP_SCRIPTING_CAN_SENSOR_ENABLED

--- a/libraries/AP_Scripting/docs/docs.lua
+++ b/libraries/AP_Scripting/docs/docs.lua
@@ -4076,18 +4076,8 @@ mavlink = {}
 -- Initializes scripting MAVLink bufffer, check for items in the buffer with `receive_chan`
 ---@param msg_queue_length uint32_t_ud|integer|number -- Larger que allows script to deal with bursts of incomming messages or check for received messages less often
 ---@param num_rx_msgid uint32_t_ud|integer|number -- Number of unique messages to be received, register ids with `register_rx_msgid`
+---@return ScriptingMAVLinkBuffer_ud
 function mavlink:init(msg_queue_length, num_rx_msgid) end
-
--- marks mavlink message for receive, message id can be get using mavlink_msgs.get_msgid("MSG_NAME")
----@param msg_id number
----@return boolean -- false if id has been registered already
-function mavlink:register_rx_msgid(msg_id) end
-
--- receives mavlink message marked for receive using mavlink:register_rx_msgid
----@return string -- bytes
----@return number -- mavlink channel
----@return uint32_t_ud -- receive_timestamp
-function mavlink:receive_chan() end
 
 -- sends mavlink message, to use this function the call should be like this:
 -- mavlink:send(chan, mavlink_msgs.encode("MSG_NAME", {param1 = value1, param2 = value2, ...}})
@@ -4101,6 +4091,20 @@ function mavlink:send_chan(chan, msgid, message) end
 ---@param comand_id integer
 ---@return boolean
 function mavlink:block_command(comand_id) end
+
+-- TODO
+ScriptingMAVLinkBuffer_ud = {}
+
+-- marks mavlink message for receive in buffer, message id can be get using mavlink_msgs.get_msgid("MSG_NAME")
+---@param msg_id number
+---@return boolean -- false if id has been registered already
+function ScriptingMAVLinkBuffer_ud:register_rx_msgid(msg_id) end
+
+-- receives mavlink message from buffer marked for receive using ScriptingMAVLinkBuffer_ud:register_rx_msgid
+---@return string -- bytes
+---@return number -- mavlink channel
+---@return uint32_t_ud -- receive_timestamp
+function ScriptingMAVLinkBuffer_ud:receive_chan() end
 
 -- Geofence library
 fence = {}

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -1068,7 +1068,6 @@ global manual remove lua_removefile 1 3
 global manual print lua_print 1 0
 
 include AP_Scripting/AP_Scripting_MAVLink.h depends (HAL_GCS_ENABLED && !defined(HAL_BUILD_AP_PERIPH))
-ap_object ScriptingMAVLinkBuffer depends (HAL_GCS_ENABLED && !defined(HAL_BUILD_AP_PERIPH))
 
 singleton mavlink depends (HAL_GCS_ENABLED && !defined(HAL_BUILD_AP_PERIPH))
 singleton mavlink manual init lua_mavlink_init 2 1

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -1067,11 +1067,17 @@ global manual dirlist lua_dirlist 1 2
 global manual remove lua_removefile 1 3
 global manual print lua_print 1 0
 
+include AP_Scripting/AP_Scripting_MAVLink.h depends (HAL_GCS_ENABLED && !defined(HAL_BUILD_AP_PERIPH))
+ap_object ScriptingMAVLinkBuffer depends (HAL_GCS_ENABLED && !defined(HAL_BUILD_AP_PERIPH))
+
 singleton mavlink depends (HAL_GCS_ENABLED && !defined(HAL_BUILD_AP_PERIPH))
-singleton mavlink manual init lua_mavlink_init 2 0
-singleton mavlink manual register_rx_msgid lua_mavlink_register_rx_msgid 1 1
+singleton mavlink manual init lua_mavlink_init 2 1
+
+ap_object ScriptingMAVLinkBuffer depends (HAL_GCS_ENABLED && !defined(HAL_BUILD_AP_PERIPH))
+ap_object ScriptingMAVLinkBuffer manual register_rx_msgid lua_mavlink_register_rx_msgid 1 1
+ap_object ScriptingMAVLinkBuffer manual receive_chan    lua_mavlink_receive_chan    0 3
+
 singleton mavlink manual send_chan lua_mavlink_send_chan 3 1
-singleton mavlink manual receive_chan lua_mavlink_receive_chan 0 3
 singleton mavlink manual block_command lua_mavlink_block_command 1 1
 
 include AC_Fence/AC_Fence.h depends AP_FENCE_ENABLED

--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -68,14 +68,14 @@ int lua_mavlink_init(lua_State *L) {
 
     binding_argcheck(L, 3);
     // get the depth of receive queue
-    const uint32_t queue_size = get_uint32(L, 2, 0, 25);
+    const uint32_t queue_size = get_uint32(L, 2, 1, 25);
     // get number of msgs to accept
-    const uint32_t num_msgs = get_uint32(L, 3, 0, 25);
+    const uint32_t num_msgs = get_uint32(L, 3, 1, 25);
 
     struct AP_Scripting::mavlink &data = AP::scripting()->mavlink_data;
 
     auto* buffer = NEW_NOTHROW ScriptingMAVLinkBuffer(queue_size, num_msgs);
-    if (buffer == nullptr) {
+    if (buffer == nullptr || !buffer->init_ok()) {
         delete buffer;
         return luaL_error(L, "out of memory");
     }
@@ -95,8 +95,6 @@ int lua_mavlink_init(lua_State *L) {
 }
 
 int lua_mavlink_receive_chan(lua_State *L) {
-    fix_dot_access_never_add_another_call(L, "mavlink");
-
     binding_argcheck(L, 1);
 
     ScriptingMAVLinkBuffer *buffer = *check_ScriptingMAVLinkBuffer(L, 1);
@@ -119,8 +117,6 @@ int lua_mavlink_receive_chan(lua_State *L) {
 }
 
 int lua_mavlink_register_rx_msgid(lua_State *L) {
-    fix_dot_access_never_add_another_call(L, "mavlink");
-
     binding_argcheck(L, 2);
 
     ScriptingMAVLinkBuffer *buffer = *check_ScriptingMAVLinkBuffer(L, 1);

--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -99,7 +99,7 @@ int lua_mavlink_receive_chan(lua_State *L) {
 
     ScriptingMAVLinkBuffer *buffer = *check_ScriptingMAVLinkBuffer(L, 1);
 
-    struct AP_Scripting::mavlink_msg msg;
+    mavlink_msg msg;
 
     if (buffer == nullptr) {
         return luaL_error(L, "MAVLink buffer not initialized");

--- a/libraries/AP_Scripting/lua_bindings.cpp
+++ b/libraries/AP_Scripting/lua_bindings.cpp
@@ -12,6 +12,7 @@
 #include <AP_Filesystem/AP_Filesystem.h>
 #include <AP_GPS/AP_GPS.h>
 #include <AP_AHRS/AP_AHRS.h>
+#include "AP_Scripting/AP_Scripting_MAVLink.h"
 
 #include "lua_bindings.h"
 
@@ -72,34 +73,25 @@ int lua_mavlink_init(lua_State *L) {
     const uint32_t num_msgs = get_uint32(L, 3, 0, 25);
 
     struct AP_Scripting::mavlink &data = AP::scripting()->mavlink_data;
-    bool failed = false;
-    {
-        WITH_SEMAPHORE(data.sem);
-        if (data.rx_buffer == nullptr) {
-            data.rx_buffer = NEW_NOTHROW ObjectBuffer<struct AP_Scripting::mavlink_msg>(queue_size);
-        }
-        if (data.accept_msg_ids == nullptr) {
-            data.accept_msg_ids = NEW_NOTHROW uint32_t[num_msgs];
-            if (data.accept_msg_ids != nullptr) {
-                data.accept_msg_ids_size = num_msgs;
-                memset(data.accept_msg_ids, UINT32_MAX, sizeof(int) * num_msgs);
-            }
-        }
-        if ((data.rx_buffer == nullptr) || (data.accept_msg_ids == nullptr)) {
-            delete data.rx_buffer;
-            delete[] data.accept_msg_ids;
-            data.rx_buffer = nullptr;
-            data.accept_msg_ids = nullptr;
-            data.accept_msg_ids_size = 0;
-            failed = true;
-        }
-    } // release semaphore here as luaL_error will NOT do that!
 
-    if (failed) {
+    auto* buffer = NEW_NOTHROW ScriptingMAVLinkBuffer(queue_size, num_msgs);
+    if (buffer == nullptr) {
+        delete buffer;
         return luaL_error(L, "out of memory");
     }
 
-    return 0;
+    {
+        WITH_SEMAPHORE(data.sem);
+        if (data.buffer_list == nullptr) {
+            data.buffer_list = buffer;
+        } else {
+            data.buffer_list->add_buffer(buffer);
+        }
+    }
+
+    *new_ScriptingMAVLinkBuffer(L) = buffer;
+
+    return 1;
 }
 
 int lua_mavlink_receive_chan(lua_State *L) {
@@ -107,14 +99,15 @@ int lua_mavlink_receive_chan(lua_State *L) {
 
     binding_argcheck(L, 1);
 
-    struct AP_Scripting::mavlink_msg msg;
-    ObjectBuffer<struct AP_Scripting::mavlink_msg> *rx_buffer = AP::scripting()->mavlink_data.rx_buffer;
+    ScriptingMAVLinkBuffer *buffer = *check_ScriptingMAVLinkBuffer(L, 1);
 
-    if (rx_buffer == nullptr) {
-        return luaL_error(L, "RX not initialized");
+    struct AP_Scripting::mavlink_msg msg;
+
+    if (buffer == nullptr) {
+        return luaL_error(L, "MAVLink buffer not initialized");
     }
 
-    if (rx_buffer->pop(msg)) {
+    if (buffer->read_msg(msg)) {
         lua_pushlstring(L, (char *)&msg.msg, sizeof(msg.msg));
         lua_pushinteger(L, msg.chan);
         *new_uint32_t(L) = msg.timestamp_ms;
@@ -130,32 +123,16 @@ int lua_mavlink_register_rx_msgid(lua_State *L) {
 
     binding_argcheck(L, 2);
 
+    ScriptingMAVLinkBuffer *buffer = *check_ScriptingMAVLinkBuffer(L, 1);
+
     const uint32_t msgid = get_uint32(L, 2, 0, (1 << 24) - 1);
 
-    struct AP_Scripting::mavlink &data = AP::scripting()->mavlink_data;
-
-    // check that we aren't currently watching this ID
-    for (uint8_t i = 0; i < data.accept_msg_ids_size; i++) {
-        if (data.accept_msg_ids[i] == msgid) {
-            lua_pushboolean(L, false);
-            return 1;
-        }
-    }
-
-    int i = 0;
-    for (i = 0; i < data.accept_msg_ids_size; i++) {
-        if (data.accept_msg_ids[i] == UINT32_MAX) {
-            break;
-        }
-    }
-
-    if (i >= data.accept_msg_ids_size) {
-        return luaL_error(L, "no registrations free");
-    }
-
     {
-        WITH_SEMAPHORE(data.sem);
-        data.accept_msg_ids[i] = msgid;
+        WITH_SEMAPHORE(AP::scripting()->mavlink_data.sem);
+
+        if (!buffer->add_accepted_id(msgid)) {
+            return luaL_error(L, "no registrations free");
+        }
     }
 
     lua_pushboolean(L, true);


### PR DESCRIPTION
### Summary

In lua scripting, AP used a global singleton MAVLink that was accessed by every script for retrieving messages, meaning scripts would steal messages from each other. This PR changes that, creating buffers in the same way CAN scripting does.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Tested using AP's unit tests, on SITL and running in a CUAV-X25-EVO flight controller.
On SITL, tests were made by flying the drone around, using automated missions and using lua scripts that would print received mavlink messages to verify different scripts would receive the same messages. This test lua script is used later as an example in the description of this same PR.
On the CUAV-X25-EVO flight controller, only the test by running the two scripts was done. We plan on flying a drone with the firmware soon.

### Description

- All changes done in this commit are contained in the libraries/AP_Scripting folder.
- Two new files were created, the .cpp and .h for AP_Scripting_MAVLink. This data structure was made in similar fashion to the existing AP_Scripting_CANSensor buffer, trying to keep the same style of that structure by keep function name conventions.
- AP_Scripting was changed to substitute it's use of a singleton MAVLink buffer for a linked lists of MAVLink buffers, similar to what is done with CAN.
- lua_bindings and bindings.desc were changed to use the script specific buffer in the linked list for message reading instead of the singleton. *Existing lua scripts may stop working because of this change*, since init now returns a mavlink buffer and receiving and registering messages is now done through it.

Here follows an example script with the new reading. This was used for testing by putting this script into a drone, changing "ML1" to "ML2" and putting a copy of it. All commands sent to the drone through COMMAND_LONG were printed by both scripts. 
``` lua
local mavlink_msgs = require("MAVLink/mavlink_msgs")

-- ID constants
local COMMAND_LONG_ID = mavlink_msgs.get_msgid("COMMAND_LONG")

-- Command variables
local msg_map = {}
msg_map[COMMAND_LONG_ID] = "COMMAND_LONG"

-- initialize MAVLink rx with buffer depth and number of rx message IDs to register
local buffer = mavlink:init(25, 1)

-- register message id to receive
buffer:register_rx_msgid(COMMAND_LONG_ID)

function Update()
	local msg, _ = buffer:receive_chan()
	if msg == nil then
		return Update, 100
	end

	local parsed_msg = mavlink_msgs.decode(msg, msg_map)
	if parsed_msg == nil then
		gcs:send_text(0, "ML1: Invalid message received")
		return Update()
	end

	gcs:send_text(0, "ML1: Command " .. parsed_msg.command .. " received")

	return Update()
end

return Update()
```