### PR TITLE
Plane: QuadPlane backward airspeed limit to avoid reversed tail flow

### DIFF
--- a/ArduPlane/AP_Arming_Plane.cpp
+++ b/ArduPlane/AP_Arming_Plane.cpp
@@ -218,6 +218,15 @@ bool AP_Arming_Plane::quadplane_checks(bool display_failure)
         ret = false;
     }
 
+    // the backward airflow reporting threshold has to sit below the speed
+    // the limiter holds, otherwise nothing is logged until it is already
+    // intervening and there is no warning of the approach
+    if (plane.quadplane.bkflow_enable != QuadPlane::BackwardFlowUse::OFF &&
+        plane.quadplane.bkflow_spd_min >= plane.quadplane.bkflow_spd_max) {
+        check_failed(Check::PARAMETERS, display_failure, "Q_BKF_SPD_MIN must be below Q_BKF_SPD_MAX");
+        ret = false;
+    }
+
     // combining Q_RTL_MODE with either of the RTL_AUTOLAND options
     // leads to precedence questions, so just don't allow it:
     if (plane.g.rtl_autoland != RtlAutoland::RTL_DISABLE &&

--- a/ArduPlane/mode_qhover.cpp
+++ b/ArduPlane/mode_qhover.cpp
@@ -40,6 +40,7 @@ void ModeQHover::run()
         quadplane.relax_attitude_control();
         pos_control->D_relax_controller(0);
     } else {
+        plane.quadplane.backward_flow_limit_speed();
         plane.quadplane.assign_tilt_to_fwd_thr();
         quadplane.hold_hover(quadplane.get_pilot_desired_climb_rate_cms());
     }

--- a/ArduPlane/mode_qloiter.cpp
+++ b/ArduPlane/mode_qloiter.cpp
@@ -126,6 +126,7 @@ void ModeQLoiter::run()
     plane.nav_roll_cd = loiter_nav->get_roll_cd();
     plane.nav_pitch_cd = loiter_nav->get_pitch_cd();
 
+    plane.quadplane.backward_flow_limit_speed();
     plane.quadplane.assign_tilt_to_fwd_thr();
 
     if (quadplane.transition->set_VTOL_roll_pitch_limit(plane.nav_roll_cd, plane.nav_pitch_cd)) {

--- a/ArduPlane/mode_qrtl.cpp
+++ b/ArduPlane/mode_qrtl.cpp
@@ -105,6 +105,7 @@ void ModeQRTL::run()
             plane.nav_roll_cd = pos_control->get_roll_cd();
             plane.nav_pitch_cd = pos_control->get_pitch_cd();
 
+            plane.quadplane.backward_flow_limit_speed();
             plane.quadplane.assign_tilt_to_fwd_thr();
 
             if (quadplane.transition->set_VTOL_roll_pitch_limit(plane.nav_roll_cd, plane.nav_pitch_cd)) {

--- a/ArduPlane/mode_qstabilize.cpp
+++ b/ArduPlane/mode_qstabilize.cpp
@@ -48,6 +48,7 @@ void ModeQStabilize::run()
         return;
     }
 
+    plane.quadplane.backward_flow_limit_speed();
     plane.quadplane.assign_tilt_to_fwd_thr();
 
     // special check for ESC calibration in QSTABILIZE

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -572,6 +572,49 @@ const AP_Param::GroupInfo QuadPlane::var_info2[] = {
     // @Bitmask: 1: Disable thrust loss detection in transtions and fixed wing modes. Thrust loss detection will only run in VTOL modes.
     AP_GROUPINFO("THRST_LOSS_OPT", 42, QuadPlane, thrust_loss.options, 0),
 
+    // @Param: BKF_ENABLE
+    // @DisplayName: Backward airflow protection
+    // @Description: Protection against flying tail first fast enough in VTOL modes to reverse and separate the flow over the tail, which can produce a large uncommanded nose down pitch. A backward airspeed is estimated from the EKF ground velocity and wind estimate, resolved onto the body forward axis. Set to 1 to only log the BAKF message, so data can be gathered on an airframe without changing how it flies. Set to 2 to also hold the vehicle to Q_BKF_SPD_MAX. This caps how fast the vehicle can be flown backwards at all: in a tailwind stronger than Q_BKF_SPD_MAX it will drift downwind, so weathervaning (Q_WVANE_ENABLE) should be left on as the primary defence. IMPORTANT: the wind estimate is only observable to the EKF in forward flight, or in VTOL flight if EK3_DRAG_BCOEF_X/Y are set. Before the first transition of a sortie the estimate falls back to backward groundspeed, which under reads in a tailwind and over reads in a headwind, so a VTOL only sortie is not protected unless EK3_DRAG_BCOEF_X/Y are set. BAKF.WSpd logs the wind actually used. The defaults come from a single flight log and need confirming by flight test on each airframe.
+    // @Values: 0:Disabled,1:Log only,2:Log and limit backward speed
+    // @User: Advanced
+    AP_GROUPINFO("BKF_ENABLE", 43, QuadPlane, bkflow_enable, uint8_t(BackwardFlowUse::OFF)),
+
+    // @Param: BKF_SPD_MIN
+    // @DisplayName: Backward airflow limiting start speed
+    // @Description: Estimated backward (tail first) airspeed at which the limiter starts squeezing the pitch back demand, and at which the BAKF message starts being logged and the one shot warning is sent. Between this and Q_BKF_SPD_MAX the pitch back demand the pilot or navigation controller can ask for falls linearly to zero. Setting it well below Q_BKF_SPD_MAX gives a gentle squeeze and plenty of logged data before the limit is reached; setting it close makes the intervention abrupt. Has no effect unless Q_BKF_ENABLE is non zero.
+    // @Units: m/s
+    // @Range: 0.5 10.0
+    // @Increment: 0.1
+    // @User: Advanced
+    AP_GROUPINFO("BKF_SPD_MIN", 44, QuadPlane, bkflow_spd_min, 1.5f),
+
+    // @Param: BKF_SPD_MAX
+    // @DisplayName: Backward airflow speed limit
+    // @Description: The backward (tail first) airspeed the limiter holds the vehicle to. Between Q_BKF_SPD_MIN and this speed the pitch back demand is progressively squeezed to zero, at this speed the vehicle is held level, and above it nose down is commanded to arrest the backward motion. Set this below the backward airspeed at which the tail flow is known to separate on your airframe, with enough margin that the limiter has time to act. Has no effect unless Q_BKF_ENABLE is 2.
+    // @Units: m/s
+    // @Range: 1.0 15.0
+    // @Increment: 0.1
+    // @User: Advanced
+    AP_GROUPINFO("BKF_SPD_MAX", 45, QuadPlane, bkflow_spd_max, 3.0f),
+
+    // @Param: BKF_GAIN
+    // @DisplayName: Backward airflow limiter gain
+    // @Description: How hard the limiter pushes once past Q_BKF_SPD_MAX, in degrees of commanded nose down per m/s of overshoot, up to Q_BKF_ANG_MAX. Larger values recover the speed limit faster but make the intervention more abrupt. This has no effect below Q_BKF_SPD_MAX, where the squeeze is set by Q_BKF_SPD_MIN instead. Set to zero to disable the limit while leaving logging active. Has no effect unless Q_BKF_ENABLE is 2.
+    // @Units: deg/m/s
+    // @Range: 0.0 20.0
+    // @Increment: 0.5
+    // @User: Advanced
+    AP_GROUPINFO("BKF_GAIN", 46, QuadPlane, bkflow_gain, 5.0f),
+
+    // @Param: BKF_ANG_MAX
+    // @DisplayName: Backward airflow maximum nose down
+    // @Description: The largest nose down pitch angle the limiter is allowed to command in order to arrest backward motion. This bounds how hard the vehicle will push forward when it is well past Q_BKF_SPD_MAX. Keep it small: a large commanded nose down in reversed flow is the attitude this feature exists to avoid. Has no effect unless Q_BKF_ENABLE is 2.
+    // @Units: deg
+    // @Range: 0.0 25.0
+    // @Increment: 0.5
+    // @User: Advanced
+    AP_GROUPINFO("BKF_ANG_MAX", 47, QuadPlane, bkflow_ang_max, 10.0f),
+
     AP_GROUPEND
 };
 
@@ -1710,6 +1753,9 @@ void QuadPlane::update(void)
     // keep motors interlock state upto date with E-stop
     motors->set_interlock(!SRV_Channels::get_emergency_stop());
 
+    // capture the wind estimate while it is still valid, see update_wind_cache()
+    update_wind_cache();
+
     if ((ahrs_view != NULL) && !is_equal(_last_ahrs_trim_pitch, ahrs_trim_pitch.get())) {
         _last_ahrs_trim_pitch = ahrs_trim_pitch.get();
         ahrs_view->set_pitch_trim(_last_ahrs_trim_pitch);
@@ -1745,6 +1791,11 @@ void QuadPlane::update(void)
         }
         // todo: do you want to set the throttle at this point?
         pos_control->D_relax_controller(0);
+
+        // re-arm the one shot backward airflow warning and drop the cached
+        // wind estimate so the next flight starts clean
+        backward_flow.warned = false;
+        backward_flow.wind_valid = false;
     }
 
     const uint32_t now = AP_HAL::millis();
@@ -2689,6 +2740,7 @@ void QuadPlane::vtol_position_controller(void)
         plane.nav_roll_cd = pos_control->get_roll_cd();
         plane.nav_pitch_cd = pos_control->get_pitch_cd();
 
+        backward_flow_limit_speed();
         assign_tilt_to_fwd_thr();
 
         if (transition->set_VTOL_roll_pitch_limit(plane.nav_roll_cd, plane.nav_pitch_cd)) {
@@ -2744,6 +2796,7 @@ void QuadPlane::vtol_position_controller(void)
         plane.nav_roll_cd = pos_control->get_roll_cd();
         plane.nav_pitch_cd = pos_control->get_pitch_cd();
 
+        backward_flow_limit_speed();
         assign_tilt_to_fwd_thr();
 
         if (transition->set_VTOL_roll_pitch_limit(plane.nav_roll_cd, plane.nav_pitch_cd)) {
@@ -2790,6 +2843,7 @@ void QuadPlane::vtol_position_controller(void)
         plane.nav_roll_cd = pos_control->get_roll_cd();
         plane.nav_pitch_cd = pos_control->get_pitch_cd();
 
+        backward_flow_limit_speed();
         assign_tilt_to_fwd_thr();
 
         // call attitude controller
@@ -3079,6 +3133,218 @@ void QuadPlane::assign_tilt_to_fwd_thr(void)
 }
 
 /*
+  remember the last valid AHRS wind estimate, for backward_flow_limit_speed().
+
+  EKF3 freezes the wind states when the vehicle leaves fixed wing flight, and
+  AP_AHRS::get_wind() then reports them as invalid. The last learned value is
+  far better than assuming zero wind for the VTOL phase, so cache it. This
+  runs in all modes so the estimate is captured while still flying forwards.
+
+  Before the first transition there is nothing cached and the backward
+  airspeed falls back to groundspeed. Setting EK3_DRAG_BCOEF_X/Y makes the
+  wind observable in VTOL flight and removes that dependency. BAKF.WSpd logs
+  the value actually used.
+ */
+void QuadPlane::update_wind_cache(void)
+{
+    Vector3f wind_ned;
+    if (ahrs.get_wind(wind_ned)) {
+        backward_flow.wind_ne = wind_ned.xy();
+        backward_flow.wind_valid = true;
+    }
+}
+
+/*
+  hold the vehicle to a maximum backward (tail first) airspeed in VTOL modes.
+
+  Backing up into a tailwind while descending can take a conventional
+  quadplane tail past the angle at which its flow separates. The tail then
+  loses its damping and the aircraft can pitch hard nose down with the VTOL
+  rate controller unable to arrest it. The source log reached 4.4 m/s
+  backwards on only 3 to 7 degrees of commanded lean held for six seconds,
+  so limiting the lean angle cannot prevent it; the backward speed itself is
+  what has to be limited.
+
+  The ceiling on the pitch demand follows the backward airspeed, and is
+  continuous across both joins:
+
+    below Q_BKF_SPD_MIN   ceiling = Q_A_ANGLE_MAX, ie no restriction
+    up to Q_BKF_SPD_MAX   ceiling falls linearly from Q_A_ANGLE_MAX to zero
+    above Q_BKF_SPD_MAX   ceiling = -(excess * Q_BKF_GAIN), to -Q_BKF_ANG_MAX
+
+  Detection cannot come from the AOA or the airspeed sensor. The AOA is not a
+  vane; AP_AHRS::update_AOA_SSA() derives it from the same EKF velocity and
+  wind and forces it to exactly zero whenever the body forward airspeed is
+  negative, so it reports that reversed flow is present but discards how fast
+  it is. A pitot cannot sense direction at all. Resolving the EKF air
+  velocity onto the body forward axis recovers the signed magnitude.
+
+  Deliberately not covered:
+
+   - QPOS_AIRBRAKE, where the demand comes from TECS while still decelerating
+     out of forward flight and airbrake needs its nose up authority.
+
+   - the SystemID attitude offset, which is added after this runs and is
+     meant to bypass the normal shaping and constraints.
+
+   - QACRO and QAUTOTUNE, which do not command a lean angle through this path.
+ */
+void QuadPlane::backward_flow_limit_speed(void)
+{
+    backward_flow.limiting = false;
+
+    if (bkflow_enable == BackwardFlowUse::OFF ||
+        tailsitter.enabled() ||
+        force_fw_control_recovery ||
+        !plane.arming.is_armed_and_safety_off()) {
+        /*
+          nothing to do.
+
+          A tailsitter hovers with its tail down and has no conventional tail
+          surfaces in the airflow, so this does not apply to it.
+
+          We also stand aside during a fixed wing attitude recovery. That is
+          triggered at twice Q_A_ANGLE_MAX, which is the attitude a tail flow
+          separation event produces if it happens anyway. The recovery needs
+          nose up authority to pull out of it, and this limiter commands nose
+          down, so it must not be running then.
+         */
+        backward_flow.in_band = false;
+        backward_flow.airspeed_ms = 0;
+        backward_flow.pitch_limit_cd = 0;
+        return;
+    }
+
+    Vector3f vel_ned;
+    if (!ahrs.get_velocity_NED(vel_ned)) {
+        // without a velocity estimate we cannot form the synthetic airspeed
+        backward_flow.in_band = false;
+        return;
+    }
+
+    // with no wind estimate at all this degrades to backward groundspeed,
+    // which under estimates the backward airspeed in a tailwind. That is the
+    // case we care about, so it is a degraded but still useful fallback
+    const Vector2f wind_ne = backward_flow.wind_valid ? backward_flow.wind_ne : Vector2f{};
+
+    // velocity of the airframe through the air mass. The EKF does not
+    // estimate vertical wind, so only the horizontal components of the air
+    // mass velocity can be removed
+    const Vector3f air_vel_ned{vel_ned.x - wind_ne.x, vel_ned.y - wind_ne.y, vel_ned.z};
+
+    /*
+      resolve onto the body forward axis rather than onto the horizontal
+      heading. Descending with the nose up puts flow on the tail from behind
+      even with no horizontal motion at all, and reduced throttle with the
+      stick held back produces exactly that combination. Projecting onto the
+      horizontal would miss it, and would also overstate the axial flow
+      produced by horizontal motion by a factor of 1/cos(pitch).
+
+      A negative body forward airspeed means the air is arriving from behind.
+     */
+    backward_flow.airspeed_ms = -ahrs.earth_to_body(air_vel_ned).x;
+
+#if HAL_LOGGING_ENABLED
+    // only needed to form the BAKF message below
+    const float backward_gnd_speed_ms = -ahrs.earth_to_body(vel_ned).x;
+    const bool was_in_band = backward_flow.in_band;
+#endif
+
+    // clamp to zero so that a negative Q_BKF_SPD_MIN cannot leave the logging
+    // band, and the warning with it, permanently active in a normal hover
+    const float spd_min = MAX(bkflow_spd_min, 0.0f);
+    // keep the squeeze non degenerate so the interpolation is well defined
+    const float spd_max = MAX(bkflow_spd_max, spd_min + 0.1f);
+
+    backward_flow.in_band = backward_flow.airspeed_ms > spd_min;
+
+    // the ceiling on the pitch demand
+    const float angle_max_cd = attitude_control->lean_angle_max_cd();
+    const float ang_max_cd = constrain_float(bkflow_ang_max * 100.0f, 0.0f, angle_max_cd);
+    if (backward_flow.airspeed_ms <= spd_max) {
+        // squeeze the pitch back demand to nothing as the limit is approached
+        backward_flow.pitch_limit_cd = linear_interpolate(angle_max_cd, 0.0f,
+                                                          backward_flow.airspeed_ms,
+                                                          spd_min, spd_max);
+    } else {
+        // past the limit, command nose down to arrest the backward motion
+        backward_flow.pitch_limit_cd = -MIN((backward_flow.airspeed_ms - spd_max) * bkflow_gain * 100.0f,
+                                            ang_max_cd);
+    }
+
+    if (bkflow_enable == BackwardFlowUse::LIMIT && is_positive(bkflow_gain)) {
+        const int32_t limit_cd = (int32_t)backward_flow.pitch_limit_cd;
+        if (plane.nav_pitch_cd > limit_cd) {
+            plane.nav_pitch_cd = limit_cd;
+            backward_flow.limiting = true;
+            if (pos_control->NE_is_active()) {
+                // tell the position controller it is being limited so it
+                // does not wind up against a limit it cannot see
+                pos_control->NE_set_externally_limited();
+            }
+        }
+    }
+
+    if (backward_flow.in_band && !backward_flow.warned) {
+        // one shot text message per flight so this shows up in a quick log
+        // scan without having to graph the BAKF message
+        backward_flow.warned = true;
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "QuadPlane: backward airflow %.1fm/s",
+                      (double)backward_flow.airspeed_ms);
+    }
+
+#if HAL_LOGGING_ENABLED
+    const uint32_t now_ms = AP_HAL::millis();
+    // log at 5Hz while above Q_BKF_SPD_MIN, plus one sample on the way out,
+    // and whenever the limiter is actually intervening
+    if ((backward_flow.in_band && now_ms - backward_flow.last_log_ms >= 200) ||
+        (!backward_flow.in_band && was_in_band) ||
+        (backward_flow.limiting && now_ms - backward_flow.last_log_ms >= 200)) {
+        backward_flow.last_log_ms = now_ms;
+
+        float eas = 0;
+        IGNORE_RETURN(ahrs.airspeed_EAS(eas));
+
+        float diff_press_pa = 0;
+#if AP_AIRSPEED_ENABLED
+        const AP_Airspeed *airspeed = AP::airspeed();
+        if (airspeed != nullptr && airspeed->healthy()) {
+            diff_press_pa = airspeed->get_differential_pressure();
+        }
+#endif
+
+        // @LoggerMessage: BAKF
+        // @Description: QuadPlane backward (tail first) airflow protection
+        // @Field: TimeUS: Time since system startup
+        // @Field: BSpd: backward airspeed on the body forward axis, from ground velocity and wind
+        // @Field: BGnd: backward groundspeed on the same axis, for comparison with BSpd
+        // @Field: WSpd: speed of the cached wind estimate used to form BSpd
+        // @Field: ASpd: AHRS equivalent airspeed estimate
+        // @Field: DP: airspeed sensor differential pressure
+        // @Field: AOA: AHRS angle of attack, which is pinned to zero while BSpd is positive
+        // @Field: Pitch: current pitch angle
+        // @Field: PLim: ceiling on the pitch demand called for by BSpd
+        // @Field: Lim: true if the limiter reduced the commanded pitch this loop
+        AP::logger().WriteStreaming("BAKF",
+                                    "TimeUS,BSpd,BGnd,WSpd,ASpd,DP,AOA,Pitch,PLim,Lim",  // labels
+                                    "snnnnPddd-",   // units
+                                    "F---------",   // multipliers
+                                    "QffffffffB",   // fmt
+                                    AP_HAL::micros64(),
+                                    (double)backward_flow.airspeed_ms,
+                                    (double)backward_gnd_speed_ms,
+                                    (double)wind_ne.length(),
+                                    (double)eas,
+                                    (double)diff_press_pa,
+                                    (double)ahrs.getAOA(),
+                                    (double)ahrs.get_pitch_deg(),
+                                    (double)(backward_flow.pitch_limit_cd * 0.01f),
+                                    (uint8_t)backward_flow.limiting);
+    }
+#endif  // HAL_LOGGING_ENABLED
+}
+
+/*
   we want to limit WP speed to a lower speed when more than 20 degrees
   off pointing at the destination. quadplanes are often
   unstable when flying sideways or backwards
@@ -3217,6 +3483,7 @@ void QuadPlane::takeoff_controller(void)
         plane.nav_roll_cd = pos_control->get_roll_cd();
         plane.nav_pitch_cd = pos_control->get_pitch_cd();
 
+        backward_flow_limit_speed();
         assign_tilt_to_fwd_thr();
     }
 
@@ -3275,6 +3542,7 @@ void QuadPlane::waypoint_controller(void)
     plane.nav_roll_cd = wp_nav->get_roll();
     plane.nav_pitch_cd = wp_nav->get_pitch();
 
+    backward_flow_limit_speed();
     assign_tilt_to_fwd_thr();
 
     if (transition->set_VTOL_roll_pitch_limit(plane.nav_roll_cd, plane.nav_pitch_cd)) {

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -393,6 +393,32 @@ private:
     // limit applied to back pitch to prevent wing producing excessive lift
     AP_Float q_bck_pitch_lim;
 
+    /*
+      backward (tail first) airflow protection. See
+      QuadPlane::backward_flow_limit_speed() for the rationale.
+     */
+    enum class BackwardFlowUse : uint8_t {
+        OFF   = 0,
+        LOG   = 1,
+        LIMIT = 2,
+    };
+    AP_Enum<BackwardFlowUse> bkflow_enable;
+    AP_Float bkflow_spd_min;    // backward airspeed (m/s) at which BAKF logging starts
+    AP_Float bkflow_spd_max;    // backward airspeed (m/s) the limiter holds the vehicle to
+    AP_Float bkflow_gain;       // pitch demand (deg) per m/s of backward airspeed error
+    AP_Float bkflow_ang_max;    // largest nose down angle (deg) the limiter may command
+
+    struct {
+        float airspeed_ms;      // synthetic backward airspeed, positive when flying tail first
+        float pitch_limit_cd;   // ceiling on the pitch demand that the current airspeed calls for
+        Vector2f wind_ne;       // last valid AHRS wind estimate, see update_wind_cache()
+        bool wind_valid;        // true once wind_ne has been filled in this flight
+        bool in_band;           // synthetic backward airspeed is above Q_BKF_SPD_MIN
+        bool limiting;          // the limit actually reduced the pitch demand this loop
+        bool warned;            // one shot GCS warning has been sent this flight
+        uint32_t last_log_ms;
+    } backward_flow {};
+
     // which fwd throttle handling method is active
     enum class ActiveFwdThr : uint8_t {
         NONE = 0,
@@ -712,6 +738,18 @@ private:
       limit forward pitch demand if using rotor tilt or forward flight motor to provide forward acceleration.
      */
     void assign_tilt_to_fwd_thr(void);
+
+    /*
+      remember the last valid AHRS wind estimate, for backward_flow_limit_speed()
+     */
+    void update_wind_cache(void);
+
+    /*
+      hold the vehicle to a maximum backward airspeed in VTOL modes, to keep
+      it out of the regime where the flow over the tail reverses and
+      separates. Also handles the BAKF logging and the one shot GCS warning.
+     */
+    void backward_flow_limit_speed(void);
 
     /*
       get a scaled Q_WP_SPD based on direction of movement

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -2615,6 +2615,114 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
                 self.progress("Wind estimates correlated")
                 break
 
+    def BackwardFlowLimit(self):
+        '''test the Q_BKF_ backward airflow speed limiter'''
+        spd_min = 0.5     # report early, so the log-only run captures the build up
+        spd_max = 1.5     # low enough that backing up in QLOITER overshoots it
+        gain = 5.0
+        ang_max = 10.0
+        self.set_parameters({
+            "Q_BKF_ENABLE": 0,
+            "Q_BKF_SPD_MIN": spd_min,
+            "Q_BKF_SPD_MAX": spd_max,
+            "Q_BKF_GAIN": gain,
+            "Q_BKF_ANG_MAX": ang_max,
+            "Q_WVANE_ENABLE": 0,  # hold heading so the backward axis is fixed
+        })
+        angle_max = self.get_parameter("Q_A_ANGLE_MAX")  # degrees
+
+        def fly_backwards(seconds):
+            '''take off, hold the pitch stick hard aft, then land. Returns the
+            BAKF records from this flight.'''
+            tstart = self.get_sim_time()
+            self.takeoff(40, mode='QLOITER', timeout=90)
+            self.set_rc(2, 1900)
+            self.delay_sim_time(seconds, "flying backwards")
+            self.set_rc(2, 1500)
+            self.delay_sim_time(5, "settling")
+            self.do_RTL()
+            # the onboard log is not guaranteed to rotate between the flights
+            # in this test, so take only the records from this one
+            mlog = self.dfreader_for_current_onboard_log()
+            records = []
+            while True:
+                m = mlog.recv_match(type='BAKF', blocking=False)
+                if m is None:
+                    break
+                if m.TimeUS >= tstart * 1e6:
+                    records.append(m)
+            return records
+
+        self.progress("Q_BKF_ENABLE=0: nothing at all should happen")
+        self.context_collect('STATUSTEXT')
+        records = fly_backwards(8)
+        if len(records) != 0:
+            raise NotAchievedException("BAKF logged %u times with Q_BKF_ENABLE=0" % len(records))
+        if self.statustext_in_collections("backward airflow"):
+            raise NotAchievedException("backward airflow warning issued with Q_BKF_ENABLE=0")
+        self.context_clear_collection('STATUSTEXT')
+
+        self.progress("Q_BKF_ENABLE=1: report but do not intervene")
+        self.set_parameter("Q_BKF_ENABLE", 1)
+        records = fly_backwards(20)
+        if len(records) == 0:
+            raise NotAchievedException("no BAKF messages logged with Q_BKF_ENABLE=1")
+        self.wait_statustext("backward airflow", check_context=True, timeout=1)
+        if any(x.Lim for x in records):
+            raise NotAchievedException("limiter intervened with Q_BKF_ENABLE=1")
+        free_speed = max(x.BSpd for x in records)
+        self.progress("%u BAKF records, unrestrained backward speed reached %.2fm/s"
+                      % (len(records), free_speed))
+        if free_speed < spd_max + 0.5:
+            raise NotAchievedException(
+                "did not fly backwards fast enough to exercise the limit (%.2fm/s)" % free_speed)
+        self.context_clear_collection('STATUSTEXT')
+
+        self.progress("Q_BKF_ENABLE=2: hold the vehicle to Q_BKF_SPD_MAX")
+        self.set_parameter("Q_BKF_ENABLE", 2)
+        records = fly_backwards(20)
+        if len(records) == 0:
+            raise NotAchievedException("no BAKF messages logged with Q_BKF_ENABLE=2")
+        self.wait_statustext("backward airflow", check_context=True, timeout=1)
+
+        for x in records:
+            if x.PLim > angle_max + 0.1:
+                raise NotAchievedException("BAKF PLim %.1f above Q_A_ANGLE_MAX %.1f" % (x.PLim, angle_max))
+            if x.PLim < -ang_max - 0.1:
+                raise NotAchievedException("BAKF PLim %.1f below -Q_BKF_ANG_MAX %.1f" % (x.PLim, -ang_max))
+
+        if not any(x.Lim for x in records):
+            raise NotAchievedException("limiter never reduced the commanded pitch")
+
+        # the ceiling has to have been squeezed well down, otherwise the
+        # limiter was only nibbling at the top of the pitch range
+        min_plim = min(x.PLim for x in records)
+        if min_plim > angle_max * 0.5:
+            raise NotAchievedException("ceiling only came down to %.1fdeg of %.1fdeg" %
+                                       (min_plim, angle_max))
+
+        # and wherever the speed limit was actually exceeded the ceiling must
+        # be negative, ie nose down is commanded to arrest the backward motion
+        # rather than merely declining to command any more pitch back. Holding
+        # the speed below the limit is the intended outcome, so this is only
+        # checked if an overshoot happened at all.
+        over = [x for x in records if x.BSpd > spd_max + 0.1]
+        if len(over) > 0 and not any(x.PLim < 0 for x in over):
+            raise NotAchievedException("no nose down commanded despite %u samples above Q_BKF_SPD_MAX"
+                                       % len(over))
+
+        # the point of the whole feature: the backward speed must actually be
+        # held down, not just the pitch demand
+        held_speed = max(x.BSpd for x in records)
+        self.progress("limited backward speed reached %.2fm/s (was %.2fm/s unrestrained)"
+                      % (held_speed, free_speed))
+        if held_speed >= free_speed - 0.3:
+            raise NotAchievedException(
+                "limiter did not reduce the backward speed (%.2f vs %.2fm/s)" % (held_speed, free_speed))
+        if held_speed > spd_max + 1.0:
+            raise NotAchievedException(
+                "backward speed %.2fm/s overshot Q_BKF_SPD_MAX %.2fm/s too far" % (held_speed, spd_max))
+
     def QLoiterRecovery(self):
         '''test QLOITER recovery from bad attitude'''
         self.install_example_script_context("sim_arming_pos.lua")
@@ -3861,6 +3969,7 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             self.DoRepositionTerrain,
             self.DoRepositionTerrain2,
             self.QLoiterRecovery,
+            self.BackwardFlowLimit,
             self.SimBatteryResistance,
             self.FastInvertedRecovery,
             self.CruiseRecovery,


### PR DESCRIPTION
### Summary

**AI-assistance disclosure (AGENTS.md):** this contribution was AI-assisted. The design, the log analysis it came from, the SITL and replay testing, and the decision to submit are mine, and I take full responsibility for it; the code, comments and autotest were written with Claude, as the `Co-Authored-By` trailers on both commits record.

Adds an opt-in limit on how fast a QuadPlane may fly backwards in VTOL modes, to keep it out of the regime where the flow over the tail reverses and separates and produces a large uncommanded nose-down pitch. Disabled by default; a log-only mode is provided so the behaviour can be characterised on an airframe before anything is armed.

### Classification & Testing (check all that apply and add your own)

- [ ] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

**This has never been flown, or run on hardware at all.** It is SITL and offline log analysis only. It is off by default and I would not suggest anyone set `Q_BKF_ENABLE=2` without working through the tuning procedure below first.

What was actually done:

* **New autotest**, `QuadPlane.BackwardFlowLimit`. Flies the same QLOITER profile three times, once per `Q_BKF_ENABLE` mode, and asserts against the `BAKF` dataflash records. The log-only run is the control: it establishes the backward speed reached with nothing intervening and fails if that is not comfortably past the limit, so the comparison cannot pass vacuously. Latest run on this branch: 2.25 m/s unrestrained against 1.36 m/s limited, `Q_BKF_SPD_MAX` 1.5.
* **SITL, seven VTOL frames** (`quadplane`, `-tri`, `-tilt`, `-tilttri`, `-tilttrivec`, `-tilthvec`, `-cl84`), identical ~250 s profile in a 4 m/s wind with `Q_BKF_ENABLE=1`, to measure how often the limiter would engage in ordinary flying. Frames that translate by leaning sit at 11-12% of VTOL time with the squeeze active; tilt-rotor frames peak at 1.4 m/s of backward airspeed and would never reach the defaults.
* **SITL wind path**, with `EK3_DRAG_BCOEF_X/Y` set so the wind stays observable in the hover. Holding station in a 6 m/s tailwind the estimate reached 7 m/s of backward airspeed while the *ground* speed component was negative, ie the vehicle was moving forwards over the ground. That is the case a groundspeed-only check cannot see.
* **Pre-arm check** verified in SITL for valid, inverted, equal and disabled parameter combinations.
* **Offline replay against one real flight log** (ArduPlane 4.7.0, TRI quadplane, an aircraft that suffered this event). Please read this as weaker evidence than it sounds: it is the same arithmetic reimplemented in numpy over the logged `XKF1`/`XKF2`/`ATT`, not the firmware executing. It does not prove the code is right, only that the signal is there and the thresholds are plausible.
* Builds clean for SITL and CubeOrange. Parameter and logger metadata both regenerate without errors. `flake8` clean.

**SITL cannot validate the aerodynamics here and I have not tried to make it.** `SIM_Plane` clamps alpha in the lift curve, computes dynamic pressure from an airspeed magnitude, and extrapolates a linear `c_m_a` to alpha near 180 degrees in reversed flow. It will happily produce a nose-down divergence flying backwards that looks like a reproduction of the real event and means nothing. All the SITL work above is about the cost and the plumbing, never the threshold.

### Description

#### The problem

Backing a QuadPlane up into a tailwind while descending can drive the flow over a conventional tail past separation. The tail loses its damping and the aircraft pitches hard nose-down with the VTOL rate controller saturated. In the source log the pitch went from +1 to -62 degrees in 0.4 s with the demand unchanged at +1 to +3 degrees, `ATT` and `AHR2` agreeing throughout, and the rate loop demanding +75 deg/s of nose-up while the measured rate ran to -211 deg/s the other way.

Nothing was logged when it happened.

#### Why the existing signals do not cover it

`AOA` in a Plane log is not a vane, and there is no AOA sensor in ArduPilot. It comes from `AP_AHRS::update_AOA_SSA()`, derived from the same EKF velocity and wind, and it contains:

```c
if (aoa_velocity.x > 0) { _AOA = degrees(atanf(z/x)); } else { _AOA = 0; }
```

so it is pinned to exactly zero whenever the body-forward airspeed is negative. Of the 2799 samples reading exactly 0.0 in the source log, 87% have negative body-forward airspeed and the rest are the separate 2 m/s magnitude cutoff in the same function; 10 samples out of 20351 disagree. It reports that reversed flow is *present* and discards how fast it is. Its jump to +71.6 degrees is the moment the aircraft stopped flying backwards, ie a consequence of the nose dropping rather than a warning of it. A pitot cannot sense direction at all and reads near zero flying tail-first.

So the detection resolves the EKF air velocity onto the body-forward axis, which recovers the signed magnitude neither exposes. Body axis rather than horizontal heading, so that a descent with the nose up is counted: that puts flow on the tail from behind with no horizontal motion at all, and reduced throttle with the stick held back produces exactly that combination.

#### Why this limits speed and not lean angle

I built the lean-angle version first and it does not work. Replayed against the source log, a limiter that squeezed the pitch-back angle towards a positive floor was active for **0.0%** of the six-second build-up and cut **0.0 degrees**, because the commanded lean was only 3 to 7 degrees the whole time while the backward airspeed went from 0.02 to 4.39 m/s. The lean angle was never the problem; the time integral was.

The ceiling on the pitch demand therefore follows the speed:

```
below Q_BKF_SPD_MIN   ceiling = Q_A_ANGLE_MAX, ie no restriction
up to Q_BKF_SPD_MAX   ceiling falls linearly from Q_A_ANGLE_MAX to zero
above Q_BKF_SPD_MAX   ceiling = -(excess * Q_BKF_GAIN), to -Q_BKF_ANG_MAX
```

Continuous across both joins. Past the limit the ceiling goes negative, so nose-down is commanded and the backward motion is actually arrested rather than merely not commanded to grow. Replayed with the defaults, this first cuts the demand 3.1 s before the divergence and first commands nose-down 2.8 s before it, cutting up to 9.8 degrees and reaching 6.9 degrees of nose-down.

#### Parameters

| | default | |
|---|---|---|
| `Q_BKF_ENABLE` | 0 | 0 off, 1 log only, 2 log and limit |
| `Q_BKF_SPD_MIN` | 1.5 m/s | where the squeeze and the logging start |
| `Q_BKF_SPD_MAX` | 3.0 m/s | the backward airspeed held |
| `Q_BKF_GAIN` | 5 deg/m/s | nose-down commanded per m/s past the limit |
| `Q_BKF_ANG_MAX` | 10 deg | the most nose-down it may command |

An inverted band is rejected at arming rather than silently reinterpreted. New `BAKF` log message at 5 Hz above `Q_BKF_SPD_MIN` and whenever the limiter intervenes, plus a one-shot `STATUSTEXT` the first time the threshold is crossed in a flight.

Not applied to tailsitters, QACRO or QAUTOTUNE. Also deliberately not applied during `QPOS_AIRBRAKE`, where the demand comes from TECS while still decelerating out of forward flight and airbrake needs its nose-up authority, nor to the SystemID attitude offset, which is added after this runs and is meant to bypass constraints. The limit is dropped entirely while `force_fw_control_recovery` is set: that triggers at twice `Q_A_ANGLE_MAX`, which is the attitude a separation event produces if it happens anyway, and the recovery needs nose-up authority while this limiter commands nose-down.

#### Caveats that need to go in the wiki before this is usable

1. **The wind half of the estimate depends on having flown forward.** EKF3 only makes the wind states observable in forward flight, or in VTOL if `EK3_DRAG_BCOEF_X/Y` are set. Before the first transition of a sortie there is nothing cached and the calculation falls back to backward groundspeed. Across all seven SITL frames, a vehicle holding station in a 4 m/s tailwind during its initial VTOL climb genuinely sees 4.0 m/s over the tail and the estimate reads **0.00**. A VTOL takeoff, or a sortie that never transitions, is unprotected. EKF3 also re-seeds the wind states when it re-enables estimation, which on one frame left a legitimately-valid-but-wrong 0.00 cached for the whole VTOL phase. After a transition it tracks to about 0.5 m/s conservative. `BAKF.WSpd` logs the value actually used so which case applied is always visible.
2. **The fallback is wrong in both directions.** Without a wind estimate it under-reads in a tailwind (no protection) and over-reads backing into a headwind (limits when it need not).
3. **This caps how fast the aircraft can be flown backwards at all.** In a tailwind stronger than `Q_BKF_SPD_MAX` it cannot hold position and will drift downwind. In SITL with a 6 m/s tailwind and weathervaning off, QLOITER drifted at 3-4 m/s. Weathervaning turns the tailwind into a headwind and remains the primary defence; `Q_WVANE_ENABLE` should be left on.
4. **Interaction with `Q_FWD_THR_USE`.** `assign_tilt_to_fwd_thr()` runs immediately after this limiter in every mode it is wired into, and clamps the same `nav_pitch_cd` from both sides.
    * *Below*, by `Q_FWD_PIT_LIM`: with forward-throttle-for-pitch active the nose-down demand is bounded and the forward motor does the work instead. That composes correctly but changes the character of the intervention, and the effective nose-down authority is then the smaller of the two.
    * *Above*, by `Q_BCK_PIT_LIM`: that is a second ceiling on the pitch-back demand, so the two compose as the minimum and the squeeze may in practice be provided by whichever is lower. It is not a substitute for this limiter and does not overlap with what it protects against: `Q_BCK_PIT_LIM` scales off `ahrs.airspeed_EAS()`, a pitot magnitude, so flying tail-first it reads near zero, the `(AIRSPEED_MIN/IAS)^2` scaler blows up, and the limit clamps to `Q_A_ANGLE_MAX`, ie no restriction at all in exactly the regime this PR is about. Note also that #34177 fixes a units mixup that left that filter effectively unfiltered; with it applied the ceiling lags rather than tracking the raw scaled limit, which is more restrictive on pitch-back in the transient out of forward flight, ie the same direction this limiter pushes. The two PRs touch different functions and apply cleanly over each other.
5. **The defaults come from one event.** In the source log the divergence peaked at 4.39 m/s where the whole flight peaked at 4.92 m/s. There is no clean separation between the event and ordinary backward flight in that data. `Q_BKF_SPD_MAX` is an envelope limit, not an event discriminator.

#### Refining the parameters by flight test

Nobody should take the defaults on trust. Suggested procedure:

**Phase 1, characterise, `Q_BKF_ENABLE=1`.** Nothing intervenes. Set `Q_BKF_SPD_MIN` low, 0.5 m/s or so, to log widely, and set `EK3_DRAG_BCOEF_X/Y` if the VTOL phases matter. Fly several normal sorties and graph `BAKF.BSpd` against `BAKF.BGnd` and `BAKF.WSpd`. Two things come out: the p95 and peak backward airspeed in ordinary flying, which is what determines how intrusive any given limit will be, and whether `WSpd` is sane during the VTOL phases or has been lost to one of the cases in caveat 1.

**Phase 2, find the onset.** At altitude with plenty of margin, in QLOITER, back up progressively faster in stages and watch the pitch tracking error. The number wanted is the `BSpd` at which the aircraft first shows an uncommanded nose-down excursion. In the source log that was about 4.4 m/s. Approach it in small steps and stop at the first sign, rather than trying to reproduce a full divergence.

**Phase 3, choose values.**
* `Q_BKF_SPD_MAX` at roughly 60-70% of the onset speed from phase 2. 3.0 against an onset of 4.4 is the ratio the defaults use.
* `Q_BKF_SPD_MIN` at about the p90-p95 of the normal-operations `BSpd` from phase 1, so the squeeze rarely bites in ordinary flying. If `BAKF.Lim` is set during routine manoeuvring, it is too low.
* `Q_BKF_GAIN` 5 to start. Higher recovers the limit faster and feels more abrupt.
* `Q_BKF_ANG_MAX` 10 to start, and keep it small. A large commanded nose-down in reversed flow is the attitude this feature exists to avoid.

**Phase 4, arm it, `Q_BKF_ENABLE=2`.** At altitude with margin. Confirm the backward speed is actually held near `Q_BKF_SPD_MAX` and that the intervention is acceptable to fly. Then check QLAND and QRTL in wind specifically, since the limit reduces the ability to hold the landing point in a tailwind and that is the case most likely to bite operationally.

Iterating on further logs is expected. I would not describe the numbers here as more than a starting point.


