### PR TITLE
Copter: prevent arming when avoidance requires backup

### DIFF
--- a/ArduCopter/AP_Arming_Copter.cpp
+++ b/ArduCopter/AP_Arming_Copter.cpp
@@ -318,21 +318,30 @@ bool AP_Arming_Copter::parameter_checks(bool display_failure)
 
 bool AP_Arming_Copter::oa_checks(bool display_failure)
 {
+#if AP_AVOIDANCE_ENABLED
+    if (copter.avoid.requires_backup_velocity(copter.pos_control->NE_get_pos_p().kP(),
+                                              copter.pos_control->NE_get_max_accel_mss() * 100.0f,
+                                              copter.pos_control->D_get_pos_p().kP(),
+                                              copter.pos_control->D_get_max_accel_mss() * 100.0f,
+                                              copter.G_Dt)) {
+        check_failed(display_failure, "Avoidance: Vehicle requires backup");
+        return false;
+    }
+#endif
+
 #if AP_OAPATHPLANNER_ENABLED
     char failure_msg[100] = {};
-    if (copter.g2.oa.pre_arm_check(failure_msg, ARRAY_SIZE(failure_msg))) {
-        return true;
+    if (!copter.g2.oa.pre_arm_check(failure_msg, ARRAY_SIZE(failure_msg))) {
+        // display failure
+        if (strlen(failure_msg) == 0) {
+            check_failed(display_failure, "%s", "Check Object Avoidance");
+        } else {
+            check_failed(display_failure, "%s", failure_msg);
+        }
+        return false;
     }
-    // display failure
-    if (strlen(failure_msg) == 0) {
-        check_failed(display_failure, "%s", "Check Object Avoidance");
-    } else {
-        check_failed(display_failure, "%s", failure_msg);
-    }
-    return false;
-#else
-    return true;
 #endif
+    return true;
 }
 
 bool AP_Arming_Copter::rc_calibration_checks(bool display_failure)

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -10652,7 +10652,14 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.do_RTL()
 
     def check_avoidance_corners(self):
+        # These tests exercise avoidance while flying near fence corners.  Arm
+        # and take off with avoidance disabled so the pre-arm backup check does
+        # not reject their deliberately constrained starting position, then
+        # restore the test's original avoidance configuration before flying.
+        avoid_enable = self.get_parameter("AVOID_ENABLE")
+        self.set_parameter("AVOID_ENABLE", 0)
         self.takeoff(10, mode="LOITER")
+        self.set_parameter("AVOID_ENABLE", avoid_enable)
         here = self.mav.location()
         # the vehicle starts a test at home but with whatever heading
         # the previous test left it; face west like the other corner

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -2514,6 +2514,63 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.fly_fence_avoid_test_radius_check(avoid_behave=1, timeout=timeout)
         self.fly_fence_avoid_test_radius_check(avoid_behave=0, timeout=timeout)
 
+    def FenceMarginArming(self):
+        '''Prevent arming inside the horizontal fence avoidance margin'''
+        fence_radius = 15
+        fence_margin = 3
+        self.change_mode("LOITER")
+        self.set_parameters({
+            "FENCE_ENABLE": 1,
+            "FENCE_TYPE": 2,
+            "FENCE_RADIUS": fence_radius,
+            "FENCE_MARGIN": fence_margin,
+            "FENCE_ACTION": 0,
+            "AVOID_ENABLE": 1,
+        })
+        self.wait_ready_to_arm()
+        self.zero_throttle()
+        self.arm_vehicle()
+        self.progress("Control: armed outside the fence avoidance margin")
+        self.disarm_vehicle()
+
+        self.set_parameter("AVOID_ENABLE", 0)
+        self.arm_vehicle()
+        self.set_rc(3, 1700)
+        self.wait_altitude(3, 6, relative=True)
+        self.set_rc(3, 1500)
+        self.set_rc(2, 1400)
+        self.wait_distance_to_home(11.8, 12.2, timeout=30)
+        self.set_rc(2, 1500)
+        self.land_and_disarm()
+
+        landed_distance = self.distance_to_home(use_cached_home=True)
+        inner_radius = fence_radius - fence_margin
+        self.progress("Landed %.2fm from home; avoidance begins at %.2fm" %
+                      (landed_distance, inner_radius))
+        if landed_distance <= inner_radius or landed_distance >= fence_radius:
+            raise PreconditionFailedException(
+                "Vehicle did not land inside the fence avoidance margin")
+
+        self.set_parameter("AVOID_ENABLE", 1)
+        self.change_mode("LOITER")
+        self.assert_prearm_failure("Avoidance: Vehicle requires backup")
+
+        # Return to the startup location so this regression composes with
+        # the standard autotest harness cleanup checks.
+        self.set_parameters({
+            "FENCE_ENABLE": 0,
+            "AVOID_ENABLE": 0,
+        })
+        self.zero_throttle()
+        self.arm_vehicle()
+        self.set_rc(3, 1700)
+        self.wait_altitude(3, 6, relative=True)
+        self.set_rc(3, 1500)
+        self.set_rc(2, 1600)
+        self.wait_distance_to_home(11.8, 12.2, timeout=30)
+        self.set_rc(2, 1500)
+        self.land_and_disarm()
+
     # fly_fence_test - fly east until you hit the horizontal circular fence
     def HorizontalFence(self, timeout=180):
         '''Test horizontal fence'''
@@ -16307,6 +16364,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         ret = ([
              self.HorizontalFence,
              self.HorizontalAvoidFence,
+             self.FenceMarginArming,
              self.MaxAltFence,
              self.MaxAltFenceAvoid,
              self.MinAltFence,

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -322,6 +322,34 @@ void AC_Avoid::adjust_velocity(Vector3f &desired_vel_neu_cms, bool &backing_up, 
 #endif
 }
 
+bool AC_Avoid::requires_backup_velocity(float kP, float accel_cmss, float kP_z, float accel_z_cmss, float dt)
+{
+    if (_enabled == AC_AVOID_DISABLED) {
+        return false;
+    }
+
+    // A non-zero probe is required because some fence checks exit early for
+    // a stationary vehicle.  Only backup velocity is inspected; ordinary
+    // limiting of the probe velocity does not prevent arming.
+    const Vector3f probe_velocity_neu_cms{1.0f, 1.0f, 1.0f};
+    Vector3f desired_vel_neu_cms = probe_velocity_neu_cms;
+    Vector3f backup_vel_neu_cms;
+
+    if (proximity_avoidance_enabled() && _proximity_alt_enabled) {
+        adjust_velocity_proximity(kP, accel_cmss, desired_vel_neu_cms, backup_vel_neu_cms, kP_z, accel_z_cmss, dt);
+        if ((!backup_vel_neu_cms.xy().is_zero() && is_positive(_backup_speed_max_ne_ms)) ||
+            (!is_zero(backup_vel_neu_cms.z) && is_positive(_backup_speed_max_u_ms))) {
+            return true;
+        }
+    }
+
+    desired_vel_neu_cms = probe_velocity_neu_cms;
+    backup_vel_neu_cms.zero();
+    adjust_velocity_fence(kP, accel_cmss, desired_vel_neu_cms, backup_vel_neu_cms, kP_z, accel_z_cmss, dt);
+    return (!backup_vel_neu_cms.xy().is_zero() && is_positive(_backup_speed_max_ne_ms)) ||
+           (!is_zero(backup_vel_neu_cms.z) && is_positive(_backup_speed_max_u_ms));
+}
+
 /*
 * Limit acceleration so that change of velocity output by avoidance library is controlled
 * This helps reduce jerks and sudden movements in the vehicle

--- a/libraries/AC_Avoidance/AC_Avoid.h
+++ b/libraries/AC_Avoidance/AC_Avoid.h
@@ -67,6 +67,10 @@ public:
         desired_vel_ned_ms = Vector3f{desired_vel_neu_cms.x, desired_vel_neu_cms.y, -desired_vel_neu_cms.z} * 0.01;
     }
 
+    // return true if avoidance would command the vehicle to back away from
+    // a fence or obstacle.  This probe does not update avoidance state.
+    bool requires_backup_velocity(float kP, float accel_cmss, float kP_z, float accel_z_cmss, float dt);
+
     // This method limits velocity and calculates backaway velocity from various supported fences
     // Also limits vertical velocity using adjust_velocity_z method
     void adjust_velocity_fence(float kP, float accel_cmss, Vector3f &desired_vel_neu_cms, Vector3f &backup_vel_cms, float kP_z, float accel_z_cmss, float dt);


### PR DESCRIPTION
### Summary

Prevents Copter from arming when enabled avoidance would immediately command backup movement because the vehicle is inside a fence or obstacle margin.

Fixes #20166.

### Testing

* Copter SITL build passed.
* New `FenceMarginArming` regression passed.
* Existing `HorizontalAvoidFence` test passed.
* Confirmed normal arming remains possible outside the fence margin.
* Confirmed arming inside the margin is rejected with `PreArm: Avoidance: Vehicle requires backup`.

### Description

Adds a side-effect-free avoidance check before arming. Arming is rejected only when avoidance would command immediate backup movement; ordinary velocity limiting does not prevent arming.
