### PR TITLE
autotest: fly TestAutoSpeedFlaps' flap check at cruise, not full throttle

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -1217,8 +1217,14 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.set_parameter("FLAP_1_SPEED", 26)  # above typical cruise of ~22 m/s
         self.set_parameter("FLIGHT_OPTIONS", 1 << 15)  # enable FLAP_ACTUAL_SPEED
         self.change_mode("FBWA")
-        self.set_rc(3, 1700)
-        self.wait_airspeed(18, 24, timeout=30)  # confirm flying below new threshold
+        # cruise throttle, not full throttle: at 1700 the aircraft settles around
+        # 26.6m/s, *above* the FLAP_1_SPEED we just set, so the flaps deploy on the
+        # way up through 26 and retract again a few seconds later.  Both assertions
+        # below then only hold during that transient, and which side of the bound
+        # the first sample lands on decides the run.
+        self.set_rc(3, 1500)
+        # a settled airspeed below the threshold, not one passing through it:
+        self.wait_airspeed(18, 24, timeout=30, minimum_duration=5)
         self.wait_servo_channel_value(servo_ch, flap_1_pwm, epsilon=pwm_epsilon, timeout=15)
 
         self.progress("Flaps retract when FLAP_ACTUAL_SPEED option is disabled")


### PR DESCRIPTION
### Summary
g
Fix new TestAutoSpeedFlaps to check steady state rather than rely on sampling at a transient airspeed

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

The FLAP_ACTUAL_SPEED subtest sets FLAP_1_SPEED=26 "above typical cruise of ~22 m/s", then commands RC3=1700 - which is not cruise.  The aircraft settles at 26.6 m/s, *above* the threshold it just set, so the flaps deploy on the way up through 26 and retract again a few seconds later:

    t=52.9  airspeed 24.37  flap 1380 (deployed)
    t=55.4  airspeed 26.08  flap 1380
    t=56.2  airspeed 26.31  flap 1200 (retracted)
    t=59.6  airspeed 26.60  flap 1200  ... for the rest of the test

Both assertions can therefore only hold during that 3.3s transient, and wait_airspeed(18, 24) needs its first sample inside the ~0.3s the aircraft spends between 22 and 24 while accelerating at 7.7 m/s/s.  On a slower machine the first sample landed at 24.15 - 0.15 m/s late - and the test failed; on faster ones it landed at 23.2-23.4 and passed.  Every pass so far has been won on that transient, on a premise which is false at equilibrium.

Fly the subtest at cruise throttle instead, so measured airspeed settles below FLAP_1_SPEED and the flaps stay deployed, and require the airspeed to be *held* in the band rather than merely pass through it - so if a future change moves the settled speed back out of the band the test says so instead of quietly going back to sampling a transient.

Settled airspeed at RC3=1500, 6 runs: 22.4 - 22.8 m/s, 6/6 pass.
