### PR TITLE
AP_Math: fix tests on SITL that need DEBUG

### DIFF
--- a/libraries/AP_Math/tests/test_math.cpp
+++ b/libraries/AP_Math/tests/test_math.cpp
@@ -83,13 +83,13 @@ TEST(VectorTest, Rotations)
     TEST_ROTATION(ROTATION_ROLL_315, 1, SQRT_2, 0);
     EXPECT_EQ(ROTATION_MAX, rotation_count) << "All rotations are expect to be tested";
 
-#if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
-    TEST_ROTATION(ROTATION_CUSTOM_OLD, 1, 1, 1);
-    TEST_ROTATION(ROTATION_MAX, 1, 1, 1);
-#elif CONFIG_HAL_BOARD == HAL_BOARD_SITL
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL && defined(HAL_DEBUG_BUILD)
     Vector3F v {1, 1, 1};
     EXPECT_EXIT(v.rotate(ROTATION_CUSTOM_OLD), testing::KilledBySignal(SIGABRT), "AP_InternalError::error_t::bad_rotation");
     EXPECT_EXIT(v.rotate(ROTATION_MAX), testing::KilledBySignal(SIGABRT), "AP_InternalError::error_t::bad_rotation");
+#else
+    TEST_ROTATION(ROTATION_CUSTOM_OLD, 1, 1, 1);
+    TEST_ROTATION(ROTATION_MAX, 1, 1, 1);
 #endif
 }
 
@@ -388,12 +388,12 @@ TEST(MathTest, Constrain)
     EXPECT_EQ(10,    constrain_int32( 0xFFFFFFFFU, 10U, 1200U));
     EXPECT_EQ(1200U, constrain_uint32(0xFFFFFFFFU, 10U, 1200U));
 
-#if CONFIG_HAL_BOARD == HAL_BOARD_LINUX
-    EXPECT_EQ(1.0f, constrain_float(nanf("0x4152"), 1.0f, 1.0f));
-    EXPECT_EQ(1.0f, constrain_value(nanf("0x4152"), 1.0f, 1.0f));
-#elif CONFIG_HAL_BOARD == HAL_BOARD_SITL
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL && defined(HAL_DEBUG_BUILD)
     EXPECT_EXIT(constrain_float(nanf("0x4152"), 1.0f, 1.0f), testing::KilledBySignal(SIGABRT), "AP_InternalError::error_t::cnstring_nan");
     EXPECT_EXIT(constrain_value(nanf("0x4152"), 1.0f, 1.0f), testing::KilledBySignal(SIGABRT), "AP_InternalError::error_t::cnstring_nan");
+#else
+    EXPECT_EQ(1.0f, constrain_float(nanf("0x4152"), 1.0f, 1.0f));
+    EXPECT_EQ(1.0f, constrain_value(nanf("0x4152"), 1.0f, 1.0f));
 #endif
 }
 


### PR DESCRIPTION
### Summary

AP_InternalError::error_t is only output on SITL when in DEBUG  !
fix both tests missing it

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
