### PR TITLE
Limit 4.8 migration to be only from 4.3 and younger

### DIFF
--- a/AntennaTracker/system.cpp
+++ b/AntennaTracker/system.cpp
@@ -46,8 +46,6 @@ void Tracker::init_ardupilot()
 #endif
 
     // initialise rc channels including setting mode
-    // PARAMETER_CONVERSION - Added: Sep-2021 for Tracker-4.5
-    rc().convert_options(RC_Channel::AUX_FUNC::ARMDISARM_UNUSED, RC_Channel::AUX_FUNC::ARMDISARM);
     rc().init();
 
     // initialise servos

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -968,10 +968,6 @@ private:
 
     // Parameters.cpp
     void load_parameters(void) override;
-    void convert_pid_parameters(void);
-#if HAL_PROXIMITY_ENABLED
-    void convert_prx_parameters();
-#endif
 
     // precision_landing.cpp
     void init_precland();

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1271,11 +1271,6 @@ void Copter::load_parameters(void)
 {
     AP_Vehicle::load_parameters(g.format_version, Parameters::k_format_version);
 
-    // PARAMETER_CONVERSION - Added: Mar-2022
-#if AP_FENCE_ENABLED
-    AP_Param::convert_class(g.k_param_fence_old, &fence, fence.var_info, 0, true);
-#endif
-
     // PARAMETER_CONVERSION - Added: Jul-2025 for ArduPilot-4.7
 #if AP_RPM_ENABLED
     AP_Param::convert_class(g.k_param_rpm_sensor_old, &rpm_sensor, rpm_sensor.var_info, 0, true, true);
@@ -1363,88 +1358,3 @@ void Copter::load_parameters(void)
     // setup AP_Param frame type flags
     AP_Param::set_frame_type_flags(AP_PARAM_FRAME_COPTER);
 }
-
-// handle conversion of PID gains
-void Copter::convert_pid_parameters(void)
-{
-    const AP_Param::ConversionInfo angle_and_filt_conversion_info[] = {
-        // PARAMETER_CONVERSION - Added: Aug-2021
-        { Parameters::k_param_pi_vel_xy, 3, AP_PARAM_FLOAT, "PSC_NE_VEL_FLTE" },
-    };
-
-    // convert angle controller gain and filter without scaling
-    for (const auto &info : angle_and_filt_conversion_info) {
-        AP_Param::convert_old_parameter(&info, 1.0f);
-    }
-
-#if AP_INERTIALSENSOR_HARMONICNOTCH_ENABLED
-#if HAL_INS_NUM_HARMONIC_NOTCH_FILTERS > 1
-    if (!ins.harmonic_notches[1].params.enabled()) {
-        // notch filter parameter conversions (moved to INS_HNTC2) for 4.2.x, converted from fixed notch
-        const AP_Param::ConversionInfo notchfilt_conversion_info[] {
-            // PARAMETER_CONVERSION - Added: Apr-2022 for ArduPilot-4.2
-            { Parameters::k_param_ins, 101, AP_PARAM_INT8,  "INS_HNTC2_ENABLE" },
-            { Parameters::k_param_ins, 293, AP_PARAM_FLOAT, "INS_HNTC2_ATT" },
-            { Parameters::k_param_ins, 357, AP_PARAM_FLOAT, "INS_HNTC2_FREQ" },
-            { Parameters::k_param_ins, 421, AP_PARAM_FLOAT, "INS_HNTC2_BW" },
-        };
-        AP_Param::convert_old_parameters(&notchfilt_conversion_info[0], ARRAY_SIZE(notchfilt_conversion_info));
-        AP_Param::set_default_by_name("INS_HNTC2_MODE", 0);
-        AP_Param::set_default_by_name("INS_HNTC2_HMNCS", 1);
-    }
-#endif
-#endif  // AP_INERTIALSENSOR_HARMONICNOTCH_ENABLED
-
-    // ACRO_RP_P and ACRO_Y_P replaced with ACRO_RP_RATE and ACRO_Y_RATE for Copter-4.2
-    // PARAMETER_CONVERSION - Added: Sep-2021
-    const AP_Param::ConversionInfo acro_rpy_conversion_info[] = {
-        { Parameters::k_param_acro_rp_p, 0, AP_PARAM_FLOAT, "ACRO_RP_RATE" },
-        { Parameters::k_param_acro_yaw_p,  0, AP_PARAM_FLOAT, "ACRO_Y_RATE" }
-    };
-    for (const auto &info : acro_rpy_conversion_info) {
-        AP_Param::convert_old_parameter(&info, 45.0);
-    }
-
-    // convert rate and expo command model parameters for Copter-4.3
-    // PARAMETER_CONVERSION - Added: Jun-2022 for ArduPilot-4.3
-    const AP_Param::ConversionInfo cmd_mdl_conversion_info[] = {
-        { Parameters::k_param_g2, 47, AP_PARAM_FLOAT, "ACRO_RP_RATE" },
-        { Parameters::k_param_acro_rp_expo,  0, AP_PARAM_FLOAT, "ACRO_RP_EXPO" },
-        { Parameters::k_param_g2,  48, AP_PARAM_FLOAT, "ACRO_Y_RATE" },
-        { Parameters::k_param_g2,  9, AP_PARAM_FLOAT, "ACRO_Y_EXPO" },
-        { Parameters::k_param_g2,  49, AP_PARAM_FLOAT, "PILOT_Y_RATE" },
-        { Parameters::k_param_g2,  50, AP_PARAM_FLOAT, "PILOT_Y_EXPO" },
-    };
-    for (const auto &info : cmd_mdl_conversion_info) {
-        AP_Param::convert_old_parameter(&info, 1.0);
-    }
-
-    // make any SRV_Channel upgrades needed
-    SRV_Channels::upgrade_parameters();
-}
-
-#if HAL_PROXIMITY_ENABLED
-void Copter::convert_prx_parameters()
-{
-    // convert PRX to PRX1_ parameters for Copter-4.3
-    // PARAMETER_CONVERSION - Added: Aug-2022
-    static const AP_Param::ConversionInfo prx_conversion_info[] = {
-        { Parameters::k_param_g2, 72, AP_PARAM_INT8, "PRX1_TYPE" },
-        { Parameters::k_param_g2, 136, AP_PARAM_INT8, "PRX1_ORIENT" },
-        { Parameters::k_param_g2, 200, AP_PARAM_INT16, "PRX1_YAW_CORR" },
-        { Parameters::k_param_g2, 264, AP_PARAM_INT16, "PRX1_IGN_ANG1" },
-        { Parameters::k_param_g2, 328, AP_PARAM_INT8, "PRX1_IGN_WID1" },
-        { Parameters::k_param_g2, 392, AP_PARAM_INT16, "PRX1_IGN_ANG2" },
-        { Parameters::k_param_g2, 456, AP_PARAM_INT8, "PRX1_IGN_WID2" },
-        { Parameters::k_param_g2, 520, AP_PARAM_INT16, "PRX1_IGN_ANG3" },
-        { Parameters::k_param_g2, 584, AP_PARAM_INT8, "PRX1_IGN_WID3" },
-        { Parameters::k_param_g2, 648, AP_PARAM_INT16, "PRX1_IGN_ANG4" },
-        { Parameters::k_param_g2, 712, AP_PARAM_INT8, "PRX1_IGN_WID4" },
-        { Parameters::k_param_g2, 1224, AP_PARAM_FLOAT, "PRX1_MIN" },
-        { Parameters::k_param_g2, 1288, AP_PARAM_FLOAT, "PRX1_MAX" },
-    };
-    for (const auto &info : prx_conversion_info) {
-        AP_Param::convert_old_parameter(&info, 1.0);
-    }
-}
-#endif

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -509,14 +509,8 @@ void Copter::allocate_motors(void)
     }
     
     // upgrade parameters. This must be done after allocating the objects
-    convert_pid_parameters();
 #if FRAME_CONFIG == HELI_FRAME
     motors->heli_motors_param_conversions();
-#endif
-
-#if HAL_PROXIMITY_ENABLED
-    // convert PRX to PRX1_ parameters
-    convert_prx_parameters();
 #endif
 
     // upgrade attitude controller parameters

--- a/ArduCopter/system.cpp
+++ b/ArduCopter/system.cpp
@@ -64,8 +64,6 @@ void Copter::init_ardupilot()
     allocate_motors();
 
     // initialise rc channels including setting mode
-    // PARAMETER_CONVERSION - Added: Sep-2021 for Copter-4.2
-    rc().convert_options(RC_Channel::AUX_FUNC::ARMDISARM_UNUSED, RC_Channel::AUX_FUNC::ARMDISARM_AIRMODE);
     rc().init();
 
     // sets up motors and output to escs

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1360,8 +1360,6 @@ void Plane::load_parameters(void)
     g2.servo_channels.set_default_function(CH_2, SRV_Channel::k_elevator);
     g2.servo_channels.set_default_function(CH_3, SRV_Channel::k_throttle);
     g2.servo_channels.set_default_function(CH_4, SRV_Channel::k_rudder);
-        
-    SRV_Channels::upgrade_parameters();
 
 #if HAL_QUADPLANE_ENABLED
     if (quadplane.enable) {
@@ -1385,137 +1383,8 @@ void Plane::load_parameters(void)
         }
     }
 
-
-// PARAMETER_CONVERSION - Added: Mar-2021 for ArduPlane-4.1
-#if AP_FENCE_ENABLED
-    enum ap_var_type ptype_fence_type;
-    AP_Int8 *fence_type_new = (AP_Int8*)AP_Param::find("FENCE_TYPE", &ptype_fence_type);
-    if (fence_type_new && !fence_type_new->configured()) {
-        // If we find the new parameter and it hasn't been configured
-        // attempt to upgrade the altitude fences.
-        int8_t fence_type_new_val = AC_FENCE_TYPE_POLYGON;
-        AP_Int16 fence_alt_min_old;
-        AP_Param::ConversionInfo fence_alt_min_info_old = {
-            Parameters::k_param_fence_minalt,
-            0,
-            AP_PARAM_INT16,
-            nullptr
-        };
-        if (AP_Param::find_old_parameter(&fence_alt_min_info_old, &fence_alt_min_old)) {
-            if (fence_alt_min_old.configured()) {
-                //
-                fence_type_new_val |= AC_FENCE_TYPE_ALT_MIN;
-            }
-        }
-
-        AP_Int16 fence_alt_max_old;
-        AP_Param::ConversionInfo fence_alt_max_info_old = {
-            Parameters::k_param_fence_maxalt,
-            0,
-            AP_PARAM_INT16,
-            nullptr
-        };
-        if (AP_Param::find_old_parameter(&fence_alt_max_info_old, &fence_alt_max_old)) {
-            if (fence_alt_max_old.configured()) {
-                fence_type_new_val |= AC_FENCE_TYPE_ALT_MAX;
-            }
-        }
-
-        fence_type_new->set_and_save((int8_t)fence_type_new_val);
-    }
-
-    AP_Int8 fence_action_old;
-    AP_Param::ConversionInfo fence_action_info_old = {
-        Parameters::k_param_fence_action,
-        0,
-        AP_PARAM_INT8,
-        "FENCE_ACTION"
-    };
-    if (AP_Param::find_old_parameter(&fence_action_info_old, &fence_action_old)) {
-        enum ap_var_type ptype;
-        AP_Int8 *fence_action_new = (AP_Int8*)AP_Param::find(&fence_action_info_old.new_name[0], &ptype);
-        AC_Fence::Action fence_action_new_val;
-        if (fence_action_new && !fence_action_new->configured()) {
-            switch(fence_action_old.get()) {
-                case 0: // FENCE_ACTION_NONE
-                case 2: // FENCE_ACTION_REPORT_ONLY
-                default:
-                    fence_action_new_val = AC_Fence::Action::REPORT_ONLY;
-                    break;
-                case 1: // FENCE_ACTION_GUIDED
-                    fence_action_new_val = AC_Fence::Action::GUIDED;
-                    break;
-                case 3: // FENCE_ACTION_GUIDED_THR_PASS
-                    fence_action_new_val = AC_Fence::Action::GUIDED_THROTTLE_PASS;
-                    break;
-                case 4: // FENCE_ACTION_RTL
-                    fence_action_new_val = AC_Fence::Action::RTL_AND_LAND;
-                    break;
-            }
-            fence_action_new->set_and_save((int8_t)fence_action_new_val);
-            
-            // Now upgrade the new fence enable at the same time
-            enum ap_var_type ptype_fence_enable;
-            AP_Int8 *fence_enable = (AP_Int8*)AP_Param::find("FENCE_ENABLE", &ptype_fence_enable);
-            // fences were used if there was a count, and the old fence action was not zero
-            AC_Fence *ap_fence = AP::fence();
-            bool fences_exist = false;
-            if (ap_fence) {
-                // If the fence library is present, attempt to read the fence count
-                fences_exist = ap_fence->polyfence().total_fence_count() > 0;
-            }
-            
-            bool fences_used = fence_action_old.get() != 0;
-            if (fence_enable && !fence_enable->configured()) {
-                // The fence enable parameter exists, so now set it accordingly
-                fence_enable->set_and_save(fences_exist && fences_used);
-            }
-        }
-    }
-#endif // AP_FENCE_ENABLED
-
-#if AP_TERRAIN_AVAILABLE
-    // PARAMETER_CONVERSION - Added: Mar-2021 for ArduPlane-4.1
-    g.terrain_follow.convert_parameter_width(AP_PARAM_INT8);
-#endif
-
-    // PARAMETER_CONVERSION - Added: Jun-2021 for ArduPlane-4.1
-    g.use_reverse_thrust.convert_parameter_width(AP_PARAM_INT16);
-
     // PARAMETER_CONVERSION - Added: Jun-2026 for FBWB_CLIMB_RATE width change
     g.flybywire_climb_rate.convert_parameter_width(AP_PARAM_INT8);
-
-#if AP_AIRSPEED_ENABLED
-    // PARAMETER_CONVERSION - Added: Jan-2022
-    {
-        const uint16_t old_key = g.k_param_airspeed;
-        const uint16_t old_index = 0;       // Old parameter index in the tree
-        AP_Param::convert_class(old_key, &airspeed, airspeed.var_info, old_index, true);
-    }
-#endif
-
-#if AP_INERTIALSENSOR_HARMONICNOTCH_ENABLED
-#if HAL_INS_NUM_HARMONIC_NOTCH_FILTERS > 1
-    if (!ins.harmonic_notches[1].params.enabled()) {
-        // notch filter parameter conversions (moved to INS_HNTC2) for 4.2.x, converted from fixed notch
-        const AP_Param::ConversionInfo notchfilt_conversion_info[] {
-            // PARAMETER_CONVERSION - Added: Apr-2022 for ArduPlane-4.2
-            { Parameters::k_param_ins, 101, AP_PARAM_INT8,  "INS_HNTC2_ENABLE" },
-            { Parameters::k_param_ins, 293, AP_PARAM_FLOAT, "INS_HNTC2_ATT" },
-            { Parameters::k_param_ins, 357, AP_PARAM_FLOAT, "INS_HNTC2_FREQ" },
-            { Parameters::k_param_ins, 421, AP_PARAM_FLOAT, "INS_HNTC2_BW" },
-        };
-        AP_Param::convert_old_parameters(&notchfilt_conversion_info[0], ARRAY_SIZE(notchfilt_conversion_info));
-        AP_Param::set_default_by_name("INS_HNTC2_MODE", 0);
-        AP_Param::set_default_by_name("INS_HNTC2_HMNCS", 1);
-    }
-#endif // HAL_INS_NUM_HARMONIC_NOTCH_FILTERS
-#endif  // AP_INERTIALSENSOR_HARMONICNOTCH_ENABLED
-
-    // PARAMETER_CONVERSION - Added: Mar-2022
-#if AP_FENCE_ENABLED
-    AP_Param::convert_class(g.k_param_fence, &fence, fence.var_info, 0, true);
-#endif
 
     // PARAMETER_CONVERSION - Added: Jul-2025 for ArduPilot-4.7
 #if AP_RPM_ENABLED
@@ -1541,10 +1410,6 @@ void Plane::load_parameters(void)
     landing.convert_parameters();
 
     static const AP_Param::G2ObjectConversion g2_conversions[] {
-    // PARAMETER_CONVERSION - Added: Oct-2021
-#if HAL_EFI_ENABLED
-        { &efi, efi.var_info, 22 },
-#endif
 #if AP_STATS_ENABLED
     // PARAMETER_CONVERSION - Added: Jan-2024 for Plane-4.6
         { &stats, stats.var_info, 5 },

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -1305,55 +1305,9 @@ ParametersG2::ParametersG2(void) :
     AP_Param::setup_object_defaults(this, var_info);
 }
 
-/*
-  This is a conversion table from old parameter values to new
-  parameter names. The startup code looks for saved values of the old
-  parameters and will copy them across to the new parameters if the
-  new parameter does not yet have a saved value. It then saves the new
-  value.
-  
-  Note that this works even if the old parameter has been removed. It
-  relies on the old k_param index not being removed
-  
-  The second column below is the index in the var_info[] table for the
-  old object. This should be zero for top level parameters.
- */
-static const AP_Param::ConversionInfo conversion_table[] = {
-    // PARAMETER_CONVERSION - Added: Mar-2021 for ArduPlane-4.1
-    { Parameters::k_param_fence_minalt,       0,     AP_PARAM_INT16, "FENCE_ALT_MIN"},
-    { Parameters::k_param_fence_maxalt,       0,     AP_PARAM_INT16, "FENCE_ALT_MAX"},
-    { Parameters::k_param_fence_retalt,       0,     AP_PARAM_INT16, "FENCE_RET_ALT"},
-    { Parameters::k_param_fence_ret_rally,    0,      AP_PARAM_INT8, "FENCE_RET_RALLY"},
-    { Parameters::k_param_fence_autoenable,   0,      AP_PARAM_INT8, "FENCE_AUTOENABLE"},
-};
-
-struct RCConversionInfo {
-    uint16_t old_key; // k_param_*
-    uint32_t old_group_element; // index in old object
-    RC_Channel::AUX_FUNC fun; // new function
-};
-
-static const RCConversionInfo rc_option_conversion[] = {
-    { Parameters::k_param_flapin_channel_old, 0, RC_Channel::AUX_FUNC::FLAP},
-    { Parameters::k_param_g2, 968, RC_Channel::AUX_FUNC::SOARING},
-#if AP_FENCE_ENABLED
-    { Parameters::k_param_fence_channel, 0, RC_Channel::AUX_FUNC::FENCE},
-#endif
-#if AP_MISSION_ENABLED
-    { Parameters::k_param_reset_mission_chan, 0, RC_Channel::AUX_FUNC::MISSION_RESET},
-#endif
-#if HAL_PARACHUTE_ENABLED
-    { Parameters::k_param_parachute_channel, 0, RC_Channel::AUX_FUNC::PARACHUTE_RELEASE},
-#endif
-    { Parameters::k_param_fbwa_tdrag_chan, 0, RC_Channel::AUX_FUNC::FBWA_TAILDRAGGER},
-    { Parameters::k_param_reset_switch_chan, 0, RC_Channel::AUX_FUNC::MODE_SWITCH_RESET},
-};
-
 void Plane::load_parameters(void)
 {
     AP_Vehicle::load_parameters(g.format_version, Parameters::k_format_version);
-
-    AP_Param::convert_old_parameters(&conversion_table[0], ARRAY_SIZE(conversion_table));
 
     // setup defaults in SRV_Channels
     g2.servo_channels.set_default_function(CH_1, SRV_Channel::k_aileron);
@@ -1369,19 +1323,6 @@ void Plane::load_parameters(void)
 #endif
 
     AP_Param::set_frame_type_flags(AP_PARAM_FRAME_PLANE);
-
-    // Convert chan params to RCx_OPTION
-    // PARAMETER_CONVERSION - Added: Mar-2021 for ArduPlane-4.1
-    for (uint8_t i=0; i<ARRAY_SIZE(rc_option_conversion); i++) {
-        AP_Int8 chan_param;
-        AP_Param::ConversionInfo info {rc_option_conversion[i].old_key, rc_option_conversion[i].old_group_element, AP_PARAM_INT8, nullptr};
-        if (AP_Param::find_old_parameter(&info, &chan_param) && chan_param.get() > 0) {
-            RC_Channel *chan = rc().channel(chan_param.get() - 1);
-            if (chan != nullptr && !chan->option.configured()) {
-                chan->option.set_and_save((int16_t)rc_option_conversion[i].fun); // save the new param
-            }
-        }
-    }
 
     // PARAMETER_CONVERSION - Added: Jun-2026 for FBWB_CLIMB_RATE width change
     g.flybywire_climb_rate.convert_parameter_width(AP_PARAM_INT8);

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -606,46 +606,6 @@ static const struct AP_Param::defaults_table_struct defaults_table[] = {
     { "Q_A_ACC_Y_MAX", 100 },
 };
 
-/*
-  conversion table for quadplane parameters
- */
-const AP_Param::ConversionInfo q_conversion_table[] = {
-    // PARAMETER_CONVERSION - Added: Jul-2021 for ArduPlane-4.2
-    // tailsitter params have moved but retain the same names
-    { Parameters::k_param_quadplane, 48,  AP_PARAM_INT8,  "Q_TAILSIT_ANGLE" },
-    { Parameters::k_param_quadplane, 61,  AP_PARAM_INT8,  "Q_TAILSIT_ANG_VT" },
-    { Parameters::k_param_quadplane, 50,  AP_PARAM_INT8,  "Q_TAILSIT_INPUT" },
-    { Parameters::k_param_quadplane, 53,  AP_PARAM_FLOAT, "Q_TAILSIT_VFGAIN" },
-    { Parameters::k_param_quadplane, 54,  AP_PARAM_FLOAT, "Q_TAILSIT_VHGAIN" },
-    { Parameters::k_param_quadplane, 56,  AP_PARAM_FLOAT, "Q_TAILSIT_VHPOW" },
-    { Parameters::k_param_quadplane, 251,   AP_PARAM_FLOAT, "Q_TAILSIT_GSCMAX" },
-    { Parameters::k_param_quadplane, 379,   AP_PARAM_FLOAT, "Q_TAILSIT_RLL_MX" },
-    { Parameters::k_param_quadplane, 635,   AP_PARAM_INT16, "Q_TAILSIT_MOTMX" },
-    { Parameters::k_param_quadplane, 1147,  AP_PARAM_INT16, "Q_TAILSIT_GSCMSK" },
-    { Parameters::k_param_quadplane, 1211,  AP_PARAM_FLOAT, "Q_TAILSIT_GSCMIN" },
-    { Parameters::k_param_quadplane, 1403,  AP_PARAM_FLOAT, "Q_TAILSIT_DSKLD" },
-    { Parameters::k_param_quadplane, 1595,  AP_PARAM_FLOAT, "Q_TAILSIT_RAT_FW" },
-    { Parameters::k_param_quadplane, 1659,  AP_PARAM_FLOAT, "Q_TAILSIT_RAT_FW" },
-
-    // PARAMETER_CONVERSION - Added: Sep-2021 for ArduPlane-4.2
-    // tiltrotor params have moved but retain the same names
-    { Parameters::k_param_quadplane, 37,  AP_PARAM_INT16,  "Q_TILT_MASK" },
-    { Parameters::k_param_quadplane, 38,  AP_PARAM_INT16,  "Q_TILT_RATE_UP" },
-    { Parameters::k_param_quadplane, 39,  AP_PARAM_INT8,  "Q_TILT_MAX" },
-    { Parameters::k_param_quadplane, 47,  AP_PARAM_INT8,  "Q_TILT_TYPE" },
-    { Parameters::k_param_quadplane, 49,  AP_PARAM_INT16,  "Q_TILT_RATE_DN" },
-    { Parameters::k_param_quadplane, 55,  AP_PARAM_FLOAT,  "Q_TILT_YAW_ANGLE" },
-    { Parameters::k_param_quadplane, 1467,  AP_PARAM_FLOAT,  "Q_TILT_FIX_ANGLE" },
-    { Parameters::k_param_quadplane, 1531,  AP_PARAM_FLOAT,  "Q_TILT_FIX_GAIN" },
-
-    // PARAMETER_CONVERSION - Added: Jan-2022 for ArduPlane-4.2
-    { Parameters::k_param_quadplane, 33,  AP_PARAM_FLOAT, "Q_WVANE_GAIN" },     // Moved from quadplane to weathervane library
-    { Parameters::k_param_quadplane, 34,  AP_PARAM_FLOAT, "Q_WVANE_ANG_MIN" },  // Q_WVANE_MINROLL moved from quadplane to weathervane library
-
-    // PARAMETER_CONVERSION - Added: Jul-2022 for ArduPlane-4.3
-    { Parameters::k_param_quadplane, 25,  AP_PARAM_FLOAT, "Q_PLT_Y_RATE" },   // Moved from quadplane to command model library
-};
-
 // PARAMETER_CONVERSION - Added: Oct-2021
 const AP_Param::ConversionInfo mot_pwm_conversion_table[] = {
     { Parameters::k_param_quadplane, 22,  AP_PARAM_INT16, "Q_M_PWM_MIN" },
@@ -818,8 +778,6 @@ bool QuadPlane::setup(void)
     }
 
     setup_defaults();
-
-    AP_Param::convert_old_parameters(&q_conversion_table[0], ARRAY_SIZE(q_conversion_table));
 
     // PARAMETER_CONVERSION - Added: Jan-2024 for ArduPlane-4.5
     land_final_speed_ms.convert_centi_parameter(AP_PARAM_INT16);

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -606,12 +606,6 @@ static const struct AP_Param::defaults_table_struct defaults_table[] = {
     { "Q_A_ACC_Y_MAX", 100 },
 };
 
-// PARAMETER_CONVERSION - Added: Oct-2021
-const AP_Param::ConversionInfo mot_pwm_conversion_table[] = {
-    { Parameters::k_param_quadplane, 22,  AP_PARAM_INT16, "Q_M_PWM_MIN" },
-    { Parameters::k_param_quadplane, 23,  AP_PARAM_INT16, "Q_M_PWM_MAX" },
-};
-
 QuadPlane::QuadPlane(AP_AHRS &_ahrs) :
     ahrs(_ahrs)
 {
@@ -760,12 +754,6 @@ bool QuadPlane::setup(void)
     motors->update_throttle_range();
     motors->set_update_rate(rc_speed);
     attitude_control->parameter_sanity_check();
-
-    // Try to convert mot PWM params, if still invalid force conversion
-    AP_Param::convert_old_parameters(&mot_pwm_conversion_table[0], ARRAY_SIZE(mot_pwm_conversion_table));
-    if (!motors->check_mot_pwm_params()) {
-        AP_Param::convert_old_parameters(&mot_pwm_conversion_table[0], ARRAY_SIZE(mot_pwm_conversion_table), AP_Param::CONVERT_FLAG_FORCE);
-    }
 
     // setup the trim of any motors used by AP_Motors so I/O board
     // failsafe will disable motors

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -12,9 +12,6 @@ void Plane::init_ardupilot()
 
     ins.set_log_raw_bit(MASK_LOG_IMU_RAW);
 
-    rollController.convert_pid();
-    pitchController.convert_pid();
-
     // initialise rc channels including setting mode
     // PARAMETER_CONVERSION - Added: Sep-2021 for ArduPlane-4.2
 #if HAL_QUADPLANE_ENABLED

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -13,12 +13,6 @@ void Plane::init_ardupilot()
     ins.set_log_raw_bit(MASK_LOG_IMU_RAW);
 
     // initialise rc channels including setting mode
-    // PARAMETER_CONVERSION - Added: Sep-2021 for ArduPlane-4.2
-#if HAL_QUADPLANE_ENABLED
-    rc().convert_options(RC_Channel::AUX_FUNC::ARMDISARM_UNUSED, (quadplane.enabled() && quadplane.option_is_set(QuadPlane::Option::AIRMODE_UNUSED) && (rc().find_channel_for_option(RC_Channel::AUX_FUNC::AIRMODE) == nullptr)) ? RC_Channel::AUX_FUNC::ARMDISARM_AIRMODE : RC_Channel::AUX_FUNC::ARMDISARM);
-#else
-    rc().convert_options(RC_Channel::AUX_FUNC::ARMDISARM_UNUSED, RC_Channel::AUX_FUNC::ARMDISARM);
-#endif
     rc().init();
 
 #if AP_RELAY_ENABLED

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -800,7 +800,6 @@ void Sub::load_parameters()
 
     AP_Param::set_frame_type_flags(AP_PARAM_FRAME_SUB);
 
-    convert_old_parameters();
     AP_Param::set_defaults_from_table(defaults_table, ARRAY_SIZE(defaults_table));
     // We should ignore this parameter since ROVs are neutral buoyancy
     AP_Param::set_by_name("MOT_THST_HOVER", 0.5);
@@ -874,19 +873,6 @@ void Sub::load_parameters()
         { 2, 21, AP_PARAM_FLOAT, "AHRS_ORIGIN_ALT" },   // ORIGIN_ALT moved to AHRS_ORIGIN_ALT
     };
     AP_Param::convert_old_parameters(&origin_conversion_info[0], ARRAY_SIZE(origin_conversion_info));
-}
-
-void Sub::convert_old_parameters()
-{
-    // attitude control filter parameter changes from _FILT to FLTE or FLTD
-    // PARAMETER_CONVERSION - Added: Jul-2019 for ArduSub-4.0
-    const AP_Param::ConversionInfo filt_conversion_info[] = {
-        // move ATC_RAT_RLL/PIT_FILT to FLTD, move ATC_RAT_YAW_FILT to FLTE
-        { Parameters::k_param_attitude_control, 385, AP_PARAM_FLOAT, "ATC_RAT_RLL_FLTE" },
-        { Parameters::k_param_attitude_control, 386, AP_PARAM_FLOAT, "ATC_RAT_PIT_FLTE" },
-        { Parameters::k_param_attitude_control, 387, AP_PARAM_FLOAT, "ATC_RAT_YAW_FLTE" },
-    };
-    AP_Param::convert_old_parameters(&filt_conversion_info[0], ARRAY_SIZE(filt_conversion_info));
 }
 
 #if LEAKDETECTOR_MAX_INSTANCES > 0

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -805,21 +805,12 @@ void Sub::load_parameters()
     // We should ignore this parameter since ROVs are neutral buoyancy
     AP_Param::set_by_name("MOT_THST_HOVER", 0.5);
 
-    // PARAMETER_CONVERSION - Added: Mar-2022
-#if AP_FENCE_ENABLED
-    AP_Param::convert_class(g.k_param_fence_old, &fence, fence.var_info, 0, true);
-#endif
-
     // PARAMETER_CONVERSION - Added: Jul-2025 for ArduPilot-4.7
 #if AP_RPM_ENABLED
     AP_Param::convert_class(g.k_param_rpm_sensor_old, &rpm_sensor, rpm_sensor.var_info, 0, true, true);
 #endif
 
     static const AP_Param::G2ObjectConversion g2_conversions[] {
-#if AP_AIRSPEED_ENABLED
-    // PARAMETER_CONVERSION - Added: Jan-2022 for ArduSub-4.5
-        { &airspeed, airspeed.var_info, 19 },
-#endif
 #if AP_STATS_ENABLED
     // PARAMETER_CONVERSION - Added: Jan-2024
         { &stats, stats.var_info, 1 },
@@ -896,8 +887,6 @@ void Sub::convert_old_parameters()
         { Parameters::k_param_attitude_control, 387, AP_PARAM_FLOAT, "ATC_RAT_YAW_FLTE" },
     };
     AP_Param::convert_old_parameters(&filt_conversion_info[0], ARRAY_SIZE(filt_conversion_info));
-
-    SRV_Channels::upgrade_parameters();
 }
 
 #if LEAKDETECTOR_MAX_INSTANCES > 0

--- a/ArduSub/Parameters.cpp
+++ b/ArduSub/Parameters.cpp
@@ -783,20 +783,9 @@ ParametersG2::ParametersG2()
     AP_Param::setup_object_defaults(this, var_info);
 }
 
-const AP_Param::ConversionInfo conversion_table[] = {
-    // PARAMETER_CONVERSION - Added: Mar-2018 for ArduSub-4.0
-    { Parameters::k_param_fs_batt_voltage,   0,      AP_PARAM_FLOAT,  "BATT_LOW_VOLT" },
-    { Parameters::k_param_fs_batt_mah,       0,      AP_PARAM_FLOAT,  "BATT_LOW_MAH" },
-    { Parameters::k_param_failsafe_battery_enabled,       0,      AP_PARAM_INT8,  "BATT_FS_LOW_ACT" },
-    // PARAMETER_CONVERSION - Added: Apr-2019 for ArduSub-4.0
-    { Parameters::k_param_compass_enabled_deprecated,       0,      AP_PARAM_INT8, "COMPASS_ENABLE" },
-};
-
 void Sub::load_parameters()
 {
     AP_Vehicle::load_parameters(g.format_version, Parameters::k_format_version);
-
-    AP_Param::convert_old_parameters(&conversion_table[0], ARRAY_SIZE(conversion_table));
 
     AP_Param::set_frame_type_flags(AP_PARAM_FRAME_SUB);
 

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -558,7 +558,6 @@ private:
 
     uint16_t get_pilot_speed_dn() const;
 
-    void convert_old_parameters(void);
 
 #if LEAKDETECTOR_MAX_INSTANCES > 0
     void update_leak_pins();

--- a/ArduSub/system.cpp
+++ b/ArduSub/system.cpp
@@ -48,8 +48,6 @@ void Sub::init_ardupilot()
     gcs().setup_uarts();
 
     // initialise rc channels including setting mode
-    // PARAMETER_CONVERSION - Added: Sep-2021 for ArduSub-4.5
-    rc().convert_options(RC_Channel::AUX_FUNC::ARMDISARM_UNUSED, RC_Channel::AUX_FUNC::ARMDISARM);
     rc().init();
 
 

--- a/Blimp/system.cpp
+++ b/Blimp/system.cpp
@@ -46,8 +46,6 @@ void Blimp::init_ardupilot()
     AP_Param::invalidate_count();
 
     // initialise rc channels including setting mode
-    // PARAMETER_CONVERSION - Added: Sep-2021 for ArduPilot-4.2
-    rc().convert_options(RC_Channel::AUX_FUNC::ARMDISARM_UNUSED, RC_Channel::AUX_FUNC::ARMDISARM);
     rc().init();
 
     // sets up motors and output to escs

--- a/Rover/Parameters.cpp
+++ b/Rover/Parameters.cpp
@@ -788,8 +788,6 @@ void Rover::load_parameters(void)
         g2.crash_angle.set_default(30);
     }
 
-    SRV_Channels::upgrade_parameters();
-
     // convert CH7_OPTION to RC7_OPTION for Rover-3.4 to 3.5 upgrade
     // PARAMETER_CONVERSION - Added: Jan-2019 for Rover-3.5
     const AP_Param::ConversionInfo ch7_option_info = { Parameters::k_param_ch7_option, 0, AP_PARAM_INT8, "RC7_OPTION" };
@@ -837,18 +835,6 @@ void Rover::load_parameters(void)
 #endif
 
     static const AP_Param::G2ObjectConversion g2_conversions[] {
-#if AP_AIRSPEED_ENABLED
-// PARAMETER_CONVERSION - Added: Jan-2022 for Rover-4.2
-        { &airspeed, airspeed.var_info, 37 },
-#endif
-#if AP_AIS_ENABLED
-// PARAMETER_CONVERSION - Added: Mar-2022 for Rover-4.4
-        { &ais, ais.var_info, 50 },
-#endif
-#if AP_FENCE_ENABLED
-// PARAMETER_CONVERSION - Added: Mar-2022 for Rover-4.4
-        { &fence, fence.var_info, 17 },
-#endif
 #if AP_STATS_ENABLED
     // PARAMETER_CONVERSION - Added: Jan-2024 for Rover-4.6
         { &stats, stats.var_info, 1 },

--- a/Rover/Parameters.cpp
+++ b/Rover/Parameters.cpp
@@ -718,50 +718,6 @@ ParametersG2::ParametersG2(void)
   old object. This should be zero for top level parameters.
  */
 const AP_Param::ConversionInfo conversion_table[] = {
-    // PARAMETER_CONVERSION - Added: Oct-2013 for APMrover2-2.44
-    { Parameters::k_param_battery_monitoring, 0,      AP_PARAM_INT8,  "BATT_MONITOR" },
-    { Parameters::k_param_battery_volt_pin,   0,      AP_PARAM_INT8,  "BATT_VOLT_PIN" },
-    { Parameters::k_param_battery_curr_pin,   0,      AP_PARAM_INT8,  "BATT_CURR_PIN" },
-    { Parameters::k_param_volt_div_ratio,     0,      AP_PARAM_FLOAT, "BATT_VOLT_MULT" },
-    { Parameters::k_param_curr_amp_per_volt,  0,      AP_PARAM_FLOAT, "BATT_AMP_PERVOLT" },
-    { Parameters::k_param_pack_capacity,      0,      AP_PARAM_INT32, "BATT_CAPACITY" },
-    // PARAMETER_CONVERSION - Added: Jan-2015 for APMrover2-2.49
-    { Parameters::k_param_serial0_baud,       0,      AP_PARAM_INT16, "SERIAL0_BAUD" },
-    { Parameters::k_param_serial1_baud,       0,      AP_PARAM_INT16, "SERIAL1_BAUD" },
-    { Parameters::k_param_serial2_baud,       0,      AP_PARAM_INT16, "SERIAL2_BAUD" },
-    // PARAMETER_CONVERSION - Added: Aug-2017 for Rover-3.2
-    { Parameters::k_param_throttle_min_old,   0,      AP_PARAM_INT8,  "MOT_THR_MIN" },
-    { Parameters::k_param_throttle_max_old,   0,      AP_PARAM_INT8,  "MOT_THR_MAX" },
-    // PARAMETER_CONVERSION - Added: Apr-2019 for Rover-4.0
-    { Parameters::k_param_compass_enabled_deprecated,       0,      AP_PARAM_INT8, "COMPASS_ENABLE" },
-    // PARAMETER_CONVERSION - Added: May-2019 for Rover-4.0
-    { Parameters::k_param_waypoint_radius_old,    0,  AP_PARAM_FLOAT,  "WP_RADIUS" },
-    // PARAMETER_CONVERSION - Added: Dec-2021 for Rover-4.4
-    { Parameters::k_param_g2,               299,      AP_PARAM_INT16,  "WP_PIVOT_ANGLE" },
-    { Parameters::k_param_g2,               363,      AP_PARAM_INT16,  "WP_PIVOT_RATE" },
-    { Parameters::k_param_g2,               491,      AP_PARAM_FLOAT,  "WP_PIVOT_DELAY" },
-    // PARAMETER_CONVERSION - Added: May-2019 for Rover-4.0
-    { Parameters::k_param_g2,                32,      AP_PARAM_FLOAT,  "SAIL_ANGLE_MIN" },
-    { Parameters::k_param_g2,                33,      AP_PARAM_FLOAT,  "SAIL_ANGLE_MAX" },
-    { Parameters::k_param_g2,                34,      AP_PARAM_FLOAT,  "SAIL_ANGLE_IDEAL" },
-    { Parameters::k_param_g2,                35,      AP_PARAM_FLOAT,  "SAIL_HEEL_MAX" },
-    { Parameters::k_param_g2,                36,      AP_PARAM_FLOAT,  "SAIL_NO_GO_ANGLE" },
-    // PARAMETER_CONVERSION - Added: May-2021 for Rover-4.1
-    { Parameters::k_param_turn_max_g_old,     0,     AP_PARAM_FLOAT,  "ATC_TURN_MAX_G" },
-    // PARAMETER_CONVERSION - Added: Aug-2022 for Rover-4.4
-    { Parameters::k_param_g2,                82,     AP_PARAM_INT8 , "PRX1_TYPE" },
-    { Parameters::k_param_g2,               146,     AP_PARAM_INT8 , "PRX1_ORIENT" },
-    { Parameters::k_param_g2,               210,     AP_PARAM_INT16, "PRX1_YAW_CORR" },
-    { Parameters::k_param_g2,               274,     AP_PARAM_INT16, "PRX1_IGN_ANG1" },
-    { Parameters::k_param_g2,               338,     AP_PARAM_INT8,  "PRX1_IGN_WID1" },
-    { Parameters::k_param_g2,               402,     AP_PARAM_INT16, "PRX1_IGN_ANG2" },
-    { Parameters::k_param_g2,               466,     AP_PARAM_INT8,  "PRX1_IGN_WID2" },
-    { Parameters::k_param_g2,               530,     AP_PARAM_INT16, "PRX1_IGN_ANG3" },
-    { Parameters::k_param_g2,               594,     AP_PARAM_INT8,  "PRX1_IGN_WID3" },
-    { Parameters::k_param_g2,               658,     AP_PARAM_INT16, "PRX1_IGN_ANG4" },
-    { Parameters::k_param_g2,               722,     AP_PARAM_INT8,  "PRX1_IGN_WID4" },
-    { Parameters::k_param_g2,               1234,    AP_PARAM_FLOAT, "PRX1_MIN" },
-    { Parameters::k_param_g2,               1298,    AP_PARAM_FLOAT, "PRX1_MAX" },
     // PARAMETER_CONVERSION - Added: May-2024 for Rover-4.6
     { Parameters::k_param_g2,               113,     AP_PARAM_INT8, "TRQ1_TYPE" },
     { Parameters::k_param_g2,               177,     AP_PARAM_INT8, "TRQ1_ONOFF_PIN" },
@@ -787,33 +743,6 @@ void Rover::load_parameters(void)
     if (is_balancebot()) {
         g2.crash_angle.set_default(30);
     }
-
-    // set AR_WPNav's WP_SPEED to be old WP_SPEED (if set) or CRUISE_SPEED (if set)
-    // PARAMETER_CONVERSION - Added: May-2019 for Rover-4.0
-    const AP_Param::ConversionInfo wp_speed_old_info = { Parameters::k_param_g2, 14, AP_PARAM_FLOAT, "WP_SPEED" };
-    const AP_Param::ConversionInfo cruise_speed_info = { Parameters::k_param_speed_cruise, 0, AP_PARAM_FLOAT, "WP_SPEED" };
-    AP_Float wp_speed_old;
-    if (AP_Param::find_old_parameter(&wp_speed_old_info, &wp_speed_old)) {
-        // old WP_SPEED parameter value was set so copy to new WP_SPEED
-        AP_Param::convert_old_parameter(&wp_speed_old_info, 1.0f);
-    } else {
-        // copy CRUISE_SPEED to new WP_SPEED
-        AP_Param::convert_old_parameter(&cruise_speed_info, 1.0f);
-    }
-
-    // attitude control FF and FILT parameter changes for Rover-3.6
-    // PARAMETER_CONVERSION - Added: Jul-2019 for Rover-4.0
-    const AP_Param::ConversionInfo ff_and_filt_conversion_info[] = {
-        { Parameters::k_param_g2, 24650, AP_PARAM_FLOAT, "ATC_STR_RAT_FLTE" },
-        { Parameters::k_param_g2, 28746, AP_PARAM_FLOAT, "ATC_STR_RAT_FF" },
-        { Parameters::k_param_g2, 24714, AP_PARAM_FLOAT, "ATC_SPEED_FLTE" },
-        { Parameters::k_param_g2, 28810, AP_PARAM_FLOAT, "ATC_SPEED_FF" },
-        { Parameters::k_param_g2, 25226, AP_PARAM_FLOAT, "ATC_BAL_FLTE" },
-        { Parameters::k_param_g2, 29322, AP_PARAM_FLOAT, "ATC_BAL_FF" },
-        { Parameters::k_param_g2, 25354, AP_PARAM_FLOAT, "ATC_SAIL_FLTE" },
-        { Parameters::k_param_g2, 29450, AP_PARAM_FLOAT, "ATC_SAIL_FF" },
-    };
-    AP_Param::convert_old_parameters(&ff_and_filt_conversion_info[0], ARRAY_SIZE(ff_and_filt_conversion_info));
 
     // configure safety switch to allow stopping the motors while armed
 #if HAL_HAVE_SAFETY_SWITCH

--- a/Rover/Parameters.cpp
+++ b/Rover/Parameters.cpp
@@ -788,18 +788,6 @@ void Rover::load_parameters(void)
         g2.crash_angle.set_default(30);
     }
 
-    // convert CH7_OPTION to RC7_OPTION for Rover-3.4 to 3.5 upgrade
-    // PARAMETER_CONVERSION - Added: Jan-2019 for Rover-3.5
-    const AP_Param::ConversionInfo ch7_option_info = { Parameters::k_param_ch7_option, 0, AP_PARAM_INT8, "RC7_OPTION" };
-    AP_Int8 ch7_opt_old;
-    if (AP_Param::find_old_parameter(&ch7_option_info, &ch7_opt_old)) {
-        const uint8_t ch7_opt_map[] = {0,7,50,41,51,52,53,54,16,4,42,55,56};
-        const uint8_t ch7_opt_old_val = (uint8_t)ch7_opt_old.get();
-        if (ch7_opt_old_val < ARRAY_SIZE(ch7_opt_map)) {
-            AP_Param::set_default_by_name(ch7_option_info.new_name, ch7_opt_map[ch7_opt_old_val]);
-        }
-    }
-
     // set AR_WPNav's WP_SPEED to be old WP_SPEED (if set) or CRUISE_SPEED (if set)
     // PARAMETER_CONVERSION - Added: May-2019 for Rover-4.0
     const AP_Param::ConversionInfo wp_speed_old_info = { Parameters::k_param_g2, 14, AP_PARAM_FLOAT, "WP_SPEED" };

--- a/Rover/system.cpp
+++ b/Rover/system.cpp
@@ -134,9 +134,6 @@ void Rover::init_ardupilot()
     set_mode(*initial_mode, ModeReason::INITIALISED);
 
     // initialise rc channels
-    // PARAMETER_CONVERSION - Added: Sep-2021 for Rover-4.2
-    rc().convert_options(RC_Channel::AUX_FUNC::ARMDISARM_UNUSED, RC_Channel::AUX_FUNC::ARMDISARM);
-    rc().convert_options(RC_Channel::AUX_FUNC::SAVE_TRIM, RC_Channel::AUX_FUNC::TRIM_TO_CURRENT_SERVO_RC);
     rc().init();
 
     rover.g2.sailboat.init();

--- a/libraries/APM_Control/AP_PitchController.cpp
+++ b/libraries/APM_Control/AP_PitchController.cpp
@@ -303,35 +303,3 @@ float AP_PitchController::run_axis_rate_control(float desired_rate_degs, float s
 
     return run_rate_control(desired_rate_degs, scaler, disable_integrator, ground_mode);
 }
-
-/*
-  convert from old to new PIDs
-  this is a temporary conversion function during development
- */
-// PARAMETER_CONVERSION - Added: Apr-2021 for ArduPilot-4.1
-void AP_PitchController::convert_pid()
-{
-    AP_Float &ff = rate_pid.ff();
-    if (ff.configured()) {
-        return;
-    }
-
-    float old_ff=0, old_p=1.0, old_i=0.3, old_d=0.08;
-    int16_t old_imax = 3000;
-    bool have_old = AP_Param::get_param_by_index(this, 1, AP_PARAM_FLOAT, &old_p);
-    have_old |= AP_Param::get_param_by_index(this, 3, AP_PARAM_FLOAT, &old_i);
-    have_old |= AP_Param::get_param_by_index(this, 2, AP_PARAM_FLOAT, &old_d);
-    have_old |= AP_Param::get_param_by_index(this, 8, AP_PARAM_FLOAT, &old_ff);
-    have_old |= AP_Param::get_param_by_index(this, 7, AP_PARAM_FLOAT, &old_imax);
-    if (!have_old) {
-        // none of the old gains were set
-        return;
-    }
-
-    const float kp_ff = MAX((old_p - old_i * gains.tau) * gains.tau  - old_d, 0);
-    rate_pid.ff().set_and_save(old_ff + kp_ff);
-    rate_pid.kI().set_and_save_ifchanged(old_i * gains.tau);
-    rate_pid.kP().set_and_save_ifchanged(old_d);
-    rate_pid.kD().set_and_save_ifchanged(0);
-    rate_pid.kIMAX().set_and_save_ifchanged(old_imax/4500.0);
-}

--- a/libraries/APM_Control/AP_PitchController.h
+++ b/libraries/APM_Control/AP_PitchController.h
@@ -12,7 +12,6 @@ public:
 
     static const struct AP_Param::GroupInfo var_info[];
 
-    void convert_pid();
 
 private:
     AP_Float _roll_ff;

--- a/libraries/APM_Control/AP_RollController.cpp
+++ b/libraries/APM_Control/AP_RollController.cpp
@@ -245,34 +245,3 @@ float AP_RollController::run_axis_rate_control(float desired_rate_degs, float sc
 
     return run_rate_control(desired_rate_degs, scaler, disable_integrator, ground_mode);
 }
-
-/*
-  convert from old to new PIDs
-  this is a temporary conversion function during development
- */
-// PARAMETER_CONVERSION - Added: Apr-2021 for ArduPilot-4.1
-void AP_RollController::convert_pid()
-{
-    AP_Float &ff = rate_pid.ff();
-    if (ff.configured()) {
-        return;
-    }
-    float old_ff=0, old_p=1.0, old_i=0.3, old_d=0.08;
-    int16_t old_imax=3000;
-    bool have_old = AP_Param::get_param_by_index(this, 1, AP_PARAM_FLOAT, &old_p);
-    have_old |= AP_Param::get_param_by_index(this, 3, AP_PARAM_FLOAT, &old_i);
-    have_old |= AP_Param::get_param_by_index(this, 2, AP_PARAM_FLOAT, &old_d);
-    have_old |= AP_Param::get_param_by_index(this, 6, AP_PARAM_FLOAT, &old_ff);
-    have_old |= AP_Param::get_param_by_index(this, 5, AP_PARAM_INT16, &old_imax);
-    if (!have_old) {
-        // none of the old gains were set
-        return;
-    }
-
-    const float kp_ff = MAX((old_p - old_i * gains.tau) * gains.tau  - old_d, 0);
-    rate_pid.ff().set_and_save(old_ff + kp_ff);
-    rate_pid.kI().set_and_save_ifchanged(old_i * gains.tau);
-    rate_pid.kP().set_and_save_ifchanged(old_d);
-    rate_pid.kD().set_and_save_ifchanged(0);
-    rate_pid.kIMAX().set_and_save_ifchanged(old_imax/4500.0);
-}

--- a/libraries/APM_Control/AP_RollController.h
+++ b/libraries/APM_Control/AP_RollController.h
@@ -12,7 +12,6 @@ public:
 
     static const struct AP_Param::GroupInfo var_info[];
 
-    void convert_pid();
 
     /*
       set the in_recovery flag, which is used during a VTOL upset recovery

--- a/libraries/AP_BoardConfig/AP_BoardConfig.cpp
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.cpp
@@ -495,9 +495,6 @@ const AP_Param::GroupInfo AP_BoardConfig::var_info[] = {
 
 void AP_BoardConfig::init()
 {
-    // PARAMETER_CONVERSION - Added: Apr-2022 for ArduPilot-4.3
-    vehicleSerialNumber.convert_parameter_width(AP_PARAM_INT16);
-
     board_setup();
 
 #if AP_RTC_ENABLED

--- a/libraries/AP_Compass/AP_Compass.cpp
+++ b/libraries/AP_Compass/AP_Compass.cpp
@@ -719,24 +719,6 @@ void Compass::init()
     }
 
 #if COMPASS_MAX_INSTANCES > 1
-    // PARAMETER_CONVERSION - Added: Feb-2020 for ArduPilot-4.0
-    // Look if there was a primary compass setup in previous version
-    // if so and the primary compass is not set in current setup
-    // make the devid as primary.
-    if (_priority_did_stored_list[Priority(0)] == 0) {
-        uint16_t k_param_compass;
-        if (AP_Param::find_top_level_key_by_pointer(this, k_param_compass)) {
-            const AP_Param::ConversionInfo primary_compass_old_param = {k_param_compass, 12, AP_PARAM_INT8, ""};
-            AP_Int8 value;
-            value.set(0);
-            bool primary_param_exists = AP_Param::find_old_parameter(&primary_compass_old_param, &value);
-            int8_t oldvalue = value.get();
-            if ((oldvalue!=0) && (oldvalue<COMPASS_MAX_INSTANCES) && primary_param_exists) {
-                _priority_did_stored_list[Priority(0)].set_and_save_ifchanged(_state[StateIndex(oldvalue)].dev_id);
-            }
-        }
-    }
-
     // Load priority list from storage, the changes to priority list
     // by user only take effect post reboot, after this
     if (!suppress_devid_save) {

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -320,13 +320,6 @@ void AP_GPS::init()
 
     convert_parameters();
 
-    // Set new primary param based on old auto_switch use second option
-    // PARAMETER_CONVERSION - Added: Nov-2020 for ArduPilot-4.1
-    if ((_auto_switch.get() == 3) && !_primary.configured()) {
-        _primary.set_and_save(1);
-        _auto_switch.set_and_save(0);
-    }
-
     // search for serial ports with gps protocol
     const auto &serial_manager = AP::serialmanager();
     uint8_t uart_idx = 0;

--- a/libraries/AP_Logger/AP_Logger.cpp
+++ b/libraries/AP_Logger/AP_Logger.cpp
@@ -223,10 +223,6 @@ void AP_Logger::init(const AP_Int32 &log_bitmask, const struct LogStructure *str
 {
     _log_bitmask = &log_bitmask;
 
-    // PARAMETER_CONVERSION - Added: Nov-2020 for ArduPilot-4.1
-    // convert from 8 bit to 16 bit LOG_FILE_BUFSIZE
-    _params.file_bufsize.convert_parameter_width(AP_PARAM_INT8);
-
     if (hal.util->was_watchdog_armed()) {
         GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Forcing logging for watchdog reset");
         _params.log_disarmed.set(LogDisarmed::LOG_WHILE_DISARMED);

--- a/libraries/AP_Mount/AP_Mount.cpp
+++ b/libraries/AP_Mount/AP_Mount.cpp
@@ -61,9 +61,6 @@ void AP_Mount::init()
         return;
     }
 
-    // perform any required parameter conversion
-    convert_params();
-
     // primary is reset to the first instantiated mount
     bool primary_set = false;
 
@@ -1091,100 +1088,6 @@ void AP_Mount::handle_gimbal_device_attitude_status(const mavlink_message_t &msg
     for (uint8_t instance=0; instance<AP_MOUNT_MAX_INSTANCES; instance++) {
         if (_backends[instance] != nullptr) {
             _backends[instance]->handle_gimbal_device_attitude_status(msg);
-        }
-    }
-}
-
-// perform any required parameter conversion
-void AP_Mount::convert_params()
-{
-    // exit immediately if MNT1_TYPE has already been configured
-    if (_params[0].type.configured()) {
-        return;
-    }
-
-    // PARAMETER_CONVERSION - Added: Sep-2022 for ArduPilot-4.3
-
-    // convert MNT_TYPE to MNT1_TYPE
-    int8_t mnt_type = 0;
-    IGNORE_RETURN(AP_Param::get_param_by_index(this, 19, AP_PARAM_INT8, &mnt_type));
-    if (mnt_type == 0) {
-        // if the mount was not previously set, no need to perform the upgrade logic
-        return;
-    } else if (mnt_type > 0) {
-        int8_t stab_roll = 0;
-        int8_t stab_pitch = 0;
-        IGNORE_RETURN(AP_Param::get_param_by_index(this, 4, AP_PARAM_INT8, &stab_roll));
-        IGNORE_RETURN(AP_Param::get_param_by_index(this, 5, AP_PARAM_INT8, &stab_pitch));
-        if (mnt_type == 1 && stab_roll == 0 && stab_pitch == 0)  {
-            // Servo type without stabilization is changed to BrushlessPWM
-            // conversion is still done even if HAL_MOUNT_SERVO_ENABLED is false
-            mnt_type = 7;  // (int8_t)Type::BrushlessPWM;
-        }
-        // if the mount was previously set, then we need to save the upgraded mount type
-        _params[0].type.set_and_save(mnt_type);
-    }
-
-    // convert MNT_JSTICK_SPD to MNT1_RC_RATE
-    int8_t jstick_spd = 0;
-    if (AP_Param::get_param_by_index(this, 16, AP_PARAM_INT8, &jstick_spd) && (jstick_spd > 0)) {
-        _params[0].rc_rate_max.set_and_save(jstick_spd * 0.3);
-    }
-
-    // find Mount's top level key
-    uint16_t k_param_mount_key;
-    if (!AP_Param::find_top_level_key_by_pointer(this, k_param_mount_key)) {
-        return;
-    }
-
-    // table of mount parameters to be converted without scaling
-    static const AP_Param::ConversionInfo mnt_param_conversion_info[] {
-        { k_param_mount_key, 0, AP_PARAM_INT8, "MNT1_DEFLT_MODE" },
-        { k_param_mount_key, 1, AP_PARAM_VECTOR3F, "MNT1_RETRACT" },
-        { k_param_mount_key, 2, AP_PARAM_VECTOR3F, "MNT1_NEUTRAL" },
-        { k_param_mount_key, 17, AP_PARAM_FLOAT, "MNT1_LEAD_RLL" },
-        { k_param_mount_key, 18, AP_PARAM_FLOAT, "MNT1_LEAD_PTCH" },
-    };
-    uint8_t table_size = ARRAY_SIZE(mnt_param_conversion_info);
-    for (uint8_t i=0; i<table_size; i++) {
-        AP_Param::convert_old_parameter(&mnt_param_conversion_info[i], 1.0f);
-    }
-
-    // mount parameters conversion from centi-degrees to degrees
-    static const AP_Param::ConversionInfo mnt_param_deg_conversion_info[] {
-        { k_param_mount_key, 8, AP_PARAM_INT16, "MNT1_ROLL_MIN" },
-        { k_param_mount_key, 9, AP_PARAM_INT16, "MNT1_ROLL_MAX" },
-        { k_param_mount_key, 11, AP_PARAM_INT16, "MNT1_PITCH_MIN" },
-        { k_param_mount_key, 12, AP_PARAM_INT16, "MNT1_PITCH_MAX" },
-        { k_param_mount_key, 14, AP_PARAM_INT16, "MNT1_YAW_MIN" },
-        { k_param_mount_key, 15, AP_PARAM_INT16, "MNT1_YAW_MAX" },
-    };
-    table_size = ARRAY_SIZE(mnt_param_deg_conversion_info);
-    for (uint8_t i=0; i<table_size; i++) {
-        AP_Param::convert_old_parameter(&mnt_param_deg_conversion_info[i], 0.01f);
-    }
-
-    // struct and array holding mapping between old param table index and new RCx_OPTION value
-    struct MountRCConversionTable {
-        uint8_t old_rcin_idx;
-        uint16_t new_rc_option;
-    };
-    const struct MountRCConversionTable mnt_rc_conversion_table[] = {
-        {7, 212},   // MTN_RC_IN_ROLL to RCx_OPTION = 212 (MOUNT1_ROLL)
-        {10, 213},  // MTN_RC_IN_TILT to RCx_OPTION = 213 (MOUNT1_PITCH)
-        {13, 214},  // MTN_RC_IN_PAN to RCx_OPTION = 214 (MOUNT1_YAW)
-    };
-    for (uint8_t i = 0; i < ARRAY_SIZE(mnt_rc_conversion_table); i++) {
-        int8_t mnt_rcin = 0;
-        if (AP_Param::get_param_by_index(this, mnt_rc_conversion_table[i].old_rcin_idx, AP_PARAM_INT8, &mnt_rcin) && (mnt_rcin > 0)) {
-            // get pointers to the appropriate RCx_OPTION parameter
-            char pname[17];
-            enum ap_var_type ptype;
-            snprintf(pname, sizeof(pname), "RC%u_OPTION", (unsigned)mnt_rcin);
-            AP_Int16 *rcx_option = (AP_Int16 *)AP_Param::find(pname, &ptype);
-            if ((rcx_option != nullptr) && !rcx_option->configured()) {
-                rcx_option->set_and_save(mnt_rc_conversion_table[i].new_rc_option);
-            }
         }
     }
 }

--- a/libraries/AP_Mount/AP_Mount.h
+++ b/libraries/AP_Mount/AP_Mount.h
@@ -371,9 +371,6 @@ private:
     void handle_global_position_int(const mavlink_message_t &msg);
     void handle_gimbal_device_information(const mavlink_message_t &msg);
     void handle_gimbal_device_attitude_status(const mavlink_message_t &msg);
-
-    // perform any required parameter conversion
-    void convert_params();
 };
 
 namespace AP {

--- a/libraries/AP_NavEKF3/AP_NavEKF3.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.cpp
@@ -803,11 +803,6 @@ bool NavEKF3::InitialiseFilter(void)
     // expected number of IMU frames per prediction
     _framesPerPrediction = uint8_t((EKF_TARGET_DT / (_frameTimeUsec * 1.0e-6) + 0.5));
 
-#if !APM_BUILD_TYPE(APM_BUILD_AP_DAL_Standalone)
-    // convert parameters if necessary
-    convert_parameters();
-#endif
-
 #if APM_BUILD_TYPE(APM_BUILD_Replay)
     if (ins.get_accel_count() == 0) {
         return false;
@@ -1787,108 +1782,6 @@ void NavEKF3::writeTerrainData(float alt_m)
         }
     }
 #endif
-}
-
-// parameter conversion of EKF3 parameters
-// PARAMETER_CONVERSION - Added: Nov-2020 for ArduPilot-4.1
-void NavEKF3::convert_parameters()
-{
-    // exit immediately if param conversion has been done before
-    if (sources.configured()) {
-        return;
-    }
-
-    // find EKF3's top level key
-    uint16_t k_param_ekf3;
-    if (!AP_Param::find_top_level_key_by_pointer(this, k_param_ekf3)) {
-        return;
-    }
-
-    // use EK3_GPS_TYPE to set EK3_SRC1_POSXY, EK3_SRC1_VELXY, EK3_SRC1_VELZ
-    const AP_Param::ConversionInfo gps_type_info = {k_param_ekf3, 1, AP_PARAM_INT8, "EK3_GPS_TYPE"};
-    AP_Int8 gps_type_old;
-    const bool found_gps_type = AP_Param::find_old_parameter(&gps_type_info, &gps_type_old);
-    if (found_gps_type) {
-        switch (gps_type_old.get()) {
-        case 0:
-            // EK3_GPS_TYPE == 0 (GPS 3D Vel and 2D Pos)
-            AP_Param::set_and_save_by_name("EK3_SRC1_POSXY", (int8_t)AP_NavEKF_Source::SourceXY::GPS);
-            AP_Param::set_and_save_by_name("EK3_SRC1_VELXY", (int8_t)AP_NavEKF_Source::SourceXY::GPS);
-            AP_Param::set_and_save_by_name("EK3_SRC1_VELZ", (int8_t)AP_NavEKF_Source::SourceZ::GPS);
-            break;
-        case 1:
-            // EK3_GPS_TYPE == 1 (GPS 2D Vel and 2D Pos) then EK3_SRC1_POSXY = GPS(1), EK3_SRC1_VELXY = GPS(1), EK3_SRC1_VELZ = NONE(0)
-            AP_Param::set_and_save_by_name("EK3_SRC1_POSXY", (int8_t)AP_NavEKF_Source::SourceXY::GPS);
-            AP_Param::set_and_save_by_name("EK3_SRC1_VELXY", (int8_t)AP_NavEKF_Source::SourceXY::GPS);
-            AP_Param::set_and_save_by_name("EK3_SRC1_VELZ", (int8_t)AP_NavEKF_Source::SourceZ::NONE);
-            break;
-        case 2:
-            // EK3_GPS_TYPE == 2 (GPS 2D Pos) then EK3_SRC1_POSXY = GPS(1), EK3_SRC1_VELXY = None(0), EK3_SRC1_VELZ = NONE(0)
-            AP_Param::set_and_save_by_name("EK3_SRC1_POSXY", (int8_t)AP_NavEKF_Source::SourceXY::GPS);
-            AP_Param::set_and_save_by_name("EK3_SRC1_VELXY", (int8_t)AP_NavEKF_Source::SourceXY::NONE);
-            AP_Param::set_and_save_by_name("EK3_SRC1_VELZ", (int8_t)AP_NavEKF_Source::SourceZ::NONE);
-            break;
-        case 3:
-        default:
-            // EK3_GPS_TYPE == 3 (No GPS) we don't know what to do, could be optical flow, beacon or external nav
-            sources.mark_configured();
-            break;
-        }
-    } else {
-        // mark configured in storage so conversion is only run once
-        sources.mark_configured();
-    }
-
-    // use EK3_ALT_SOURCE to set EK3_SRC1_POSZ
-    const AP_Param::ConversionInfo alt_source_info = {k_param_ekf3, 9, AP_PARAM_INT8, "EK3_ALT_SOURCE"};
-    AP_Int8 alt_source_old;
-    if (AP_Param::find_old_parameter(&alt_source_info, &alt_source_old)) {
-        switch (alt_source_old.get()) {
-        case 0:
-            // EK3_ALT_SOURCE = BARO, the default so do nothing
-            break;
-        case 1:
-            // EK3_ALT_SOURCE == 1 (RangeFinder)
-            AP_Param::set_and_save_by_name("EK3_SRC1_POSZ", (int8_t)AP_NavEKF_Source::SourceZ::RANGEFINDER);
-            break;
-        case 2:
-            // EK3_ALT_SOURCE == 2 (GPS)
-            AP_Param::set_and_save_by_name("EK3_SRC1_POSZ", (int8_t)AP_NavEKF_Source::SourceZ::GPS);
-            break;
-        case 3:
-            // EK3_ALT_SOURCE == 3 (Beacon)
-            AP_Param::set_and_save_by_name("EK3_SRC1_POSZ", (int8_t)AP_NavEKF_Source::SourceZ::BEACON);
-            break;
-        case 4:
-            // EK3_ALT_SOURCE == 4 (ExtNav)
-            AP_Param::set_and_save_by_name("EK3_SRC1_POSZ", (int8_t)AP_NavEKF_Source::SourceZ::EXTNAV);
-            break;
-        default:
-            // do nothing
-            break;
-        }
-    }
-
-    // use EK3_MAG_CAL to set EK3_SRC1_YAW
-    switch (_magCal.get()) {
-    case 5:
-        // EK3_MAG_CAL = 5 (External Yaw sensor).  We rely on effective_magCal to interpret old "5" values as "Never"
-        AP_Param::set_and_save_by_name("EK3_SRC1_YAW", (int8_t)AP_NavEKF_Source::SourceYaw::GPS);
-        break;
-    case 6:
-        // EK3_MAG_CAL = 6 (ExtYaw with Compass fallback).  We rely on effective_magCal to interpret old "6" values as "When Flying"
-        AP_Param::set_and_save_by_name("EK3_SRC1_YAW", (int8_t)AP_NavEKF_Source::SourceYaw::GPS_COMPASS_FALLBACK);
-        break;
-    default:
-        // do nothing
-        break;
-    }
-
-    // if GPS and optical flow enabled set EK3_SRC2_VELXY to optical flow
-    // EK3_SRC_OPTIONS should default to 1 meaning both GPS and optical flow velocities will be fused
-    if (dal.opticalflow_enabled() && (!found_gps_type || (gps_type_old.get() <= 2))) {
-        AP_Param::set_and_save_by_name("EK3_SRC2_VELXY", (int8_t)AP_NavEKF_Source::SourceXY::OPTFLOW);
-    }
 }
 
 // Set to true if the terrain underneath is stable enough to be used as a height reference

--- a/libraries/AP_NavEKF3/AP_NavEKF3.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3.h
@@ -366,9 +366,6 @@ public:
     // Writes the default equivalent airspeed and 1-sigma uncertainty in m/s to be used in forward flight if a measured airspeed is required and not available.
     void writeDefaultAirSpeed(float airspeed, float uncertainty);
 
-    // parameter conversion
-    void convert_parameters();
-
     // returns true when the yaw angle has been aligned
     bool yawAlignmentComplete(void) const;
 

--- a/libraries/AP_VideoTX/AP_VideoTX.cpp
+++ b/libraries/AP_VideoTX/AP_VideoTX.cpp
@@ -150,9 +150,6 @@ bool AP_VideoTX::init(void)
         return false;
     }
 
-    // PARAMETER_CONVERSION - Added: Sep-2022 for ArduPilot-4.3
-    _options.convert_parameter_width(AP_PARAM_INT16);
-
     // find the index into the power table
     for (uint8_t i = 0; i < VTX_MAX_POWER_LEVELS; i++) {
         if (_power_mw <= _power_levels[i].mw) {

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -2151,20 +2151,4 @@ bool RC_Channels::duplicate_options_exist()
     return false;
 }
 
-// convert option parameter from old to new
-// PARAMETER_CONVERSION - Added: Sep-2021 for ArduPilot-4.2
-void RC_Channels::convert_options(const RC_Channel::AUX_FUNC old_option, const RC_Channel::AUX_FUNC new_option)
-{
-    for (uint8_t i=0; i<NUM_RC_CHANNELS; i++) {
-        RC_Channel *c = channel(i);
-        if (c == nullptr) {
-            // odd?
-            continue;
-        }
-        if ((RC_Channel::AUX_FUNC)c->option.get() == old_option) {
-            c->option.set_and_save((int16_t)new_option);
-        }
-    }
-}
-
 #endif  // AP_RC_CHANNEL_ENABLED

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -645,7 +645,6 @@ public:
 
     class RC_Channel *find_channel_for_option(const RC_Channel::AUX_FUNC option);
     bool duplicate_options_exist();
-    void convert_options(const RC_Channel::AUX_FUNC old_option, const RC_Channel::AUX_FUNC new_option);
 
     void init_aux_all();
     void read_aux_all();

--- a/libraries/SRV_Channel/SRV_Channel.h
+++ b/libraries/SRV_Channel/SRV_Channel.h
@@ -565,9 +565,6 @@ public:
 #endif
     }
 
-    // SERVO* parameters
-    static void upgrade_parameters(void);
-
     // given a zero-based motor channel, return the k_motor function for that channel
     static SRV_Channel::Function get_motor_function(uint8_t channel) {
         if (channel < 8) {

--- a/libraries/SRV_Channel/SRV_Channel_aux.cpp
+++ b/libraries/SRV_Channel/SRV_Channel_aux.cpp
@@ -907,21 +907,6 @@ void SRV_Channels::constrain_pwm(SRV_Channel::Function function)
     }
 }
 
-/*
-  upgrade SERVO* parameters. This does the following:
-
-   - update to 16 bit FUNCTION from AP_Int8
-*/
-void SRV_Channels::upgrade_parameters(void)
-{
-    // PARAMETER_CONVERSION - Added: Jan-2020
-    for (uint8_t i=0; i<NUM_SERVO_CHANNELS; i++) {
-        SRV_Channel &c = channels[i];
-        // convert from AP_Int8 to AP_Int16
-        c.function.convert_parameter_width(AP_PARAM_INT8);
-    }
-}
-
 // set RC output frequency on a function output
 void SRV_Channels::set_rc_frequency(SRV_Channel::Function function, uint16_t frequency_hz)
 {


### PR DESCRIPTION
### Summary

Moves the oldest firmware version we support migrating parameters from up to
4.3, and deletes the parameter conversion code that predates it.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Builds clean for SITL across Copter, Plane, Rover, Sub, Blimp and Tracker.

Every removal was justified by reading release tags rather than dates: for each
conversion, that vehicle's release tags were walked in version order to find the
first release whose file actually contains the conversion.  `git tag --contains`
was deliberately not used - the 4.3 release branch carries some conversions as
separate cherry-picks, so ancestry reports a later release than the truth.  The
legacy tag prefixes were taken into account (`ArduPlane-4.0.x` becomes
`Plane-4.1.2`, `APMrover2-` becomes `Rover-`, `ArduSub-` becomes `Sub-`), as was
the fact that Rover has no 4.3 and Sub has no 4.2 to 4.4 at all.

No autotest depends on any of the removed code: the surviving references to
`LOG_FILE_BUFSIZE`, `VTX_OPTIONS` and `GPS_AUTO_SWITCH` in `Tools/autotest/` all
use current parameter names and in-range values, and `MNT_TYPE` appears only in
comments.

```
Board                    AP_Periph  antennatracker  blimp  bootloader  copter  heli   iofirmware  plane  rover  sub
CubeOrange-periph-heavy  -64                               *                                                    
Durandal                            -776            -776   *           -2448   -2440              -3996  -2900  -1836
Hitec-Airspeed           *                                 *                                                    
KakuteH7-bdshot                     -776            -776   *           -2440   -2448              -3996  -2908  -1836
MatekF405                           -784            -784   *           -1536   -1408              -3232  -2408  -1124
Pixhawk1-1M-bdshot                  -784            -776               -1528   -1408              -3240  -2256  -1124
f103-QiotekPeriph        *                                 *                                                    
f303-Universal           -48                               *                                                    
iomcu                                                                                 *                         
revo-mini                           -784            -776   *           -1528   -1400              -3224  -2408  -1124
skyviper-v2450                                                         -1832                                    
```

### Description

Built on top of https://github.com/ArduPilot/ardupilot/pull/34188

```
● Copter-4.3.0 — 31 October 2022. Plane-4.3.0 was a few weeks earlier, 9 October 2022.
```

#### What and why

ArduPilot carries parameter conversion code so that a user upgrading from an old
release keeps their settings.  That code is never free - it costs flash on every
board, it runs on every boot, and it is a long tail of rarely-exercised paths
that still has to be read and maintained.  It is only worth carrying back as far
as the oldest release we actually promise to migrate from.

The wiki has not stated what that floor is (see ArduPilot/ardupilot_wiki#7981,
where the proposed support table had invented version numbers).  This PR takes
the floor to be **4.3** and removes everything below it: 26 commits, 837 lines
deleted across 30 files, retiring conversions covering roughly 119 parameter
names.

A conversion is only removed here if it is present in the oldest release a user
of that vehicle can be moving from once the floor is 4.3 - which means such a
user has already had it applied and saved, and so arrives at 4.8 with the new
parameters already written.

#### Relationship to the annotation PR

This is the second of two PRs.  The first is comment-only: it normalises every
`PARAMETER_CONVERSION - Added: <Mon>-<YYYY> for <Release>` annotation and adds
the ones that were missing, so that the vintage of each conversion is greppable.
Those 28 commits are included at the base of this branch and should be reviewed
and merged first; this PR is the removal step that the annotations make
checkable.

#### Three things worth a reviewer's attention

These are the only places where a user can notice something beyond "my old
parameter is no longer migrated".

1. **`ArduPlane: remove magic repair of Q_M_PWM_MIN/Q_M_PWM_MAX`** is a
   deliberate behaviour change, in a commit of its own.  The old code ran the
   conversion a second time with `CONVERT_FLAG_FORCE` on *every* boot whenever
   the current values were invalid, so a vehicle with bad `Q_M_PWM_MIN/MAX` was
   silently overwritten from the legacy quadplane slots over and over.  That is
   gone: such a vehicle now fails the existing arming check, "Check Q_M_PWM_MIN
   and Q_M_PWM_MAX", and the user fixes it themselves.

2. **`AP_Compass: remove primary compass parameter conversion`** has a caveat
   spelled out in its commit message.  The conversion sat below Compass::init()'s
   `if (!_enabled) return;`, so "present in the release" is not quite "has run".
   A user who has had `COMPASS_ENABLE=0` for every release since 4.3 and then
   enables the compass on 4.8 will not have their old `COMPASS_PRIMARY` honoured.
   Judged too unlikely, and the parameter too old, to keep the conversion for.

3. **The `RCn_OPTION` and `GPS_AUTO_SWITCH` removals** leave stale stored values
   behind rather than rejecting them.  A surviving `RCn_OPTION` of 41
   (`ARMDISARM_UNUSED`), or 5 on Rover, becomes an unhandled auxiliary function
   and does nothing; a surviving `GPS_AUTO_SWITCH` of 3 is no longer any of the
   handled cases and falls through to the "UseBest" path.  In both cases that is
   the same outcome as any other option number the firmware does not know, and
   the retired enum values stay reserved in their enums so the numbers are not
   handed out again.

#### Parameter and migration considerations

- No parameter is added, removed or renamed.  What changes is only whether an
  *old* name is still translated into its current name at boot.
- A user moving to 4.8 from 4.3 or later is unaffected: their conversion already
  ran on the release they are coming from and the new values are in storage.
- A user moving to 4.8 from before 4.3 will need to reconfigure the affected
  parameters by hand.  That is the intended meaning of the migration floor, and
  is the thing the wiki change documents.
- The recommended upgrade path for anyone on an older release remains to step
  through a supported release first.

#### Not included

Two things that look like candidates but are deliberately left alone, because
neither is purely a migration - both still run for new vehicles, so they do not
retire when the floor moves:

- `AP_MotorsMulticopter::convert_pwm_min_max_param()`, which stamps
  `MOT_PWM_MIN`/`MOT_PWM_MAX` from the throttle RC calibration on any vehicle
  that has never had them configured.
- The `Q_TAILSIT_ENABLE` and `Q_TILT_ENABLE` heuristics in `Tailsitter::setup()`
  and `Tiltrotor::setup()`.

#### AI disclosure

This contribution was AI-assisted.  Claude (Claude Code) did the audit of the
conversion code, the release-by-content verification of every conversion's
vintage, and wrote the commits and this description; a second model (OpenAI
Codex) was used as an independent reviewer over both branches and its findings
were checked and acted on.  The work was directed, reviewed and is submitted by
a human, who bears full responsibility for it.
