### PR TITLE
AC_PrecLand: rename and rescale PLND_YAW_ALIGN to degrees

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -1359,6 +1359,21 @@ void Copter::load_parameters(void)
         };
         AP_Param::convert_old_parameters_scaled(pilot_conversion_info, ARRAY_SIZE(pilot_conversion_info), 0.01, 0);
     }
+    
+
+
+
+    #if AC_PRECLAND_ENABLED
+    // convert PLND_YAW_ALIGN to PLND_ORIENT_YAW and scale from centidegrees to degrees
+    {
+        static const AP_Param::ConversionInfo plnd_conversion_info[] = {
+            { Parameters::k_param_precland, 2, AP_PARAM_FLOAT, "PLND_ORIENT_YAW" },
+        };
+        AP_Param::convert_old_parameters_scaled(plnd_conversion_info, ARRAY_SIZE(plnd_conversion_info), 0.01f, 0);
+    }
+#endif
+
+
 
     // setup AP_Param frame type flags
     AP_Param::set_frame_type_flags(AP_PARAM_FRAME_COPTER);

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -15765,7 +15765,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             "PLND_TIMEOUT": 4.000000,
             "PLND_TYPE": 4,
             "PLND_XY_DIST_MAX": 2.500000,
-            "PLND_YAW_ALIGN": 0.000000,
+            "PLND_ORIENT_YAW": 0.000000,
 
             "SIM_PLD_ALT_LMT": 15.000000,
             "SIM_PLD_DIST_LMT": 10.000000,

--- a/libraries/AC_PrecLand/AC_PrecLand.cpp
+++ b/libraries/AC_PrecLand/AC_PrecLand.cpp
@@ -46,14 +46,14 @@ const AP_Param::GroupInfo AC_PrecLand::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("TYPE",    1, AC_PrecLand, _type, 0),
 
-    // @Param: YAW_ALIGN
+    // @Param: ORIENT_YAW
     // @DisplayName: Sensor yaw alignment
     // @Description: Yaw angle from body x-axis to sensor x-axis.
-    // @Range: 0 36000
-    // @Increment: 10
+    // @Range: 0 360
+    // @Increment: 1
     // @User: Advanced
-    // @Units: cdeg
-    AP_GROUPINFO("YAW_ALIGN",    2, AC_PrecLand, _yaw_align_cd, 0),
+    // @Units: deg
+    AP_GROUPINFO("ORIENT_YAW", 19, AC_PrecLand, _orient_yaw, 0),
 
     // @Param: LAND_OFS_X
     // @DisplayName: Land offset forward
@@ -629,9 +629,9 @@ bool AC_PrecLand::retrieve_los_meas(Vector3f& target_vec_unit, VectorFrame& fram
     const uint32_t los_meas_time_ms = _backend->los_meas_time_ms();
     if ((los_meas_time_ms != _last_backend_los_meas_ms) && _backend->get_los_meas(target_vec_unit, frame)) {
         _last_backend_los_meas_ms = los_meas_time_ms;
-        if (!is_zero(_yaw_align_cd)) {
+        if (!is_zero(_orient_yaw)) {
             // Apply sensor yaw alignment rotation
-            target_vec_unit.rotate_xy(cd_to_rad(_yaw_align_cd));
+           target_vec_unit.rotate_xy(radians(_orient_yaw)); 
         }
 
         // rotate vector based on sensor orientation to get correct body frame vector

--- a/libraries/AC_PrecLand/AC_PrecLand.h
+++ b/libraries/AC_PrecLand/AC_PrecLand.h
@@ -199,7 +199,7 @@ private:
     AP_Int8                     _bus;                   // which sensor bus
     AP_Enum<EstimatorType>      _estimator_type;        // precision landing estimator type
     AP_Float                    _lag_s;                 // sensor lag in seconds
-    AP_Float                    _yaw_align_cd;          // Yaw angle from body x-axis to sensor x-axis.
+    AP_Float                    _orient_yaw;          // Yaw angle from body x-axis to sensor x-axis.
     AP_Float                    _land_ofs_cm_x;         // Desired landing position of the camera forward of the target in vehicle body frame
     AP_Float                    _land_ofs_cm_y;         // Desired landing position of the camera right of the target in vehicle body frame
     AP_Float                    _accel_noise;           // accelerometer process noise


### PR DESCRIPTION
### Summary
This PR renames the precision landing parameter `PLND_YAW_ALIGN` to `PLND_ORIENT_YAW` and rescales its units from centidegrees to degrees to comply with the 4.7 SI unit standardization.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

* **AC_PrecLand:** Renamed the parameter, updated the `AP_GROUPINFO` table, and modified the `rotate_xy` logic to evaluate radians instead of centidegrees.
* **Copter:** Implemented the parameter migration and centidegree-to-degree scaling inside `ArduCopter/Parameters.cpp`. This conversion is wrapped in an `#if AC_PRECLAND_ENABLED` guard to maintain compatibility and prevent missing reference errors on small-board build targets (e.g., QURT).
* **Autotest:** Updated `Tools/autotest/arducopter.py` to use the new `PLND_ORIENT_YAW` string.
* Resolves issue #33364.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
