### PR TITLE
AC_Avoidance: correct OA_MARGIN_MAX description

### DIFF
--- a/libraries/AC_Avoidance/AP_OABendyRuler.h
+++ b/libraries/AC_Avoidance/AP_OABendyRuler.h
@@ -79,7 +79,7 @@ private:
 #endif
 
     // OA common parameters
-    float _margin_max;              // object avoidance will ignore objects more than this many meters from vehicle
+    float _margin_max;              // minimum distance in meters to keep from obstacles and fences
     
     // BendyRuler parameters
     AP_Float _lookahead;            // object avoidance will look this many meters ahead of vehicle

--- a/libraries/AC_Avoidance/AP_OAPathPlanner.cpp
+++ b/libraries/AC_Avoidance/AP_OAPathPlanner.cpp
@@ -48,7 +48,7 @@ const AP_Param::GroupInfo AP_OAPathPlanner::var_info[] = {
 
     // @Param: MARGIN_MAX
     // @DisplayName: Object Avoidance wide margin distance
-    // @Description: Object Avoidance will ignore objects more than this many meters from vehicle
+    // @Description: Minimum distance in meters that the vehicle will try to stay away from obstacles and fences. BendyRuler only accepts a candidate path whose clearance exceeds this, and Dijkstra uses it as the margin held from fences. This is not a detection range: use OA_BR_LOOKAHEAD to limit how far ahead BendyRuler looks for obstacles.
     // @Units: m
     // @Range: 0.1 100
     // @Increment: 1

--- a/libraries/AC_Avoidance/AP_OAPathPlanner.h
+++ b/libraries/AC_Avoidance/AP_OAPathPlanner.h
@@ -119,7 +119,7 @@ private:
 
     // parameters
     AP_Int8 _type;                  // avoidance algorithm to be used
-    AP_Float _margin_max;           // object avoidance will ignore objects more than this many meters from vehicle
+    AP_Float _margin_max;           // minimum distance in meters to keep from obstacles and fences
     AP_Int16 _options;              // Bitmask for options while recovering from Object Avoidance
     
     // internal variables used by front end


### PR DESCRIPTION
`OA_MARGIN_MAX`'s `@Description` currently reads:

> Object Avoidance will ignore objects more than this many meters from vehicle

That is `OA_BR_LOOKAHEAD`'s meaning, not this parameter's. `OA_MARGIN_MAX` is the clearance the vehicle tries to keep, which is the opposite sense.

**In the code:**

- BendyRuler computes a candidate path's clearance with `calc_avoidance_margin()` and accepts the path only when the clearance *exceeds* the parameter - `if (margin > _margin_max)` at `AP_OABendyRuler.cpp:177`, `:202`, `:281`, `:303`, commented "this bearing avoids obstacles out to the lookahead_step1_dist". So it is a minimum required clearance.
- Dijkstra receives it as a fence margin: `_oadijkstra->set_fence_margin(_margin_max)` at `AP_OAPathPlanner.cpp:334` and `:381`.
- The parameter that actually limits how far ahead obstacles are considered is `OA_BR_LOOKAHEAD`, whose own description says exactly that.

**Why it matters:** this has confused users. ArduPilot/ardupilot_wiki#3099 asks which of the two meanings is correct, because the wiki documents `OA_MARGIN_MAX` correctly as the stand-off distance while the parameter description in Mission Planner says the reverse. The wiki also carries a note specifically warning users not to confuse these two parameters.

**This PR** rewrites the `@Description` to state the stand-off meaning, say what each planner does with the value, and explicitly point at `OA_BR_LOOKAHEAD` for the detection-range question. `@DisplayName`, `@Units`, `@Range` and `@Increment` are unchanged. The two `_margin_max` member comments in `AP_OAPathPlanner.h` and `AP_OABendyRuler.h`, which repeated the same incorrect sentence, are updated to match.

No functional change - metadata and comments only.

Checked with `Tools/autotest/param_metadata/param_parse.py --vehicle ArduCopter --format xml`: parses clean and the full text survives into `apm.pdef.xml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
