### PR TITLE
Plane: remove conflict marker from ReleaseNotes.txt

### DIFF
--- a/ArduPlane/ReleaseNotes.txt
+++ b/ArduPlane/ReleaseNotes.txt
@@ -5057,7 +5057,6 @@ series!
 Happy flying!
 
 
->>>>>>> a9d5581378... Plane: updated release notes for 3.9.8-beta1
 Release 3.9.2beta3, 20th September 2018
 ---------------------------------------
 


### PR DESCRIPTION
### Summary

Removes a patch conflict marker from ReleaseNotes.txt

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

... someone fluffed the conflict resolution.

Remove so that greps trying to find conflicts don't get a false positive here
