### PR TITLE
Tests div1000 improve

### DIFF
--- a/Tools/CPUInfo/CPUInfo.cpp
+++ b/Tools/CPUInfo/CPUInfo.cpp
@@ -213,22 +213,77 @@ static void show_timings(void)
     TIMEIT("SEM", { WITH_SEMAPHORE(sem); v_out_32 += v_32;}, 100);
 }
 
+static void div1000_check(uint64_t v)
+{
+    const uint64_t v1 = v / 1000ULL;
+    const uint64_t v2 = uint64_div1000(v);
+    if (v1 != v2) {
+        AP_HAL::panic("ERROR: 0x%llx v1=0x%llx v2=0x%llx",
+                      (unsigned long long)v, (unsigned long long)v1, (unsigned long long)v2);
+    }
+}
+
+/*
+  Uniform random 64-bit values are all enormous - millions of draws
+  produce nothing below 2^35 - so on their own they never exercise the
+  range this board's clock actually runs in, which stays under 2^35
+  for the first 9.5 hours of uptime.  Cover that range and the
+  algorithm's boundaries explicitly before the random sweep below.
+  MathTest.div1000_structured makes the same argument at length.
+ */
+static void test_div1000_structured(void)
+{
+    // the sub-second range, densely: covers zero and every
+    // 1000-boundary and pre-shift window within it
+    for (uint64_t v = 0; v < 200000ULL; v++) {
+        div1000_check(v);
+    }
+
+    // top of the range
+    for (uint64_t i = 0; i < 20000ULL; i++) {
+        div1000_check(UINT64_MAX - i);
+    }
+
+    // powers of two and their neighbourhoods: 2^32 is where a_lo
+    // overflows, 2^35 where a_hi stops being zero
+    for (uint8_t bit = 0; bit < 64; bit++) {
+        const uint64_t p = 1ULL << bit;
+        for (int8_t d = -9; d <= 9; d++) {
+            if (d < 0 && p < (uint64_t)(-d)) {
+                continue;
+            }
+            div1000_check(p + d);
+        }
+    }
+
+    // instants this board's microsecond clock passes through
+    static const uint64_t instants[] = {
+        1000ULL,              // 1 ms
+        1000000ULL,           // 1 s
+        3600000000ULL,        // 1 hour
+        34359738368ULL,       // 2^35 us, ~9.5 hours
+        86400000000ULL,       // 1 day
+        4294967296000ULL,     // 2^32 ms, where a 32-bit millis wraps
+        31536000000000ULL,    // 1 year
+    };
+    for (uint8_t i = 0; i < ARRAY_SIZE(instants); i++) {
+        for (int8_t d = -8; d <= 8; d++) {
+            div1000_check(instants[i] + d);
+        }
+    }
+}
+
 static void test_div1000(void)
 {
     hal.console->printf("Testing div1000\n");
+    test_div1000_structured();
     for (uint32_t i=0; i<2000000; i++) {
         uint64_t v = 0;
         if (!hal.util->get_random_vals((uint8_t*)&v, sizeof(v))) {
             AP_HAL::panic("ERROR: div1000 no random");
             break;
         }
-        uint64_t v1 = v / 1000ULL;
-        uint64_t v2 = uint64_div1000(v);
-        if (v1 != v2) {
-            AP_HAL::panic("ERROR: 0x%llx v1=0x%llx v2=0x%llx",
-                          (unsigned long long)v, (unsigned long long)v1, (unsigned long long)v2);
-            return;
-        }
+        div1000_check(v);
     }
 #if CONFIG_HAL_BOARD == HAL_BOARD_CHIBIOS
     // test from locked context

--- a/libraries/AP_Math/tests/test_math.cpp
+++ b/libraries/AP_Math/tests/test_math.cpp
@@ -719,6 +719,92 @@ TEST(MathTest, div1000)
     }
 }
 
+/*
+  Uniform random 64-bit values are all enormous - millions of draws
+  produce nothing below 2^35 - so on their own they never exercise the
+  range this board's clock actually runs in, which stays under 2^35
+  for the first 9.5 hours of uptime.  Cover that range and the
+  algorithm's boundaries explicitly before the random sweep below.
+  MathTest.div1000_structured makes the same argument at length.
+ */
+TEST(MathTest, div1000_structured)
+{
+    // exhaustive over the sub-second range: covers zero, every
+    // 1000-boundary and every pre-shift window within it
+    for (uint64_t v = 0; v < 1000000ULL; v++) {
+        ASSERT_EQ(v / 1000ULL, uint64_div1000(v)) << "v=" << v;
+    }
+
+    // the top of the range, where the 64-bit product is widest
+    for (uint64_t i = 0; i < 100000ULL; i++) {
+        const uint64_t v = UINT64_MAX - i;
+        ASSERT_EQ(v / 1000ULL, uint64_div1000(v)) << "v=" << v;
+    }
+
+    // every power of two and its neighbourhood: 2^32 and 2^35 are
+    // where a_lo overflows and where a_hi stops being zero
+    for (unsigned bit = 0; bit < 64; bit++) {
+        const uint64_t p = 1ULL << bit;
+        for (int d = -9; d <= 9; d++) {
+            if (d < 0 && p < (uint64_t)(-d)) {
+                continue;
+            }
+            const uint64_t v = p + d;
+            ASSERT_EQ(v / 1000ULL, uint64_div1000(v)) << "2^" << bit << " + " << d;
+        }
+    }
+
+    // 1000-boundaries and pre-shift windows at every decade
+    for (uint64_t mag = 1; mag <= 10000000000000000ULL; mag *= 10) {
+        for (uint64_t k = 0; k < 1000ULL; k++) {
+            const uint64_t base = mag + k*1000ULL;
+            for (int d = -2; d <= 9; d++) {
+                if (d < 0 && base < 2) {
+                    continue;
+                }
+                const uint64_t v = base + d;
+                ASSERT_EQ(v / 1000ULL, uint64_div1000(v)) << "v=" << v;
+            }
+        }
+    }
+
+    // instants a real microsecond clock passes through, including the
+    // 2^35 point where a_hi first becomes non-zero and the 49.7 days
+    // at which millis() truncated to 32 bits wraps
+    static const uint64_t instants[] = {
+        1ULL,                       // 1 us
+        1000ULL,                    // 1 ms
+        1000000ULL,                 // 1 s
+        60000000ULL,                // 1 min
+        3600000000ULL,              // 1 hour
+        34359738368ULL,             // 2^35 us, ~9.5 hours
+        86400000000ULL,             // 1 day
+        4294967296000ULL,           // 2^32 ms, ~49.7 days
+        31536000000000ULL,          // 1 year
+        315360000000000ULL,         // 10 years
+    };
+    for (const uint64_t t : instants) {
+        for (int d = -8; d <= 8; d++) {
+            if (d < 0 && t < (uint64_t)(-d)) {
+                continue;
+            }
+            const uint64_t v = t + d;
+            ASSERT_EQ(v / 1000ULL, uint64_div1000(v)) << "instant " << t << " + " << d;
+        }
+    }
+
+    // a reproducible pseudo-random sweep, so random coverage does not
+    // depend on the run
+    uint64_t s = 0x243F6A8885A308D3ULL;
+    for (uint32_t i = 0; i < 500000; i++) {
+        s ^= s << 13; s ^= s >> 7; s ^= s << 17;
+        // both the full-width value and one scaled into clock range
+        ASSERT_EQ(s / 1000ULL, uint64_div1000(s)) << "s=" << s;
+        const uint64_t clockish = s >> 24;
+        ASSERT_EQ(clockish / 1000ULL, uint64_div1000(clockish)) << "clockish=" << clockish;
+    }
+}
+
 AP_GTEST_PANIC()
 AP_GTEST_MAIN()
 


### PR DESCRIPTION
### Summary

<!-- Put a one or two line summary of what your PR does here -->
add better test coverage for our div1000() function by explicitly testing the first 9.5 hours of uptime that are more representative of what we are generally using.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
