### PR TITLE
SITL: warn when home altitude mismatches terrain

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -6078,6 +6078,14 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         '''
         self.context_push()
         try:
+            self.install_terrain_handlers_context()
+            self.set_parameter("TERRAIN_ENABLE", 1)
+
+            # the warning is emitted once, shortly after boot, so it may
+            # well arrive before we get a chance to wait for it.  Collect
+            # statustexts so the wait can examine ones already received.
+            self.context_collect("STATUSTEXT")
+
             # Boot at the usual start location but with a deliberately wrong
             # home altitude (0).  SRTM at CMAC is ~584m so the mismatch
             # warning must fire.  The start lat/lng are unchanged so the
@@ -6086,12 +6094,8 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 ["--home", "%f,%f,0,%u" % (SITL_START_LOCATION.lat,
                                            SITL_START_LOCATION.lng,
                                            SITL_START_LOCATION.heading)])
-            self.reboot_sitl(check_position=False)
 
-            self.install_terrain_handlers_context()
-            self.set_parameter("TERRAIN_ENABLE", 1)
-
-            self.wait_statustext("SIM: home.alt", timeout=120)
+            self.wait_statustext("SIM: home.alt", timeout=120, check_context=True)
         finally:
             # restore the correct home altitude for subsequent tests
             self.customise_SITL_commandline(
@@ -6099,7 +6103,6 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                                             SITL_START_LOCATION.lng,
                                             int(SITL_START_LOCATION.alt),
                                             SITL_START_LOCATION.heading)])
-            self.reboot_sitl(check_position=False)
         self.context_pop()
 
     def WP_SPEED(self):

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -6068,6 +6068,40 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.set_parameter("TERRAIN_ENABLE", 0)
         self.fly_mission("wp.txt")
 
+    def TerrainHomeAltMismatchWarning(self):
+        '''SIM should warn when home.alt badly mismatches SRTM terrain data
+
+        A large mismatch between home.alt and SRTM terrain raises the
+        simulated ground and SITL silently clamps the vehicle to it.
+        The sim should warn about the mismatch as soon as terrain data
+        becomes available.
+        '''
+        self.context_push()
+        try:
+            # Boot at the usual start location but with a deliberately wrong
+            # home altitude (0).  SRTM at CMAC is ~584m so the mismatch
+            # warning must fire.  The start lat/lng are unchanged so the
+            # terrain tile cache is used.
+            self.customise_SITL_commandline(
+                ["--home", "%f,%f,0,%u" % (SITL_START_LOCATION.lat,
+                                           SITL_START_LOCATION.lng,
+                                           SITL_START_LOCATION.heading)])
+            self.reboot_sitl(check_position=False)
+
+            self.install_terrain_handlers_context()
+            self.set_parameter("TERRAIN_ENABLE", 1)
+
+            self.wait_statustext("SIM: home.alt", timeout=120)
+        finally:
+            # restore the correct home altitude for subsequent tests
+            self.customise_SITL_commandline(
+                ["--home", "%f,%f,%u,%u" % (SITL_START_LOCATION.lat,
+                                            SITL_START_LOCATION.lng,
+                                            int(SITL_START_LOCATION.alt),
+                                            SITL_START_LOCATION.heading)])
+            self.reboot_sitl(check_position=False)
+        self.context_pop()
+
     def WP_SPEED(self):
         '''ensure resetting WP_SPD during a mission works'''
 
@@ -16297,6 +16331,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
              self.SetpointGlobalVel,
              self.SetpointBadVel,
              self.SplineTerrain,
+             self.TerrainHomeAltMismatchWarning,
              self.TakeoffCheck,
              self.GainBackoffTakeoff,
         ])

--- a/libraries/SITL/SIM_Aircraft.cpp
+++ b/libraries/SITL/SIM_Aircraft.cpp
@@ -54,6 +54,8 @@ Aircraft::Aircraft(const char *frame_str)
     // make the SIM_* variables available to simulator backends
     sitl = AP::sitl();
 
+    warned_home_alt_terrain_mismatch = false;
+
     set_speedup(1.0f);
 
     last_wall_time_us = get_wall_time_us();
@@ -172,6 +174,25 @@ bool Aircraft::on_ground() const
 */
 void Aircraft::update_position(void)
 {
+    // warn once if home.alt does not match terrain data; a large mismatch
+    // raises the simulated ground and silently clamps the vehicle to it
+#if AP_TERRAIN_AVAILABLE
+    if (sitl != nullptr &&
+        sitl->terrain_enable &&
+        !warned_home_alt_terrain_mismatch) {
+        AP_Terrain *terrain = AP::terrain();
+        float home_terrain_height;
+        if (terrain != nullptr &&
+            terrain->height_amsl(home, home_terrain_height, false) &&
+            fabsf(home_terrain_height - home.alt * 0.01f) > 10.0f) {
+            warned_home_alt_terrain_mismatch = true;
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING,
+                          "SIM: home.alt %.0fm vs SRTM %.0fm - ground mismatch",
+                          home.alt * 0.01f, home_terrain_height);
+        }
+    }
+#endif
+
     location = origin;
     location.offset(position.x, position.y);
 

--- a/libraries/SITL/SIM_Aircraft.h
+++ b/libraries/SITL/SIM_Aircraft.h
@@ -310,6 +310,9 @@ protected:
     bool use_smoothing;
     bool disable_origin_movement;
 
+    // true once we have warned that home.alt does not match terrain data
+    bool warned_home_alt_terrain_mismatch;
+
     float ground_height_difference() const;
 
     virtual bool on_ground() const;


### PR DESCRIPTION
## Problem

With terrain enabled, if `home.alt` does not match the SRTM terrain data at the home position, SITL raises the simulated ground (via `ground_height_difference()`) and **silently clamps the vehicle to it**. The vehicle just stops mid-flight with no message and no log hint, which makes this extremely hard to debug.

## How this was found

While testing a VTOL at Da Nang in SITL, the aircraft repeatedly froze during a fixed-wing loiter. After lengthy debugging the cause turned out to be a test setup error: `home.alt=0` while SRTM terrain at the location is ~25m AMSL. Once the vehicle flew towards a target at ~70m AMSL terrain, `hagl()` went to zero, `on_ground()` returned true and SITL clamped the vehicle to the raised ground. Nothing warned about the mismatch at any point.

## What this PR does

Adds a one-shot GCS warning, sent as soon as terrain data at the home position becomes available and differs from `home.alt` by more than 10 metres (SRTM vertical error margin):

```
SIM: home.alt 0m vs SRTM 25m - ground mismatch
```

The warning lives in the SITL library only (`libraries/SITL/SIM_Aircraft.cpp`), so it applies to all simulated vehicle types and has **zero effect on production firmware** (no flash/RAM impact).

## Testing steps

- [x] `./waf configure --board sitl && ./waf copter` builds clean
- [x] New autotest `Copter.TerrainHomeAltMismatchWarning`: boots at the usual start location with a deliberately wrong `home.alt=0` (SRTM at CMAC is ~584m) and expects the warning once terrain data has loaded
- [x] flake8 clean on the modified autotest file

The test intentionally keeps the stock start lat/lng so existing cached terrain tiles are used, does not modify any parameters, and restores the home altitude in a `finally` block so subsequent tests are unaffected.

*This contribution was AI-assisted: the warning code, autotest and PR description were drafted with AI assistance and reviewed/verified by the human submitter.*