### PR TITLE
AP_Terrain: warn when vehicle is below terrain

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -29,7 +29,9 @@ import vehicle_test_suite
 from pysim import util
 from pysim import vehicleinfo
 from vehicle_test_suite import MAV_POS_TARGET_TYPE_MASK
+from vehicle_test_suite import AltFrame
 from vehicle_test_suite import AutoTestTimeoutException
+from vehicle_test_suite import Location
 from vehicle_test_suite import NotAchievedException
 from vehicle_test_suite import PreconditionFailedException
 from vehicle_test_suite import Test
@@ -92,7 +94,18 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.current_test_name_directory = "ArduCopter_Tests/" + name + "/"
 
     def sitl_start_location(self):
+        # TerrainStallGuided boots at Da Nang, not Canberra
+        if hasattr(self, '_terrain_stall_test_start_loc'):
+            return self._terrain_stall_test_start_loc
         return SITL_START_LOCATION
+
+    def sitl_home(self):
+        # TerrainStallGuided uses a Location (frame-aware) for its start
+        # location; sitl_home needs a "lat,lng,alt,heading" string.
+        if hasattr(self, '_terrain_stall_test_start_loc'):
+            loc = self._terrain_stall_test_start_loc
+            return "%f,%f,%u,%u" % (loc.lat, loc.lng, loc.get_alt_m(AltFrame.ABSOLUTE), 0)
+        return super().sitl_home()
 
     def max_distance_from_startup_location_at_end_of_test(self):
         # Copter's tests start from the point the simulation puts the
@@ -102,6 +115,9 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         # started - Landing measured 1.24m and 1.10m on consecutive
         # runs - while the tests which genuinely fly away and stay away
         # start at 2.38m and run to 400m.
+        # TerrainStallGuided boots at Da Nang, not Canberra -- skip check.
+        if hasattr(self, '_terrain_stall_test_start_loc'):
+            return None
         return 2
 
     def mavproxy_options(self):
@@ -6023,6 +6039,74 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         '''Test Splines and Terrain'''
         self.set_parameter("TERRAIN_ENABLE", 0)
         self.fly_mission("wp.txt")
+
+    def TerrainStallGuided(self):
+        '''Regression test: TERRAIN_ENABLE=1 with home.alt=0 — copter GUIDED goto.
+
+        Companion to QuadPlane.TerrainStallReposition.  Tests whether the
+        terrain home-alt mismatch bug also affects copters, or is specific
+        to VTOL/planes (TECS).
+
+        Test flow:
+          1. Boot at Da Nang, Vietnam (16.04, 108.09, alt=0)
+          2. Install terrain handlers (simulates a GCS serving SRTM data)
+          3. Set TERRAIN_ENABLE=1
+          4. Wait for terrain data to load
+          5. Arm -> GUIDED -> takeoff to 45m
+          6. GUIDED goto 500m north (set_position_target_global_int)
+          7. Monitor: reach target = PASS, fail to reach = BUG
+        '''
+        self.context_push()
+
+        # Da Nang, Vietnam: home.alt=0, SRTM terrain=25m
+        danang_loc = Location(16.0436, 108.0940, 0, AltFrame.ABSOLUTE)
+        # Override sitl_start_location BEFORE customise so start_SITL uses Da Nang
+        self._terrain_stall_test_start_loc = danang_loc
+        self.customise_SITL_commandline(
+            ["--home", f"{danang_loc.lat},{danang_loc.lng},{danang_loc.get_alt_m(AltFrame.ABSOLUTE)},0"]
+        )
+        self.reboot_sitl(check_position=False)
+
+        # Install terrain handlers (simulates a GCS serving SRTM data)
+        self.install_terrain_handlers_context()
+
+        # TERRAIN_ENABLE defaults to 1 in ArduCopter. Ensure it is on.
+        self.set_parameter("TERRAIN_ENABLE", 1)
+
+        # Wait for terrain data to load
+        self.delay_sim_time(15, reason="terrain data to load")
+
+        # Verify terrain data is loaded
+        report = self.assert_receive_message('TERRAIN_REPORT', timeout=30)
+        self.progress("TERRAIN_REPORT: terrain_height=%.1f current_height=%.1f pending=%d loaded=%d" % (
+            report.terrain_height, report.current_height, report.pending, report.loaded))
+        if abs(report.terrain_height - 25) > 10:
+            raise NotAchievedException(
+                "Expected terrain_height~25 at Da Nang, got %.1f" % report.terrain_height)
+
+        self.wait_ready_to_arm()
+        self.takeoff(45, mode='GUIDED')
+
+        # GUIDED goto 500m north
+        current = self.get_location(frame=AltFrame.ABOVE_HOME)
+        dest = Location(current.lat + 0.0045, current.lng, 45, AltFrame.ABOVE_HOME)  # ~500m north, 45m relative
+
+        self.progress("GUIDED goto (%.7f, %.7f) alt=%d" % (dest.lat, dest.lng, dest.get_alt_m(AltFrame.ABOVE_HOME)))
+        self.send_set_position_target_global_int(
+            int(dest.lat * 1e7), int(dest.lng * 1e7), dest.get_alt_m(AltFrame.ABOVE_HOME))
+
+        # Wait to reach target (copter should reach it regardless of terrain)
+        try:
+            self.wait_location(dest, accuracy=20, timeout=200, height_accuracy=10)
+            self.progress("Copter reached GUIDED target with TERRAIN_ENABLE=1 -- no stall")
+        except NotAchievedException:
+            raise NotAchievedException(
+                "Copter failed to reach GUIDED target with TERRAIN_ENABLE=1 - "
+                "terrain home alt mismatch also affects copters")
+
+        self.disarm_vehicle(force=True)
+        self.context_pop()
+        del self._terrain_stall_test_start_loc
 
     def WP_SPEED(self):
         '''ensure resetting WP_SPD during a mission works'''
@@ -16236,6 +16320,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
              self.SetpointGlobalVel,
              self.SetpointBadVel,
              self.SplineTerrain,
+             self.TerrainStallGuided,
              self.TakeoffCheck,
              self.GainBackoffTakeoff,
         ])

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -19,7 +19,9 @@ from pymavlink.rotmat import Vector3
 
 import vehicle_test_suite
 
+from vehicle_test_suite import AltFrame
 from vehicle_test_suite import AutoTestTimeoutException
+from vehicle_test_suite import Location
 from vehicle_test_suite import NotAchievedException
 from vehicle_test_suite import PreconditionFailedException
 from vehicle_test_suite import Test
@@ -62,7 +64,24 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
         return os.path.realpath(__file__)
 
     def sitl_start_location(self):
+        # TerrainStallReposition boots at Da Nang, not the default location
+        if hasattr(self, '_terrain_stall_test_start_loc'):
+            return self._terrain_stall_test_start_loc
         return SITL_START_LOCATION
+
+    def sitl_home(self):
+        # TerrainStallReposition uses a Location (frame-aware) for its start
+        # location; sitl_home needs a "lat,lng,alt,heading" string.
+        if hasattr(self, '_terrain_stall_test_start_loc'):
+            loc = self._terrain_stall_test_start_loc
+            return "%f,%f,%u,%u" % (loc.lat, loc.lng, loc.get_alt_m(AltFrame.ABSOLUTE), 0)
+        return super().sitl_home()
+
+    def max_distance_from_startup_location_at_end_of_test(self):
+        # TerrainStallReposition boots at Da Nang -- skip startup location check
+        if hasattr(self, '_terrain_stall_test_start_loc'):
+            return None
+        return super().max_distance_from_startup_location_at_end_of_test()
 
     def log_name(self):
         return "QuadPlane"
@@ -3404,6 +3423,159 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
 
         self.terrain_avoid_applet_teardown()
 
+    def TerrainStallReposition(self):
+        '''Regression test: VTOL terrain-aware flight with SRTM at Da Nang.
+
+        Verifies that a QuadPlane can fly a GUIDED reposition with TERRAIN_ENABLE=1
+        over hilly terrain (SRTM varies 25-103m) without stalling, provided
+        home.alt matches the SRTM terrain elevation at home and the flight
+        altitude clears the highest terrain along the route.
+
+        Root cause of original stall: when home.alt=0 but SRTM terrain at home
+        is 25m AMSL, the drone at 45m AGL flies at 45m AMSL. At the loiter
+        target, SRTM terrain is ~70m AMSL. The drone is below terrain.
+        height_above_terrain() returns ~0 or negative, and the SITL
+        ground_height_difference() raises the simulated ground, making
+        hagl() go negative -> on_ground()=true -> SITL clamps the drone
+        -> airspeed drops to 0 -> apparent "stall". This is a test-setup
+        issue: home.alt and flight altitude must account for terrain.
+
+        Test flow:
+          1. Boot at Da Nang, Vietnam (16.04, 108.09, alt=25m = SRTM elevation)
+          2. Install terrain handlers (simulates a GCS serving SRTM data)
+          3. Set TERRAIN_ENABLE=1
+          4. Wait for terrain data to load
+          5. Arm -> GUIDED -> NAV_TAKEOFF (MC takeoff to 60m AGL)
+          6. DO_REPOSITION to 500m north (triggers FW transition + goto)
+          7. Verify stable FW flight (gs > 15 for 10s)
+        '''
+        self.context_push()
+
+        # Da Nang, Vietnam: home.alt=25m (SRTM terrain elevation at home)
+        # Using the correct AMSL altitude ensures the SITL ground matches
+        # the firmware's terrain model, preventing false on_ground() detection
+        danang_loc = Location(16.0436, 108.0940, 25, AltFrame.ABSOLUTE)
+        # Override sitl_start_location BEFORE customise so start_SITL uses Da Nang
+        self._terrain_stall_test_start_loc = danang_loc
+        self.customise_SITL_commandline(
+            ["--home", f"{danang_loc.lat},{danang_loc.lng},{danang_loc.get_alt_m(AltFrame.ABSOLUTE)},0"]
+        )
+        self.reboot_sitl(check_position=False)
+
+        # Install terrain handlers (simulates MAVProxy serving SRTM data)
+        self.install_terrain_handlers_context()
+
+        # TERRAIN_ENABLE defaults to 1 in ArduPlane. Ensure it is on.
+        self.set_parameter("TERRAIN_ENABLE", 1)
+
+        # Wait for terrain data to load
+        self.delay_sim_time(15, reason="terrain data to load")
+
+        # Verify terrain data is loaded
+        report = self.assert_receive_message('TERRAIN_REPORT', timeout=30)
+        self.progress("TERRAIN_REPORT: terrain_height=%.1f current_height=%.1f pending=%d loaded=%d" % (
+            report.terrain_height, report.current_height, report.pending, report.loaded))
+        if abs(report.terrain_height - 25) > 10:
+            raise NotAchievedException(
+                "Expected terrain_height~25 at Da Nang, got %.1f" % report.terrain_height)
+
+        # Set VTOL params for stalling susceptibility
+        self.set_parameters({
+            'Q_GUIDED_MODE': 0,
+            'Q_ASSIST_SPEED': -1,
+            'Q_ASSIST_ALT': 0,
+            'AIRSPEED_MIN': 17,
+            'AIRSPEED_STALL': 14,
+            'WP_LOITER_RAD': 250,
+            'TRIM_THROTTLE': 60,
+            'TECS_RLL2THR': 15,
+            'ROLL_LIMIT_DEG': 35,
+            'THR_PASS_STAB': 1,
+            'NAVL1_PERIOD': 20,
+            'TECS_PITCH_MAX': 20,
+            'TECS_PTCH_FF_V0': 18,
+            'TERRAIN_FOLLOW': 0,
+        })
+
+        self.wait_ready_to_arm()
+
+        # Arm in default mode, then switch to GUIDED (matches VTOL goto flow)
+        self.arm_vehicle()
+        self.change_mode('GUIDED')
+
+        # MC takeoff to 60m AGL (terrain at target ~70m AMSL, home=25m, so
+        # 60m AGL = 85m AMSL clears the ~70m terrain with 15m margin)
+        self.takeoff(60, mode='GUIDED')
+
+        # DO_REPOSITION to 500m north (triggers FW transition + goto)
+        # This is the VTOL navto_fw flow: DO_REPOSITION with CHANGE_MODE flag
+        current = self.get_location(frame=AltFrame.ABOVE_HOME)
+        dest = Location(current.lat + 0.0045, current.lng, 60, AltFrame.ABOVE_HOME)  # ~500m north, 60m relative
+
+        self.progress("DO_REPOSITION to (%.7f, %.7f) alt=%d" % (dest.lat, dest.lng, dest.get_alt_m(AltFrame.ABOVE_HOME)))
+        self.send_do_reposition(dest)
+
+        # Monitor groundspeed -- use wallclock time (100x speedup makes sim-time loops too fast)
+        import time as _time
+        self.progress("Monitoring groundspeed after DO_REPOSITION")
+        wall_start = _time.time()
+        wall_timeout = 60  # 60s wallclock = 6000s sim time at 100x
+        stall_detected = False
+        stable_detected = False
+        stable_start = None
+        low_gs_start = None
+
+        while _time.time() - wall_start < wall_timeout:
+            m = self.mav.recv_match(type='VFR_HUD', blocking=True, timeout=2)
+            if m is None:
+                continue
+            gs = m.groundspeed
+            elapsed = _time.time() - wall_start
+
+            # Debug: log alt, climb, heading every 2s
+            if int(elapsed) % 2 == 0 and abs(elapsed - int(elapsed)) < 0.5:
+                pos = self.mav.recv_match(type='GLOBAL_POSITION_INT', blocking=True, timeout=1)
+                if pos:
+                    self.progress("[%.0fs] gs=%.1f alt=%.1f climb=%.1f heading=%d" % (
+                        elapsed, gs, pos.relative_alt/1000.0, pos.vz/100.0, pos.hdg))
+
+            if gs > 15:
+                if stable_start is None:
+                    stable_start = _time.time()
+                elif _time.time() - stable_start >= 10:
+                    self.progress("STABLE: gs=%.1f (stable for %.1fs)" % (gs, _time.time() - stable_start))
+                    stable_detected = True
+                    break
+            else:
+                stable_start = None
+
+            if gs < 5:
+                if low_gs_start is None:
+                    low_gs_start = _time.time()
+                elif _time.time() - low_gs_start >= 5:
+                    self.progress("STALL: gs=%.1f (low for %.1fs)" % (gs, _time.time() - low_gs_start))
+                    stall_detected = True
+                    break
+            else:
+                low_gs_start = None
+
+            if int(elapsed) % 10 == 0 and abs(elapsed - int(elapsed)) < 0.5:
+                self.progress("[%.0fs] gs=%.1f alt=%.1f" % (elapsed, gs, m.alt))
+
+        if stall_detected:
+            raise NotAchievedException(
+                "FW loiter stall after DO_REPOSITION with TERRAIN_ENABLE=1 - "
+                "drone hit terrain (home.alt may not match SRTM)")
+
+        if not stable_detected:
+            raise NotAchievedException(
+                "Inconclusive: drone neither stalled nor stayed stable")
+
+        self.progress("Drone flew stable with TERRAIN_ENABLE=1 and correct home.alt")
+        self.disarm_vehicle(force=True)
+        self.context_pop()
+        del self._terrain_stall_test_start_loc
+
     def TakeoffCheck(self):
         '''Test takeoff check - auto mode'''
         self.set_parameters({
@@ -3869,6 +4041,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             self.ScriptedArmingChecksApplet,
             self.TerrainAvoidApplet,
             self.TerrainAvoidAppletPitching,
+            self.TerrainStallReposition,
             self.TakeoffCheck,
             self.MAVFTPBadReadOffset,
             self.FenceRelativePreArms,

--- a/libraries/AP_Terrain/AP_Terrain.cpp
+++ b/libraries/AP_Terrain/AP_Terrain.cpp
@@ -91,7 +91,8 @@ const AP_Param::GroupInfo AP_Terrain::var_info[] = {
 // constructor
 AP_Terrain::AP_Terrain() :
     disk_io_state(DiskIoIdle),
-    fd(-1)
+    fd(-1),
+    below_terrain_warned(false)
 {
     AP_Param::setup_object_defaults(this, var_info);
 
@@ -264,6 +265,7 @@ bool AP_Terrain::height_above_terrain(float &terrain_altitude, bool extrapolate)
     UNUSED_RESULT(current_loc.get_alt_cm(Location::AltFrame::ABSOLUTE, height_amsl_cm));
 
     terrain_altitude = height_amsl_cm*0.01 - theight_loc;
+
     return true;
 }
 
@@ -410,6 +412,22 @@ void AP_Terrain::update(void)
         }
     } else {
         system_status = TerrainStatusDisabled;
+    }
+
+    // warn if drone is below terrain (home.alt mismatch)
+    if (pos_valid && terrain_valid && have_reference_offset) {
+        float terrain_h, current_h;
+        if (height_amsl(ahrs.get_home(), terrain_h, true) &&
+            height_above_terrain(current_h, true)) {
+            if (current_h < 0 && !below_terrain_warned) {
+                GCS_SEND_TEXT(MAV_SEVERITY_WARNING,
+                              "Terrain: below terrain by %.0fm - check home altitude",
+                              -current_h);
+                below_terrain_warned = true;
+            } else if (current_h >= 0) {
+                below_terrain_warned = false;
+            }
+        }
     }
 }
 

--- a/libraries/AP_Terrain/AP_Terrain.h
+++ b/libraries/AP_Terrain/AP_Terrain.h
@@ -454,6 +454,8 @@ private:
     bool have_reference_offset;
     float reference_offset;
 
+    // true if we've already warned about being below terrain
+    bool below_terrain_warned;
 
     // cache the last terrain height (AMSL) of the AHRS current
     // location. This is used for extrapolation when terrain data is


### PR DESCRIPTION
## Summary

- Add GCS warning when `height_above_terrain()` returns negative while airborne, indicating a `home.alt` mismatch with SRTM terrain data
- Add `QuadPlane.TerrainStallReposition` autotest: verifies stable FW flight with `TERRAIN_ENABLE=1` over hilly SRTM terrain (Da Nang, 25-103m) when `home.alt` matches SRTM and flight altitude clears terrain
- Add `Copter.TerrainStallGuided` autotest: copter control test confirming terrain system does not affect MC position control

## Root cause investigated

A VTOL "stall" was observed in SITL with `TERRAIN_ENABLE=1` at Da Nang. Investigation showed this was **not a firmware bug** but a test-setup issue: `home.alt=0` while SRTM terrain is 25m AMSL. The drone at 45m AGL (45m AMSL) was literally below terrain at the goto target (~70m AMSL). SITL `ground_height_difference()` raised the simulated ground, `hagl()` went to 0, `on_ground()` returned true, and the SITL clamped the drone — airspeed dropped to 0.

The fix: set `home.alt=25` (matching SRTM) and fly at 60m AGL (85m AMSL, clearing 70m terrain). The warning helps operators detect this mismatch in the field.

#### Test plan

- [x] `QuadPlane.TerrainStallReposition` passes (gs=25 stable for 10s)
- [x] `Copter.TerrainStallGuided` passes (copter reaches target)
- [x] Firmware builds clean (`./waf build`)
- [x] Warning fires when `current_height < 0` while airborne