### PR TITLE
AP_Mount: Topotek track SD card state as unknown/present/absent

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Topotek.cpp
+++ b/libraries/AP_Mount/AP_Mount_Topotek.cpp
@@ -161,8 +161,11 @@ bool AP_Mount_Topotek::take_picture()
         return false;
     }
 
-    // exit immediately if the memory card is abnormal
-    if (!_sdcard_status) {
+    // exit immediately if the memory card is confirmed absent - UNKNOWN (no SDC
+    // reply yet) is allowed through, since that reply can take a while and we'd
+    // rather attempt the capture than silently refuse every request until it
+    // arrives
+    if (_sdcard_state == SDCardState::ABSENT) {
         GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "%s SD card error", send_message_prefix);
         return false;
     }
@@ -180,8 +183,8 @@ bool AP_Mount_Topotek::record_video(bool start_recording)
         return false;
     }
 
-    // exit immediately if the memory card is abnormal
-    if (!_sdcard_status) {
+    // exit immediately if the memory card is confirmed absent (see take_picture())
+    if (_sdcard_state == SDCardState::ABSENT) {
         GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "%s SD card error", send_message_prefix);
         return false;
     }
@@ -884,10 +887,10 @@ void AP_Mount_Topotek::gimbal_sdcard_analyse()
 {
     if (('N' == _msg_buff[10]) && ('N' == _msg_buff[11]) && ('N' == _msg_buff[12]) && ('N' == _msg_buff[13])) {
         // memory card exception
-        _sdcard_status = false;
+        _sdcard_state = SDCardState::ABSENT;
         return;
     }
-    _sdcard_status = true;
+    _sdcard_state = SDCardState::PRESENT;
 
     // send UTC time to the camera
     if (_sent_time_count < 7) {

--- a/libraries/AP_Mount/AP_Mount_Topotek.h
+++ b/libraries/AP_Mount/AP_Mount_Topotek.h
@@ -185,6 +185,16 @@ private:
     // identifier bytes
     typedef char Identifier[3];
 
+    // memory card state, as last reported by "SDC" (see gimbal_sdcard_analyse()).
+    // UNKNOWN until the first reply arrives - camera-addressed replies can take a
+    // while, so capture attempts must not be blocked on a card that may simply not
+    // have reported in yet
+    enum class SDCardState : uint8_t {
+        UNKNOWN = 0,
+        PRESENT = 1,
+        ABSENT = 2,
+    };
+
     // send text prefix string
     static const char* send_message_prefix;
 
@@ -272,7 +282,7 @@ private:
     bool _is_tracking;                                          // whether to enable the tracking state
     TrackingStatus _last_tracking_state = TrackingStatus::STOPPED_TRACKING; // last tracking state received from gimbal
     uint8_t _last_mode;                                         // mode during latest update, used to detect mode changes and cancel tracking
-    bool _sdcard_status;                                        // memory card status (received from gimbal)
+    SDCardState _sdcard_state = SDCardState::UNKNOWN;           // memory card state, as last reported by the gimbal (see SDCardState)
     bool _last_lock;                                            // last lock mode sent to gimbal
     bool _got_gimbal_version;                                   // true if gimbal's version has been received
     bool _got_gimbal_model_name;                                // true if gimbal's model name has been received


### PR DESCRIPTION
### Summary

Fix Topotek gimbal `take_picture()`/`record_video()` refusing every request while SD-card status is still unknown (default at boot), not just when the card is actually absent.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Found and confirmed on real KHP415 hardware: Mission Planner's Aux Function Camera Trigger/Record threw a misleading "SD card error" shortly after boot, before the gimbal's first "SDC" status reply had arrived. Mirrors an equivalent fix already applied to the SkyDroid driver.

### Description

`take_picture()`/`record_video()` refused every request while `_sdcard_status` was `false` — which was also its default, uninitialized-until-first-reply value. Since the gimbal's own "SDC" status reply can take a moment after boot, any capture attempt in that window was refused with a misleading "SD card error", even with a working card in the camera.

This replaces the bool with a tri-state (`UNKNOWN`/`PRESENT`/`ABSENT`) and only refuses a request once the gimbal has confirmed the card is actually `ABSENT`, letting captures through while still `UNKNOWN`.

*This PR was developed with AI assistance (Claude).*