### PR TITLE
Plane: reset ALT_OFFSET on navigation changes

### DIFF
--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -228,11 +228,12 @@ const AP_Param::Info Plane::var_info[] = {
 
     // @Param: ALT_OFFSET
     // @DisplayName: Altitude offset
-    // @Description: This is added to the target altitude in automatic flight. It can be used to add a global altitude offset to a mission
+    // @Description: This is added to the target altitude in automatic flight. It can be used to add a global altitude offset to a mission. The offset resets to zero on reboot
     // @Units: m
     // @Range: -32767 32767
     // @Increment: 1
     // @User: Advanced
+    // @Volatile: True
     GSCALAR(alt_offset, "ALT_OFFSET",                 0),
 
     // @Param: WP_RADIUS
@@ -1074,6 +1075,7 @@ const AP_Param::GroupInfo ParametersG2::var_info[] = {
     // @Bitmask: 14: In AUTO - climb to next waypoint altitude immediately instead of linear climb
     // @Bitmask: 15: Enable autoflap in manual modes and use minimum of target and actual speed for flap setting
     // @Bitmask: 16: Enable full aerodynamic load factor-based roll limits when an airspeed sensor is enabled and AIRSPEED_STALL is set
+    // @Bitmask: 17: Reset ALT_OFFSET on flight mode or AUTO waypoint changes
     // @User: Advanced
     AP_GROUPINFO("FLIGHT_OPTIONS", 13, ParametersG2, flight_options, 0),
 

--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -910,6 +910,7 @@ private:
     int32_t adjusted_altitude_cm(void);
     int32_t adjusted_relative_altitude_cm(void);
     float mission_alt_offset(void);
+    void reset_alt_offset(bool force = false);
     float height_above_target(void);
     float lookahead_adjustment(void);
     void fix_terrain_WP(Location &loc, uint32_t linenum);

--- a/ArduPlane/altitude.cpp
+++ b/ArduPlane/altitude.cpp
@@ -592,6 +592,20 @@ float Plane::mission_alt_offset(void)
     return ret;
 }
 
+void Plane::reset_alt_offset(bool force)
+{
+    if (!force && !flight_option_enabled(FlightOptions::RESET_ALT_OFFSET)) {
+        return;
+    }
+
+    if (g.alt_offset == 0) {
+        return;
+    }
+
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Reset ALT_OFFSET");
+    g.alt_offset.set(0);
+}
+
 /*
   return the height in meters above the next_WP_loc altitude
  */

--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -5,6 +5,12 @@
 /********************************************************************************/
 bool Plane::start_command(const AP_Mission::Mission_Command& cmd)
 {
+    if (control_mode == &mode_auto &&
+        AP_Mission::is_nav_cmd(cmd) &&
+        mission.get_prev_nav_cmd_index() != cmd.index) {
+        reset_alt_offset();
+    }
+
     // default to non-VTOL loiter
     auto_state.vtol_loiter = false;
 

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -164,6 +164,7 @@ enum FlightOptions {
     IMMEDIATE_CLIMB_IN_AUTO = (1<<14),
     FLAP_ACTUAL_SPEED = (1<<15),
     ENABLE_FULL_AERO_LF_ROLL_LIMITS = (1<<16),
+    RESET_ALT_OFFSET = (1<<17),
 };
 
 enum CrowFlapOptions {

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -104,6 +104,9 @@ void Plane::init_ardupilot()
 
     AP_Param::reload_defaults_file(true);
 
+    // ALT_OFFSET always starts at zero, independently of FLIGHT_OPTIONS.
+    reset_alt_offset(true);
+
     set_mode(mode_initializing, ModeReason::INITIALISED);
 
 #if (GROUND_START_DELAY > 0)
@@ -315,6 +318,10 @@ bool Plane::set_mode(Mode &new_mode, const ModeReason reason)
     const ModeReason  old_previous_mode_reason = previous_mode_reason;
     previous_mode_reason = control_mode_reason;
     control_mode_reason = reason;
+
+    // Apply the reset before mode entry so altitude targets use the new value,
+    // including when mode entry subsequently fails.
+    reset_alt_offset();
 
     // attempt to enter new mode
     if (!new_mode.enter()) {

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -2310,6 +2310,62 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
         self.fly_home_land_and_disarm(timeout=240)
 
+    def AltOffsetReset(self):
+        '''Test automatic ALT_OFFSET reset'''
+        reset_alt_offset_option = 1 << 17
+        self.change_mode("MANUAL")
+        self.set_parameters({
+            "FLIGHT_OPTIONS": 0,
+            "ALT_OFFSET": 100,
+            "SOAR_ENABLE": 0,
+        })
+
+        self.change_mode("LOITER")
+        self.wait_parameter_value("ALT_OFFSET", 100)
+
+        self.context_collect("STATUSTEXT")
+        self.set_parameter("FLIGHT_OPTIONS", reset_alt_offset_option)
+        self.run_cmd_do_set_mode(
+            "THERMAL",
+            want_result=mavutil.mavlink.MAV_RESULT_FAILED,
+        )
+        self.assert_mode("LOITER")
+        self.wait_text("Reset ALT_OFFSET", check_context=True)
+        self.wait_parameter_value("ALT_OFFSET", 0)
+
+        self.context_clear_collection("STATUSTEXT")
+        self.set_parameter("ALT_OFFSET", 100)
+        self.change_mode("MANUAL")
+        self.wait_text("Reset ALT_OFFSET", check_context=True)
+        self.wait_parameter_value("ALT_OFFSET", 0)
+
+        self.upload_simple_relhome_mission([
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 100, 0, 50),
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 200, 0, 50),
+        ])
+        self.change_mode("AUTO")
+        self.wait_current_waypoint(1)
+
+        self.context_clear_collection("STATUSTEXT")
+        self.set_parameter("ALT_OFFSET", 100)
+        self.set_current_waypoint(2)
+        self.wait_text("Reset ALT_OFFSET", check_context=True)
+        self.wait_parameter_value("ALT_OFFSET", 0)
+
+        # ALT_OFFSET always resets at boot, independently of FLIGHT_OPTIONS.
+        self.set_parameters({
+            "FLIGHT_OPTIONS": 0,
+            "ALT_OFFSET": 100,
+        })
+        self.context_clear_collection("STATUSTEXT")
+        self.reboot_sitl()
+        self.wait_parameter_value("ALT_OFFSET", 0)
+
+        # The reset is not saved, so the stored value is reset again next boot.
+        self.context_clear_collection("STATUSTEXT")
+        self.reboot_sitl()
+        self.wait_parameter_value("ALT_OFFSET", 0)
+
     def RTL_CLIMB_MIN(self):
         '''Test RTL_CLIMB_MIN'''
         self.wait_ready_to_arm()
@@ -9033,6 +9089,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.AirspeedDrivers,
             self.RTL_CLIMB_MIN,
             self.ClimbBeforeTurn,
+            self.AltOffsetReset,
             self.IMUTempCal,
             self.MAV_CMD_DO_AUX_FUNCTION,
             self.SmartBattery,


### PR DESCRIPTION
### Summary

Add a Plane `FLIGHT_OPTIONS` bit to reset `ALT_OFFSET` on flight-mode attempts and AUTO waypoint changes, while always resetting the live offset at boot.

This was motivated by BVLOS flights where we get unexpectedly low cloud cover and to stay within our operating procedures we have to duck below the cloud while not keeping the ALT_OFFSET if a RTL is triggered.

It also fixes an issue where an ALT_OFFSET is remembered between flights which is very unlikely to be what the user wants

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

Testing performed:

- Plane SITL build (`./waf plane`)
- Focused Plane `AltOffsetReset` SITL autotest
- Branch convention checks

The autotest covers the option-disabled case, failed and successful mode-entry attempts, AUTO waypoint changes, reset status text, unconditional boot reset, and preservation of the stored value across runtime resets.

### Description

This adds bit 17 to Plane's `FLIGHT_OPTIONS`. When enabled, any non-zero `ALT_OFFSET` is reset before entering a different flight mode, including when mode entry subsequently fails. In AUTO, it is reset when the navigation waypoint index changes, before height and glide-slope setup for the new waypoint.

`ALT_OFFSET` is also reset unconditionally at boot after parameters are loaded. Resets use `set(0)`, so only the live value is changed; a persisted non-zero value remains stored and is loaded then reset again at each boot. A `Reset ALT_OFFSET` status text is sent whenever a non-zero value is reset.

The parameter metadata documents the boot behavior and marks `ALT_OFFSET` volatile.
