### PR TITLE
autotest: serve terrain to the UTMGlobalPosition tests

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -20349,6 +20349,7 @@ return update, 1000
 
     def UTMGlobalPosition(self):
         '''test UTM_GLOBAL_POSITION message sending'''
+        self.install_terrain_handlers_context()
         self.wait_ready_to_arm()
         m = self.assert_received_message_field_values("UTM_GLOBAL_POSITION", {
             "flight_state": mavutil.mavlink.UTM_FLIGHT_STATE_GROUND,

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -9198,6 +9198,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
     def UTMGlobalPosition(self):
         '''test UTM_GLOBAL_POSITION message sending'''
+        self.install_terrain_handlers_context()
         self.wait_ready_to_arm()
         m = self.assert_received_message_field_values("UTM_GLOBAL_POSITION", {
             "flight_state": mavutil.mavlink.UTM_FLIGHT_STATE_GROUND,


### PR DESCRIPTION
### Summary

Adds a handler so teh "GCS" can supply terrain.  Breaks ordering dependency.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

UTM_GLOBAL_POSITION's RELATIVE_ALTITUDE_AVAILABLE flag is set from AP_Terrain::height_above_terrain(), so the vehicle needs terrain data for the test to see it.  Nothing was serving it: the framework only answers terrain requests for tests which install the handlers.

These tests passed anyway for two reasons, both of which have gone. Run from the repo root the terrain cache has already been filled in by other tests; and until height_above_terrain() was taught to check have_current_loc_height it returned true with an extrapolation from a value which had never been set, so the flag was set even with no terrain data at all.

Under --parallel each worker has its own working directory and starts with an empty cache, so with the vehicle now correctly declining to report a height above terrain it has no data for, the flag is absent and the test fails:

    UTMGlobalPosition (Expected flags 0x7e, got 0x6f)

Only Copter and Plane assert that flag.
