### PR TITLE
AP_Baro: Add support for LPS22DF barometer in AP_Baro_LPS2XH

### DIFF
--- a/libraries/AP_Baro/AP_Baro_LPS2XH.cpp
+++ b/libraries/AP_Baro/AP_Baro_LPS2XH.cpp
@@ -25,6 +25,7 @@ extern const AP_HAL::HAL &hal;
 // WHOAMI values
 #define LPS22HB_WHOAMI 0xB1
 #define LPS25HB_WHOAMI 0xBD
+#define LPS22DF_WHOAMI 0xB4
 
 #define REG_ID                     0x0F
 
@@ -52,6 +53,36 @@ extern const AP_HAL::HAL &hal;
 #define TEMP_OUT_ADDR      		   0x2B
 #define PRESS_OUT_XL_ADDR		   0x28
 #define STATUS_ADDR		  		   0x27
+
+#define LPS22DF_CTRL_REG1           0x10
+#define LPS22DF_CTRL_REG2           0x11
+#define LPS22DF_IF_CTRL             0x0E
+
+#define LPS22DF_IF_CTRL_I2C_I3C_DIS (1 << 6)
+
+#define LPS22DF_CTRL_REG1_AVG_4     (0 << 0)
+#define LPS22DF_CTRL_REG1_AVG_8     (1 << 0)
+#define LPS22DF_CTRL_REG1_AVG_16    (2 << 0)
+#define LPS22DF_CTRL_REG1_AVG_32    (3 << 0)
+#define LPS22DF_CTRL_REG1_AVG_64    (4 << 0)
+#define LPS22DF_CTRL_REG1_AVG_128   (5 << 0)
+#define LPS22DF_CTRL_REG1_AVG_512   (7 << 0)
+
+#define LPS22DF_CTRL_REG1_ODR_1HZ   (1 << 3)
+#define LPS22DF_CTRL_REG1_ODR_4HZ   (2 << 3)
+#define LPS22DF_CTRL_REG1_ODR_10HZ  (3 << 3)
+#define LPS22DF_CTRL_REG1_ODR_25HZ  (4 << 3)
+#define LPS22DF_CTRL_REG1_ODR_50HZ  (5 << 3)
+#define LPS22DF_CTRL_REG1_ODR_75HZ  (6 << 3)
+#define LPS22DF_CTRL_REG1_ODR_100HZ (7 << 3)
+#define LPS22DF_CTRL_REG1_ODR_200HZ (8 << 3)
+
+#define LPS22DF_CTRL_REG2_ONESHOT   (1 << 0)
+#define LPS22DF_CTRL_REG2_SWRESET   (1 << 2)
+#define LPS22DF_CTRL_REG2_BDU       (1 << 3)
+#define LPS22DF_CTRL_REG2_EN_LPFP   (1 << 4)
+#define LPS22DF_CTRL_REG2_LFPF_CFG  (1 << 5)
+#define LPS22DF_CTRL_REG2_BOOT      (1 << 7)
 
 //putting 1 in the MSB of those two registers turns on Auto increment for faster reading.
 
@@ -169,6 +200,28 @@ bool AP_Baro_LPS2XH::_init()
         CallTime = 1000000/75;
     }
 
+    if (_lps2xh_type == BARO_LPS22DF) {
+        bool ok = _dev->write_register(LPS22DF_CTRL_REG2, LPS22DF_CTRL_REG2_SWRESET);
+        hal.scheduler->delay(10);
+        if (_dev->bus_type() == AP_HAL::Device::BUS_TYPE_SPI) {
+            ok &= _dev->write_register(LPS22DF_IF_CTRL, LPS22DF_IF_CTRL_I2C_I3C_DIS);
+        }
+        ok &= _dev->write_register(LPS22DF_CTRL_REG2,
+                                   LPS22DF_CTRL_REG2_BDU |
+                                   LPS22DF_CTRL_REG2_EN_LPFP |
+                                   LPS22DF_CTRL_REG2_LFPF_CFG);
+        ok &= _dev->write_register(LPS22DF_CTRL_REG1,
+                                   LPS22DF_CTRL_REG1_ODR_75HZ |
+                                   LPS22DF_CTRL_REG1_AVG_32);
+        if (!ok) {
+            _dev->get_semaphore()->give();
+            return false;
+        }
+
+        // request 75Hz update
+        CallTime = 1000000/75;
+    }
+
     _instance = _frontend.register_sensor();
 
     _dev->set_device_type(DEVTYPE_BARO_LPS2XH);
@@ -196,6 +249,9 @@ bool AP_Baro_LPS2XH::_check_whoami(void)
         return true;
     case LPS25HB_WHOAMI:
         _lps2xh_type = BARO_LPS25H;
+        return true;
+    case LPS22DF_WHOAMI:
+        _lps2xh_type = BARO_LPS22DF;
         return true;
     }
 
@@ -244,12 +300,14 @@ void AP_Baro_LPS2XH::_update_temperature(void)
 
     WITH_SEMAPHORE(_sem);
 
-    if (_lps2xh_type == BARO_LPS25H) {
+    switch (_lps2xh_type) {
+    case BARO_LPS25H:
         _temperature = (Temp_Reg_s16 * (1.0/480)) + 42.5;
-    }
-
-    if (_lps2xh_type == BARO_LPS22H) {
+        break;
+    case BARO_LPS22H:
+    case BARO_LPS22DF:
         _temperature = Temp_Reg_s16 * 0.01;
+        break;
     }
 }
 

--- a/libraries/AP_Baro/AP_Baro_LPS2XH.h
+++ b/libraries/AP_Baro/AP_Baro_LPS2XH.h
@@ -21,6 +21,7 @@ public:
     enum LPS2XH_TYPE {
         BARO_LPS22H = 0,
         BARO_LPS25H = 1,
+        BARO_LPS22DF = 2,
     };
 
     AP_Baro_LPS2XH(AP_Baro &baro, AP_HAL::Device &dev);


### PR DESCRIPTION
### Summary

Add support for the ST LPS22DF barometer within the existing `AP_Baro_LPS2XH` backend, alongside the already-supported LPS22H/LPS25H.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Tested on the T3 Gemstone O1 board with a real LPS22DF sensor.

### Description

`AP_Baro_LPS2XH` previously recognized the LPS22H and LPS25H WHOAMI IDs only. This PR adds a third variant, LPS22DF (WHOAMI `0xB4`):

- Adds a new `BARO_LPS22DF` entry to the `LPS2XH_TYPE` enum.
- Adds `LPS22DF_WHOAMI`, `LPS22DF_CTRL_REG1`/`REG2` register addresses, and their ODR/averaging/config bit definitions.
- `_check_whoami()` recognizes the LPS22DF WHOAMI value and sets `_lps2xh_type` accordingly.
- `_init()` performs the LPS22DF-specific init sequence (software reset, then BDU + low-pass filter enable, then ODR 75Hz / averaging 32) and sets the 75Hz update rate, matching the existing LPS22H init pattern.
- `_update_temperature()` uses the same temperature scaling (`0.01 °C/LSB`) as LPS22H for LPS22DF, since both share the same temperature register format.

No existing LPS22H/LPS25H code paths are changed.