### PR TITLE
AP_Logger: fixes for corrupt logs and poor error tracking

### DIFF
--- a/libraries/AP_Logger/AP_Logger_File.cpp
+++ b/libraries/AP_Logger/AP_Logger_File.cpp
@@ -592,7 +592,7 @@ void AP_Logger_File::get_log_boundaries(const uint16_t list_entry, uint32_t & st
  */
 int16_t AP_Logger_File::get_log_data(const uint16_t list_entry, const uint16_t page, const uint32_t offset, const uint16_t len, uint8_t *data)
 {
-    if (!_initialised || recent_open_error()) {
+    if (!_initialised) {
         return -1;
     }
 

--- a/libraries/AP_Logger/AP_Logger_File.cpp
+++ b/libraries/AP_Logger/AP_Logger_File.cpp
@@ -615,14 +615,16 @@ int16_t AP_Logger_File::get_log_data(const uint16_t list_entry, const uint16_t p
         EXPECT_DELAY_MS(3000);
         _read_fd = AP::FS().open(fname, O_RDONLY);
         if (_read_fd == -1) {
-            _open_error_ms = AP_HAL::millis();
-            int saved_errno = errno;
+            const int saved_errno = errno;
+            if (saved_errno != ENOENT) {
+                _open_error_ms = AP_HAL::millis();
+            }
             ::printf("Log read open fail for %s - %s\n",
                      fname, strerror(saved_errno));
             DEV_PRINTF("Log read open fail for %s - %s\n",
                                 fname, strerror(saved_errno));
             free(fname);
-            return -1;            
+            return -1;
         }
         free(fname);
         _read_offset = 0;

--- a/libraries/AP_Logger/AP_Logger_File.cpp
+++ b/libraries/AP_Logger/AP_Logger_File.cpp
@@ -828,6 +828,7 @@ void AP_Logger_File::start_new_log(void)
     ensure_log_directory_exists();
 
     EXPECT_DELAY_MS(3000);
+    _writebuf.clear();
     _write_fd = AP::FS().open(_write_filename, O_WRONLY|O_CREAT|O_TRUNC);
     _cached_oldest_log = 0;
 
@@ -845,7 +846,6 @@ void AP_Logger_File::start_new_log(void)
     _last_write_ms = AP_HAL::millis();
     _open_error_ms = 0;
     _write_offset = 0;
-    _writebuf.clear();
     write_fd_semaphore.give();
 
     // now update lastlog.txt with the new log number


### PR DESCRIPTION
### Summary

Fixes a log corruption bug where we could end up not writing out a FMT message.  Two more fixes for tracking open errors correctly.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Exercised by full parallel autotest runs (all vehicles, --parallel=32/33/36, ~1050 tests, green). The autotests that specifically cover pruned and holed log lists -  TestLogDownloadAfterPrune, TestLogDownloadLogGap, and extended log-list coverage for wrap/empty/multiple holes - are on a separate branch and are not part of this PR; that branch depends on these fixes.

### Description

  All three surfaced in heavily parallel SITL autotest runs, where log downloads and logging restarts overlap far more often than they do by hand.

  Records written with no FMT to decode them by. A writer thread which slipped a block into the write buffer between _write_fd becoming valid and the buffer being cleared had those bytes
  silently discarded. When the discarded bytes were an FMT message the backend had already marked that format as written-to-this-log, so it was never re-emitted, and the rest of the log
  carried records of that type with nothing to decode them. Logs showing exactly this — PARM, BARO and MAG records with no corresponding FMT anywhere in the file — were captured from
  autotest runs. Clearing the buffer before the fd becomes visible closes the window.
  
  Downloads truncated at a logging restart. _open_error_ms is set whenever an open fails, on the read path as well as the write path, but everything it gates is writer-side: starting a log,
  writing to one, and reporting whether logging works. start_new_log() also sets it speculatively on entry — a deliberate re-entrancy guard, so that a GCS_SEND_TEXT() further down that path
  cannot recurse back into opening a log — and clears it only once the new file is open. Every logging restart therefore leaves recent_open_error() true for up to LOGGER_FILE_REOPEN_MS with
  nothing having gone wrong. get_log_data() consulted that flag, and start_new_log() closes _read_fd too, so a download straddling a restart reopens inside the window the restart created and
  gets -1 back. The MAVLink log transfer reports -1 as EOF, so the client receives a zero-length LOG_DATA mid-file and stops:
  
  REQ id=7 ofs=56259 count=67  ->  DAT ofs=56259 count=67
  REQ id=7 ofs=56211 count=48  ->  DAT ofs=56211 count=0
  
  A missing log poisoning everything else for five seconds. Requesting a log that is not on the card — a hole in the sequence, advertised in the log list as a zero-size/zero-time entry — set
  _open_error_ms from the read-side open failure. That pauses logging, fails downloads of logs which do exist with an immediate zero-length EOF, and fails arming checks (PreArm: Logging 
  failed) for the next five seconds. A missing log is an expected condition, unlike the I/O errors from a failing card that the backoff exists to protect against, so ENOENT no longer sets
  the flag.
