### PR TITLE
Rover: remove unused parameter member and non-functional RST_SWITCH_CH

### DIFF
--- a/Rover/Parameters.cpp
+++ b/Rover/Parameters.cpp
@@ -21,11 +21,7 @@ const AP_Param::Info Rover::var_info[] = {
     // @User: Advanced
     GSCALAR(log_bitmask,            "LOG_BITMASK",      DEFAULT_LOG_BITMASK),
 
-    // @Param: RST_SWITCH_CH
-    // @DisplayName: Reset Switch Channel
-    // @Description: RC channel to use to reset to last flight mode after geofence takeover.
-    // @User: Advanced
-    GSCALAR(reset_switch_chan,      "RST_SWITCH_CH",    0),
+    // RST_SWITCH_CH was here
 
     // @Param: INITIAL_MODE
     // @DisplayName: Initial driving mode

--- a/Rover/Parameters.h
+++ b/Rover/Parameters.h
@@ -41,7 +41,7 @@ public:
         //
         k_param_log_bitmask_old = 10,  // unused
         k_param_num_resets_old,         // unused
-        k_param_reset_switch_chan,
+        k_param_reset_switch_chan,  // unused
         k_param_initial_mode,
         k_param_scheduler,
         k_param_relay,
@@ -237,7 +237,6 @@ public:
     // Misc
     //
     AP_Int32    log_bitmask;
-    AP_Int8     reset_switch_chan;
     AP_Int8     initial_mode;
 
     // navigation parameters

--- a/Rover/Parameters.h
+++ b/Rover/Parameters.h
@@ -124,7 +124,7 @@ public:
         k_param_speed_cruise,
         k_param_speed_turn_gain,    // unused
         k_param_speed_turn_dist,    // unused
-        k_param_ch7_option,         // unused
+        k_param_ch7_option,         // unused as a parameter; key retained for the RC7_OPTION conversion
         k_param_auto_trigger_pin,
         k_param_auto_kickstart,
         k_param_turn_circle,  // unused
@@ -243,7 +243,6 @@ public:
     // navigation parameters
     //
     AP_Float    speed_cruise;
-    AP_Int8     ch7_option;
     AP_Int8     auto_trigger_pin;
     AP_Float    auto_kickstart;
     AP_Int16    gcs_pid_mask;


### PR DESCRIPTION
### Summary

Removes two dead things from Rover's parameters: a member bound to no parameter, and a documented user facing parameter that nothing reads. Unlike its companion #34213 these do change the binary, which is why they are split out here.

**AI-assistance disclosure (AGENTS.md):** this contribution was AI-assisted. I identified the dead code and take full responsibility for the change; the patches, commit messages and verification were prepared with Claude.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

`./waf rover` builds clean at both commits. Flash use on SITL goes from 4333790 to 4333710 bytes.

Rover parameter metadata was regenerated against master. The only difference is `Rover:RST_SWITCH_CH` going away; nothing else changes and nothing is added.

Both commits change the binary, deliberately, which is why they are not in #34213 (whose five commits are all byte identical). Neither changes behaviour: see each commit below for why.

Applies cleanly alongside #34213 in either order, verified with `git merge-tree` (no conflicts). The two PRs touch different regions of `Parameters.cpp` and, after this split, only this PR touches `Parameters.h`.

### Description

**1. `ch7_option` member.** One reference in the tree, its own declaration. It is not in var_info, so it is bound to no parameter and its value is never read. Removing it changes no stored parameter, since the old `CH7_OPTION` value is located by `k_param` index through `ConversionInfo` rather than through this member. It does change the binary: the `Parameters` struct shrinks by a byte and the members after it shift.

The `k_param_ch7_option` key is kept, with its comment corrected. It reads "unused", which is true of the parameter but not of the key: `load_parameters()` still passes it to `find_old_parameter()` to carry an old `CH7_OPTION` setting across to `RC7_OPTION`. Removing the enumerator would also renumber every key after it.

**2. `RST_SWITCH_CH` parameter.** Documented as "RC channel to use to reset to last flight mode after geofence takeover", but nothing reads it: `reset_switch_chan` has exactly two references in the tree, its declaration and its `GSCALAR`. The behaviour its description promises does not exist in Rover.

Plane has already been through this. It removed its own `RST_SWITCH_CH` in favour of the `MODE_SWITCH_RESET` RC auxiliary function and carries `{ k_param_reset_switch_chan, 0, AUX_FUNC::MODE_SWITCH_RESET }` in its `conversion_table[]`. `MODE_SWITCH_RESET` is handled only in `RC_Channel_Plane.cpp`; Rover has no handler, so there is nothing here to convert to and no behaviour to preserve.

Removed in the usual way, leaving a `// RST_SWITCH_CH was here` marker and keeping `k_param_reset_switch_chan` so the enumeration after it does not shift.

This is the one change in either PR that is visible to users: anyone who has `RST_SWITCH_CH` set will see it disappear. It was doing nothing, so nothing changes on the vehicle, but it is a parameter going away and wants a maintainer's eye rather than being folded into a dead-macro cleanup. The companion `RESET_SWITCH_CHAN_PWM` define, the other half of the same removed feature, is in #34213.

#### Noticed while here, not touched

`libraries/SITL/examples/SilentWings/Params/Rolladen-Schneider-LS8b.param` and `Schleicher-ASW27B.param` both still carry `RST_SWITCH_CH,0`. Those are Plane glider examples, so they have been referencing a parameter Plane itself no longer has for some time. Both set it to 0. Happy to clean those up separately if wanted.
