### PR TITLE
AC_Avoidance/AC_Fence: Dijkstras works when started from outside the fence

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -10850,6 +10850,73 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.set_parameter("FENCE_ENABLE", 1)
         self.check_avoidance_corners()
 
+    def AC_Avoidance_Dijkstra_OutsideFence(self):
+        '''Test Dijkstra's object avoidance can plan a path home
+        from outside a T-shaped polygon fence.  Check vehicle passes
+        close to one of the fence vertices rather than flying straight home'''
+
+        self.set_parameters({
+            "FENCE_ENABLE": 1,
+            "OA_TYPE": 2,        # Dijkstra's
+            "RC11_OPTION": 11,   # RC aux switch to enable/disable the fence
+        })
+        self.reboot_sitl()
+
+        # T-shaped inclusion fence.  Home sits inside the "stalk"; the "bar"
+        # is to the north.  Vertices are offsets (north, east) from home
+        home_loc = self.home_position_as_location()
+        home_loc_plus_15m = self.offset_location_up(home_loc, 15)
+        stalk_bottom_left = self.offset_location_ne(home_loc_plus_15m, -10, -20)
+        stalk_bottom_right = self.offset_location_ne(home_loc_plus_15m, -10, 20)
+        stalk_top_right = self.offset_location_ne(home_loc_plus_15m, 50, 20)
+        bar_bottom_right = self.offset_location_ne(home_loc_plus_15m, 50, 60)
+        bar_top_right = self.offset_location_ne(home_loc_plus_15m, 80, 60)
+        bar_top_left = self.offset_location_ne(home_loc_plus_15m, 80, -60)
+        bar_bottom_left = self.offset_location_ne(home_loc_plus_15m, 50, -60)
+        stalk_top_left = self.offset_location_ne(home_loc_plus_15m, 50, -20)
+
+        self.upload_fences_from_locations([
+            (mavutil.mavlink.MAV_CMD_NAV_FENCE_POLYGON_VERTEX_INCLUSION, [
+                stalk_bottom_left,
+                stalk_bottom_right,
+                stalk_top_right,
+                bar_bottom_right,
+                bar_top_right,
+                bar_top_left,
+                bar_bottom_left,
+                stalk_top_left,
+            ]),
+        ])
+
+        # enable fence
+        self.set_rc(11, 2000)
+
+        # takeoff in Loiter and face North
+        self.takeoff(15, mode="LOITER")
+        self.reach_heading_manual(0)
+
+        # roll left and pitch forward, sliding along the fence
+        # until reaching the North-West corner
+        self.set_rc(1, 1400)
+        self.set_rc(2, 1400)
+        self.wait_location(bar_top_left, timeout=100)
+
+        # stop pitching forward; keep rolling left
+        self.set_rc(2, 1500)
+
+        # disable the fence and let the vehicle fly out past the corner to the west
+        self.set_rc(11, 1000)
+        self.wait_distance_to_home(150, 300, timeout=60)
+
+        # centre the roll stick and re-enable the fence; this should trigger
+        # RTL, and Dijkstra must route the vehicle home passing close to
+        # the stalk-top-left point rather than flying straight home
+        self.set_rc(1, 1500)
+        self.set_rc(11, 2000)
+        self.wait_mode("RTL")
+        self.wait_location(stalk_top_left, accuracy=5, timeout=100)
+        self.wait_rtl_complete()
+
     def AvoidanceAltFence(self):
         '''Test fence avoidance at minimum and maximum altitude'''
         self.context_push()
@@ -16228,6 +16295,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
              self.AC_Avoidance_Proximity,
              self.AC_Avoidance_Proximity_AVOID_ALT_MIN,
              self.AC_Avoidance_Fence,
+             self.AC_Avoidance_Dijkstra_OutsideFence,
              self.AC_Avoidance_Beacon,
              self.AvoidanceAltFence,
              self.BaroWindCorrection,

--- a/libraries/AC_Avoidance/AP_OADijkstra.cpp
+++ b/libraries/AC_Avoidance/AP_OADijkstra.cpp
@@ -879,9 +879,28 @@ bool AP_OADijkstra::find_closest_node_idx(node_index &node_idx) const
 // resulting path is stored in _shortest_path array as vector offsets from EKF origin
 bool AP_OADijkstra::calc_shortest_path(const Location &origin, const Location &destination, AP_OADijkstra_Error &err_id)
 {
+    const AC_Fence *fence = AC_Fence::get_singleton();
+    if (fence == nullptr) {
+        err_id = AP_OADijkstra_Error::DIJKSTRA_ERROR_FENCE_DISABLED;
+        return false;
+    }
+
+    // if origin or destination are outside the fence, replace with the closest point within the
+    // fence so that a path can still be planned
+    Location origin_in_fence;
+    if (!fence->polyfence().get_closest_loc_within_fence(origin, _polyfence_margin * 100.0f, origin_in_fence)) {
+        err_id = AP_OADijkstra_Error::DIJKSTRA_ERROR_COULD_NOT_FIND_PATH;
+        return false;
+    }
+    Location destination_in_fence;
+    if (!fence->polyfence().get_closest_loc_within_fence(destination, _polyfence_margin * 100.0f, destination_in_fence)) {
+        err_id = AP_OADijkstra_Error::DIJKSTRA_ERROR_COULD_NOT_FIND_PATH;
+        return false;
+    }
+
     // convert origin and destination to offsets from EKF origin
-    if (!origin.get_vector_xy_from_origin_NE_cm(_path_source) ||
-        !destination.get_vector_xy_from_origin_NE_cm(_path_destination)) {
+    if (!origin_in_fence.get_vector_xy_from_origin_NE_cm(_path_source) ||
+        !destination_in_fence.get_vector_xy_from_origin_NE_cm(_path_destination)) {
         err_id = AP_OADijkstra_Error::DIJKSTRA_ERROR_NO_POSITION_ESTIMATE;
         return false;
     }

--- a/libraries/AC_Fence/AC_PolyFence_loader.cpp
+++ b/libraries/AC_Fence/AC_PolyFence_loader.cpp
@@ -339,6 +339,127 @@ bool AC_PolyFence_loader::breached(const Location& loc, float& distance_outside_
     return false;
 }
 
+// get_closest_loc_within_fence - finds the closest point to loc that does not breach
+// any loaded inclusion/exclusion polygon or circle, expanded/contracted by margin_cm.
+// if loc does not breach the fence then loc_closest is simply set to loc.
+// returns false if no such point could be found (e.g. fence not loaded)
+bool AC_PolyFence_loader::get_closest_loc_within_fence(const Location& loc, float margin_cm, Location& loc_closest) const
+{
+    if (!loaded() || total_fence_count() == 0) {
+        return false;
+    }
+
+    // if loc does not breach the fence then no adjustment is required
+    if (!breached(loc)) {
+        loc_closest = loc;
+        return true;
+    }
+
+    // calculate loc as an offset (in cm) from the EKF origin
+    Vector2f scaled_pos_cm;
+    Vector2l latlon { loc.lat, loc.lng };
+    if (!scale_latlon_from_origin(loaded_origin, latlon, scaled_pos_cm)) {
+        return false;
+    }
+
+    bool found = false;
+    float closest_dist_cm_sq = 0.0f;
+    Location closest_loc;
+
+    // check each inclusion polygon
+    for (uint8_t i=0; i<_num_loaded_inclusion_boundaries; i++) {
+        const InclusionBoundary &boundary = _loaded_inclusion_boundary[i];
+        Vector2f closest_vec_cm;
+        if (Polygon_closest_distance_point(boundary.points, boundary.count, scaled_pos_cm, closest_vec_cm)) {
+            const Vector2f candidate_pos_cm = move_pos_away_from_boundary(scaled_pos_cm, closest_vec_cm, margin_cm);
+            compare_closest_point_candidate(candidate_pos_cm, scaled_pos_cm, found, closest_dist_cm_sq, closest_loc);
+        }
+    }
+
+    // check each exclusion polygon
+    for (uint8_t i=0; i<_num_loaded_exclusion_boundaries; i++) {
+        const ExclusionBoundary &boundary = _loaded_exclusion_boundary[i];
+        Vector2f closest_vec_cm;
+        if (Polygon_closest_distance_point(boundary.points, boundary.count, scaled_pos_cm, closest_vec_cm)) {
+            const Vector2f candidate_pos_cm = move_pos_away_from_boundary(scaled_pos_cm, closest_vec_cm, margin_cm);
+            compare_closest_point_candidate(candidate_pos_cm, scaled_pos_cm, found, closest_dist_cm_sq, closest_loc);
+        }
+    }
+
+    // check each inclusion circle
+    for (uint8_t i=0; i<get_inclusion_circle_count(); i++) {
+        Vector2f center_pos_cm;
+        float radius_m;
+        if (get_inclusion_circle(i, center_pos_cm, radius_m)) {
+            const Vector2f center_to_pos_cm = scaled_pos_cm - center_pos_cm;
+            if (!center_to_pos_cm.is_zero()) {
+                const Vector2f closest_vec_cm = (center_to_pos_cm.normalized() * (radius_m * 100.0f)) - center_to_pos_cm;
+                const Vector2f candidate_pos_cm = move_pos_away_from_boundary(scaled_pos_cm, closest_vec_cm, margin_cm);
+                compare_closest_point_candidate(candidate_pos_cm, scaled_pos_cm, found, closest_dist_cm_sq, closest_loc);
+            }
+        }
+    }
+
+    // check each exclusion circle
+    for (uint8_t i=0; i<get_exclusion_circle_count(); i++) {
+        Vector2f center_pos_cm;
+        float radius_m;
+        if (get_exclusion_circle(i, center_pos_cm, radius_m)) {
+            const Vector2f center_to_pos_cm = scaled_pos_cm - center_pos_cm;
+            if (!center_to_pos_cm.is_zero()) {
+                const Vector2f closest_vec_cm = (center_to_pos_cm.normalized() * (radius_m * 100.0f)) - center_to_pos_cm;
+                const Vector2f candidate_pos_cm = move_pos_away_from_boundary(scaled_pos_cm, closest_vec_cm, margin_cm);
+                compare_closest_point_candidate(candidate_pos_cm, scaled_pos_cm, found, closest_dist_cm_sq, closest_loc);
+            }
+        }
+    }
+
+    if (!found) {
+        return false;
+    }
+
+    loc_closest = closest_loc;
+    return true;
+}
+
+// helper for get_closest_loc_within_fence: moves a point to the far side of the nearest fence
+// boundary, clearing it by margin_cm.  Works for both inclusion and exclusion boundaries
+//   from_pos_cm: point to move, as an offset in cm from the EKF origin
+//   closest_vec_cm: vector from from_pos_cm to the nearest point on the boundary
+//   margin_cm: distance to clear the boundary by
+// returns the new point, as an offset in cm from the EKF origin
+Vector2f AC_PolyFence_loader::move_pos_away_from_boundary(const Vector2f &from_pos_cm, const Vector2f &closest_vec_cm, float margin_cm) const
+{
+    if (closest_vec_cm.is_zero()) {
+        return from_pos_cm;
+    }
+    return from_pos_cm + closest_vec_cm + (closest_vec_cm.normalized() * margin_cm);
+}
+
+// helper for get_closest_loc_within_fence: keeps candidate_pos_cm if it does not breach the
+// fence and is closer to scaled_pos_cm than the best candidate found so far
+//   candidate_pos_cm: candidate point to test, as an offset in cm from the EKF origin
+//   scaled_pos_cm: point candidates are being compared against, as an offset in cm from the EKF origin
+//   found, closest_dist_cm_sq, closest_loc: best candidate found so far; updated if candidate_pos_cm is better
+void AC_PolyFence_loader::compare_closest_point_candidate(const Vector2f &candidate_pos_cm,
+                                                            const Vector2f &scaled_pos_cm,
+                                                            bool &found,
+                                                            float &closest_dist_cm_sq,
+                                                            Location &closest_loc) const
+{
+    Location candidate_loc = loaded_origin;
+    candidate_loc.offset(candidate_pos_cm.x * 0.01f, candidate_pos_cm.y * 0.01f);
+    if (breached(candidate_loc)) {
+        return;
+    }
+    const float dist_cm_sq = (candidate_pos_cm - scaled_pos_cm).length_squared();
+    if (!found || (dist_cm_sq < closest_dist_cm_sq)) {
+        found = true;
+        closest_dist_cm_sq = dist_cm_sq;
+        closest_loc = candidate_loc;
+    }
+}
+
 bool AC_PolyFence_loader::formatted() const
 {
     return (fence_storage.read_uint8(0) == new_fence_storage_magic &&
@@ -1401,6 +1522,7 @@ bool AC_PolyFence_loader::get_inclusion_circle(uint8_t index, Vector2f &center_p
 
 bool AC_PolyFence_loader::breached() const { return false; }
 bool AC_PolyFence_loader::breached(const Location& loc, float& distance_outside_fence, Vector2f& fence_direction) const { return false; }
+bool AC_PolyFence_loader::get_closest_loc_within_fence(const Location& loc, float margin_cm, Location& loc_closest) const { return false; }
 
 uint16_t AC_PolyFence_loader::max_items() const { return 0; }
 

--- a/libraries/AC_Fence/AC_PolyFence_loader.h
+++ b/libraries/AC_Fence/AC_PolyFence_loader.h
@@ -154,6 +154,12 @@ public:
         return breached(loc, distance_outside_fence, breach_direction);
     }
 
+    // get_closest_loc_within_fence - finds the closest point to loc that does not breach
+    // any loaded inclusion/exclusion polygon or circle, expanded/contracted by margin_cm.
+    // if loc does not breach the fence then loc_closest is simply set to loc.
+    // returns false if no such point could be found (e.g. fence not loaded)
+    bool get_closest_loc_within_fence(const Location& loc, float margin_cm, Location& loc_closest) const WARN_IF_UNUSED;
+
     // returns true if a polygonal include fence could be returned
     bool inclusion_boundary_available() const WARN_IF_UNUSED {
         return _num_loaded_inclusion_boundaries != 0;
@@ -371,7 +377,27 @@ private:
     bool scale_latlon_from_origin(const Location &origin,
                                   const Vector2l &point,
                                   Vector2f &pos_cm) const WARN_IF_UNUSED;
-   
+
+    // helper for get_closest_loc_within_fence: moves a point to the far side of the nearest fence
+    // boundary, clearing it by margin_cm.  Works for both inclusion and exclusion boundaries
+    //   from_pos_cm: point to move, as an offset in cm from the EKF origin
+    //   closest_vec_cm: vector from from_pos_cm to the nearest point on the boundary
+    //   margin_cm: distance to clear the boundary by
+    // returns the new point, as an offset in cm from the EKF origin
+    Vector2f move_pos_away_from_boundary(const Vector2f &from_pos_cm, const Vector2f &closest_vec_cm, float margin_cm) const;
+
+    // helper for get_closest_loc_within_fence: keeps candidate_pos_cm if it does not breach the
+    // fence and is closer to scaled_pos_cm than the best candidate found so far
+    //   candidate_pos_cm: candidate point to test, as an offset in cm from the EKF origin
+    //   scaled_pos_cm: point candidates are being compared against, as an offset in cm from the EKF origin
+    //   found, closest_dist_cm_sq, closest_loc: best candidate found so far; updated if candidate_pos_cm is better
+    void compare_closest_point_candidate(const Vector2f &candidate_pos_cm,
+                                          const Vector2f &scaled_pos_cm,
+                                          bool &found,
+                                          float &closest_dist_cm_sq,
+                                          Location &closest_loc) const;
+
+
     // read_polygon_from_storage - reads vertex_count
     // latitude/longitude points from offset in permanent storage,
     // transforms them into an offset-from-origin and deposits the


### PR DESCRIPTION
### Summary

This resolves https://github.com/ArduPilot/ardupilot/issues/31399 which is caused by Dijkstras being unable to create a path from the "origin" to the "destination" if either is outside of the fences.  The issue can be reproduced in SITL by doing the following:

- param set FENCE_ENABLE 1
- param set FENCE_TYPE 4 (Inclusion/exclusion Circle+Polygon)
- param set OA_TYPE 2 (Dijkstras)
- param set RC11_OPTION 11 (aux function to enable/disable fence)
- restart SITL
- Create a polygon fence
- rc 11 (disable the fence)
- fly the vehicle outside the fence
- rc 11 2000 (to enable the fence)
- the error message, "Dijkstras could not find path" will be displayed

<img width="814" height="1021" alt="image" src="https://github.com/user-attachments/assets/194aee24-d26b-485d-b725-bae8d7f594fe" />

The proposed fix is to shift the origin and destination to be within the fence before calculating the return path.  

This has been moderately well tested in SITL:

1. The copter RTLs home successfully when started from outside the fence
2. The copter RTLs all the way to home even if home is outside the fence (this was slightly unexpected)
3. The copter will fly directly to home if there is a straight line path from its current location to home (e.g. does not cross over a fence)
4. an autotest has been added to lock-in the ability.

<img width="814" height="695" alt="image" src="https://github.com/user-attachments/assets/05da702c-ff1f-4ba3-bd75-5a8714c1f112" />

Some questions:

- If both the starting point and final destination are outside of the fence, the vehicle will only attempt to get back inside the fence if the straight line path between start and destination crosses over a fence and/or the distance to a safe point within the fence is closer than the distance between start and destination.  Below are pictures where it does and does not fly back within the fence
<img width="412" height="348" alt="image" src="https://github.com/user-attachments/assets/5ee7f480-8633-48bd-8fdd-028de388b864" />
<img width="485" height="348" alt="image" src="https://github.com/user-attachments/assets/afc9ecd0-b6f2-4984-8998-4a41a534ba83" />

- An alternative solution could be to skip the "breached" check for the path between the origin and safe points (e.g. points in the "vis graphs")
- This has been tested on Copter but not Rover

This is a more comprehensive solution than: https://github.com/ArduPilot/ardupilot/pull/31827

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request
