### PR TITLE
AP_GPS: fix out-of-bounds write in NMEA KSXT parser

### DIFF
--- a/libraries/AP_GPS/AP_GPS_NMEA.cpp
+++ b/libraries/AP_GPS/AP_GPS_NMEA.cpp
@@ -669,10 +669,16 @@ bool AP_GPS_NMEA::_term_complete()
             _phd.itow = strtoul(_term, nullptr, 10);
             break;
         case _GPS_SENTENCE_PHD + 6 ... _GPS_SENTENCE_PHD + 11: // PHD message, fields
-            _phd.fields[_term_number-6] = atol(_term);
+            // guard on the sentence type: _term_number is unbounded, so a longer
+            // sentence of another type can otherwise alias into this case range
+            if (_sentence_type == _GPS_SENTENCE_PHD) {
+                _phd.fields[_term_number-6] = atol(_term);
+            }
             break;
         case _GPS_SENTENCE_KSXT + 1 ... _GPS_SENTENCE_KSXT + 21: // KSXT message, fields (21 fields, indices 0..20)
-            _ksxt.fields[_term_number-1] = atof(_term);
+            if (_sentence_type == _GPS_SENTENCE_KSXT) {
+                _ksxt.fields[_term_number-1] = atof(_term);
+            }
             break;
 #if AP_GPS_NMEA_UNICORE_ENABLED
         case _GPS_SENTENCE_AGRICA + 1 ... _GPS_SENTENCE_AGRICA + 65: // AGRICA message

--- a/libraries/AP_GPS/AP_GPS_NMEA.cpp
+++ b/libraries/AP_GPS/AP_GPS_NMEA.cpp
@@ -671,7 +671,7 @@ bool AP_GPS_NMEA::_term_complete()
         case _GPS_SENTENCE_PHD + 6 ... _GPS_SENTENCE_PHD + 11: // PHD message, fields
             _phd.fields[_term_number-6] = atol(_term);
             break;
-        case _GPS_SENTENCE_KSXT + 1 ... _GPS_SENTENCE_KSXT + 22: // KSXT message, fields
+        case _GPS_SENTENCE_KSXT + 1 ... _GPS_SENTENCE_KSXT + 21: // KSXT message, fields (21 fields, indices 0..20)
             _ksxt.fields[_term_number-1] = atof(_term);
             break;
 #if AP_GPS_NMEA_UNICORE_ENABLED


### PR DESCRIPTION
Fixes #34136.

## Root cause

The KSXT field buffer in `AP_GPS_NMEA.h` is:

```cpp
struct {
    double fields[21];
} _ksxt;
```

Valid indices are 0..20, matching the 21 KSXT terms — the sentence-type enum says so explicitly (`_GPS_SENTENCE_KSXT = 170, // extension for Unicore, 21 fields`), and counting the example sentence in the header comment gives 21 fields.

But `_term_complete()` in `AP_GPS_NMEA.cpp` accepted terms 1..22:

```cpp
case _GPS_SENTENCE_KSXT + 1 ... _GPS_SENTENCE_KSXT + 22: // KSXT message, fields
    _ksxt.fields[_term_number-1] = atof(_term);
```

A KSXT sentence with a 22nd field drives `_term_number` to 22 and writes `_ksxt.fields[21]`. `_term_complete()` runs on the data term when `_decode()` reaches `*`, before the checksum term is validated, so a valid checksum is not required to reach the write.

## The wider problem

Narrowing that bound alone does not close the hole, as [@peterbarker pointed out in review](https://github.com/ArduPilot/ardupilot/pull/34224#issuecomment-5471915185). The switch dispatches on `_sentence_type + _term_number` but indexes with the raw `_term_number`, which is unbounded within a sentence, so one sentence type's term range aliases into another's case range. Confirmed against the enum values in `AP_GPS_NMEA.h` (`RMC = 32`, `PHD = 138`, `THS = 160`, `KSXT = 170`, `AGRICA = 193`):

- `THS + 22 == KSXT + 12 == 182`, inside the narrowed `KSXT + 1 ... KSXT + 21` range, writing `_ksxt.fields[21]` — the same byte this PR set out to protect.
- `RMC + 159 == KSXT + 21 == 191`, writing `_ksxt.fields[158]`.
- `RMC + 112..117` lands in the PHD case, writing `_phd.fields[106..111]` past an `int32_t[8]`.
- `KSXT + 24 == AGRICA + 1 == 194`, so an earlier claim in this description that AGRICA was "well clear of `170 + 22`" was wrong; it compared against a bound `_term_number` is not held to. That claim has been removed.

The value written is `atof()`/`atol()` of the term, so it is controlled by whatever arrives on the GPS UART, and as with the original case no valid checksum is required.

**How it presents:** the near cases are intra-object. `_ksxt` is followed by `_agrica` in the class, so `_ksxt.fields[21]` corrupts `_agrica` rather than leaving the allocation. Only the far aliasing indices (`_ksxt.fields[158]`, `_phd.fields[106..111]`) escape the 592-byte driver object — those are the ones a sanitizer can see.

## Fix

Narrow the KSXT case upper bound from `+ 22` to `+ 21`, **and** guard both indexed case ranges on the actual sentence type so aliased sentence types cannot reach them:

```cpp
case _GPS_SENTENCE_PHD + 6 ... _GPS_SENTENCE_PHD + 11: // PHD message, fields
    if (_sentence_type == _GPS_SENTENCE_PHD) {
        _phd.fields[_term_number-6] = atol(_term);
    }
    break;
case _GPS_SENTENCE_KSXT + 1 ... _GPS_SENTENCE_KSXT + 21: // KSXT message, fields
    if (_sentence_type == _GPS_SENTENCE_KSXT) {
        _ksxt.fields[_term_number-1] = atof(_term);
    }
    break;
```

The removed 22nd field is not read anywhere: the KSXT handler uses at most `fields[18]`, so no legitimate data path changes. The AGRICA/VERSIONA/UNIHEADINGA handlers switch on fixed term numbers rather than indexing an array by `_term_number`, so aliasing into them touches parse state only.

## Verification

Built and run under SITL — [full output here](https://github.com/ArduPilot/ardupilot/pull/34224#issuecomment-5473520233).

- **Normal operation:** SITL KSXT emitter (`SIM_GPS1_HDG 3`) with the guards gives `GPS_RAW_INT fix_type=3 sats=10 lat=376000000 lon=-1224000000 yaw=36000`. The populated yaw only reaches `state.gps_yaw` via `_ksxt.fields[4]`, so the guarded KSXT case is really being taken.
- **Red:** ASan SITL build, SITL emitter temporarily sending a 159-term `$GPRMC`, without the guards →
  `AddressSanitizer: heap-buffer-overflow ... WRITE of size 4 ... AP_GPS_NMEA.cpp:672`, `located 80 bytes after 592-byte region`, reached through `AP_GPS::update()` on a normal scheduler tick.
- **Green:** same build and same injected sentence with the guards → no AddressSanitizer error, vehicle continues running.

The first revision of this PR relied on a standalone AddressSanitizer reproduction instead. That was the wrong tool: it modelled the index arithmetic rather than the real `_sentence_type + _term_number` dispatch, so it could neither find the aliasing nor represent the original bug correctly (it made an intra-object corruption look like a heap overflow). It has been replaced by the SITL runs above.

Disclosure: prepared with the help of an AI code assistant; the SITL and sanitizer output linked above is from real runs.
