### PR TITLE
Copter: interpolate the rate target in the fast rate thread

### DIFF
--- a/ArduCopter/rate_thread.cpp
+++ b/ArduCopter/rate_thread.cpp
@@ -208,6 +208,12 @@ void Copter::rate_controller_thread()
     uint8_t main_loop_count = 0;
     uint8_t filter_loop_count = 0;
 
+    // rate target ramp state, see the interpolation below
+    Vector3f ang_vel_interp_start_rads;
+    Vector3f ang_vel_interp_end_rads;
+    uint8_t ang_vel_interp_count = 0;
+    uint8_t ang_vel_interp_steps = 0;
+
     while (true) {
 
 #ifdef RATE_LOOP_TIMING_DEBUG
@@ -222,6 +228,7 @@ void Copter::rate_controller_thread()
             }
             hal.scheduler->delay_microseconds(500);
             last_run_us = AP_HAL::micros();
+            ang_vel_interp_steps = 0;
             continue;
         }
 
@@ -259,10 +266,39 @@ void Copter::rate_controller_thread()
             rate_loop_count++;
         }
 
+        // take a copy of the target so that it can't be changed from under us.
+        Vector3f ang_vel_target_rads = attitude_control->get_ang_vel_body_rads();
+
+        // the target only updates at the main loop rate, so stepping it would inject shot
+        // noise at that rate and its harmonics into the PIDs. ramp to each new target over
+        // one main loop period instead, triggered by the target changing rather than by
+        // main_loop_count since the main loop runs asynchronously to this thread.
+        if (rates.main_loop_rate > 1 && !ang_vel_target_rads.is_nan() && !ang_vel_target_rads.is_inf()) {
+            const uint8_t steps = rates.main_loop_rate;
+            if (steps != ang_vel_interp_steps) {
+                // start from the live target after the ramp was idle or the step count changed
+                ang_vel_interp_start_rads = ang_vel_interp_end_rads = ang_vel_target_rads;
+                ang_vel_interp_count = steps;
+                ang_vel_interp_steps = steps;
+            }
+            if (ang_vel_target_rads != ang_vel_interp_end_rads) {
+                // restart from the current output so the sequence stays continuous
+                ang_vel_interp_start_rads += (ang_vel_interp_end_rads - ang_vel_interp_start_rads) * ((float)ang_vel_interp_count / steps);
+                ang_vel_interp_end_rads = ang_vel_target_rads;
+                ang_vel_interp_count = 0;
+            }
+            if (ang_vel_interp_count < steps) {
+                ang_vel_interp_count++;
+            }
+            ang_vel_target_rads = ang_vel_interp_start_rads + (ang_vel_interp_end_rads - ang_vel_interp_start_rads) * ((float)ang_vel_interp_count / steps);
+        } else {
+            ang_vel_interp_steps = 0;
+        }
+
         // run the rate controller on all available samples
         // it is important not to drop samples otherwise the filtering will be fubar
         // there is no need to output to the motors more than once for every batch of samples
-        attitude_control->rate_controller_run_dt(gyro + ahrs.get_gyro_drift(), sensor_dt);
+        attitude_control->rate_controller_run_dt(gyro + ahrs.get_gyro_drift(), sensor_dt, ang_vel_target_rads);
 
 #ifdef RATE_LOOP_TIMING_DEBUG
         rate_controller_time_us += AP_HAL::micros() - rate_now_us;

--- a/ArduCopter/rate_thread.cpp
+++ b/ArduCopter/rate_thread.cpp
@@ -209,8 +209,10 @@ void Copter::rate_controller_thread()
     uint8_t filter_loop_count = 0;
 
     // rate target ramp state, see the interpolation below
+    Vector3f ang_vel_target_rads;
     Vector3f ang_vel_interp_start_rads;
     Vector3f ang_vel_interp_end_rads;
+    uint32_t ang_vel_target_count = 0;
     uint8_t ang_vel_interp_count = 0;
     uint8_t ang_vel_interp_steps = 0;
 
@@ -266,31 +268,38 @@ void Copter::rate_controller_thread()
             rate_loop_count++;
         }
 
-        // take a copy of the target so that it can't be changed from under us.
-        Vector3f ang_vel_target_rads = attitude_control->get_ang_vel_body_rads();
+        // take a copy of the target so that it can't be changed from under us. the count is read
+        // first because the main loop bumps it after storing the target, so a target read once the
+        // count has moved on is one that the main loop has finished writing.
+        const uint32_t target_count = attitude_control->get_ang_vel_body_count();
+        const bool target_updated = target_count != ang_vel_target_count;
+        if (target_updated) {
+            ang_vel_target_rads = attitude_control->get_ang_vel_body_rads();
+            ang_vel_target_count = target_count;
+        }
+        Vector3f ang_vel_body_rads = ang_vel_target_rads;
 
         // the target only updates at the main loop rate, so stepping it would inject shot
         // noise at that rate and its harmonics into the PIDs. ramp to each new target over
-        // one main loop period instead, triggered by the target changing rather than by
-        // main_loop_count since the main loop runs asynchronously to this thread.
-        if (rates.main_loop_rate > 1 && !ang_vel_target_rads.is_nan() && !ang_vel_target_rads.is_inf()) {
+        // one main loop period instead, triggered by the target being republished rather than
+        // by main_loop_count since the main loop runs asynchronously to this thread.
+        if (rates.main_loop_rate > 1 && !ang_vel_body_rads.is_nan() && !ang_vel_body_rads.is_inf()) {
             const uint8_t steps = rates.main_loop_rate;
             if (steps != ang_vel_interp_steps) {
                 // start from the live target after the ramp was idle or the step count changed
-                ang_vel_interp_start_rads = ang_vel_interp_end_rads = ang_vel_target_rads;
+                ang_vel_interp_start_rads = ang_vel_interp_end_rads = ang_vel_body_rads;
                 ang_vel_interp_count = steps;
                 ang_vel_interp_steps = steps;
-            }
-            if (ang_vel_target_rads != ang_vel_interp_end_rads) {
+            } else if (target_updated) {
                 // restart from the current output so the sequence stays continuous
                 ang_vel_interp_start_rads += (ang_vel_interp_end_rads - ang_vel_interp_start_rads) * ((float)ang_vel_interp_count / steps);
-                ang_vel_interp_end_rads = ang_vel_target_rads;
+                ang_vel_interp_end_rads = ang_vel_body_rads;
                 ang_vel_interp_count = 0;
             }
             if (ang_vel_interp_count < steps) {
                 ang_vel_interp_count++;
             }
-            ang_vel_target_rads = ang_vel_interp_start_rads + (ang_vel_interp_end_rads - ang_vel_interp_start_rads) * ((float)ang_vel_interp_count / steps);
+            ang_vel_body_rads = ang_vel_interp_start_rads + (ang_vel_interp_end_rads - ang_vel_interp_start_rads) * ((float)ang_vel_interp_count / steps);
         } else {
             ang_vel_interp_steps = 0;
         }
@@ -298,7 +307,7 @@ void Copter::rate_controller_thread()
         // run the rate controller on all available samples
         // it is important not to drop samples otherwise the filtering will be fubar
         // there is no need to output to the motors more than once for every batch of samples
-        attitude_control->rate_controller_run_dt(gyro + ahrs.get_gyro_drift(), sensor_dt, ang_vel_target_rads);
+        attitude_control->rate_controller_run_dt(gyro + ahrs.get_gyro_drift(), sensor_dt, ang_vel_body_rads);
 
 #ifdef RATE_LOOP_TIMING_DEBUG
         rate_controller_time_us += AP_HAL::micros() - rate_now_us;

--- a/ArduCopter/rate_thread.cpp
+++ b/ArduCopter/rate_thread.cpp
@@ -160,6 +160,11 @@ static inline bool run_decimated_callback(uint8_t decimation_rate, uint8_t& deci
     return decimation_rate > 0 && ++decimation_count >= decimation_rate;
 }
 
+// How far past the latest rate target the ramp below aims, as a fraction of that
+// target's last increment. 0 lags a whole main loop period, 1 predicts a full
+// period ahead but trebles the target's own noise at the loop rate Nyquist.
+static constexpr float RATE_TARGET_PREDICT_FRACTION = 0.5f;
+
 //#define RATE_LOOP_TIMING_DEBUG
 /*
   thread for rate control
@@ -210,6 +215,7 @@ void Copter::rate_controller_thread()
 
     // rate target ramp state, see the interpolation below
     Vector3f ang_vel_target_rads;
+    Vector3f ang_vel_prev_target_rads;
     Vector3f ang_vel_interp_start_rads;
     Vector3f ang_vel_interp_end_rads;
     uint32_t ang_vel_target_count = 0;
@@ -274,26 +280,30 @@ void Copter::rate_controller_thread()
         const uint32_t target_count = attitude_control->get_ang_vel_body_count();
         const bool target_updated = target_count != ang_vel_target_count;
         if (target_updated) {
+            ang_vel_prev_target_rads = ang_vel_target_rads;
             ang_vel_target_rads = attitude_control->get_ang_vel_body_rads();
             ang_vel_target_count = target_count;
         }
         Vector3f ang_vel_body_rads = ang_vel_target_rads;
 
         // the target only updates at the main loop rate, so stepping it would inject shot
-        // noise at that rate and its harmonics into the PIDs. ramp to each new target over
-        // one main loop period instead, triggered by the target being republished rather than
-        // by main_loop_count since the main loop runs asynchronously to this thread.
+        // noise at that rate and its harmonics into the PIDs. ramp across one main loop
+        // period instead, triggered by the target being republished rather than by
+        // main_loop_count since the main loop runs asynchronously to this thread.
         if (rates.main_loop_rate > 1 && !ang_vel_body_rads.is_nan() && !ang_vel_body_rads.is_inf()) {
             const uint8_t steps = rates.main_loop_rate;
             if (steps != ang_vel_interp_steps) {
                 // start from the live target after the ramp was idle or the step count changed
+                ang_vel_prev_target_rads = ang_vel_target_rads;
                 ang_vel_interp_start_rads = ang_vel_interp_end_rads = ang_vel_body_rads;
                 ang_vel_interp_count = steps;
                 ang_vel_interp_steps = steps;
             } else if (target_updated) {
-                // restart from the current output so the sequence stays continuous
+                // restart from the current output so the sequence stays continuous, and aim
+                // part way past the new target along its last increment so that the ramp is
+                // not still delivering a whole period old target when it ends
                 ang_vel_interp_start_rads += (ang_vel_interp_end_rads - ang_vel_interp_start_rads) * ((float)ang_vel_interp_count / steps);
-                ang_vel_interp_end_rads = ang_vel_body_rads;
+                ang_vel_interp_end_rads = ang_vel_target_rads + (ang_vel_target_rads - ang_vel_prev_target_rads) * RATE_TARGET_PREDICT_FRACTION;
                 ang_vel_interp_count = 0;
             }
             if (ang_vel_interp_count < steps) {

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -9468,6 +9468,22 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.context_pop()
         self.reboot_sitl()
 
+    def SITLGyroRate(self):
+        '''SITL gyro rate follows INS_GYRO_RATE with fast sampling enabled'''
+        self.set_parameters({
+            "FSTRATE_ENABLE": 3,
+            "FSTRATE_DIV": 1,
+        })
+        self.context_collect("STATUSTEXT")
+        # the rate thread reports the rate it runs at, which is the gyro
+        # rate with FSTRATE_DIV at 1
+        for gyro_rate, pattern in ((0, r".*rate set to (99[0-9]|1000)Hz"),
+                                   (1, r".*rate set to (199[0-9]|2000)Hz"),
+                                   (2, r".*rate set to (399[0-9]|4000)Hz")):
+            self.set_parameter("INS_GYRO_RATE", gyro_rate)
+            self.reboot_sitl()
+            self.wait_statustext(pattern, regex=True, timeout=60, check_context=True)
+
     def hover_and_check_matched_frequency(self, *, dblevel=-15, minhz=200, maxhz=300, fftLength=32, peakhz=None):
         '''do a simple up-and-down test flight with current vehicle state.
         Check that the onboard filter comes up with the same peak-frequency that
@@ -19917,6 +19933,7 @@ return update, 1000
             self.PositionWhenGPSIsZero,
             self.DynamicRpmNotches, # Do not add attempts to this - failure is sign of a bug
             self.DynamicRpmNotchesRateThread,
+            self.SITLGyroRate,
             self.PIDNotches,
             self.mission_NAV_LOITER_TURNS,
             self.mission_NAV_LOITER_TURNS_off_center,

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -14486,12 +14486,24 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         # ensure that the blended solution is always about half-way
         # between the two GPSs:
+        # the cores set their origins on different loops and XKF1
+        # reports zero for a core without one, so only compare the
+        # cores while armed
         current_ts = None
         max_errors = [0, 0, 0]
+        armed = False
         while True:
-            m = current_log_file.recv_match(type='XKF1')
+            m = current_log_file.recv_match(type=['XKF1', 'EV'])
             if m is None:
                 break
+            if m.get_type() == 'EV':
+                if m.Id == 10:  # LogEvent::ARMED
+                    armed = True
+                elif m.Id == 11:  # LogEvent::DISARMED
+                    armed = False
+                continue
+            if not armed:
+                continue
             if current_ts is None:
                 if m.C != 0:  # noqa
                     continue

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp
@@ -242,6 +242,14 @@ const Vector3f AC_AttitudeControl::get_latest_gyro() const
 #endif
 }
 
+// Publish the body-frame angular velocity target for the rate controller. The count is bumped
+// after the target so that a reader checking it first cannot pick up a partially written target.
+void AC_AttitudeControl::publish_ang_vel_body_rads(const Vector3f& ang_vel_body_rads)
+{
+    _ang_vel_body_rads = ang_vel_body_rads;
+    _ang_vel_body_count++;
+}
+
 // Ensure attitude controller have zero errors to relax rate controller output
 void AC_AttitudeControl::relax_attitude_controllers()
 {
@@ -267,7 +275,7 @@ void AC_AttitudeControl::relax_attitude_controllers()
     // Reset the I terms
     reset_rate_controller_I_terms();
     // finally update the attitude target
-    _ang_vel_body_rads = gyro;
+    publish_ang_vel_body_rads(gyro);
 }
 
 void AC_AttitudeControl::reset_rate_controller_I_terms()
@@ -672,7 +680,7 @@ void AC_AttitudeControl::input_rate_bf_roll_pitch_yaw_2_rads(float roll_rate_bf_
     body_to_euler_derivative(_attitude_target, _ang_vel_target_rads, _euler_rate_target_rads);
 
     // Update body-frame angular velocity target used by the rate controller.
-    _ang_vel_body_rads = _ang_vel_target_rads;
+    publish_ang_vel_body_rads(_ang_vel_target_rads);
 }
 
 // Sets the desired roll, pitch, and yaw angular rates in body-frame (in centidegrees/s).
@@ -738,7 +746,7 @@ void AC_AttitudeControl::input_rate_bf_roll_pitch_yaw_3_rads(float roll_rate_bf_
     ang_vel_body_rads += _ang_vel_target_rads;
 
     // Update body-frame angular velocity target used by the rate controller
-    _ang_vel_body_rads = ang_vel_body_rads;
+    publish_ang_vel_body_rads(ang_vel_body_rads);
 }
 
 /*
@@ -778,7 +786,7 @@ void AC_AttitudeControl::input_rate_bf_roll_pitch_yaw_no_shaping_rads(float roll
     body_to_euler_derivative(_attitude_target, _ang_vel_target_rads, _euler_rate_target_rads);
 
     // Update body-frame angular velocity target used by the rate controller.
-    _ang_vel_body_rads = _ang_vel_target_rads;
+    publish_ang_vel_body_rads(_ang_vel_target_rads);
 }
 
 // Applies a one-time angular offset to the attitude target using body-frame roll, pitch,
@@ -822,7 +830,7 @@ void AC_AttitudeControl::input_rate_step_bf_roll_pitch_yaw_rads(float roll_rate_
     _euler_rate_target_rads.zero();
 
     // Apply the requested body-frame angular rate step directly to the rate controller input.
-    _ang_vel_body_rads = Vector3f{roll_rate_step_bf_rads, pitch_rate_step_bf_rads, yaw_rate_step_bf_rads};
+    publish_ang_vel_body_rads(Vector3f{roll_rate_step_bf_rads, pitch_rate_step_bf_rads, yaw_rate_step_bf_rads});
 }
 
 // Sets the desired thrust vector and a yaw/heading rate input (radians/s).
@@ -1025,7 +1033,7 @@ void AC_AttitudeControl::attitude_controller_run_quat()
     // Record error to handle EKF resets
     _attitude_ang_error = attitude_body.inverse() * _attitude_target;
     // finally update the attitude target
-    _ang_vel_body_rads = ang_vel_body_rads;
+    publish_ang_vel_body_rads(ang_vel_body_rads);
 }
 
 // thrust_heading_rotation_angles - calculates two ordered rotations to move the attitude_body quaternion to the attitude_target quaternion.

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -305,8 +305,6 @@ public:
 
     // Run the angular velocity controller with a specified timestep and rate target. Must be implemented by derived class.
     virtual void rate_controller_run_dt(const Vector3f& gyro_rads, float dt, const Vector3f& ang_vel_body_rads) { AP_BoardConfig::config_error("rate_controller_run_dt() must be defined"); };
-    // Run the angular velocity controller with a specified timestep on the current rate target.
-    void rate_controller_run_dt(const Vector3f& gyro_rads, float dt) { rate_controller_run_dt(gyro_rads, dt, _ang_vel_body_rads); }
 
     // euler_derivative_to_body - transform euler angle derivative to body-frame
     // Converts euler derivatives (rate, acceleration, etc.) to body-frame equivalents.

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -182,10 +182,12 @@ public:
     ////// begin rate update functions //////
     // These functions all update _ang_vel_body_rads which is used as the rate target by the rate controller.
     // Since _ang_vel_body_rads can be seen by the rate controller thread all these functions only set it
-    // at the end once all of the calculations have been performed. This avoids intermediate results being
-    // used by the rate controller when running concurrently. _ang_vel_body_rads is accessed so commonly that
-    // locking proves to be moderately expensive, however since this is changing incrementally values combining 
-    // previous and current elements are safe and do not have an impact on control.
+    // at the end once all of the calculations have been performed, via publish_ang_vel_body_rads() which
+    // also bumps _ang_vel_body_count after the store so that the rate thread can tell when the target has
+    // moved on. This avoids intermediate results being used by the rate controller when running
+    // concurrently. _ang_vel_body_rads is accessed so commonly that locking proves to be moderately
+    // expensive, however since this is changing incrementally values combining previous and current
+    // elements are safe and do not have an impact on control.
     // Any additional functions that are added to manipulate _ang_vel_body_rads should follow this pattern.
 
     // Calculates the body frame angular velocities to follow the target attitude
@@ -384,7 +386,12 @@ public:
     Vector3f rate_bf_targets() const { return _ang_vel_body_rads + _sysid_ang_vel_body_rads; }
 
     // Return the body-frame angular velocity target (in rad/s) without the sysid contribution
-    const Vector3f& get_ang_vel_body_rads() const { return _ang_vel_body_rads; }
+    Vector3f get_ang_vel_body_rads() const { return _ang_vel_body_rads; }
+
+    // Return the number of updates made to the target above. It is bumped after the target itself,
+    // so a reader that checks this first and only then reads the target cannot pick up one that the
+    // main loop is part way through writing.
+    uint32_t get_ang_vel_body_count() const { return _ang_vel_body_count; }
 
     // return the angular velocity of the target (setpoint) attitude rad/s
     const Vector3f& get_rate_ef_target_rads() const { return _euler_rate_target_rads; }
@@ -560,6 +567,10 @@ protected:
     // Ensures minimum latency when rate control is run before or after attitude control.
     const Vector3f get_latest_gyro() const;
 
+    // Publish the body-frame angular velocity target for the rate controller, see the rate
+    // update function notes above.
+    void publish_ang_vel_body_rads(const Vector3f& ang_vel_body_rads);
+
     // Maximum rate the yaw target can be updated in Loiter, RTL, Auto flight modes
     AP_Float            _rate_wp_yaw_max_degs;
 
@@ -635,6 +646,8 @@ protected:
     // This represents the angular velocity in radians per second in the body frame, used in the angular
     // velocity controller and most importantly the rate controller.
     Vector3f            _ang_vel_body_rads;
+    // Count of updates to _ang_vel_body_rads, bumped after the target itself has been stored
+    uint32_t            _ang_vel_body_count;
 
     // This is the angular velocity in radians per second in the body frame, added to the output angular
     // attitude controller by the System Identification Mode.

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl.h
@@ -303,8 +303,10 @@ public:
     // reset the rate controller target loop updates
     void rate_controller_target_reset();
 
-    // Run the angular velocity controller with a specified timestep. Must be implemented by derived class.
-    virtual void rate_controller_run_dt(const Vector3f& gyro_rads, float dt) { AP_BoardConfig::config_error("rate_controller_run_dt() must be defined"); };
+    // Run the angular velocity controller with a specified timestep and rate target. Must be implemented by derived class.
+    virtual void rate_controller_run_dt(const Vector3f& gyro_rads, float dt, const Vector3f& ang_vel_body_rads) { AP_BoardConfig::config_error("rate_controller_run_dt() must be defined"); };
+    // Run the angular velocity controller with a specified timestep on the current rate target.
+    void rate_controller_run_dt(const Vector3f& gyro_rads, float dt) { rate_controller_run_dt(gyro_rads, dt, _ang_vel_body_rads); }
 
     // euler_derivative_to_body - transform euler angle derivative to body-frame
     // Converts euler derivatives (rate, acceleration, etc.) to body-frame equivalents.
@@ -382,6 +384,9 @@ public:
 
     // Return the body-frame angular velocity (in rad/s) used by the angular velocity controller.
     Vector3f rate_bf_targets() const { return _ang_vel_body_rads + _sysid_ang_vel_body_rads; }
+
+    // Return the body-frame angular velocity target (in rad/s) without the sysid contribution
+    const Vector3f& get_ang_vel_body_rads() const { return _ang_vel_body_rads; }
 
     // return the angular velocity of the target (setpoint) attitude rad/s
     const Vector3f& get_rate_ef_target_rads() const { return _euler_rate_target_rads; }
@@ -600,6 +605,8 @@ protected:
     // Angle limit
     AP_Float            _angle_max_deg;
 
+    // Body-frame angular velocity target (rad/s) as given to the rate controller
+    Vector3f            _rate_target_rads;
     // Latest body-frame gyro measurement (rad/s) used by rate controller
     Vector3f            _rate_gyro_rads;
     // timestamp of the latest gyro measurement (in microseconds) value used by the rate controller

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Heli.cpp
@@ -342,6 +342,7 @@ void AC_AttitudeControl_Heli::rate_controller_run()
 {	
     _ang_vel_body_rads += _sysid_ang_vel_body_rads;
 
+    _rate_target_rads = _ang_vel_body_rads;
     _rate_gyro_rads = _ahrs.get_gyro_latest();
     _rate_gyro_time_us = AP_HAL::micros64();
 

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Logging.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Logging.cpp
@@ -30,7 +30,7 @@ void AC_AttitudeControl::Write_ANG() const
 // Write a rate packet
 void AC_AttitudeControl::Write_Rate(const AC_PosControl &pos_control) const
 {
-    const Vector3f rate_targets_degs = rate_bf_targets() * RAD_TO_DEG;
+    const Vector3f rate_targets_degs = _rate_target_rads * RAD_TO_DEG;
     const Vector3f &accel_target_ned_mss = pos_control.get_accel_target_NED_mss();
     const Vector3f gyro_rate = _rate_gyro_rads * RAD_TO_DEG;
     const struct log_Rate pkt_rate{

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.cpp
@@ -453,10 +453,10 @@ void AC_AttitudeControl_Multi::update_throttle_rpy_mix()
     _throttle_rpy_mix = constrain_float(_throttle_rpy_mix, 0.1f, AC_ATTITUDE_CONTROL_MAX);
 }
 
-void AC_AttitudeControl_Multi::rate_controller_run_dt(const Vector3f& gyro_rads, float dt)
+void AC_AttitudeControl_Multi::rate_controller_run_dt(const Vector3f& gyro_rads, float dt, const Vector3f& ang_vel_body_rads)
 {
     // take a copy of the target so that it can't be changed from under us.
-    Vector3f ang_vel_body = _ang_vel_body_rads;
+    Vector3f ang_vel_body = ang_vel_body_rads;
 
     // boost angle_p/pd each cycle on high throttle slew
     update_throttle_gain_boost();
@@ -466,6 +466,7 @@ void AC_AttitudeControl_Multi::rate_controller_run_dt(const Vector3f& gyro_rads,
 
     ang_vel_body += _sysid_ang_vel_body_rads;
 
+    _rate_target_rads = ang_vel_body;
     _rate_gyro_rads = gyro_rads;
     _rate_gyro_time_us = AP_HAL::micros64();
 
@@ -487,7 +488,7 @@ void AC_AttitudeControl_Multi::rate_controller_run_dt(const Vector3f& gyro_rads,
 void AC_AttitudeControl_Multi::rate_controller_run()
 {
     Vector3f gyro_latest_rads = _ahrs.get_gyro_latest();
-    rate_controller_run_dt(gyro_latest_rads, _dt_s);
+    rate_controller_run_dt(gyro_latest_rads, _dt_s, _ang_vel_body_rads);
 }
 
 // sanity check parameters.  should be called once before takeoff

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.h
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Multi.h
@@ -76,7 +76,7 @@ public:
     bool is_throttle_mix_min() const override { return (_throttle_rpy_mix < 1.25f * _thr_mix_min); }
 
     // run lowest level body-frame rate controller and send outputs to the motors
-    void rate_controller_run_dt(const Vector3f& gyro_rads, float dt) override;
+    void rate_controller_run_dt(const Vector3f& gyro_rads, float dt, const Vector3f& ang_vel_body_rads) override;
     void rate_controller_run() override;
 
     // sanity check parameters.  should be called once before take-off

--- a/libraries/AC_AttitudeControl/AC_AttitudeControl_Sub.cpp
+++ b/libraries/AC_AttitudeControl/AC_AttitudeControl_Sub.cpp
@@ -423,6 +423,7 @@ void AC_AttitudeControl_Sub::rate_controller_run()
     // move throttle vs attitude mixing towards desired (called from here because this is conveniently called on every iteration)
     update_throttle_rpy_mix();
 
+    _rate_target_rads = _ang_vel_body_rads;
     _rate_gyro_rads = _ahrs.get_gyro_latest();
     _rate_gyro_time_us = AP_HAL::micros64();
 

--- a/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_SITL.cpp
@@ -213,7 +213,7 @@ void AP_InertialSensor_SITL::generate_accel()
 void AP_InertialSensor_SITL::generate_gyro()
 {
     Vector3f gyro_accum;
-    uint8_t nsamples = enable_fast_sampling(gyro_instance) ? 8 : 1;
+    const uint8_t nsamples = gyro_nsamples;
 
     const float _gyro_drift = gyro_drift();
     for (uint8_t j = 0; j < nsamples; j++) {
@@ -316,7 +316,7 @@ void AP_InertialSensor_SITL::generate_gyro()
     gyro_accum.rotate(sitl->imu_orientation);
 
     _rotate_and_correct_gyro(gyro_instance, gyro_accum);
-    _notify_new_gyro_raw_sample(gyro_instance, gyro_accum, AP_HAL::micros64());
+    _notify_new_gyro_raw_sample(gyro_instance, gyro_accum, gyro_sample_us);
 }
 
 void AP_InertialSensor_SITL::timer_update(void)
@@ -359,20 +359,23 @@ void AP_InertialSensor_SITL::timer_update(void)
     }
     if (now >= next_gyro_sample) {
         if (((1U << gyro_instance) & sitl->gyro_fail_mask) == 0) {
+            if (next_gyro_sample == 0 || now - next_gyro_sample > 10000UL) {
+                // first sample, or a gap from the fail mask or a clock jump:
+                // resync rather than generate every missed sample
+                next_gyro_sample = now;
+            }
+            // the timer runs at the simulation rate, which can be below the
+            // gyro rate, so generate every sample that is due
+            while (now >= next_gyro_sample) {
+                gyro_sample_us = next_gyro_sample;
 #if AP_SIM_INS_FILE_ENABLED
-            if (sitl->gyro_file_rw == SITL::SIM::INSFileMode::INS_FILE_READ
-                || sitl->gyro_file_rw == SITL::SIM::INSFileMode::INS_FILE_READ_STOP_ON_EOF) {
-                read_gyro_from_file();
-            } else
+                if (sitl->gyro_file_rw == SITL::SIM::INSFileMode::INS_FILE_READ
+                    || sitl->gyro_file_rw == SITL::SIM::INSFileMode::INS_FILE_READ_STOP_ON_EOF) {
+                    read_gyro_from_file();
+                } else
 #endif
-            generate_gyro();
-
-            if (next_gyro_sample == 0) {
-                next_gyro_sample = now + 1000000UL / gyro_sample_hz;
-            } else {
-                while (now >= next_gyro_sample) {
-                    next_gyro_sample += 1000000UL / gyro_sample_hz;
-                }
+                generate_gyro();
+                next_gyro_sample += 1000000UL / gyro_sample_hz;
             }
         }
     }
@@ -394,6 +397,7 @@ void AP_InertialSensor_SITL::update_from_frame(void)
         generate_accel();
     }
     if (((1U << gyro_instance) & sitl->gyro_fail_mask) == 0) {
+        gyro_sample_us = AP_HAL::micros64();
         generate_gyro();
     }
 }
@@ -431,6 +435,17 @@ void AP_InertialSensor_SITL::start()
         return;
     }
     bus_id++;
+
+    // fast sampling simulates a raw stream at 8x the base rate decimated to the
+    // backend rate, which follows INS_GYRO_RATE as in the Invensense FIFO driver
+    gyro_nsamples = 1;
+    if (enable_fast_sampling(gyro_instance)) {
+        const uint8_t mult = constrain_int16(get_fast_sampling_rate(), 1, 8);
+        gyro_sample_hz *= mult;
+        gyro_nsamples = 8 / mult;
+        _set_gyro_raw_sample_rate(gyro_instance, gyro_sample_hz);
+    }
+
     hal.scheduler->register_timer_process(FUNCTOR_BIND_MEMBER(&AP_InertialSensor_SITL::timer_update, void));
 
 #if AP_SIM_INS_FILE_ENABLED
@@ -462,7 +477,7 @@ void AP_InertialSensor_SITL::read_gyro_from_file()
 
     float buf[8 * 3 * sizeof(float)];
 
-    uint8_t nsamples = enable_fast_sampling(gyro_instance) ? 8 : 1;
+    const uint8_t nsamples = gyro_nsamples;
     ssize_t ret = ::read(gyro_fd, buf, nsamples * 3 * sizeof(float));
     if (ret == (ssize_t)(nsamples * 3 * sizeof(float))) {
         read_gyro(buf, nsamples);
@@ -499,7 +514,7 @@ void AP_InertialSensor_SITL::read_gyro(const float* buf, uint8_t nsamples)
     }
     gyro_accum /= nsamples;
     _rotate_and_correct_gyro(gyro_instance, gyro_accum);
-    _notify_new_gyro_raw_sample(gyro_instance, gyro_accum, AP_HAL::micros64());
+    _notify_new_gyro_raw_sample(gyro_instance, gyro_accum, gyro_sample_us);
 }
 
 void AP_InertialSensor_SITL::write_gyro_to_file(const Vector3f& gyro)

--- a/libraries/AP_InertialSensor/AP_InertialSensor_SITL.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_SITL.h
@@ -43,8 +43,12 @@ private:
 #endif
     SITL::SIM *sitl;
 
-    const uint16_t gyro_sample_hz;
+    uint16_t gyro_sample_hz;
     const uint16_t accel_sample_hz;
+    // simulated raw gyro samples per backend sample
+    uint8_t gyro_nsamples;
+    // timestamp of the gyro sample being generated
+    uint64_t gyro_sample_us;
 
     uint64_t next_gyro_sample;
     uint64_t next_accel_sample;


### PR DESCRIPTION
## Summary

With the fast rate thread the rate PIDs run at the gyro rate on a target that only updates at the main loop rate, so they consume a zero-order-hold staircase. Ramp the target across the fast loop steps instead, and log the target the controller was actually given.

## Testing (more checks increases chance of being merged)

- [x] Checked by a human programmer
- [x] Tested in SITL
- [x] Tested on hardware
- [x] Autotest included

## Description

The held target's error is sawtooth-like, so the step train puts a comb at the update rate and its harmonics, plus broadband images of the target's own content, into the P, D and D_FF paths. The D paths differentiate the steps into impulses, which flattens the comb, so the un-notched harmonics dominate exactly where shot noise hurts most. A PID target notch (ATC_RAT_*_NTF) cannot fix this and was the original complaint ("notch set, no effect"): a notch removes one line of the comb and none of the image floor. In SITL it took -19 dB off the fundamental and -0.7 dB off the second harmonic.

Interpolating the target across the fast loop steps removes the whole comb and the floor with it. SITL A/B at 200 Hz loop and 2 kHz rate thread, 1 Hz full-stick roll sine in AltHold with FLTT=FLTD=100 and D_FF set so the derivative path is visible:

| roll, dB | ZOH baseline | ZOH + notch at 200 Hz | ramped target |
|---|---|---|---|
| target line at 200 Hz | -50.4 | -69.0 | -83.7 |
| target line at 400 Hz | -58.3 | -58.7 | -99.7 |
| D term 150-450 Hz | -44.1 | -52.1 | -69.5 |
| D_FF 20-500 Hz | -47.4 | -52.3 | -64.3 |
| RMS rate error, rad/s | 0.129 | 0.128 | 0.118 |

The ramp costs a flat +2.25 ms of target-path group delay over ZOH, 0.3 deg of phase at 1 Hz. That smoothing is what a low FLTT was previously providing at several times the phase cost (stock FLTT 20 alone is 10 ms), so FLTT can be raised afterwards and the overall target-path latency comes out lower than before. On a 4 inch quad, raising FLTT from 30 to 60 with this change cut RMS rate error 36% and the update-rate imaging in the target dropped from -36 dB to -51 dB relative to the vehicle's own motion. Worst case added target latency is one main loop period.

<img width="1680" height="1080" alt="rate_target_sitl_spectra" src="https://github.com/user-attachments/assets/c67b3635-9ec5-4a48-98ae-ae900501b152" />

<img width="1680" height="624" alt="rate_target_phase_lag" src="https://github.com/user-attachments/assets/bc0864d1-1bc7-42c1-af08-64a7b5725736" />

Implementation notes:

- The interpolation lives in Copter::rate_controller_thread(), not in AC_AttitudeControl_Multi. rate_controller_run_dt() is also the main-loop path and the class is shared with QuadPlane, which has no rate thread, so in attitude control it would be dead weight plus a per-iteration division everywhere else. The rate thread already holds the step count, and the ramp state is only touched by that thread. rate_controller_run_dt() takes the target as a parameter so the main loop path is provably unchanged. The signature change and its caller are one commit because neither compiles without the other.
- The ramp restarts when the target changes, not on the decimation counter, because the main loop runs asynchronously to the rate thread and the counter's phase drifts. It resyncs to the live target after the thread has been idle or the step count has changed.
- Sysid is added downstream of the interpolation so chirps still inject as crisp steps. AutoTune's rate steps are ramped over one main loop period like any other target.
- RATE.*Des was taken from rate_bf_targets() at log time, which is the target the next rate controller run will use, while RATE.* is a gyro snapshot taken inside the rate controller, so demand and response were a loop apart; with the target interpolated they are different signals altogether. The applied target is now snapshotted alongside the gyro. RATE.*Des lands one loop later than in older logs. PIDR.Tar was always correct and is unchanged.
- The SITL IMU always ran at 1 kHz, so the effect could not be reproduced there. With fast sampling enabled the SITL backend rate now follows INS_GYRO_RATE as on the Invensense v3 IMUs; the default is unchanged. Above the simulation rate the samples arrive in bursts, which the dynamic fast rate mode reads as the thread running slow, so use a fixed rate or raise SIM_RATE_HZ to match. SITLGyroRate checks the rate thread reports 1, 2 and 4 kHz for INS_GYRO_RATE 0, 1 and 2.
