### PR TITLE
AC_Avoidance: don't process a never-posted avoidance request

### DIFF
--- a/libraries/AC_Avoidance/AP_OAPathPlanner.cpp
+++ b/libraries/AC_Avoidance/AP_OAPathPlanner.cpp
@@ -291,8 +291,9 @@ void AP_OAPathPlanner::avoidance_thread()
         bool dest_to_next_dest_clear = false;
         {
             WITH_SEMAPHORE(_rsem);
-            if (now - avoidance_request.request_time_ms > OA_TIMEOUT_MS) {
-                // this is a very old request, don't process it
+            if (avoidance_request.request_time_ms == 0 ||
+                now - avoidance_request.request_time_ms > OA_TIMEOUT_MS) {
+                // no request has ever been posted, or this is a very old request, don't process it
                 continue;
             }
 


### PR DESCRIPTION
Fixes #34169.

`avoidance_thread()`'s first cycle can beat the first `mission_avoidance()` call; while `millis() < OA_TIMEOUT_MS` the staleness subtraction cannot tell the zero-initialized never-posted request from a fresh one, and the planners process an all-zero `Location` — a SITL panic in `Location::get_alt_cm()`, and after it a permanently dead avoidance thread (`OA_ERROR` → `AC_WPNav_OA` loiters at the current position for the rest of the flight). It reproduces deterministically in JSON-backend bringups (e.g. `ardupilot_gazebo`), where `SIM_JSON` defaults `AHRS_EKF_TYPE=10` and the SIM AHRS provides the EKF origin at boot. Details, timings, and the full mechanism walk are in the linked issue.

The fix treats `request_time_ms == 0` explicitly as "no request has ever been posted".

Tested in SITL (Gazebo Harmonic JSON bringup, `OA_TYPE=1`, `PRX1_TYPE=2`):
- before: `PANIC: Should not be called on invalid location: Location cannot be (0, 0, 0)` at ~2.3 s of uptime, 3/3 bringups, no arming required;
- after: clean bringup (30 s+ of uptime), and an armed AUTO mission (takeoff + waypoint leg) with the avoidance thread alive and returning results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
