### PR TITLE
AP_Terrain: do not extrapolate height above terrain from an unset value

### DIFF
--- a/libraries/AP_Terrain/AP_Terrain.cpp
+++ b/libraries/AP_Terrain/AP_Terrain.cpp
@@ -250,7 +250,7 @@ bool AP_Terrain::height_above_terrain(float &terrain_altitude, bool extrapolate)
 
     float theight_loc;
     if (!height_amsl(current_loc, theight_loc)) {
-        if (!extrapolate) {
+        if (!extrapolate || !have_current_loc_height) {
             return false;
         }
         // we don't have data at the current location, but the caller


### PR DESCRIPTION
### Summary

Fix passing back an essentially undefined value from `AP_Terrain::height_above_terrain`

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

I've actually seen this happen on real vehicles recently.

### Description

height_above_terrain() falls back to last_current_loc_height when there is no terrain data at the current location and the caller asked for extrapolation.  It never checked have_current_loc_height, so before any terrain data has arrived it extrapolated from a value which has never been set - zero - and returned the vehicle's full AMSL altitude as its height above terrain.  At CMAC that is 584m for a vehicle sitting on the ground.

The other two callers of last_current_loc_height, in height_terrain_difference_home() and send_terrain_report(), both guard on have_current_loc_height already.

Copter feeds this straight to RangeFinder::set_estimated_terrain_height(), so a rangefinder with RNGFNDx_PWRRNG set powers itself down on the ground and blocks arming:

    PreArm: Rangefinder 1: Powered Down

which is reproducible by emptying the vehicle's terrain cache.
