### PR TITLE
fix: initialized `yaw_deltat` in AP_AHRS_DCM.cpp

### DIFF
--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -626,7 +626,7 @@ AP_AHRS_DCM::drift_correction_yaw(void)
 {
     bool new_value = false;
     float yaw_error;
-    float yaw_deltat;
+    float yaw_deltat = 0.0f;
 
     const AP_GPS &_gps = AP::gps();
 


### PR DESCRIPTION
### Summary

This commit initializes the variable `yaw_deltat` in the file `libraries/AP_AHRS/AP_AHRS_DCM.cpp`.
<!-- Put a one or two line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->
This commit initializes the variable `yaw_deltat` in the file `libraries/AP_AHRS/AP_AHRS_DCM.cpp` as 0, so those compiling the project no longer get the "uninitialized variable" error which stops compilation. Compilation still stops at a later error, which I plan to fix in a later PR.

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
