### PR TITLE
AP_Mission: ignore coordinate-less terrain items

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -4962,6 +4962,17 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.reboot_sitl()
 
+    def TerrainDBCoordinateLessMission(self):
+        '''ensure coordinate-less mission items do not require terrain data'''
+        self.upload_simple_relhome_mission([
+            (mavutil.mavlink.MAV_CMD_NAV_TAKEOFF, 0, 0, 20, {
+                "frame": mavutil.mavlink.MAV_FRAME_GLOBAL_TERRAIN_ALT,
+            }),
+            (mavutil.mavlink.MAV_CMD_NAV_RETURN_TO_LAUNCH, 0, 0, 0),
+        ])
+
+        self.wait_ready_to_arm(timeout=30)
+
     def CopterMission(self):
         '''fly mission which tests a significant number of commands'''
         # Fly mission #1
@@ -19939,6 +19950,7 @@ return update, 1000
             self.RCOverridesNoRCReceiver,
             self.RCOverridesClearByPilotInput,
             self.TerrainDBPreArm,
+            self.TerrainDBCoordinateLessMission,
             self.ThrottleGainBoost,
             self.ScriptMountPOI,
             self.ScriptMountAllModes,

--- a/libraries/AP_Mission/AP_Mission.cpp
+++ b/libraries/AP_Mission/AP_Mission.cpp
@@ -3032,7 +3032,8 @@ bool AP_Mission::cmd_has_location(const uint16_t command)
 }
 
 /*
-  return true if the mission has a terrain relative item.  ~2200us for 530 items on H7
+  return true if the mission has a terrain relative item with a location.
+  ~2200us for 530 items on H7
  */
 bool AP_Mission::contains_terrain_alt_items(void)
 {
@@ -3054,7 +3055,9 @@ bool AP_Mission::calculate_contains_terrain_alt_items(void) const
         if (!read_cmd_from_storage(i, tmp)) {
             continue;
         }
-        if (stored_in_location(tmp.id) && tmp.content.location.terrain_alt) {
+        if (stored_in_location(tmp.id) &&
+            tmp.content.location.terrain_alt &&
+            (tmp.content.location.lat != 0 || tmp.content.location.lng != 0)) {
             return true;
         }
     }

--- a/libraries/AP_Mission/AP_Mission.h
+++ b/libraries/AP_Mission/AP_Mission.h
@@ -753,7 +753,7 @@ public:
     // returns true if the mission contains the requested items
     bool contains_item(MAV_CMD command) const;
 
-    // returns true if the mission has a terrain relative mission item
+    // returns true if the mission has a terrain relative mission item with a location
     bool contains_terrain_alt_items(void);
     
     // returns true if the mission cmd has a location


### PR DESCRIPTION
### Summary

Coordinate-less terrain-frame mission items could make Copter wait indefinitely for terrain data before arming, even though terrain mission prefetch already skips items whose latitude and longitude are both zero.

This change applies the same location boundary when determining whether a mission requires terrain data and adds a Copter SITL regression for a terrain-frame takeoff followed by RTL.

Fixes #34016.

### Classification & Testing

- [ ] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

Validation performed:

- Baseline `test.CopterTests2b.TerrainDBCoordinateLessMission` failed with `PreArm: waiting for terrain data` and `Prearm bit never went true`.
- After the patch, the same regression test passed.
- Existing `test.CopterTests2b.TerrainDBPreArm` passed.
- Existing `test.CopterTests1b.TerrainFailsafe` passed, including terrain-unavailable failsafe, RTL, landing, and disarm.
- `./waf copter` passed.
- `python3 -m py_compile Tools/autotest/arducopter.py` passed.
- `git diff --check` and `git show --check` passed.

### Description

`AP_Mission::calculate_contains_terrain_alt_items()` previously treated any stored terrain-relative location as requiring terrain data. Terrain mission prefetch deliberately ignores items at `(lat, lng) == (0, 0)`, so a coordinate-less takeoff could request terrain data that prefetch would never load.

The arming requirement now only counts terrain-relative mission items that contain a latitude or longitude. Real terrain-dependent missions remain covered by the existing pre-arm and terrain-failsafe tests.

### AI assistance

This change was developed with OpenAI Codex assistance. The contributor reviewed the issue, root-cause analysis, proposed behavior, patch, and test results and takes responsibility for the contribution.