### PR TITLE
SITL: fixes for parallel runs

### DIFF
--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -67,9 +67,14 @@ public:
      */
     void set_instance(uint8_t _instance) {
         instance = _instance;
-        if (instance < MAX_SIM_INSTANCES) {
-            instances[instance] = this;
-        }
+        // register at 0 whatever our instance number is: there is only
+        // ever one Aircraft in a SITL process, and _instance is the -I
+        // number, which separates the ports and directories of separate
+        // processes rather than indexing aircraft within one.  Indexing
+        // by it left instances[0] empty for every -I but zero, so
+        // scripts calling sim:set_pose(0, ...) - as the shipped
+        // sim_arming_pos.lua example does - silently did nothing.
+        instances[0] = this;
     }
 
     /*

--- a/libraries/SITL/SIM_Ship.cpp
+++ b/libraries/SITL/SIM_Ship.cpp
@@ -28,6 +28,9 @@
 
 #include "SIM_Aircraft.h"
 #include <AP_HAL_SITL/SITL_State.h>
+#include <AP_HAL_SITL/HAL_SITL_Class.h>
+
+extern const HAL_SITL& hal_sitl;
 #include <AP_Terrain/AP_Terrain.h>
 
 using namespace SITL;
@@ -173,8 +176,12 @@ void ShipSim::update(void)
         home.offset(ofs.x, ofs.y);
         home.alt -= ofs.z*100;
 
+        target_port += 10 * hal_sitl.get_instance();
+
         initialised = true;
-        ::printf("ShipSim home %f %f\n", home.lat*1.0e-7, home.lng*1.0e-7);
+        ::printf("ShipSim home %f %f reporting to %s:%u\n",
+                 home.lat*1.0e-7, home.lng*1.0e-7,
+                 target_address, (unsigned)target_port);
         ship.sim = this;
         last_update_us = now_us;
         last_report_ms = AP_HAL::millis();

--- a/libraries/SITL/SIM_Ship.h
+++ b/libraries/SITL/SIM_Ship.h
@@ -74,7 +74,11 @@ private:
 
     Location home;
     const char *target_address = "127.0.0.1";
-    const uint16_t target_port = 5762;
+    // SERIAL0's TCP port for *this* SITL instance.  -I moves that port
+    // by ten per instance, so a fixed 5762 only ever reaches instance
+    // zero - from anywhere else the beacon goes to another vehicle, or
+    // nowhere, and ours refuses to arm with "Ship: no beacon".
+    uint16_t target_port = 5762;
 
     bool initialised;
     Ship ship;


### PR DESCRIPTION
### Summary

A couple of fixes when running tests in parallel

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Stops port conflicts on the ship sim port.

Removes reliance on `MAX_SIM_INSTANCES` so [0] is always populated.
