### PR TITLE
autotest: pace CommonOriginExternalAHRSReceives's prearm polling

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -18822,8 +18822,12 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         # are expected as the IMU-only ExternalAHRS supplies no position).
         saw_prearm = False
         tstart = self.get_sim_time()
+        prearm_last_send = 0
         while self.get_sim_time_cached() - tstart < 20:
-            self.send_mavlink_run_prearms_command()
+            now = self.get_sim_time_cached()
+            if now - prearm_last_send > 1:
+                prearm_last_send = now
+                self.send_mavlink_run_prearms_command()
             m = self.mav.recv_match(type='STATUSTEXT', blocking=True, timeout=1)
             if m is None:
                 continue


### PR DESCRIPTION
### Summary

Stops trying to arm the vehicle in (essentially) a tight loop - preventing a log flood on the flight controller side.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

The wait loop sent MAV_CMD_RUN_PREARM_CHECKS on every iteration, and the loop fed itself: each run emits several PreArm statustexts, so the recv_match never blocked and the sends never paused.  At parallel speedups this reached ~1150 commands per wall second - the vehicle's main loop dropped to 200Hz answering them, 291k MSG records (22MB) went into the session log, and the logger io thread was driven to drop 11562 messages - the only non-zero drop count in a 907-log audit of parallel-run file-backend logs.

Send at most one prearm run per simulated second, as assert_prearm_failure already does.  Validated: two commands per run (was ~15000), zero dropped messages, test passes.
