### PR TITLE
Copter: report the full navigation setpoint on both POSITION_TARGET messages

### DIFF
--- a/ArduCopter/GCS_MAVLink_Copter.cpp
+++ b/ArduCopter/GCS_MAVLink_Copter.cpp
@@ -106,73 +106,55 @@ void GCS_MAVLINK_Copter::send_attitude_target()
         thrust);                // Collective thrust, normalized to 0 .. 1
 }
 
-bool GCS_MAVLINK_Copter::get_target_location(Location &target) const
+bool GCS_MAVLINK_Copter::get_target(NavTarget &target) const
 {
-    return copter.flightmode->get_wp(target);
+    return copter.flightmode->get_target(target);
 }
 
 void GCS_MAVLINK_Copter::send_position_target_local_ned()
 {
-#if MODE_GUIDED_ENABLED
-    if (!copter.flightmode->in_guided_mode()) {
+    NavTarget target;
+    if (!get_target(target)) {
         return;
     }
 
-    const ModeGuided::SubMode guided_mode = copter.mode_guided.submode();
-    Vector3f target_pos_ned_m;
-    Vector3f target_vel_ned_ms;
-    Vector3f target_accel_ned_mss;
-    uint16_t type_mask = 0;
+    uint16_t type_mask = target.type_mask;
 
-    switch (guided_mode) {
-    case ModeGuided::SubMode::Angle:
-        // we don't have a local target when in angle mode
-        return;
-    case ModeGuided::SubMode::TakeOff:
-    case ModeGuided::SubMode::WP:
-    case ModeGuided::SubMode::Pos:
-        type_mask = POSITION_TARGET_TYPEMASK_VX_IGNORE | POSITION_TARGET_TYPEMASK_VY_IGNORE | POSITION_TARGET_TYPEMASK_VZ_IGNORE |
-                    POSITION_TARGET_TYPEMASK_AX_IGNORE | POSITION_TARGET_TYPEMASK_AY_IGNORE | POSITION_TARGET_TYPEMASK_AZ_IGNORE |
-                    POSITION_TARGET_TYPEMASK_YAW_IGNORE| POSITION_TARGET_TYPEMASK_YAW_RATE_IGNORE; // ignore everything except position
-        target_pos_ned_m = copter.mode_guided.get_target_pos_NED_m().tofloat();
-        break;
-    case ModeGuided::SubMode::PosVelAccel:
-        type_mask = POSITION_TARGET_TYPEMASK_YAW_IGNORE| POSITION_TARGET_TYPEMASK_YAW_RATE_IGNORE; // ignore everything except position, velocity & acceleration
-        target_pos_ned_m = copter.mode_guided.get_target_pos_NED_m().tofloat();
-        target_vel_ned_ms = copter.mode_guided.get_target_vel_NED_ms();
-        target_accel_ned_mss = copter.mode_guided.get_target_accel_NED_mss();
-        break;
-    case ModeGuided::SubMode::VelAccel:
-        type_mask = POSITION_TARGET_TYPEMASK_X_IGNORE | POSITION_TARGET_TYPEMASK_Y_IGNORE | POSITION_TARGET_TYPEMASK_Z_IGNORE |
-                    POSITION_TARGET_TYPEMASK_YAW_IGNORE| POSITION_TARGET_TYPEMASK_YAW_RATE_IGNORE; // ignore everything except velocity & acceleration
-        target_vel_ned_ms = copter.mode_guided.get_target_vel_NED_ms();
-        target_accel_ned_mss = copter.mode_guided.get_target_accel_NED_mss();
-        break;
-    case ModeGuided::SubMode::Accel:
-        type_mask = POSITION_TARGET_TYPEMASK_X_IGNORE | POSITION_TARGET_TYPEMASK_Y_IGNORE | POSITION_TARGET_TYPEMASK_Z_IGNORE |
-                    POSITION_TARGET_TYPEMASK_VX_IGNORE | POSITION_TARGET_TYPEMASK_VY_IGNORE | POSITION_TARGET_TYPEMASK_VZ_IGNORE |
-                    POSITION_TARGET_TYPEMASK_YAW_IGNORE| POSITION_TARGET_TYPEMASK_YAW_RATE_IGNORE; // ignore everything except velocity & acceleration
-        target_accel_ned_mss = copter.mode_guided.get_target_accel_NED_mss();
-        break;
+    // resolve the position to an offset from the EKF origin. If the target
+    // holds no position, or it cannot be resolved (no origin, or a
+    // terrain-frame target with no terrain data), report the rest with
+    // position ignored
+    Vector3p pos_ned_m;
+    if (!target.get_pos_NED_m(pos_ned_m)) {
+        pos_ned_m.zero();
+        type_mask |= POSITION_TARGET_TYPEMASK_X_IGNORE |
+                     POSITION_TARGET_TYPEMASK_Y_IGNORE |
+                     POSITION_TARGET_TYPEMASK_Z_IGNORE;
     }
+
+    if ((type_mask & NavTarget::ALL_IGNORE) == NavTarget::ALL_IGNORE) {
+        // nothing left to report
+        return;
+    }
+
+    const Vector3f target_pos_ned_m = pos_ned_m.tofloat();
 
     mavlink_msg_position_target_local_ned_send(
         chan,
         AP_HAL::millis(), // time boot ms
-        MAV_FRAME_LOCAL_NED, 
+        MAV_FRAME_LOCAL_NED,
         type_mask,
-        target_pos_ned_m.x,     // x in metres
-        target_pos_ned_m.y,     // y in metres
-        target_pos_ned_m.z,     // z in metres NED frame
-        target_vel_ned_ms.x,    // vx in m/s
-        target_vel_ned_ms.y,    // vy in m/s
-        target_vel_ned_ms.z,    // vz in m/s NED frame
-        target_accel_ned_mss.x, // afx in m/s/s
-        target_accel_ned_mss.y, // afy in m/s/s
-        target_accel_ned_mss.z, // afz in m/s/s NED frame
-        0.0f,                   // yaw
-        0.0f);                  // yaw_rate
-#endif
+        target_pos_ned_m.x,            // x in metres
+        target_pos_ned_m.y,            // y in metres
+        target_pos_ned_m.z,            // z in metres NED frame
+        target.vel_ned_ms.x,           // vx in m/s
+        target.vel_ned_ms.y,           // vy in m/s
+        target.vel_ned_ms.z,           // vz in m/s NED frame
+        target.accel_ned_mss.x,        // afx in m/s/s
+        target.accel_ned_mss.y,        // afy in m/s/s
+        target.accel_ned_mss.z,        // afz in m/s/s NED frame
+        target.yaw_rad,                // yaw in radians
+        target.yaw_rate_rads);         // yaw_rate in radians/second
 }
 
 void GCS_MAVLINK_Copter::send_nav_controller_output() const

--- a/ArduCopter/GCS_MAVLink_Copter.h
+++ b/ArduCopter/GCS_MAVLink_Copter.h
@@ -26,7 +26,7 @@ protected:
     MAV_RESULT _handle_command_preflight_calibration(const mavlink_command_int_t &packet, const mavlink_message_t &msg) override;
 
     void send_attitude_target() override;
-    bool get_target_location(Location &loc) const override;
+    bool get_target(NavTarget &target) const override;
     void send_position_target_local_ned() override;
 
     MAV_RESULT handle_command_do_set_roi(const Location &roi_loc) override;

--- a/ArduCopter/autoyaw.cpp
+++ b/ArduCopter/autoyaw.cpp
@@ -395,6 +395,50 @@ AC_AttitudeControl::HeadingCommand Mode::AutoYaw::get_heading()
     return heading;
 }
 
+// get_commanded_heading_rad - reports the most recently commanded yaw angle and
+// rate for GCS reporting, without the side effects of get_heading().
+// _yaw_angle_rad and _yaw_rate_rads are refreshed by get_heading() every
+// control loop, so the cached values are at most one loop old.
+void Mode::AutoYaw::get_commanded_heading_rad(float &yaw_angle_rad, float &yaw_rate_rads, bool &angle_valid, bool &rate_valid) const
+{
+    yaw_angle_rad = _yaw_angle_rad;
+    yaw_rate_rads = _yaw_rate_rads;
+
+    // This asks a different question from get_heading(), which reports how the
+    // attitude controller should be driven. Here we report only yaw that was
+    // asked for by a GCS or mission command, so the modes reached through
+    // set_mode_to_default() and those the vehicle picks for itself report
+    // nothing at all.
+    switch (_mode) {
+        case Mode::FIXED:
+        case Mode::ROI:
+            // an angle was commanded; both force the rate to zero
+            angle_valid = true;
+            rate_valid = false;
+            break;
+        case Mode::ANGLE_RATE:
+            angle_valid = true;
+            rate_valid = true;
+            break;
+        case Mode::RATE:
+            // a rate was commanded, the angle is only an echo of where we are
+            angle_valid = false;
+            rate_valid = true;
+            break;
+        case Mode::HOLD:
+        case Mode::LOOK_AT_NEXT_WP:
+        case Mode::LOOK_AHEAD:
+        case Mode::RESET_TO_ARMED_YAW:
+        case Mode::CIRCLE:
+        case Mode::PILOT_RATE:
+        case Mode::WEATHERVANE:
+            // the vehicle chose this heading, it is not a commanded setpoint
+            angle_valid = false;
+            rate_valid = false;
+            break;
+    }
+}
+
 // handle the interface to the weathervane library
 // pilot_yaw can be an angle or a rate or rcin from yaw channel. It just needs to represent a pilot's request to yaw the vehicle to enable pilot overrides.
 #if WEATHERVANE_ENABLED

--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -971,6 +971,69 @@ float Mode::throttle_hover() const
     return motors->get_throttle_hover();
 }
 
+// get_wp - convenience wrapper returning only the destination Location of the
+// setpoint reported by get_target()
+bool Mode::get_wp(Location &loc) const
+{
+    NavTarget target;
+    return get_target(target) && target.get_loc(loc);
+}
+
+// get_wpnav_target - fills target from wp_nav, for the modes that navigate
+// using it. Reports the destination as a Location because that is what
+// object avoidance produces; the NED form is derived on demand.
+bool Mode::get_wpnav_target(NavTarget &target, bool oa_destination) const
+{
+    Location loc;
+    if (oa_destination) {
+        if (!wp_nav->get_oa_wp_destination(loc)) {
+            return false;
+        }
+    } else if (!wp_nav->get_wp_destination_loc(loc)) {
+        return false;
+    }
+
+    target.loc = loc;
+    target.loc_valid = true;
+    target.type_mask &= ~(POSITION_TARGET_TYPEMASK_X_IGNORE |
+                          POSITION_TARGET_TYPEMASK_Y_IGNORE |
+                          POSITION_TARGET_TYPEMASK_Z_IGNORE);
+
+    // the velocity and acceleration along the path are only meaningful while
+    // the waypoint controller is actually running
+    Vector3f vel_ned_ms;
+    Vector3f accel_ned_mss;
+    if (wp_nav->get_wp_velocity_accel_NED(vel_ned_ms, accel_ned_mss)) {
+        target.vel_ned_ms = vel_ned_ms;
+        target.accel_ned_mss = accel_ned_mss;
+        target.type_mask &= ~(POSITION_TARGET_TYPEMASK_VX_IGNORE |
+                              POSITION_TARGET_TYPEMASK_VY_IGNORE |
+                              POSITION_TARGET_TYPEMASK_VZ_IGNORE |
+                              POSITION_TARGET_TYPEMASK_AX_IGNORE |
+                              POSITION_TARGET_TYPEMASK_AY_IGNORE |
+                              POSITION_TARGET_TYPEMASK_AZ_IGNORE);
+    }
+
+    get_auto_yaw_target(target);
+    return true;
+}
+
+// get_auto_yaw_target - fills target's yaw angle and rate from the shared
+// auto_yaw handler, clearing the mask bits for whichever of the two the
+// current yaw mode genuinely commands
+void Mode::get_auto_yaw_target(NavTarget &target) const
+{
+    bool angle_valid = false;
+    bool rate_valid = false;
+    auto_yaw.get_commanded_heading_rad(target.yaw_rad, target.yaw_rate_rads, angle_valid, rate_valid);
+    if (angle_valid) {
+        target.type_mask &= ~POSITION_TARGET_TYPEMASK_YAW_IGNORE;
+    }
+    if (rate_valid) {
+        target.type_mask &= ~POSITION_TARGET_TYPEMASK_YAW_RATE_IGNORE;
+    }
+}
+
 // transform pilot's manual throttle input to make hover throttle mid stick
 // used only for manual throttle modes
 // thr_mid should be in the range 0 to 1

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -168,7 +168,8 @@ public:
     virtual bool requires_terrain_failsafe() const { return false; }
 
     // functions for reporting to GCS
-    virtual bool get_wp(Location &loc) const { return false; };
+    virtual bool get_target(NavTarget &target) const { return false; }
+    bool get_wp(Location &loc) const;
     virtual float wp_bearing_deg() const { return 0; }
     virtual float wp_distance_m() const { return 0.0f; }
     virtual float crosstrack_error_m() const { return 0.0f;}
@@ -261,6 +262,15 @@ protected:
         Flying
     };
     AltHoldModeState get_alt_hold_state_D_ms(float target_climb_rate_ms);
+
+    // Fills target from wp_nav, for the modes that navigate using it.
+    // oa_destination selects the object-avoidance-adjusted destination.
+    // Returns false if wp_nav holds no valid destination.
+    bool get_wpnav_target(NavTarget &target, bool oa_destination) const;
+
+    // Fills target's yaw angle and rate, and clears the matching mask bits,
+    // from the shared auto_yaw handler.
+    void get_auto_yaw_target(NavTarget &target) const;
 
     // convenience references to avoid code churn in conversion:
     Parameters &g;
@@ -355,6 +365,14 @@ public:
 #endif
 
         AC_AttitudeControl::HeadingCommand get_heading();
+
+        // Reports the most recently commanded yaw angle and rate, as last
+        // calculated by get_heading(). angle_valid and rate_valid say which of
+        // the two the current yaw mode actually commands.
+        // Unlike get_heading(), this is read-only: it does not advance the
+        // fixed-yaw slew, sample the pilot's stick, or run the weathervane, so
+        // it is safe to call from a reporting path.
+        void get_commanded_heading_rad(float &yaw_angle_rad, float &yaw_rate_rads, bool &angle_valid, bool &rate_valid) const;
 
     private:
 
@@ -648,7 +666,7 @@ protected:
     float wp_distance_m() const override;
     float wp_bearing_deg() const override;
     float crosstrack_error_m() const override { return wp_nav->crosstrack_error_m();}
-    bool get_wp(Location &loc) const override;
+    bool get_target(NavTarget &target) const override;
 
 private:
 
@@ -1138,7 +1156,7 @@ public:
     void hold_position();
     bool set_pos_NED_m(const Vector3p& pos_ned_m, bool use_yaw = false, float yaw_rad = 0.0, bool use_yaw_rate = false, float yaw_rate_rads = 0.0, bool yaw_relative = false, bool is_terrain_alt = false);
     bool set_destination(const Location& dest_loc, bool use_yaw = false, float yaw_rad = 0.0, bool use_yaw_rate = false, float yaw_rate_rads = 0.0, bool yaw_relative = false);
-    bool get_wp(Location &loc) const override;
+    bool get_target(NavTarget &target) const override;
     void set_accel_NED_mss(const Vector3f& accel_ned_mss, bool use_yaw = false, float yaw_rad = 0.0, bool use_yaw_rate = false, float yaw_rate_rads = 0.0, bool yaw_relative = false, bool log_request = true);
     void set_vel_NED_ms(const Vector3f& vel_ned_ms, bool use_yaw = false, float yaw_rad = 0.0, bool use_yaw_rate = false, float yaw_rate_rads = 0.0, bool yaw_relative = false, bool log_request = true);
     void set_vel_accel_NED_m(const Vector3f& vel_ned_ms, const Vector3f& accel_ned_mss, bool use_yaw = false, float yaw_rad = 0.0, bool use_yaw_rate = false, float yaw_rate_rads = 0.0, bool yaw_relative = false, bool log_request = true);
@@ -1533,7 +1551,7 @@ public:
 #endif
 
     // for reporting to GCS
-    bool get_wp(Location &loc) const override;
+    bool get_target(NavTarget &target) const override;
 
     bool use_pilot_yaw() const override;
 
@@ -1683,7 +1701,7 @@ protected:
     const char *name4() const override { return "SRTL"; }
 
     // for reporting to GCS
-    bool get_wp(Location &loc) const override;
+    bool get_target(NavTarget &target) const override;
     float wp_distance_m() const override;
     float wp_bearing_deg() const override;
     float crosstrack_error_m() const override { return wp_nav->crosstrack_error_m();}
@@ -2018,11 +2036,17 @@ protected:
     const char *name4() const override { return "FOLL"; }
 
     // for reporting to GCS
-    bool get_wp(Location &loc) const override;
+    bool get_target(NavTarget &target) const override;
     float  wp_distance_m() const override;
     float wp_bearing_deg() const override;
 
     uint32_t last_log_ms;   // system time of last time desired velocity was logging
+
+    // heading commanded by the last run(); cached because this mode steers yaw
+    // itself rather than through auto_yaw, and the reporting path must not
+    // recompute it
+    float commanded_yaw_rad;
+    float commanded_yaw_rate_rads;
 };
 #endif
 

--- a/ArduCopter/mode_auto.cpp
+++ b/ArduCopter/mode_auto.cpp
@@ -947,18 +947,18 @@ float ModeAuto::wp_bearing_deg() const
     return degrees(wp_nav->get_wp_bearing_to_destination_rad());
 }
 
-bool ModeAuto::get_wp(Location& destination) const
+bool ModeAuto::get_target(NavTarget& target) const
 {
     switch (_mode) {
     case SubMode::NAVGUIDED:
-        return copter.mode_guided.get_wp(destination);
+        return copter.mode_guided.get_target(target);
     case SubMode::WP:
     case SubMode::CIRCLE_MOVE_TO_EDGE:
     case SubMode::CIRCLE:
         // the orbit and the move-to-edge leg are wp_nav legs like WP
-        return wp_nav->get_oa_wp_destination(destination);
+        return get_wpnav_target(target, true);
     case SubMode::RTL:
-        return copter.mode_rtl.get_wp(destination);
+        return copter.mode_rtl.get_target(target);
     default:
         return false;
     }

--- a/ArduCopter/mode_follow.cpp
+++ b/ArduCopter/mode_follow.cpp
@@ -143,6 +143,11 @@ void ModeFollow::run()
     pos_control->NE_update_controller();
     pos_control->D_update_controller();
 
+    // cache the commanded heading for GCS reporting; this mode steers yaw
+    // itself rather than through auto_yaw
+    commanded_yaw_rad = yaw_rad;
+    commanded_yaw_rate_rads = yaw_rate_rads;
+
     // call attitude controller
     attitude_control->input_thrust_vector_heading_rad(pos_control->get_thrust_vector(), yaw_rad, yaw_rate_rads);
 }
@@ -157,11 +162,28 @@ float ModeFollow::wp_bearing_deg() const
     return g2.follow.get_bearing_to_target_deg();
 }
 
-// Returns target location with offset applied, for MAVLink reporting
-bool ModeFollow::get_wp(Location &loc) const
+// Returns the setpoint being tracked, with the follow offset applied
+bool ModeFollow::get_target(NavTarget &target) const
 {
-    Vector3f vel_ned_ms;
-    return g2.follow.get_target_location_and_velocity_ofs(loc, vel_ned_ms);
+    // position, velocity and acceleration of the lead vehicle with the follow
+    // offset applied; this is the same triple run() feeds to the position
+    // controller, so it is the setpoint the vehicle is genuinely tracking
+    Vector3p pos_ofs_ned_m;
+    Vector3f vel_ofs_ned_ms;
+    Vector3f accel_ofs_ned_mss;
+    if (!g2.follow.get_ofs_pos_vel_accel_NED_m(pos_ofs_ned_m, vel_ofs_ned_ms, accel_ofs_ned_mss)) {
+        return false;
+    }
+
+    target.pos_ned_m = pos_ofs_ned_m;
+    target.pos_ned_valid = true;
+    target.vel_ned_ms = vel_ofs_ned_ms;
+    target.accel_ned_mss = accel_ofs_ned_mss;
+    target.yaw_rad = commanded_yaw_rad;
+    target.yaw_rate_rads = commanded_yaw_rate_rads;
+    target.type_mask = 0;
+
+    return true;
 }
 
 #endif // MODE_FOLLOW_ENABLED

--- a/ArduCopter/mode_guided.cpp
+++ b/ArduCopter/mode_guided.cpp
@@ -441,23 +441,59 @@ bool ModeGuided::set_pos_NED_m(const Vector3p& pos_ned_m, bool use_yaw, float ya
     return true;
 }
 
-bool ModeGuided::get_wp(Location& destination) const
+bool ModeGuided::get_target(NavTarget& target) const
 {
+    // the position, velocity and acceleration targets are only meaningful in
+    // the submodes that actually command them; pos_control_run() zeroes the
+    // velocity and acceleration targets every loop, so reporting them outside
+    // those submodes would claim a commanded zero that is not commanded at all
     switch (guided_mode) {
+
     case SubMode::WP:
-        return wp_nav->get_oa_wp_destination(destination);
+        return get_wpnav_target(target, true);
+
     case SubMode::Pos:
-        destination = Location::from_ekf_offset_NED_m(guided_pos_target_ned_m, guided_is_terrain_alt ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN);
-        return true;
+        // reported in the NED form the submode natively holds, avoiding a
+        // conversion that silently yields a lat/lng of zero with no EKF origin
+        target.pos_ned_m = get_target_pos_NED_m();
+        target.pos_ned_valid = true;
+        target.is_terrain_alt = guided_is_terrain_alt;
+        target.type_mask &= ~(POSITION_TARGET_TYPEMASK_X_IGNORE |
+                              POSITION_TARGET_TYPEMASK_Y_IGNORE |
+                              POSITION_TARGET_TYPEMASK_Z_IGNORE);
+        break;
+
+    case SubMode::PosVelAccel:
+        target.pos_ned_m = get_target_pos_NED_m();
+        target.pos_ned_valid = true;
+        target.is_terrain_alt = guided_is_terrain_alt;
+        target.type_mask &= ~(POSITION_TARGET_TYPEMASK_X_IGNORE |
+                              POSITION_TARGET_TYPEMASK_Y_IGNORE |
+                              POSITION_TARGET_TYPEMASK_Z_IGNORE);
+        FALLTHROUGH;
+
+    case SubMode::VelAccel:
+        target.vel_ned_ms = get_target_vel_NED_ms();
+        target.type_mask &= ~(POSITION_TARGET_TYPEMASK_VX_IGNORE |
+                              POSITION_TARGET_TYPEMASK_VY_IGNORE |
+                              POSITION_TARGET_TYPEMASK_VZ_IGNORE);
+        FALLTHROUGH;
+
+    case SubMode::Accel:
+        target.accel_ned_mss = get_target_accel_NED_mss();
+        target.type_mask &= ~(POSITION_TARGET_TYPEMASK_AX_IGNORE |
+                              POSITION_TARGET_TYPEMASK_AY_IGNORE |
+                              POSITION_TARGET_TYPEMASK_AZ_IGNORE);
+        break;
+
     case SubMode::Angle:
     case SubMode::TakeOff:
-    case SubMode::Accel:
-    case SubMode::VelAccel:
-    case SubMode::PosVelAccel:
-        break;
+        // no navigation target to report
+        return false;
     }
 
-    return false;
+    get_auto_yaw_target(target);
+    return true;
 }
 
 // sets guided mode's target from a Location object

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -581,7 +581,7 @@ void ModeRTL::compute_return_target()
     rtl_path.return_target.alt = MAX(rtl_path.return_target.alt, curr_alt_m * 100.0);
 }
 
-bool ModeRTL::get_wp(Location& destination) const
+bool ModeRTL::get_target(NavTarget& target) const
 {
     // provide target in states which use wp_nav
     switch (_state) {
@@ -590,7 +590,7 @@ bool ModeRTL::get_wp(Location& destination) const
     case SubMode::RETURN_HOME:
     case SubMode::LOITER_AT_HOME:
     case SubMode::FINAL_DESCENT:
-        return wp_nav->get_oa_wp_destination(destination);
+        return get_wpnav_target(target, true);
     case SubMode::LAND:
         return false;
     }

--- a/ArduCopter/mode_smart_rtl.cpp
+++ b/ArduCopter/mode_smart_rtl.cpp
@@ -185,7 +185,7 @@ void ModeSmartRTL::save_position()
     copter.g2.smart_rtl.update(copter.position_ok(), should_save_position);
 }
 
-bool ModeSmartRTL::get_wp(Location& destination) const
+bool ModeSmartRTL::get_target(NavTarget& target) const
 {
     // provide target in states which use wp_nav
     switch (smart_rtl_state) {
@@ -193,7 +193,7 @@ bool ModeSmartRTL::get_wp(Location& destination) const
     case SubMode::PATH_FOLLOW:
     case SubMode::PRELAND_POSITION:
     case SubMode::DESCEND:
-        return wp_nav->get_wp_destination_loc(destination);
+        return get_wpnav_target(target, false);
     case SubMode::LAND:
         return false;
     }

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -422,6 +422,10 @@ public:
     // Sets desired horizontal acceleration in m/s².
     void set_accel_desired_NE_mss(const Vector2f &accel_desired_ne_mss) { _accel_desired_ned_mss.xy() = accel_desired_ne_mss; }
 
+    // Returns desired NED acceleration in m/s². This is the trajectory
+    // feed-forward, excluding the correction applied by the controller.
+    const Vector3f& get_accel_desired_NED_mss() const { return _accel_desired_ned_mss; }
+
     // Returns target NED acceleration in m/s².
     const Vector3f& get_accel_target_NED_mss() const { return _accel_target_ned_mss; }
 

--- a/libraries/AC_WPNav/AC_WPNav.cpp
+++ b/libraries/AC_WPNav/AC_WPNav.cpp
@@ -367,6 +367,23 @@ bool AC_WPNav::get_wp_destination_loc(Location& destination) const
     return true;
 }
 
+/// get_wp_velocity_accel_NED - gets the current target velocity and acceleration
+///     along the path, in the NED frame in m/s and m/s/s
+///     returns false if the waypoint controller is not currently running
+bool AC_WPNav::get_wp_velocity_accel_NED(Vector3f& vel_ned_ms, Vector3f& accel_ned_mss) const
+{
+    if (!is_active()) {
+        return false;
+    }
+
+    // the desired values are the trajectory feed-forward and already exclude
+    // the position controller's offsets, which it adds back when forming the
+    // target, so they describe the demand along the path itself
+    vel_ned_ms = _pos_control.get_vel_desired_NED_ms();
+    accel_ned_mss = _pos_control.get_accel_desired_NED_mss();
+    return true;
+}
+
 // Sets waypoint destination using NEU position vector in centimeters from EKF origin.
 // See set_wp_destination_NED_m() for full details.
 bool AC_WPNav::set_wp_destination_NEU_cm(const Vector3f& destination_neu_cm, bool is_terrain_alt)

--- a/libraries/AC_WPNav/AC_WPNav.h
+++ b/libraries/AC_WPNav/AC_WPNav.h
@@ -185,6 +185,12 @@ public:
     // Used to unify the AC_WPNav and AC_WPNav_OA interfaces.
     virtual bool get_oa_wp_destination(Location& destination) const { return get_wp_destination_loc(destination); }
 
+    // Gets the current target velocity and acceleration along the path, in the
+    // NED frame in m/s and m/s/s. Both exclude the position controller's
+    // offsets, so they describe progress along the path itself.
+    // Returns false if the waypoint controller is not currently running.
+    bool get_wp_velocity_accel_NED(Vector3f& vel_ned_ms, Vector3f& accel_ned_mss) const;
+
     // Sets waypoint destination using NEU position vector in centimeters from EKF origin.
     // See set_wp_destination_NED_m() for full details.
     virtual bool set_wp_destination_NEU_cm(const Vector3f& destination_neu_cm, bool is_terrain_alt = false);

--- a/libraries/GCS_MAVLink/GCS.h
+++ b/libraries/GCS_MAVLink/GCS.h
@@ -11,6 +11,7 @@
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Common/AP_Common.h>
 #include "GCS_MAVLink.h"
+#include <AP_Math/AP_Math.h>
 #include <AP_Mission/AP_Mission.h>
 #include <stdint.h>
 #include "MAVLink_routing.h"
@@ -99,6 +100,36 @@ bool check_payload_size(mavlink_channel_t chan, uint16_t max_payload_len);
         return (subclass_name *)_chan[ofs];                        \
     }
 
+
+// The navigation setpoint a vehicle is commanding. Single source behind both
+// POSITION_TARGET_GLOBAL_INT and POSITION_TARGET_LOCAL_NED, so the two always
+// describe the same setpoint sampled at the same instant.
+struct NavTarget {
+
+    static const uint16_t ALL_IGNORE = 0x0DFF;  // all ignore bits, not FORCE_SET
+
+    // Position is held in whichever form the vehicle has. Converting needs a
+    // valid EKF origin, so it is done on demand by the accessors below.
+    Location loc;
+    Vector3p pos_ned_m;
+    bool loc_valid = false;
+    bool pos_ned_valid = false;
+    bool is_terrain_alt = false;
+
+    Vector3f vel_ned_ms;
+    Vector3f accel_ned_mss;
+    float yaw_rad = 0.0;
+    float yaw_rate_rads = 0.0;
+
+    // POSITION_TARGET_TYPEMASK bits: a SET bit means that dimension is NOT
+    // commanded. Starts fully ignored; the vehicle clears what it commands.
+    uint16_t type_mask = ALL_IGNORE;
+
+    // Both return false if the position cannot be produced in the form asked
+    // for, which needs a valid EKF origin and, for terrain frames, terrain data.
+    bool get_loc(Location &ret) const;
+    bool get_pos_NED_m(Vector3p &ret) const;
+};
 
 #if HAL_MAVLINK_INTERVALS_FROM_FILES_ENABLED
 class DefaultIntervalsFromFiles
@@ -383,9 +414,15 @@ public:
     void send_gps_global_origin() const;
     virtual void send_attitude_target() {};
     void send_position_target_global_int();
+    // returns the navigation setpoint the vehicle is currently commanding,
+    // including which of its dimensions are actually being commanded
+    virtual bool get_target(NavTarget &target) const { return false; }
     // returns a Location to which the vehicle is currently heading,
     // or would head to in an autonomous mode
-    virtual bool get_target_location(Location &loc) const { return false; }
+    virtual bool get_target_location(Location &loc) const {
+        NavTarget target;
+        return get_target(target) && target.get_loc(loc);
+    }
     virtual void send_position_target_local_ned() { };
     void send_servo_output_raw();
     void send_accelcal_vehicle_position(uint32_t position);

--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -6375,42 +6375,120 @@ void GCS_MAVLINK::send_set_position_target_global_int(uint8_t target_system, uin
             0,0);   // yaw, yaw_rate
 }
 
+// Returns the target as a Location, deriving it from pos_ned_m if the vehicle
+// supplied only the NED form.
+bool NavTarget::get_loc(Location &ret) const
+{
+    if (loc_valid) {
+        ret = loc;
+        return true;
+    }
+
+#if AP_AHRS_ENABLED
+    if (!pos_ned_valid) {
+        return false;
+    }
+
+    // Location::from_ekf_offset_NED_m() has no failure path: without an EKF
+    // origin it silently yields lat/lng of zero with a non-zero altitude, so
+    // check for the origin first.
+    Location origin;
+    if (!AP::ahrs().get_origin(origin)) {
+        return false;
+    }
+
+    ret = Location::from_ekf_offset_NED_m(pos_ned_m, is_terrain_alt ? Location::AltFrame::ABOVE_TERRAIN : Location::AltFrame::ABOVE_ORIGIN);
+    return true;
+#else
+    return false;
+#endif  // AP_AHRS_ENABLED
+}
+
+// Returns the target as a NED offset from the EKF origin in metres, deriving
+// it from loc if the vehicle supplied only a Location.
+bool NavTarget::get_pos_NED_m(Vector3p &ret) const
+{
+    if (is_terrain_alt) {
+        // the altitude is relative to terrain, which cannot be expressed as an
+        // offset from the EKF origin without resolving the terrain height
+        return false;
+    }
+
+    if (pos_ned_valid) {
+        ret = pos_ned_m;
+        return true;
+    }
+
+#if AP_AHRS_ENABLED
+    if (!loc_valid) {
+        return false;
+    }
+
+    // fails without an EKF origin, or when a terrain-frame location cannot be
+    // resolved against the terrain database
+    return loc.get_vector_from_origin_NED_m(ret);
+#else
+    return false;
+#endif  // AP_AHRS_ENABLED
+}
+
 void GCS_MAVLINK::send_position_target_global_int()
 {
-    Location target;
-    if (!get_target_location(target)) {
-        return;
+    NavTarget target;
+    if (!get_target(target)) {
+        // vehicles that report only a destination implement get_target_location
+        // instead; report that as a position-only setpoint
+        Location loc;
+        if (!get_target_location(loc)) {
+            return;
+        }
+        target.loc = loc;
+        target.loc_valid = true;
+        target.type_mask &= ~(POSITION_TARGET_TYPEMASK_X_IGNORE |
+                              POSITION_TARGET_TYPEMASK_Y_IGNORE |
+                              POSITION_TARGET_TYPEMASK_Z_IGNORE);
     }
-    if (!target.initialised()) {
-        return;
-    }
-    float alt_amsl_m;
-    if (!target.get_alt_m(Location::AltFrame::ABSOLUTE, alt_amsl_m)) {
-        return;
-    }
+
+    // ArduPilot has long set the undefined top nibble of the mask on this
+    // message; keep doing so here (POSITION_TARGET_LOCAL_NED never has)
     static constexpr uint16_t POSITION_TARGET_TYPEMASK_LAST_BYTE = 0xF000;
-    static constexpr uint16_t TYPE_MASK =
-        POSITION_TARGET_TYPEMASK_VX_IGNORE | POSITION_TARGET_TYPEMASK_VY_IGNORE |
-        POSITION_TARGET_TYPEMASK_VZ_IGNORE | POSITION_TARGET_TYPEMASK_AX_IGNORE |
-        POSITION_TARGET_TYPEMASK_AY_IGNORE | POSITION_TARGET_TYPEMASK_AZ_IGNORE |
-        POSITION_TARGET_TYPEMASK_YAW_IGNORE | POSITION_TARGET_TYPEMASK_YAW_RATE_IGNORE |
-        POSITION_TARGET_TYPEMASK_LAST_BYTE;
+    uint16_t type_mask = target.type_mask | POSITION_TARGET_TYPEMASK_LAST_BYTE;
+
+    // resolve the position to a global Location. If the target holds no
+    // position, or it cannot be resolved, report the rest with position ignored
+    Location loc;
+    float alt_amsl_m = 0.0;
+    if (!target.get_loc(loc) ||
+        !loc.initialised() ||
+        !loc.get_alt_m(Location::AltFrame::ABSOLUTE, alt_amsl_m)) {
+        loc = Location{};
+        alt_amsl_m = 0.0;
+        type_mask |= POSITION_TARGET_TYPEMASK_X_IGNORE |
+                     POSITION_TARGET_TYPEMASK_Y_IGNORE |
+                     POSITION_TARGET_TYPEMASK_Z_IGNORE;
+    }
+
+    if ((type_mask & NavTarget::ALL_IGNORE) == NavTarget::ALL_IGNORE) {
+        // nothing left to report
+        return;
+    }
+
     mavlink_msg_position_target_global_int_send(
         chan,
         AP_HAL::millis(), // time_boot_ms
         MAV_FRAME_GLOBAL, // targets are always global altitude
-        TYPE_MASK, // ignore everything except the x/y/z components
-        target.lat, // latitude as 1e7
-        target.lng, // longitude as 1e7
+        type_mask, // which of the dimensions below are actually being commanded
+        loc.lat, // latitude as 1e7
+        loc.lng, // longitude as 1e7
         alt_amsl_m, // altitude AMSL in metres
-        0.0f, // vx
-        0.0f, // vy
-        0.0f, // vz
-        0.0f, // afx
-        0.0f, // afy
-        0.0f, // afz
-        0.0f, // yaw
-        0.0f); // yaw_rate
+        target.vel_ned_ms.x, // vx in m/s
+        target.vel_ned_ms.y, // vy in m/s
+        target.vel_ned_ms.z, // vz in m/s NED frame
+        target.accel_ned_mss.x, // afx in m/s/s
+        target.accel_ned_mss.y, // afy in m/s/s
+        target.accel_ned_mss.z, // afz in m/s/s NED frame
+        target.yaw_rad, // yaw in radians
+        target.yaw_rate_rads); // yaw_rate in radians/second
 }
 
 #if HAL_GENERATOR_ENABLED


### PR DESCRIPTION
### Summary

POSITION_TARGET_GLOBAL_INT reported only a position, with velocity, acceleration, yaw and yaw rate hardcoded to zero and permanently masked as ignored. Both POSITION_TARGET messages now report the whole setpoint from a single accessor, so they can no longer disagree with each other.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Adds NavTarget, carrying the position, velocity, acceleration, yaw and yaw rate a vehicle is commanding along with the MAVLink type_mask saying which of those are real, and a single get_target() accessor returning it. The mask becomes data supplied by the mode rather than a constant assembled by the sender, and the whole setpoint is sampled in one call.

POSITION_TARGET_LOCAL_NED now fills from that same accessor, replacing its own per-submode type_mask switch. Each mode reports only what it genuinely commands, so a GCS is no longer told an uncommanded dimension is being held at zero.

Behaviour changes worth noting:

Message 85 is no longer Guided-only; any mode reporting a target now emits it.
Message 87 is now sent in Guided velocity and acceleration submodes with position ignored, where it was previously suppressed entirely.
Guided's Pos submode reports its native NED target instead of converting to a Location. Location::from_ekf_offset_NED_m() has no failure path, so without an EKF origin it silently produced a lat/lng of zero with a non-zero altitude, which Location::initialised() does not catch.
AutoYaw gains a const accessor for the commanded heading; get_heading() cannot be used from a reporting path because it advances the fixed-yaw slew, samples the pilot's stick, can change yaw mode and runs the weathervane. Vehicles that report only a destination keep implementing get_target_location() and the sender falls back to it, so Plane, Rover, Sub and Blimp are unaffected.
