### PR TITLE
AP_Logger: let the block backend use the configured buffer size

### DIFF
--- a/libraries/AP_Logger/AP_Logger_Block.cpp
+++ b/libraries/AP_Logger/AP_Logger_Block.cpp
@@ -42,11 +42,10 @@ void AP_Logger_Block::Init(void)
         // reserve space for version in last sector
         df_NumPages -= df_PagePerBlock;
 
-        // determine and limit file backend buffersize
+        // determine buffersize - the allocation loop below already
+        // halves this until it fits, so boards short of memory are
+        // protected without clamping the capable ones
         uint32_t bufsize = _front._params.file_bufsize;
-        if (bufsize > 64) {
-            bufsize = 64;
-        }
         bufsize *= 1024;
 
         // If we can't allocate the full size, try to reduce it until we can allocate it


### PR DESCRIPTION
### Summary

Removes an ancient clamp on the size of the buffer the dataflash backend is allowed to use

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

LOG_FILE_BUFSIZE is documented as "Logging File and Block Backend buffer size max" with a range of 4 to 200 KiB, but the block backend silently clamped its copy to 64KB after reading it - setting 200 quietly yields 64, only for this backend.  The per-board defaults already scale with memory class (16/50/80KB on small boards, ~200KB on large ones), so the clamp only ever engaged on boards with memory to spare - and the allocation loop below it already halves the size until it fits, protecting genuinely memory-short boards without it.

The 3x absorption difference is why block-backend logging dropped messages under heavy host load in oversubscribed SITL runs (2680 drops at 85 workers on 32 hardware threads) while the file backend survived the identical load with zero drops across 1184 audited logs: both backends drain through the same wall-clock io thread, and what decides survival of a scheduler stall is how much buffer absorbs the meantime.
