### PR TITLE
autotest: remove accel bias before CorrectedDeltaVelocity lands

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -16088,6 +16088,17 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         ).run()
         self.run_auxfunc(39, 0)  # disable precision loiter
 
+        # remove the accelerometer bias before landing: left in place,
+        # the land detector's filtered earth-frame acceleration sits
+        # exactly at LAND_DETECTOR_ACCEL_MAX (both are 1m/s/s), so
+        # whether landing is ever detected - and thus whether we ever
+        # disarm - hinges on noise:
+        self.set_parameters({
+            "SIM_ACC1_BIAS_X": 0,
+            "SIM_ACC2_BIAS_X": 0,
+            "SIM_ACC3_BIAS_X": 0,
+        })
+
         self.change_mode('LAND')
         self.wait_disarmed()
 


### PR DESCRIPTION
### Summary

Corrects land detection after CorrectedDeltaVelocity test; fixes flake https://github.com/ArduPilot/ardupilot/actions/runs/33283815264/job/99185820727?pr=34166


### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

The test flies with SIM_ACC*_BIAS_X of 1m/s/s - which is exactly LAND_DETECTOR_ACCEL_MAX.  With AHRS_EKF_TYPE 10 nothing corrects the bias out of get_accel_ef(), so on the ground the land detector's filtered acceleration sits precisely at its threshold and whether landing is ever detected - and thus whether we ever disarm - hinges on noise.  Incidental timing shifts (such as announcing ourselves to the vehicle on reconnect, which changes how much simulated time the post-reboot setup consumes) flip it from always-passing to always-failing on a given machine.

The bias has done its job by the time we land - the test's assertion is that precision loiter holds position despite it - so zero it before entering LAND.
