### PR TITLE
AP_Notify: add NTF_LED_OPTIONS parameter

### DIFF
--- a/libraries/AP_Notify/AP_Notify.cpp
+++ b/libraries/AP_Notify/AP_Notify.cpp
@@ -208,6 +208,13 @@ const AP_Param::GroupInfo AP_Notify::var_info[] = {
     // @RebootRequired: True
     AP_GROUPINFO("LED_LEN", 9, AP_Notify, _led_len, NOTIFY_LED_LEN_DEFAULT),
 
+    // @Param: LED_OPTIONS
+    // @DisplayName: LED Options
+    // @Description: Additional options for the RGB LED output. Swap red and green adjusts the output channels for LEDs not following the conventional driver colour order. The option applies at once to all RGBLed-derived backends (board, DroneCAN, serial/NeoPixel and I2C LEDs); it does not reach OreoLED or the per-LED scripting interface.
+    // @Bitmask: 0:Swap red and green
+    // @User: Advanced
+    AP_GROUPINFO("LED_OPTIONS", 10, AP_Notify, _led_options, 0),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_Notify/AP_Notify.h
+++ b/libraries/AP_Notify/AP_Notify.h
@@ -114,6 +114,10 @@ public:
         UAVCAN                  = (1 << 2), // UAVCAN Alarm
     };
 
+    enum class LED_Option : uint8_t {
+        SwapRedGreen       = (1 << 0), // swap red and green output channels
+    };
+
     /// notify_flags_type - bitmask of notification flags
     struct notify_flags_and_values_type {
         bool initialising;        // true if initialising and the vehicle should not be moved
@@ -227,6 +231,9 @@ public:
     uint8_t get_buzz_volume() const  { return _buzzer_volume; }
     uint8_t get_led_len() const { return _led_len; }
     uint32_t get_led_type() const { return _led_type; }
+    bool led_option_enabled(LED_Option opt) const {
+        return (_led_options.get() & uint8_t(opt)) != 0;
+    }
     int8_t get_rgb_led_brightness_percent() const;
 
 #if CONFIG_HAL_BOARD == HAL_BOARD_SITL
@@ -250,6 +257,7 @@ private:
     AP_Int8 _oreo_theme;
     AP_Int8 _buzzer_pin;
     AP_Int32 _led_type;
+    AP_Int8 _led_options;
     AP_Int8 _buzzer_level;
     AP_Int8 _buzzer_volume;
     AP_Int8 _led_len;

--- a/libraries/AP_Notify/RGBLed.cpp
+++ b/libraries/AP_Notify/RGBLed.cpp
@@ -36,6 +36,12 @@ RGBLed::RGBLed(uint8_t led_off, uint8_t led_bright, uint8_t led_medium, uint8_t 
 // set_rgb - set color as a combination of red, green and blue values
 void RGBLed::_set_rgb(uint8_t red, uint8_t green, uint8_t blue)
 {
+    if (pNotify->led_option_enabled(AP_Notify::LED_Option::SwapRedGreen)) {
+        // swap red and green output channels for LEDs not following the conventional driver colour order
+        const uint8_t tmp = red;
+        red = green;
+        green = tmp;
+    }
     if (red != _red_curr ||
         green != _green_curr ||
         blue != _blue_curr) {


### PR DESCRIPTION
### Summary

Adds a `NTF_LED_OPTIONS` bitmask parameter whose first bit ("RGB not GRB") swaps the red and green LED output channels, for LEDs expecting RGB rather than GRB colour order. Fixes #34204

### Classification & Testing (check all that apply and add your own)

- [ ] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

**Testing description:** Built SITL Copter with the change and ran a behavioural test against the SITL LP5562 RGB LED simulation, observing the colours the LED driver writes (which is what an external LED on the wire would receive). With `NTF_LED_OPTIONS=0` the standard patterns were observed unchanged: armed-solid green `(r=0,g=255,b=0)`, blue while the EKF settled, yellow pre-arm flash. Setting bit 0 (`NTF_LED_OPTIONS=1`) made the same standard pattern colours be emitted on the red channel instead (armed pattern `(255,0,0)`, held 10s while armed), with blue unaffected. The swap is orthogonal to `NTF_LED_OVERRIDE`: with the MAVLink override source active, a red `LED_CONTROL` command was shown as green with the bit set and as red with the bit cleared; restoring the parameter to 0 resumed unswapped standard output. Automated assertions over the full change log (347 samples) passed. astyle dry-run reports no changes needed for the added lines, and `Tools/scripts/check_branch_conventions.py` passes on the branch.

### Description

The Navigator flight controller has a built-in GRB-ordered LED, and exposes that same LED data signal for external indicators. Many external LEDs are RGB-ordered, so a user connecting one sees red and green swapped compared to the onboard LED (see #34204 for the full description).

Per review, this PR adds a new `NTF_LED_OPTIONS` bitmask parameter rather than a new `NTF_LED_OVERRIDE` enum value, so the option is orthogonal to the colour source and doesn't create a cross-product if other options are added later. Bit 0 ("RGB not GRB") swaps the red and green output channels in `RGBLed::_set_rgb()`, which is the single funnel all colour output goes through - the standard sequences, OutbackChallenge, TrafficLight, and the MAVLink/scripting override all honour it. Default behaviour with `NTF_LED_OPTIONS=0` is unchanged, and no existing parameter values or indices are affected.

**AI disclosure:** This change was developed with AI assistance (an AI agent implemented the code, the SITL verification, and drafted this PR). The submitting author has reviewed the change, understands it, and takes full responsibility for it per ArduPilot's AI contribution guidelines.
