### PR TITLE
board_types.txt : add board ID for AP_HW_MicoAir743v3

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -370,6 +370,7 @@ AP_HW_KT_FMU_F1                      1250
 
 AP_HW_GPILOT_P1						 1275
 
+AP_HW_MicoAir743v3                   1299
 AP_HW_SKYDROID-S3                    1300
 
 AP_HW_CBUnmanned-CM405-FC            1301


### PR DESCRIPTION
Dear ardupilot developers,

We are [MicoAir Tech.](https://micoair.com/). And this PR reserves an ID for the upcoming MicoAir743v3.

Best Regard!
Minderring, MicoAir Tech.