### PR TITLE
AP_RTC: improve _timegm and ap_mktime calculus

### DIFF
--- a/libraries/AP_Common/tests/test_time.cpp
+++ b/libraries/AP_Common/tests/test_time.cpp
@@ -111,6 +111,31 @@ TEST(ap_mktime, MonthLoopRollover)
     struct tm t = make_tm(1970, 1, 1, 0, 0, 0);
     t.tm_mon = 12; // 13 iterations: Dec wraps m→0, y→1971, then Jan added
     EXPECT_EQ((time_t)(365 * 86400), ap_mktime(&t));
+
+    // tm_mon=14 is the largest a caller can produce: AP_Filesystem_FATFS
+    // reads a 4-bit month field and subtracts one, so 0x0f arrives here
+    // as 14.  Fourteen months on from 1 January 1970 is 1 March 1971:
+    // all of 1970, then January and February.
+    t.tm_mon = 14;
+    EXPECT_EQ((time_t)((365 + 31 + 28) * 86400), ap_mktime(&t));
+}
+
+// Every caller computes tm_mon as "month - 1" from an external date
+// field, so a source reporting month 0 arrives here as -1.  Such a
+// month must contribute nothing rather than index off the front of the
+// month table.
+TEST(ap_mktime, NegativeMonth)
+{
+    struct tm jan1 = make_tm(1970, 1, 1, 0, 0, 0);
+    struct tm neg = jan1;
+    neg.tm_mon = -1;
+    EXPECT_EQ(ap_mktime(&jan1), ap_mktime(&neg));
+
+    // and it must not disturb the rest of the fields
+    struct tm neg_later = make_tm(2024, 1, 15, 6, 7, 8);
+    neg_later.tm_mon = -1;
+    struct tm jan15 = make_tm(2024, 1, 15, 6, 7, 8);
+    EXPECT_EQ(ap_mktime(&jan15), ap_mktime(&neg_later));
 }
 
 AP_GTEST_MAIN()

--- a/libraries/AP_Common/time.cpp
+++ b/libraries/AP_Common/time.cpp
@@ -1,44 +1,48 @@
 #include "time.h"
 
+#include <stdint.h>
+
 /*
-  mktime replacement from Samba
+  mktime replacement, originally from Samba
  */
 time_t ap_mktime(const struct tm *t)
 {
-    time_t epoch = 0;
-    int n;
-    int mon [] = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 }, y, m, i;
-    const unsigned MINUTE = 60;
-    const unsigned HOUR = 60*MINUTE;
-    const unsigned DAY = 24*HOUR;
-    const unsigned YEAR = 365*DAY;
+    // days elapsed from 1 January to the 1st of each month, common year
+    static const uint16_t cumdays[12] = {
+        0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334 };
 
     if (t->tm_year < 70) {
         return (time_t)-1;
     }
 
-    n = t->tm_year + 1900 - 1;
-    epoch = (t->tm_year - 70) * YEAR +
-            ((n / 4 - n / 100 + n / 400) - (1969 / 4 - 1969 / 100 + 1969 / 400)) * DAY;
-
-    y = t->tm_year + 1900;
-    m = 0;
-
-    for (i = 0; i < t->tm_mon; i++) {
-        epoch += mon [m] * DAY;
-        if (m == 1 && y % 4 == 0 && (y % 100 != 0 || y % 400 == 0)) {
-            epoch += DAY;
-        }
-
-        if (++m > 11) {
-            m = 0;
-            y++;
-        }
+    /*
+      every caller derives tm_mon from an external date field as
+      "month - 1", so it can land outside 0-11 when the source reports
+      a zero or out-of-range month.  Both cases are kept as the month
+      loop this replaced behaved: it walked its own month and year
+      counters forward, so months past December rolled into the
+      following years, and a negative month added nothing because the
+      loop simply never ran.
+     */
+    int mon = t->tm_mon;
+    int year_off = t->tm_year;
+    if (mon > 11) {
+        year_off += mon / 12;
+        mon %= 12;
+    } else if (mon < 0) {
+        mon = 0;
     }
 
-    epoch += (t->tm_mday - 1) * DAY;
-    epoch += t->tm_hour * HOUR + t->tm_min * MINUTE + t->tm_sec;
+    const uint32_t year = (uint32_t)year_off + 1900U;
+    const uint32_t n = year - 1U;
+    const bool leap = (year % 4) == 0 && ((year % 100) != 0 || (year % 400) == 0);
 
-    return epoch;
+    // leap days since the epoch, as a closed form rather than a
+    // per-year loop; 477 is the same count taken at 1969
+    const uint32_t days = (uint32_t)(year_off - 70) * 365U
+        + (n/4U - n/100U + n/400U) - 477U
+        + cumdays[mon] + (leap && mon > 1)
+        + (uint32_t)t->tm_mday - 1U;
+
+    return (time_t)days * 86400 + t->tm_hour*3600 + t->tm_min*60 + t->tm_sec;
 }
-

--- a/libraries/AP_RTC/AP_RTC.cpp
+++ b/libraries/AP_RTC/AP_RTC.cpp
@@ -161,21 +161,24 @@ uint32_t AP_RTC::_timegm(struct tm &tm)
     static const uint8_t ndays[2][12] = {
 		{31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31},
 		{31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31}};
-    uint32_t res = 0;
 
     if (tm.tm_mon > 12 ||
         tm.tm_mday > 31 ||
         tm.tm_min > 60 ||
         tm.tm_sec > 60 ||
-        tm.tm_hour > 24) {
-		/* invalid tm structure */
+        tm.tm_hour > 24 ||
+        tm.tm_year < 70) {
+		/* invalid tm structure, or pre-1970 date (matches old loop's implicit floor) */
 		return 0;
 	}
 	
-    for (auto i = 70; i < tm.tm_year; i++) {
-        res += _is_leap(i) ? 366 : 365;
-    }
-	
+    // closed-form day count instead of a per-year _is_leap loop (same identity glibc/libc++ use for civil-to-days)
+    const uint32_t calendar_year = tm.tm_year + 1900U;
+    uint32_t res = (tm.tm_year - 70U) * 365U
+        + (calendar_year - 1U) / 4U   - 492U
+        - (calendar_year - 1U) / 100U + 19U
+        + (calendar_year - 1U) / 400U - 4U;
+
     for (auto i = 0; i < tm.tm_mon; i++) {
         res += ndays[_is_leap(tm.tm_year)][i];
     }

--- a/libraries/AP_RTC/tests/test_rtc.cpp
+++ b/libraries/AP_RTC/tests/test_rtc.cpp
@@ -9,6 +9,7 @@
 
 #include <AP_gtest.h>
 
+#include <AP_Common/time.h>
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Logger/AP_Logger.h>
 #include <AP_RTC/AP_RTC.h>
@@ -133,6 +134,78 @@ TEST(AP_RTC, date_field_conversions)
 
     // an invalid month must not convert:
     EXPECT_EQ(0U, AP::rtc().date_fields_to_clock_s(2024, 13, 1, 0, 0, 0));
+}
+
+// date_fields_to_clock_s() (and so _timegm()/_is_leap()) must agree
+// with ap_mktime() across the whole range representable in the uint32
+// seconds-since-epoch it returns.  ap_mktime() is an independent
+// in-tree implementation - it counts months in a loop and tests for
+// leap years inline - so it catches errors in the closed-form day
+// count and in the _is_leap() bit trick alike.
+TEST(AP_RTC, date_fields_to_clock_s_sweep)
+{
+    // uint32 seconds since the epoch runs out during 2106-02-07:
+    for (uint16_t year = 1970; year <= 2105; year++) {
+        for (uint8_t month = 0; month < 12; month++) {
+            // 1st, 10th, 19th, 28th: every month has these, and the
+            // 28th/1st pair straddles the February leap day
+            for (uint8_t day = 1; day <= 28; day += 9) {
+                SCOPED_TRACE(year*10000 + month*100 + day);
+
+                struct tm tm {};
+                tm.tm_year = year - 1900;
+                tm.tm_mon = month;
+                tm.tm_mday = day;
+                tm.tm_hour = 7;
+                tm.tm_min = 11;
+                tm.tm_sec = 23;
+                const time_t expected = ap_mktime(&tm);
+                ASSERT_NE(time_t(-1), expected);
+
+                EXPECT_EQ(uint32_t(expected),
+                          AP::rtc().date_fields_to_clock_s(year, month, day, 7, 11, 23));
+            }
+        }
+    }
+}
+
+// February's length exercises _is_leap() through the _timegm() day
+// table; the div-100 and div-400 cases are the ones a naive
+// "divisible by 4" test gets wrong
+TEST(AP_RTC, february_length)
+{
+    static const struct {
+        uint16_t year;
+        uint8_t days;
+    } cases[] {
+        { 1972, 29 },  // first leap year after the epoch
+        { 2023, 28 },  // not divisible by 4
+        { 2024, 29 },  // divisible by 4
+        { 2000, 29 },  // divisible by 400: a leap year
+        { 2100, 28 },  // divisible by 100 but not 400: not a leap year
+        { 2104, 29 },  // divisible by 4, latest in uint32 range
+    };
+
+    for (const auto &tc : cases) {
+        SCOPED_TRACE(tc.year);
+
+        const uint32_t feb_1 = AP::rtc().date_fields_to_clock_s(tc.year, 1, 1, 0, 0, 0);
+        const uint32_t mar_1 = AP::rtc().date_fields_to_clock_s(tc.year, 2, 1, 0, 0, 0);
+        EXPECT_EQ(uint32_t(tc.days), (mar_1 - feb_1) / 86400U);
+    }
+}
+
+// dates before the epoch cannot be represented in the returned uint32
+// and must be rejected rather than wrapping around
+TEST(AP_RTC, pre_epoch_rejected)
+{
+    EXPECT_EQ(0U, AP::rtc().date_fields_to_clock_s(1969, 11, 31, 23, 59, 59));
+    EXPECT_EQ(0U, AP::rtc().date_fields_to_clock_s(1900, 0, 1, 0, 0, 0));
+    EXPECT_EQ(0U, AP::rtc().date_fields_to_clock_s(1, 0, 1, 0, 0, 0));
+
+    // the epoch itself is representable, and is the boundary case:
+    EXPECT_EQ(0U, AP::rtc().date_fields_to_clock_s(1970, 0, 1, 0, 0, 0));
+    EXPECT_EQ(1U, AP::rtc().date_fields_to_clock_s(1970, 0, 1, 0, 0, 1));
 }
 
 // get_time_utc() returns the number of milliseconds until a target


### PR DESCRIPTION
### Summary

Following a reading on https://www.benjoffe.com/fast-leap-year (great post btw), I tried to look if we could benefit from it for leap year calculus. 

Result is no as in our case we benefit better from the branching and have very fast calculus when not on leap year.
Claude was then use to try to optimize _timegm() calculation. And that lead to also update ap_mktime as we are comparing the two functions to ensure they are right.

This add more tests for both

Using Claude and Renode to check optimization : 
## Results

As of the changes that replaced the per-year loop in `_timegm()` and the month
loop in `ap_mktime()` with closed forms:

```text
CPU      MEASURED                                   instr/call  vs previous
h7       _is_leap  %4/%100/%400                           7.31            -
h7       _is_leap  Hueffner single expression            11.00        1.50x
h7       _is_leap  Drepper/Neri-Schneider %25+mask        14.00        1.92x
h7       _timegm   per-year _is_leap loop               699.15            -
h7       _timegm   closed-form day count                 77.75        0.11x
h7       ap_mktime stack table + month loop             136.94            -
h7       ap_mktime cumdays table + closed form           57.30        0.42x
f4       _is_leap  %4/%100/%400                           7.31            -
f4       _is_leap  Hueffner single expression            11.00        1.50x
f4       _is_leap  Drepper/Neri-Schneider %25+mask        14.00        1.92x
f4       _timegm   per-year _is_leap loop               746.98            -
f4       _timegm   closed-form day count                 77.75        0.10x
f4       ap_mktime stack table + month loop             144.51            -
f4       ap_mktime cumdays table + closed form           57.04        0.39x
```

`ap_mktime()` in AP_Common is measured here too: it is the same calendar
arithmetic, and the AP_RTC tests use it as their oracle, so a second harness
would have been the same harness. Its 2.5x came from dropping a month loop for
a cumulative-days table and, mostly, from making that table `static const` -
the original declared a non-const `int mon[12]` local, which has to be rebuilt
on the stack on every call.

The closed-form `_timegm()` is a 9-10x reduction: the loop it replaced ran once
per year since 1970, so its cost grew every January and was worst on the dates
the vehicle actually sees. Its figure moves by a few instructions with `N`,
which changes how the swept years land; the closed-form figure does not, having
no year-dependent work left.

Both branchless replacements for `_is_leap()` cost *more* than the plain
`%4/%100/%400` test, on both targets: 1.5x for the single-expression form and
1.9x for the `%25`-and-mask form. Dump the disassembly to see why:

```bash
arm-none-eabi-objdump -d --no-show-raw-insn <OUT>/bench_h7_v1_n2000.elf
```

`%4/%100/%400` compiles to a `lsls`/`bne` pair that returns in three
instructions for the three years in four that are not divisible by 4, and only
reaches the `%100`/`%400` magic-multiply sequence for the fourth. Neither
branchless form has an early exit, so every call pays its full cost: the
single-expression form runs load/load/`mul`/`and`/`cmp`/`ite`, and the
`%25`-and-mask form runs that plus a second `ite` to select the mask. A
short-circuit beats a branchless expression when the short circuit takes 75% of
the calls.

TLDR; Minimal speed gain on those function and better tests

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
