### PR TITLE
AP_NavEKF3: do not learn XY accel bias in unaided flight

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -2186,6 +2186,129 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.context_pop()
         self.reboot_sitl()
 
+    def fly_accel_bias_xy_pushes(self):
+        '''take off in ALT_HOLD, make eight forward pushes, yaw through
+        three turns, hover, then land.  Returns the accel bias learned by
+        each core and the landed pitch error against SIM truth'''
+        self.takeoff(altitude_min=20, mode='ALT_HOLD', takeoff_throttle=1800)
+        self.wait_climbrate(-0.5, 0.5, minimum_duration=2)
+
+        # each push dips the baro while pitched and lets it recover while
+        # level, which an unaided filter can rectify into a body-X accel bias
+        for _ in range(8):
+            self.set_rc(2, 1333)
+            self.wait_pitch(-10, accuracy=5, minimum_duration=8, timeout=20)
+            self.set_rc(2, 1500)
+            self.wait_pitch(0, accuracy=3, minimum_duration=8, timeout=20)
+
+        # a body-frame bias is only separable from tilt while the heading
+        # changes, so give an aided filter three turns to learn it
+        heading = self.get_heading()
+        self.set_rc(4, 1600)
+        for _ in range(12):
+            heading = (heading + 90) % 360
+            self.wait_heading(heading, accuracy=15)
+        self.set_rc(4, 1500)
+        # the bias states are only visible in the log, so their settling
+        # cannot be waited on
+        tsettle = self.get_sim_time()
+        self.delay_sim_time(20, "bias states to settle in the hover")
+
+        # learned accel bias per core, from log records written after the
+        # pushes so a stale log cannot pass the check
+        bias = {}
+        dfreader = self.dfreader_for_current_onboard_log()
+        while True:
+            m = dfreader.recv_match(type='XKF2')
+            if m is None:
+                break
+            if m.TimeUS * 1e-6 < tsettle:
+                continue
+            bias[m.C] = (m.AX, m.AY)
+        if len(bias) == 0:
+            raise NotAchievedException("No XKF2 messages in onboard log after the pushes")
+        for core in sorted(bias.keys()):
+            self.progress("Core %u accel bias X=%.2f Y=%.2f m/s/s" % (core, bias[core][0], bias[core][1]))
+
+        # the pushes carry the vehicle onto ground that can sit above home,
+        # so wait on the disarm rather than on the altitude above home
+        self.change_mode('LAND')
+        self.wait_disarmed(timeout=60)
+
+        # a retained body-X bias tilts the level estimate by asin(bias/g);
+        # in the hover that is masked by the drift of an unaided vehicle, so
+        # measure it on the ground where the vehicle is stationary
+        self.delay_sim_time(10, "attitude to settle on the ground")
+        n = 20
+        pitch_err_deg = 0
+        for i in range(n):
+            att = self.assert_receive_message('ATTITUDE')
+            sim = self.assert_receive_message('SIMSTATE')
+            pitch_err_deg += math.degrees(att.pitch - sim.pitch) / n
+        self.progress("Landed pitch error vs SIM truth: %.2f deg" % pitch_err_deg)
+        return bias, pitch_err_deg
+
+    def EK3NoAidAccelBiasXY(self):
+        '''XY accel bias is not learned from tilt-coupled baro error in unaided flight'''
+        self.start_subtest("XY accel bias is not learned in unaided flight")
+        # scoped so the aided flight below starts from the defaults
+        self.context_push()
+        self.set_parameters({
+            "AHRS_EKF_TYPE": 3,
+            "EK3_ENABLE": 1,
+            "EK2_ENABLE": 0,
+            "SIM_GPS1_ENABLE": 0,
+            "EK3_SRC1_POSXY": 0,
+            "EK3_SRC1_VELXY": 0,
+            "EK3_SRC1_VELZ": 0,
+            # static port error proportional to airspeed squared, the same
+            # in every horizontal direction so the yaw does not modulate it
+            "SIM_BARO_WCF_FWD": 1.0,
+            "SIM_BARO_WCF_BAK": 1.0,
+            "SIM_BARO_WCF_RGT": 1.0,
+            "SIM_BARO_WCF_LFT": 1.0,
+        })
+        self.reboot_sitl()
+        # unaided the filter sits in constant position mode, which
+        # wait_ready_to_arm() treats as an error, so arm by hand
+        self.change_mode('ALT_HOLD')
+        self.wait_ekf_flags(
+            (mavutil.mavlink.EKF_ATTITUDE |
+             mavutil.mavlink.ESTIMATOR_VELOCITY_VERT |
+             mavutil.mavlink.ESTIMATOR_POS_VERT_ABS),
+            0,
+            timeout=120,
+        )
+        self.wait_prearm_sys_status_healthy(timeout=120)
+        self.arm_vehicle()
+        bias, pitch_err_deg = self.fly_accel_bias_xy_pushes()
+        for core in sorted(bias.keys()):
+            if abs(bias[core][0]) > 0.1 or abs(bias[core][1]) > 0.1:
+                raise NotAchievedException("Core %u learned XY accel bias in unaided flight" % core)
+        if abs(pitch_err_deg) > 0.5:
+            raise NotAchievedException("Landed pitch error %.2f deg" % pitch_err_deg)
+        self.context_pop()
+
+        # positive control: the same flight with aiding must still learn a
+        # real body-X bias
+        self.start_subtest("XY accel bias is learned in aided flight")
+        self.context_push()
+        self.set_parameters({
+            "SIM_ACC1_BIAS_X": 0.5,
+            "SIM_ACC2_BIAS_X": 0.5,
+            "SIM_ACC3_BIAS_X": 0.5,
+        })
+        self.reboot_sitl()
+        bias, pitch_err_deg = self.fly_accel_bias_xy_pushes()
+        for core in sorted(bias.keys()):
+            if abs(bias[core][0] - 0.5) > 0.1:
+                raise NotAchievedException("Core %u did not learn the X accel bias in aided flight" % core)
+        if abs(pitch_err_deg) > 0.5:
+            raise NotAchievedException("Landed pitch error %.2f deg" % pitch_err_deg)
+        self.context_pop()
+        # the filter still carries the learned bias; reboot to restore EKF health
+        self.reboot_sitl()
+
     def EK3_AccelBiasInhibitOnGroundMoving(self):
         '''Test EKF3 inhibits accel bias learning when vehicle is moved on ground'''
         # When a copter is on the ground and being moved (carried, on a ship),
@@ -16568,6 +16691,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
              self.BatteryMissing,
              self.VibrationFailsafe,
              self.EK3AccelBias,
+             self.EK3NoAidAccelBiasXY,
              self.EK3_AccelBiasInhibitOnGroundMoving,
              self.EK3_AccelBiasZeroVelOptFlow,
              self.EK3_ZeroVelFusionNotUsedWithGPS,

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -1178,13 +1178,17 @@ void NavEKF3_core::CovariancePrediction(Vector3F *rotVarVecPtr)
             const uint8_t index = stateIndex - 13;
 
             // Don't attempt learning of IMU delta velocity bias if on ground.
-            // In flight: all axes are observable from velocity/position aiding.
+            // In flight: all axes are observable from velocity/position aiding. In
+            // AID_NONE the synthetic horizontal observations do not update the bias
+            // states (see FuseVelPosNED), so only a near-vertical axis is observable.
             // On ground and stationary: only the gravity-aligned axis (Z for a level
             // vehicle) is observable. XY biases remain unobservable until the vehicle
-            // accelerates horizontally in flight.
+            // accelerates horizontally in aided flight.
             // On ground and moving (e.g. carried or on a boat): inhibit all axes
             // to prevent learning biases from external motion accelerations.
-            const bool is_bias_observable = (fabsF(prevTnb[index][2]) > 0.8f && onGroundNotMoving) || !onGround;
+            const bool axisNearVertical = fabsF(prevTnb[index][2]) > 0.8f;
+            const bool is_bias_observable = (axisNearVertical && onGroundNotMoving) ||
+                                            (!onGround && (PV_AidingMode != AID_NONE || axisNearVertical));
 
             if (!is_bias_observable && !dvelBiasAxisInhibit[index]) {
                 // store variances to be reinstated wben learning can commence later


### PR DESCRIPTION
### Summary

In unaided flight (AID_NONE, baro only) the EKF learns a body-XY accel bias from tilt-coupled baro error, which tilts the level estimate. Only a near-vertical axis is observable without aiding, so stop reinstating the XY bias variances in that mode.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware

### Description

In AID_NONE the synthetic horizontal position and velocity observations are already barred from updating the accel bias states in FuseVelPosNED, but CovariancePrediction still marks all three bias axes observable in flight, so the XY bias variance is reinstated at takeoff and grows unconstrained. The observation that then drives the XY states is the height innovation coupled in through tilt. A baro static-port dip during a forward push, fused while pitched, is learned as a body-X bias; levelling off removes the coupling while the baro recovers, so repeated pushes rectify it into a one-sided bias and the level estimate tilts by atan(bias/g).

Seen on a small quad flying with no GPS: the X bias walked to -0.4 m/s2 within 30 s of forward flight and the EKF pitch read +2.2 deg on the ground after landing where it read +0.1 deg before takeoff. EK3_NOAID_M_NSE, EK3_ABIAS_P_NSE and EK3_ACC_BIAS_LIM do not address it and EK3_ALT_M_NSE 5 only halves it, because the coupling is structural rather than a noise setting.

The fix keeps the Z bias observable in unaided flight (it is learned from the height reference) and changes nothing for aided flight or on the ground. One consequence worth knowing: beyond about 37 deg of tilt in unaided flight the Z axis is inhibited too, where before all axes stayed observable in flight; Z learning resumes on levelling.

Autotest EK3NoAidAccelBiasXY: no GPS, a speed-squared baro static-port error (SIM_BARO_WCF), eight 8 s forward pushes with 8 s level between them, then a 20 s hover, land. The pitch error is measured on the ground after landing rather than in the hover: an unaided copter drifts and its true pitch swings about a degree either way while the filter reports level, so a hover sample depends on when it is taken, whereas a retained bias shows as a steady asin(bias/g) once stationary. Unfixed: X bias 0.21 m/s2 on both cores and a 1.1 deg pitch error against SIM truth on the ground. Fixed: 0.00 m/s2 and 0.06 deg. The test fails on master and passes with this change. A second flight with GPS, pitching and yawing with an injected 0.5 m/s2 X bias, checks the bias is still learned when aided (it is not learned in a steady aided hover either, where it is indistinguishable from tilt, so the control manoeuvres first).

Distinct from #32473 (vehicle-side inhibit during acro) and #32471 (hover Z-bias learning); this one is inside the filter's own observability logic and touches no other path.

<img width="1170" height="1105" alt="ek3_noaid_xy_bias_ab" src="https://github.com/user-attachments/assets/93cae47d-f0ba-409c-9a6e-f5cda49fa25f" />
