### PR TITLE
Copter: unblock takeoff spoolup when HAL_WITH_ESC_TELEM is disabled

### DIFF
--- a/ArduCopter/takeoff_check.cpp
+++ b/ArduCopter/takeoff_check.cpp
@@ -7,13 +7,15 @@
 // detects if the vehicle should be allowed to takeoff or not and sets the motors.blocked flag
 void Copter::takeoff_check()
 {
-#if HAL_WITH_ESC_TELEM && FRAME_CONFIG != HELI_FRAME
+#if FRAME_CONFIG != HELI_FRAME
     // if motors have become unblocked return immediately
     // this ensures the motors can only be blocked immediately after arming
     uint32_t now_ms = AP_HAL::millis();
     if (!motors->get_spoolup_block()) {
         takeoff_check_warning_ms = now_ms;
+#if HAL_WITH_ESC_TELEM
         takeoff_check_state.warning_ms = now_ms;
+#endif
         return;
     }
 
@@ -25,8 +27,12 @@ void Copter::takeoff_check()
         return;
     }
 
+#if HAL_WITH_ESC_TELEM
     // Run the common motor checks (called early so it can clear its warning timer when disarmed)
     const bool motor_check_passed = motors_takeoff_check(g2.takeoff_rpm_min, g2.takeoff_rpm_max);
+#else
+    const bool motor_check_passed = true;
+#endif
 
     // Check system load
     float avg_load, peak_load;


### PR DESCRIPTION
### Summary

Fix a deadlock where multicopter motors were permanently trapped in `GROUND_IDLE` when `HAL_WITH_ESC_TELEM` is disabled (`0`).

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

**Testing Details**:
Tested on ESP32-S3 brushed quadcopter (`esp32s3m5stampfly`) where `HAL_WITH_ESC_TELEM` is defined as `0`:
- **Before fix**: While RC throttle input (`RC_CHANNELS`) changed across the full range from 1100 to 1900 µs, motor PWM output (`SERVO_OUTPUT_RAW`) only varied between 1100 and 1150 µs (`MOT_SPIN_ARM` to `MOT_SPIN_MIN`) and remained permanently locked in `GROUND_IDLE` even at 100% full throttle.
- **After fix**: `takeoff_check()` clears the spoolup block, allowing motors to transition to `THROTTLE_UNLIMITED` and properly follow the full throttle stick range (1100 to 1900 µs). Successful flight verified.

*Note: This contribution was AI-assisted (Google Antigravity pair programming).*

### Description

When `HAL_WITH_ESC_TELEM` is disabled (`0`), `Copter::takeoff_check()` was completely compiled out because the entire function body was guarded by `#if HAL_WITH_ESC_TELEM && FRAME_CONFIG != HELI_FRAME`.

However, in `AP_MotorsMulticopter::output_logic()`, `set_spoolup_block(true)` is unconditionally called upon completing initial spin-up to wait for pre-takeoff clearance.

Consequently, on any board built with `HAL_WITH_ESC_TELEM=0` (such as flash/RAM-constrained micro drone targets without ESC telemetry), `motors->set_spoolup_block(false)` was never called. Motors were permanently trapped in `GROUND_IDLE` (spoolup blocked), preventing throttle from rising above ground idle spin (`MOT_SPIN_MIN` / 1150 µs).

This fix:
1. Keeps `takeoff_check()` active whenever `FRAME_CONFIG != HELI_FRAME`.
2. Only guards `motors_takeoff_check()` and `takeoff_check_state` with `#if HAL_WITH_ESC_TELEM`.
3. Ensures system load checks run and `motors->set_spoolup_block(false)` is properly cleared on all platforms.
