### PR TITLE
autotest: serve terrain to RangeFinderPowerDown

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -13691,6 +13691,8 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         '''Test rangefinder power down by altitude for multiple backends'''
         pwrrng = 10  # power down above this altitude in metres
 
+        self.install_terrain_handlers_context()
+
         backends = [
             ("SITL", {"RNGFND1_TYPE": 100}),
             ("TFMiniPlus", {"RNGFND1_TYPE": 25, "RNGFND1_ADDR": 0x09}),


### PR DESCRIPTION
### Summary

Ensure RangeFinderPowerDown can get its terrain altitude

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

The rangefinder's power-down decision is made on height above terrain, so the test needs the vehicle to have terrain data.  Nothing was serving it: the framework only answers terrain requests for tests which install the handlers, and this test did not.

It passed anyway when run from the repo root, because the terrain cache there has already been filled in by other tests.  Under --parallel each worker has its own working directory, so it starts with an empty cache, nothing answers its requests, and the vehicle never gets terrain data at all - the test then failed in every parallel run:

    RangeFinderPowerDown (Prearm bit never went true)

Emptying the terrain cache reproduces that failure on a serial run, and with the handlers installed the test passes from an empty cache.

