### PR TITLE
autotest: reproduce the Q_FWD_THR_USE pitch oscillation

### DIFF
--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -1071,6 +1071,71 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         self.set_rc(4, 1500)
         self.do_RTL()
 
+    def FwdThrInVTOLPitchOscillation(self):
+        """Q_FWD_THR_USE pitch limiting oscillates rather than holding
+
+        With Q_FWD_THR_USE=2 the forward throttle is computed from the
+        *unlimited* pitch demand (assign_tilt_to_fwd_thr) while the
+        attitude demand is clipped to the forward pitch limit at the end
+        of the same function.  When the wind needs more forward force
+        than the clipped tilt can provide, the two disagree: the vehicle
+        oscillates in pitch while the forward motor chases a demand the
+        attitude controller is never given.
+
+        This is distinct from the intended "forward thrust has failed,
+        relax the tilt limit" behaviour, which only engages once the
+        forward motor saturates - here it stays well short of full
+        throttle throughout.
+        """
+        self.set_parameters({
+            "SIM_WIND_SPD": 25,
+            "SIM_WIND_DIR": 360,
+            "Q_WVANE_ENABLE": 1,
+            "Q_WVANE_GAIN": 1,
+            "STICK_MIXING": 0,
+            "Q_FWD_THR_USE": 2,
+        })
+        self.takeoff(10, mode="QLOITER")
+        self.set_rc(2, 1000)
+        self.delay_sim_time(15, reason="settle onto the forward pitch limit")
+        # raise the wind only once airborne, and make it uniform with
+        # height: SIM_WIND_T defaults to a profile which cuts the wind
+        # right down at this altitude, and a uniform wind this strong
+        # from the ground up prevents the climb entirely
+        self.set_parameters({
+            "SIM_WIND_T": 1,
+            "SIM_WIND_SPD": 34,
+        })
+        self.delay_sim_time(15, reason="settle into the raised wind")
+
+        worst_swing = 0
+        worst_pwm = (0, 0)
+        tstart = self.get_sim_time()
+        while self.get_sim_time_cached() - tstart < 30:
+            pitches = []
+            pwms = []
+            wstart = self.get_sim_time_cached()
+            while self.get_sim_time_cached() - wstart < 5:
+                m = self.assert_receive_message('ATTITUDE')
+                pitches.append(math.degrees(m.pitch))
+                pwms.append(self.get_servo_channel_value(3))
+            swing = max(pitches) - min(pitches)
+            self.progress("pitch %.2f..%.2f swing=%.2f fwd-thr pwm %u..%u" %
+                          (min(pitches), max(pitches), swing, min(pwms), max(pwms)))
+            if swing > worst_swing:
+                worst_swing = swing
+                worst_pwm = (min(pwms), max(pwms))
+
+        # a vehicle holding its forward pitch limit is very steady - the
+        # same measurement in the wind this test takes off in gives 0.05
+        # degrees - so half a degree is generous for one which has
+        # arrived rather than one which never settles
+        if worst_swing > 0.5:
+            raise NotAchievedException(
+                "pitch oscillated by %.2f deg (want < 0.5) while the forward "
+                "motor stayed unsaturated at %u..%u pwm" %
+                (worst_swing, worst_pwm[0], worst_pwm[1]))
+
     def FwdThrInVTOL(self):
         '''test use of fwd motor throttle into wind'''
         self.set_parameters({"SIM_WIND_SPD": 25, # need very strong wind for this test
@@ -3903,6 +3968,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         ret = super(AutoTestQuadPlane, self).tests()
         ret.extend([
             self.FwdThrInVTOL,
+            self.FwdThrInVTOLPitchOscillation,
             self.AHRSSwitchBackendResets,
             self.AirMode,
             self.TestMotorMask,

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -1136,6 +1136,72 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
                 "motor stayed unsaturated at %u..%u pwm" %
                 (worst_swing, worst_pwm[0], worst_pwm[1]))
 
+    def FwdThrInVTOLCrosswindYawHunt(self):
+        """Q_FWD_THR_USE hunts in yaw when the vehicle starts crosswind
+
+        Take off pointing across a strong wind with the forward throttle
+        in use and the vehicle never settles nose-in: it enters a
+        sustained yaw limit cycle of some forty degrees peak to peak
+        which does not decay for as long as you care to watch.  The same
+        flight with Q_FWD_THR_USE at its default of 0 weathervanes into
+        the wind and holds it to within about a degree, so this is the
+        forward-throttle path rather than the wind or the weathervane
+        gain.
+
+        FwdThrInVTOL does not see this because it takes off on SITL's
+        default home heading of 8 degrees into a wind it sets from 360 -
+        the vehicle is already pointing where the weathervane wants it.
+        Started anywhere across the wind it hunts instead, which is why
+        that test fails intermittently in a parallel run: the vehicle
+        inherits whatever heading the previous test in the session left
+        it on.
+        """
+        self.customise_SITL_commandline(
+            ["--home", "-27.274439,151.290064,343.0,90"])
+        self.set_parameters({
+            "SIM_WIND_SPD": 25,
+            "SIM_WIND_DIR": 360,
+            "Q_WVANE_ENABLE": 1,
+            "Q_WVANE_GAIN": 1,
+            "STICK_MIXING": 0,
+            "Q_FWD_THR_USE": 2,
+        })
+        self.zero_throttle()
+        self.takeoff(10, mode="QLOITER")
+        self.set_rc(2, 1000)
+        self.delay_sim_time(15, reason="settle nose into wind")
+
+        worst_yaw_swing = 0
+        tstart = self.get_sim_time()
+        while self.get_sim_time_cached() - tstart < 30:
+            yaws = []
+            pitches = []
+            wstart = self.get_sim_time_cached()
+            while self.get_sim_time_cached() - wstart < 5:
+                m = self.assert_receive_message('ATTITUDE')
+                # the wind is from 360, so a vehicle pointing into it
+                # sits either side of zero; measure the hunt about north
+                # rather than across the wrap
+                yaw = math.degrees(m.yaw)
+                yaws.append(yaw if yaw <= 180 else yaw - 360)
+                pitches.append(math.degrees(m.pitch))
+            yaw_swing = max(yaws) - min(yaws)
+            self.progress("yaw %.1f..%.1f swing=%.1f (pitch %.2f..%.2f)" %
+                          (min(yaws), max(yaws), yaw_swing,
+                           min(pitches), max(pitches)))
+            worst_yaw_swing = max(worst_yaw_swing, yaw_swing)
+
+        self.set_rc(2, 1500)
+        self.change_mode('QLAND')
+        self.wait_disarmed(timeout=120)
+
+        # the same measurement with Q_FWD_THR_USE=0 gives 1.1 degrees,
+        # so five is generous for a vehicle which has settled nose-in
+        if worst_yaw_swing > 5:
+            raise NotAchievedException(
+                "yaw hunted %.1f deg peak to peak (want < 5)" %
+                (worst_yaw_swing,))
+
     def FwdThrInVTOL(self):
         '''test use of fwd motor throttle into wind'''
         self.set_parameters({"SIM_WIND_SPD": 25, # need very strong wind for this test
@@ -3969,6 +4035,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         ret.extend([
             self.FwdThrInVTOL,
             self.FwdThrInVTOLPitchOscillation,
+            self.FwdThrInVTOLCrosswindYawHunt,
             self.AHRSSwitchBackendResets,
             self.AirMode,
             self.TestMotorMask,


### PR DESCRIPTION
### Summary

Reproduces an oscillation which crops up while testing.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

With Q_FWD_THR_USE=2 the forward throttle is computed from the unlimited pitch demand at the top of assign_tilt_to_fwd_thr(), while the attitude demand is clipped to the forward pitch limit at the bottom of the same function.  When the wind needs more forward force than the clipped tilt can provide, the two disagree: the forward motor chases a demand the attitude controller is never given, and the vehicle oscillates in pitch instead of holding its limit.

The oscillation has been showing up as intermittent FwdThrInVTOL failures under load, sampled at random phase - reaching pitch values on both sides of the wanted -3.0.  This test reproduces it deterministically by raising the wind once airborne: 4/4 runs oscillate by 2.3 degrees where a vehicle holding its limit measures 0.05.

This is distinct from the intended "forward thrust has failed, relax the tilt limit" behaviour, which engages once the forward motor saturates.  Here the motor stays around 1370 of 2000 pwm throughout, and the anti-windup which would tell the position controller it is limited is keyed on forward throttle exceeding 0.95, so it never fires while the pitch clip is what is actually binding.

The test fails on master; it is added to document the defect.
