### PR TITLE
QuadPlane: fix units mixup in the back pitch limit filter

### DIFF
--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -2954,8 +2954,9 @@ void QuadPlane::assign_tilt_to_fwd_thr(void)
         nav_pitch_upper_limit_cd = MIN(nav_pitch_upper_limit_cd, angle_max_cd);
 
         const float tconst = 0.5f;
-        const float dt = AP_HAL::millis() - q_pitch_limit_update_ms;
-        q_pitch_limit_update_ms = AP_HAL::millis();
+        const uint32_t now_ms = AP_HAL::millis();
+        const float dt = 0.001f * (now_ms - q_pitch_limit_update_ms);
+        q_pitch_limit_update_ms = now_ms;
         if (is_positive(dt)) {
             const float coef = dt / (dt + tconst);
             q_bck_pitch_lim_cd = (1.0f - coef) * q_bck_pitch_lim_cd + coef * nav_pitch_upper_limit_cd;


### PR DESCRIPTION
### Summary

Makes an ineffective filter effective.  Just look at this line: `const float tconst = 0.5f;` as a clue.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

I gave some thought as to what happens to everyone's vehicles that this was previously ineffective on, then ran away.

### Description

The low-pass filter smoothing the airspeed-scaled back/up pitch limit takes its time constant in seconds but measured its timestep in milliseconds:

    const float tconst = 0.5f;
    const float dt = AP_HAL::millis() - q_pitch_limit_update_ms;
    const float coef = dt / (dt + tconst);

At a 300Hz loop that gives coef = 3.3/3.8 = 0.87 rather than the intended 0.0033/0.5033 = 0.0066, so the filter responds about 130 times faster than designed - effectively not filtering at all, and leaving q_bck_pitch_lim_cd to track the raw speed-scaled limit.  That limit is proportional to (AIRSPEED_MIN / IAS)^2, so it follows every airspeed fluctuation straight into the pitch demand it clips.

Convert the timestep to seconds, and read the clock once rather than twice while there.  Q_BCK_PIT_LIM defaults to 10 degrees, so this path is active on any quadplane using Q_FWD_THR_USE 1 or 2.
