### PR TITLE
Copter: add advanced land failsafe (LAND_FS_OPTIONS bit 0)

### DIFF
--- a/ArduCopter/Attitude.cpp
+++ b/ArduCopter/Attitude.cpp
@@ -48,7 +48,7 @@ void Copter::update_throttle_hover()
 
     // do not update if no vertical velocity estimate
     float vel_d_ms;
-    if (!AP::ahrs().get_velocity_D(vel_d_ms, vibration_check.high_vibes)) {
+    if (!AP::ahrs().get_velocity_D(vel_d_ms, vibe_comp_active())) {
         return;
     }
 

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -322,9 +322,13 @@ private:
     // vibration check
     struct {
         bool high_vibes;    // true while high vibration are detected
+        bool forced;        // compensation forced on by the flight mode
         uint32_t start_ms;  // system time high vibration were last detected
         uint32_t clear_ms;  // system time high vibrations stopped
     } vibration_check;
+
+    // vibration compensation is active when detected or forced
+    bool vibe_comp_active() const { return vibration_check.high_vibes || vibration_check.forced; }
 
     // EKF variances are unfiltered and are designed to recover very quickly when possible
     // thus failsafes should be triggered on filtered values in order to avoid transient errors 

--- a/ArduCopter/baro_ground_effect.cpp
+++ b/ArduCopter/baro_ground_effect.cpp
@@ -7,7 +7,7 @@ void Copter::update_ground_effect_detector(void)
 
     // throw mode never wants the takeoff expected EKF code
     gndeff.enable_takeoff_comp(flightmode->mode_number() != Mode::Number::THROW);
-    gndeff.set_high_vibrations(vibration_check.high_vibes);
+    gndeff.set_high_vibrations(vibe_comp_active());
 
     // ALT_HOLD has manual attitude and no NE controller, so a near-level
     // attitude target stands in for "pilot is asking for slow horizontal"

--- a/ArduCopter/crash_check.cpp
+++ b/ArduCopter/crash_check.cpp
@@ -144,7 +144,7 @@ void Copter::thrust_loss_check()
 
     // check for descent
     float vel_d_ms = 0;
-    if (!AP::ahrs().get_velocity_D(vel_d_ms, vibration_check.high_vibes) || !is_positive(vel_d_ms)) {
+    if (!AP::ahrs().get_velocity_D(vel_d_ms, vibe_comp_active()) || !is_positive(vel_d_ms)) {
         // we have no vertical velocity estimate and/or we are not descending
         thrust_loss_counter = 0;
         return;
@@ -255,7 +255,7 @@ void Copter::parachute_check()
 
     // pass sink rate to parachute library
     float vel_d_ms = 0;
-    UNUSED_RESULT(AP::ahrs().get_velocity_D(vel_d_ms, vibration_check.high_vibes));
+    UNUSED_RESULT(AP::ahrs().get_velocity_D(vel_d_ms, vibe_comp_active()));
     parachute.set_sink_rate(vel_d_ms);
 
     // exit immediately if in standby

--- a/ArduCopter/inertia.cpp
+++ b/ArduCopter/inertia.cpp
@@ -4,7 +4,7 @@
 void Copter::read_inertia()
 {
     // inertial altitude estimates. Use barometer climb rate during high vibrations
-    pos_control->update_estimates(vibration_check.high_vibes);
+    pos_control->update_estimates(vibe_comp_active());
 #if MODE_FOLLOW_ENABLED
     g2.follow.update_estimates();
 #endif

--- a/ArduCopter/land_detector.cpp
+++ b/ArduCopter/land_detector.cpp
@@ -126,7 +126,7 @@ void Copter::update_land_detector()
 
         // check that vertical speed is within 1m/s of zero
         float vel_d_ms = 0;
-        UNUSED_RESULT(AP::ahrs().get_velocity_D(vel_d_ms, copter.vibration_check.high_vibes));
+        UNUSED_RESULT(AP::ahrs().get_velocity_D(vel_d_ms, copter.vibe_comp_active()));
         const bool descent_rate_low = fabsf(vel_d_ms) < LAND_DETECTOR_VEL_Z_MAX * land_detector_scalar;
         SET_LOG_FLAG(descent_rate_low, LandDetectorLoggingFlag::DESCENT_RATE_LOW);
 

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -1310,6 +1310,7 @@ public:
 
     bool init(bool ignore_checks) override;
     void run() override;
+    void exit() override;
 
     bool requires_position() const override { return false; }
     bool has_manual_throttle() const override { return false; }
@@ -1351,12 +1352,31 @@ private:
     void gps_run();
     void nogps_run();
 
+    // advanced land failsafe (LAND_FS_OPTIONS bit 0): protect a failsafe
+    // landing against a corrupt vertical estimate flying the vehicle away
+    void update_advanced_failsafe();
+    void apply_advanced_failsafe_throttle_cap();
+
+    // LAND_FS_OPTIONS bitmask
+    enum class Option : uint8_t {
+        AdvancedFailsafe = (1U << 0),  // forced vibration compensation and a baro runaway cap
+    };
+    bool option_is_enabled(Option option) const { return (uint8_t(fs_options.get()) & uint8_t(option)) != 0; }
+
     bool control_position; // true if we are using an external reference to control position
+
+    // advanced land failsafe state, latched for the rest of the landing
+    float adv_fs_baro_alt_min_m;   // lowest baro altitude seen since engaging
+    bool adv_fs_active;            // engaged by a failsafe while armed
+    bool adv_fs_throttle_capped;   // a baro-confirmed runaway climb has latched the ceiling
+    float adv_fs_throttle_cap;     // throttle ceiling while capped
+    float adv_fs_cap_i;            // integral of the baro climb rate error, as a fraction of hover
 
     // parameters
     AP_Float land_speed_ms;
     AP_Float land_speed_high_ms;
     AP_Float land_alt_low_m;
+    AP_Int8 fs_options;
 
     uint32_t land_start_time;
     bool land_pause;

--- a/ArduCopter/mode_land.cpp
+++ b/ArduCopter/mode_land.cpp
@@ -30,6 +30,13 @@ const AP_Param::GroupInfo ModeLand::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("ALT_LOW_M", 3, ModeLand, land_alt_low_m, 10),
 
+    // @Param: FS_OPTIONS
+    // @DisplayName: Land failsafe options
+    // @Description: Options for a LAND flown while a radio, GCS or EKF failsafe is active (so the failsafe action must be Land), kept for the rest of that landing once engaged. Bit 0 forces the vibration compensation on so a corrupt EKF vertical estimate cannot make LAND add throttle and climb away, and caps the throttle from the barometer climb rate if the baro still shows a net climb of more than 10 m that the position controller did not command.
+    // @Bitmask: 0:Advanced land failsafe
+    // @User: Advanced
+    AP_GROUPINFO("FS_OPTIONS", 4, ModeLand, fs_options, 0),
+
     AP_GROUPEND
 };
 
@@ -85,6 +92,10 @@ bool ModeLand::init(bool ignore_checks)
     land_start_time = millis();
     land_pause = false;
 
+    // reset advanced land failsafe state
+    adv_fs_active = false;
+    adv_fs_throttle_capped = false;
+
     // reset flag indicating if pilot has applied roll or pitch inputs during landing
     copter.ap.land_repo_active = false;
 
@@ -107,15 +118,106 @@ bool ModeLand::init(bool ignore_checks)
     return true;
 }
 
+// advanced land failsafe (LAND_FS_OPTIONS bit 0) tuning
+// baro net ascent that confirms a runaway climb, well above ground effect and baro noise
+#define LAND_FS_RUNAWAY_CLIMB_M   10.0f
+// desired climb rate above which the position controller is still shedding a climb
+#define LAND_FS_SHEDDING_CLIMB_MS 0.25f
+// PI gains of the throttle ceiling on the baro climb rate error, as a fraction of hover per m/s.
+// The integrator trims the hover throttle error, so it only runs while the error is small,
+// otherwise what it winds up arresting a climb leaves no headroom to arrest the dive after it
+#define LAND_FS_CAP_P             0.1f
+#define LAND_FS_CAP_I             0.1f
+#define LAND_FS_CAP_I_BAND_MS     1.0f
+// ceiling headroom above hover, so the cap can arrest a descent as well as a climb
+#define LAND_FS_CAP_MAX           1.3f
+
 // land_run - runs the land controller
 // should be called at 100hz or more
 void ModeLand::run()
 {
+    update_advanced_failsafe();
+
     if (control_position) {
         gps_run();
     } else {
         nogps_run();
     }
+
+    apply_advanced_failsafe_throttle_cap();
+}
+
+// engage the advanced land failsafe (bit 0) while a failsafe has the vehicle
+void ModeLand::update_advanced_failsafe()
+{
+    // once engaged stay engaged for the rest of the landing, so a flickering
+    // link cannot release the protections and hand a corrupt estimate full throttle
+    const bool failsafe_active = copter.failsafe.radio ||
+                                 copter.failsafe.gcs ||
+                                 copter.failsafe.ekf;
+    if (!adv_fs_active && option_is_enabled(Option::AdvancedFailsafe) && failsafe_active && motors->armed()) {
+        adv_fs_active = true;
+        adv_fs_baro_alt_min_m = copter.barometer.get_altitude();
+        LOGGER_WRITE_EVENT(LogEvent::LAND_FS_ENGAGED);
+        gcs().send_text(MAV_SEVERITY_WARNING, "Land FS: engaged");
+    }
+
+    // force the vibration compensation on as check_vibration() would
+    copter.vibration_check.forced = adv_fs_active;
+    pos_control->set_vibe_comp(copter.vibe_comp_active());
+
+    if (!adv_fs_active || !motors->armed()) {
+        return;
+    }
+
+#if FRAME_CONFIG != HELI_FRAME
+    // a net ascent on the barometer that the position controller did not ask
+    // for is a fly-away whatever the estimate says. A climb it is still
+    // shedding (momentum from the previous mode, a precision landing retry)
+    // is not counted
+    const float baro_alt_m = copter.barometer.get_altitude();
+    if (pos_control->get_vel_desired_NED_ms().z < -LAND_FS_SHEDDING_CLIMB_MS) {
+        adv_fs_baro_alt_min_m = baro_alt_m;
+    } else {
+        adv_fs_baro_alt_min_m = MIN(adv_fs_baro_alt_min_m, baro_alt_m);
+    }
+    if (!adv_fs_throttle_capped && baro_alt_m - adv_fs_baro_alt_min_m > LAND_FS_RUNAWAY_CLIMB_M) {
+        gcs().send_text(MAV_SEVERITY_CRITICAL, "Land FS: baro runaway, capping throttle");
+        LOGGER_WRITE_EVENT(LogEvent::LAND_FS_THROTTLE_CAPPED);
+        adv_fs_throttle_capped = true;
+        adv_fs_cap_i = 0.0f;
+    }
+    if (adv_fs_throttle_capped) {
+        // PI on the baro climb rate error, positive when climbing or short of
+        // the landing speed; on the ground the integrator winds the ceiling
+        // through zero and the motors reach their lower limit
+        const float rate_err_ms = copter.barometer.get_climb_rate() + fabsf(get_land_speed_ms());
+        if (fabsf(rate_err_ms) < LAND_FS_CAP_I_BAND_MS) {
+            adv_fs_cap_i = constrain_float(adv_fs_cap_i + rate_err_ms * LAND_FS_CAP_I * G_Dt, 0.0f, 1.05f);
+        }
+        adv_fs_throttle_cap = constrain_float(1.0f - rate_err_ms * LAND_FS_CAP_P - adv_fs_cap_i, -0.05f, LAND_FS_CAP_MAX) * motors->get_throttle_hover();
+    }
+#endif
+}
+
+// clamp the throttle set by the vertical controller once a runaway has latched
+void ModeLand::apply_advanced_failsafe_throttle_cap()
+{
+    if (!adv_fs_throttle_capped) {
+        return;
+    }
+    if (attitude_control->get_throttle_in() > adv_fs_throttle_cap) {
+        attitude_control->set_throttle_out(adv_fs_throttle_cap, true, POSCONTROL_THROTTLE_CUTOFF_FREQ_HZ);
+    }
+}
+
+// hand the vibration compensation back to check_vibration()
+void ModeLand::exit()
+{
+    copter.vibration_check.forced = false;
+    pos_control->set_vibe_comp(copter.vibe_comp_active());
+    adv_fs_active = false;
+    adv_fs_throttle_capped = false;
 }
 
 // land_gps_run - runs the land controller
@@ -140,8 +242,13 @@ void ModeLand::gps_run()
             land_pause = false;
         }
 
-        // run normal landing or precision landing (if enabled)
-        land_run_normal_or_precland(land_pause);
+        // run normal landing or precision landing (if enabled); once a runaway
+        // has latched, precision landing retries (which climb) are not run
+        if (adv_fs_throttle_capped) {
+            land_run_horiz_and_vert_control(land_pause);
+        } else {
+            land_run_normal_or_precland(land_pause);
+        }
     }
 }
 

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import copy
 import math
+import operator
 import os
 import pathlib
 import re
@@ -562,6 +563,97 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
             2: 1500,
         })
         self.do_RTL()
+
+    def ModeLandAdvancedFailsafe(self):
+        '''LAND_FS_OPTIONS bit 0 engages on an RC-failsafe LAND and a healthy vehicle still lands without the cap tripping'''
+        self.set_parameters({
+            "FS_THR_ENABLE": 3,     # RC failsafe action = LAND
+            "LAND_FS_OPTIONS": 1,
+        })
+        self.takeoffAndMoveAway()
+        self.context_collect("STATUSTEXT")
+        self.progress("Triggering RC failsafe into LAND with advanced failsafe enabled")
+        self.set_parameter("SIM_RC_FAIL", 1)
+        self.wait_mode("LAND")
+        self.wait_statustext("Land FS: engaged", check_context=True)
+        self.wait_landed_and_disarmed()
+        if self.statustext_in_collections("baro runaway") is not None:
+            raise NotAchievedException("Runaway cap tripped on a healthy estimate")
+        self.set_parameter("SIM_RC_FAIL", 0)
+        self.reboot_sitl()  # reset to starting position
+
+    def LandFailsafeRunaway(self):
+        '''LAND_FS_OPTIONS bit 0 brings a failsafe LAND back down when it is climbing away on a corrupt vertical estimate'''
+        self.set_parameters({
+            "AHRS_EKF_TYPE": 3,
+            "EK3_ENABLE": 1,
+            "EK2_ENABLE": 0,
+            "SIM_GPS1_ENABLE": 0,
+            "EK3_SRC1_POSXY": 0,
+            "EK3_SRC1_VELXY": 0,
+            "EK3_SRC1_VELZ": 0,
+            "FS_THR_ENABLE": 3,     # RC failsafe action = LAND
+        })
+
+        for option in [0, 1]:
+            self.start_subtest("LAND_FS_OPTIONS=%u" % option)
+            self.set_parameter("LAND_FS_OPTIONS", option)
+            self.reboot_sitl()  # applies the EKF setup and resets the vehicle between subtests
+            # the estimate is about to be corrupted, so altitude is read from the simulator
+            ground_alt = self.get_altitude(altitude_source="SIM_STATE.alt")
+            # unaided the filter sits in constant position mode, which
+            # wait_ready_to_arm() treats as an error
+            self.change_mode('ALT_HOLD')
+            self.wait_ekf_flags(
+                (mavutil.mavlink.EKF_ATTITUDE |
+                 mavutil.mavlink.ESTIMATOR_VELOCITY_VERT |
+                 mavutil.mavlink.ESTIMATOR_POS_VERT_ABS),
+                0,
+                timeout=120,
+            )
+            self.wait_prearm_sys_status_healthy(timeout=120)
+            self.zero_throttle()
+            self.arm_vehicle()
+            self.takeoff(altitude_min=20, mode='ALT_HOLD', takeoff_throttle=1800)
+            self.delay_sim_time(5, "settle in the hover")
+            start_alt = self.get_altitude(altitude_source="SIM_STATE.alt")
+
+            # scoped so the second subtest gets fresh STATUSTEXT and SIM_STATE
+            # collections and the accel bias and RC failure are unwound
+            self.context_push()
+            self.context_collect("STATUSTEXT")
+            self.context_set_message_rate_hz(mavutil.mavlink.MAVLINK_MSG_ID_SIM_STATE, 10)
+            self.context_collect("SIM_STATE")
+            self.set_parameter("SIM_RC_FAIL", 1)
+            self.wait_mode("LAND")
+            if option == 1:
+                self.wait_statustext("Land FS: engaged", check_context=True)
+            # the accelerometers report a descent that is not happening, so
+            # the estimate falls while the vehicle does not
+            self.set_parameters({
+                "SIM_ACC1_BIAS_Z": 3,
+                "SIM_ACC2_BIAS_Z": 3,
+                "SIM_ACC3_BIAS_Z": 3,
+            })
+            if option == 0:
+                # without the option LAND climbs away
+                self.wait_altitude(start_alt + 15, start_alt + 100000, altitude_source="SIM_STATE.alt", timeout=60)
+                self.disarm_vehicle(force=True)
+            else:
+                # with it the runaway is caught on the baro and the vehicle is
+                # brought back down; on the ground the ceiling winds the motors
+                # to their lower limit. The land detector cannot see the landing
+                # through the corrupt estimate, so disarm is forced as it is for
+                # the vibration failsafe
+                self.wait_statustext("baro runaway", check_context=True, timeout=60)
+                self.wait_altitude(ground_alt - 1, ground_alt + 1, altitude_source="SIM_STATE.alt", timeout=120)
+                self.wait_servo_channel_value(1, 1250, timeout=60, comparator=operator.le)
+                peak = max([m.alt for m in self.context_collection("SIM_STATE")]) - start_alt
+                self.progress("Peak climb %.1f m" % peak)
+                if peak > 25:
+                    raise NotAchievedException("Climb not bounded with the option (peak %.1f m)" % peak)
+                self.disarm_vehicle(force=True)
+            self.context_pop()
 
     def fly_to_origin(self, final_alt=10):
         origin = self.poll_message("GPS_GLOBAL_ORIGIN")
@@ -16562,6 +16654,8 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
              self.AirModeStabZeroThrottle,
              self.AirModeLanding,
              self.ModeAltHold,
+             self.ModeLandAdvancedFailsafe,
+             self.LandFailsafeRunaway,
              self.ModeLoiter,
              self.SimpleMode,
              self.SuperSimpleCircle,

--- a/libraries/AP_Logger/AP_Logger.h
+++ b/libraries/AP_Logger/AP_Logger.h
@@ -97,6 +97,9 @@ enum class LogEvent : uint8_t {
 
     AIRSPEED_PRIMARY_CHANGED = 90,
 
+    LAND_FS_ENGAGED = 91,
+    LAND_FS_THROTTLE_CAPPED = 92,
+
     SURFACED = 163,
     NOT_SURFACED = 164,
     BOTTOMED = 165,


### PR DESCRIPTION
### Summary

Opt-in protection (LAND_FS_OPTIONS bit 0, default off) for a LAND flown under a failsafe, where a corrupt EKF vertical estimate can otherwise make LAND add throttle to "arrest" a descent that is not happening and fly the vehicle away with nobody on the sticks.

### Classification & Testing

- [x] Checked by a human programmer
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware

### Description

When LAND is flown under a radio, GCS or EKF failsafe the pilot cannot intervene. The reported failure was a wrong-sign vertical velocity estimate with low variance, so the stock vibration failsafe (which keys on high velocity variance) never trips: LAND sees a descent that is not happening, adds throttle to arrest it, and the vehicle climbs away. The failsafe itself is the right trigger for a backstop, because it has already declared that we are flying blind, so the vertical authority can be bounded without having to detect that the estimate is bad.

With the bit set, two layers engage once a failsafe is active on an armed LAND (so the failsafe action must be Land; an RTL's final descent is not covered), and stay engaged for the rest of that landing so a flickering link cannot release them. Engagement is announced on the GCS and logged (EV LAND_FS_ENGAGED).

- The vibration compensation is forced on, exactly as check_vibration() would engage it: the vibration-resistant throttle law and the position-derived vertical velocity in the position controller and land detector. vibration_check gains a forced flag so check_vibration() keeps ownership of the detected state, and ModeLand::exit() hands it back.
- Baro-only runaway cap. A net climb of more than 10 m on the barometer that the position controller did not ask for is a fly-away whatever the estimate says; a climb the controller is still shedding (momentum carried in from the previous mode, a precision landing retry) is not counted. The latch is logged (EV LAND_FS_THROTTLE_CAPPED), applies a throttle ceiling after the vertical controller, and skips precision landing retries from then on. The ceiling is PI on the baro climb rate error from the landing speed. A fixed fraction of hover was tried first and is not enough: a hover throttle learned a few percent high leaves a 0.9x ceiling above the real hover point, and in SITL the vehicle kept drifting up at 0.4 m/s under it. The integrator only runs while that error is small; wound up while arresting the climb it left no headroom to catch the dive after it (3 m/s in SITL, 0.6 m/s with the band). On the ground the baro stops descending, so the ceiling winds down through zero and the motors reach their lower limit. Multicopter only; heli collective is left alone.

The 10 m threshold is deliberately large. This exists to stop a hundreds-of-metres fly-away, not to police small excursions, so it sits well above near-ground baro and ground-effect noise.

Why a LAND_FS_ parameter rather than a bit in FS_OPTIONS: the behaviour only exists inside LAND and only for a failsafe-triggered landing, so it lives with the LAND parameter group next to the descent speeds it interacts with, and it is LAND_FS_OPTIONS rather than LAND_OPTIONS because every bit in it is failsafe-only. Battery failsafe LAND is not covered; the pilot still has the sticks there.

Flash cost on Pixhawk1-1M: +528 bytes, +16 bytes RAM.

SITL A/B (LandFailsafeRunaway): no GPS, RC failsafe into LAND, then a 3 m/s2 accel bias on every IMU. Unprotected, the vehicle climbs 900 m in 75 s at full throttle. With the bit set the ceiling latches at +10 m, the climb peaks at +12.6 m, the descent never exceeds 0.6 m/s, and the vehicle touches down at the landing speed 71 s later with the motors at their minimum. With the EKF height that far gone the land detector cannot see the landing, so the vehicle stays armed at minimum throttle, as it does under the stock vibration failsafe. ModeLandAdvancedFailsafe covers the healthy case: with the bit set an RC-failsafe LAND engages, still descends and disarms, and the cap does not trip. A 7 m/s climb carried into a healthy failsafe LAND does not trip it either.

Default builds are unchanged: with the bit off the LAND path is identical.

<img width="1170" height="1105" alt="land_fs_runaway_ab" src="https://github.com/user-attachments/assets/857563ff-6b70-4bfe-a857-0a7256135aca" />
