### PR TITLE
Tell the user when a safety switch is expected, and unify Copter's safety switch arming message

### DIFF
--- a/ArduCopter/AP_Arming_Copter.cpp
+++ b/ArduCopter/AP_Arming_Copter.cpp
@@ -638,9 +638,15 @@ bool AP_Arming_Copter::arm_checks(AP_Arming::Method method)
         }
     }
 
-    // check if safety switch has been pushed
+    // check if safety switch has been pushed. This deliberately does not take
+    // a Check bit, so clearing Check::SWITCH alone does not skip it: the
+    // outputs are physically inhibited while safety is on. Note that
+    // should_skip_all_checks() returns above, so clearing ARMING_CHECK
+    // entirely does still skip this gate. Use the same wording as
+    // AP_Arming::hardware_safety_check() so that a user who has skipped
+    // Check::SWITCH still recognises the message they were getting before
     if (hal.util->safety_switch_state() == AP_HAL::Util::SAFETY_DISARMED) {
-        check_failed(true, "Safety Switch");
+        check_failed(true, "Hardware safety switch");
         return false;
     }
 

--- a/libraries/AP_BoardConfig/AP_BoardConfig.h
+++ b/libraries/AP_BoardConfig/AP_BoardConfig.h
@@ -125,6 +125,15 @@ public:
         return uint32_t(state.ignore_safety_channels.get());
     }
 
+    // true if the board is configured to start up with safety engaged,
+    // i.e. the effective value of BRD_SAFETY_DEFLT. This says nothing
+    // about whether a safety switch is fitted, and nothing about the
+    // live safety state; it is the configured boot state, so it is safe
+    // to call before init_safety() has run
+    bool safety_enabled_at_boot(void) const {
+        return state.safety_enable != 0;
+    }
+
     uint32_t get_serial_number() const {
         return (uint32_t)vehicleSerialNumber.get();
     }

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -4835,6 +4835,21 @@ void GCS_MAVLINK::send_banner()
         send_text(MAV_SEVERITY_INFO, "%s", banner_msg);
     }
 
+    // tell the user when safety is engaged and still holding the outputs off.
+    // Otherwise the only indication is a pre-arm failure, so bench testing of
+    // servo directions and motors silently does nothing when the board is
+    // configured for a safety switch and none is fitted. Both conditions are
+    // needed: the configured boot state alone would nag on every board that
+    // has a switch fitted and pressed, and the live state alone would fire on
+    // BRD_SAFETY_DEFLT=0 boards, where the banner can be sent before
+    // init_safety() has forced safety off
+    const AP_BoardConfig *boardconfig = AP_BoardConfig::get_singleton();
+    if (boardconfig != nullptr &&
+        boardconfig->safety_enabled_at_boot() &&
+        hal.util->safety_switch_state() == AP_HAL::Util::SAFETY_DISARMED) {
+        send_text(MAV_SEVERITY_INFO, "Safety on: press switch or set BRD_SAFETY_DEFLT=0");
+    }
+
 #if AP_INERTIALSENSOR_ENABLED
     // output any fast sampling status messages
     for (uint8_t i = 0; i < INS_MAX_BACKENDS; i++) {


### PR DESCRIPTION
### Summary

Addresses fixes 1 and 2 from #34221: tell the user at boot when safety is engaged and holding the outputs off, and make Copter's safety switch arming failure use the same wording as the pre-arm check.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Tested in SITL on Copter, driving it over MAVLink with pymavlink and triggering the banner with a parameter-list request (which is one of the three `send_banner()` paths, see below):

| condition | result |
| --- | --- |
| `BRD_SAFETY_DEFLT=0` | no safety line in the banner |
| `BRD_SAFETY_DEFLT=1`, safety engaged | `Safety on: press switch or set BRD_SAFETY_DEFLT=0` |
| `BRD_SAFETY_DEFLT=1`, then the switch pressed | no safety line on the next banner |

`PreArm: Hardware safety switch` still appears as before, and with `ARMING_SKIPCHK` set to skip `Check::SWITCH` (bit 11) an arm attempt reports `Arm: Hardware safety switch` and still refuses to arm; the old `Arm: Safety Switch` string no longer appears.

Builds: SITL Copter and Plane, `sitl_periph_universal` AP_Periph, and CubeOrange Copter, all clean. Each of the three commits builds Copter independently. `Tools/scripts/check_branch_conventions.py` and `git diff --check` pass.

### Description

83 in-tree hwdefs declare a `SAFETY_IN` pin. Doing so sets the compiled default of `BRD_SAFETY_DEFLT` to 1 via `BOARD_SAFETY_ENABLE_DEFAULT` (`AP_BoardConfig.cpp:96-100`), so `safety_state` stays `SAFETY_DISARMED` and `RCOutput.cpp:735` zeroes every channel outside `BRD_SAFETY_MASK`. All but five of those boards leave that default in place.

A user who has not fitted a safety switch — increasingly common, as many GPS units no longer include one — therefore gets no PWM or DShot output at all. The problem is that nothing says so until they try to arm. Setting up a new board starts with bench work: check servo directions, run a motor test, calibrate ESCs. The servo direction checks and the motor test silently do nothing, because the only thing reporting the safety state is a **pre-arm** check that has not run yet. (ESC calibration is the exception — `ArduCopter/esc_calibration.cpp:174` prints "ESC calibration: Push safety switch" every 5s and blocks until it is pressed.) The natural conclusion from the silent cases is a dead board or bad wiring.

**Commits 1 and 2** add a boot banner line when the board is configured to come up with safety engaged **and** safety is still engaged. `GCS_MAVLINK::send_banner()` already carries exactly this class of non-pre-arm startup information — `IOMCU:`, the `RCOut:` output mode line, INS fast-sampling status — and is re-sent on every GCS connect.

Both conditions are needed:

- `send_banner()` is not only `MAV_CMD_DO_SEND_BANNER`. It also runs on a parameter list request (`GCS_Param.cpp:216`) and on the FTP `@PARAM/param.pck` path (`GCS_FTP.cpp:401`), so an ordinary GCS parameter download repeats it. Keying off the configured state alone would nag on every standard board that has a switch fitted and pressed.
- Keying off the live state alone fires spuriously on `BRD_SAFETY_DEFLT=0` boards, because `init_safety()` is deliberately deferred to the first loop iteration (`AP_Vehicle.cpp:593-602`) and the banner can be sent before it has called `force_safety_off()` — MAVLink is serviced during `setup()` via `scheduler_delay_callback()`. An earlier revision of this branch did exactly that and misfired in SITL.

The user this actually targets — configured on, no switch fitted — stays `SAFETY_DISARMED` indefinitely, since `board_init_safety()` leaves the state untouched when safety is enabled, so they keep being told.

`AP_BoardConfig::safety_enabled_at_boot()` reports the effective value of `BRD_SAFETY_DEFLT`. It deliberately makes no claim about a switch being fitted: the parameter can be set on a board with no switch, and cleared on a board that has one — the parameter docs explicitly permit the latter ("if a safety switch is fitted the user can still control the safety state after startup using the switch") — and a CAN-attached switch is a third case.

**Commit 3** addresses a second, smaller problem. When a user does hit `PreArm: Hardware safety switch`, it names hardware they do not have and the obvious response is to clear that check bit in `ARMING_SKIPCHK`. On Copter that silences the message completely — `check_enabled(Check::SWITCH)` at `AP_Arming.cpp:809` wraps the whole failure branch rather than sitting inside `check_failed()`, so even the usual `MAV_SEVERITY_DEBUG` demotion is skipped — but Copter still refuses to arm, via a second gate in `AP_Arming_Copter::arm_checks()` that carries no Check bit. The user had traded a continuous, correctly worded warning for silence plus a differently worded last-moment failure from another code path.

That gate carrying no Check bit is right — the outputs really are inhibited in hardware — so this just makes both sites use the same string and documents why. Note that it is not unconditional: `should_skip_all_checks()` returns earlier in `arm_checks()`, so clearing `ARMING_CHECK` entirely does still skip the gate, and `mandatory_checks()` contains no safety check. The comment now says so. No behavioural change beyond the message text; no autotest references either string.

Not addressed here, per discussion on #34221: Plane/Rover/Blimp will still arm with dead outputs if the user skips the check, and the affected-board audit (including the `JFB100` pull-up and two floating `SAFETY_IN` inputs) is left for separate PRs.
