### PR TITLE
autotest: honor TMPDIR for the SITL console log

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -19,4 +19,4 @@ jobs:
     - uses: pre-commit/action@v3.0.1
     - run: python3 -m pip install --upgrade pip
     - run: python3 -m pip install pytest
-    - run: PYTHONPATH="." pytest tests/test_pre_commit_copyright.py
+    - run: PYTHONPATH="." pytest tests/

--- a/Tools/autotest/run_in_terminal_window.sh
+++ b/Tools/autotest/run_in_terminal_window.sh
@@ -54,7 +54,7 @@ elif [ -n "$(which mintty 2>/dev/null)" ]; then
   # Cygwin native terminal - no X11 fonts required
   mintty --hold always -T "$name" -e "$@" &
 else
-  filename="/tmp/$name.log"
+  filename="${TMPDIR:-/tmp}/$name.log"
   echo "RiTW: Window access not found, logging to $filename"
   cmd="$1"
   shift

--- a/tests/test_run_in_terminal_window.py
+++ b/tests/test_run_in_terminal_window.py
@@ -1,0 +1,75 @@
+"""Tests for Tools/autotest/run_in_terminal_window.sh."""
+
+import os
+import pathlib
+import subprocess
+import time
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "Tools" / "autotest" / "run_in_terminal_window.sh"
+
+# The script chooses how to launch by probing the environment. Clear
+# everything it looks at, so it takes the headless branch under test instead
+# of opening a terminal on the machine running the tests.
+TERMINAL_VARS = ("SITL_RITW_TERMINAL", "TMUX", "DISPLAY", "STY", "ZELLIJ")
+
+
+def run_headless(name, command, tmpdir=None):
+    """Run the script with no terminal available and return the result."""
+    env = {k: v for k, v in os.environ.items() if k not in TERMINAL_VARS}
+    if tmpdir is None:
+        env.pop("TMPDIR", None)
+    else:
+        env["TMPDIR"] = str(tmpdir)
+    return subprocess.run(
+        [str(SCRIPT), name] + command,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def wait_for(path, timeout=10):
+    """The script backgrounds the command, so the log appears asynchronously."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if path.exists() and path.stat().st_size > 0:
+            return True
+        time.sleep(0.05)
+    return False
+
+
+@pytest.fixture
+def vehicle_name():
+    """A name unique to this process, so a stale log cannot mask a result."""
+    name = "RiTWTestVehicle%u" % os.getpid()
+    yield name
+    # A version that ignores TMPDIR writes here; do not leave that behind.
+    pathlib.Path("/tmp", name + ".log").unlink(missing_ok=True)
+
+
+def test_console_log_goes_to_tmpdir(tmp_path, vehicle_name):
+    """TMPDIR decides where the console log is written.
+
+    A caller running several vehicles, or sharing a machine with another
+    user, needs to control where these logs go.
+    """
+    result = run_headless(vehicle_name, ["/bin/echo", "hello"], tmpdir=tmp_path)
+    assert result.returncode == 0
+
+    log = tmp_path / (vehicle_name + ".log")
+    assert wait_for(log), "no console log in TMPDIR; stderr: %s" % result.stderr
+    assert "hello" in log.read_text()
+
+
+def test_console_log_falls_back_to_tmp(vehicle_name):
+    """With TMPDIR unset the log still lands in /tmp (the current behavior)."""
+    result = run_headless(vehicle_name, ["/bin/echo", "hello"])
+    assert result.returncode == 0
+
+    log = pathlib.Path("/tmp", vehicle_name + ".log")
+    assert wait_for(log), "no console log in /tmp; stderr: %s" % result.stderr
+    assert "hello" in log.read_text()


### PR DESCRIPTION
### Summary

The headless fallback in run_in_terminal_window.sh logs the vehicle console to a hardcoded /tmp/$name.log. Honor TMPDIR there so multiple instances (and multiple users on a shared machine) don't fight over one file.

### Classification & Testing

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Three commits, one subsystem each. The tests commit adds tests/test_run_in_terminal_window.py (two tests: the log lands in TMPDIR when set, and still lands in /tmp when unset) and comes first, failing on its own; the Tools commit makes it pass. The .github commit points the pre-commit workflow at the whole tests/ directory, since it currently names test_pre_commit_copyright.py alone and a new file in tests/ would never run in CI.

Manual testing on a shared Linux box: with /tmp/ArduPlane.log owned by another user, headless sim_vehicle.py fails today with "Permission denied" on the redirect, exits 0 anyway, and SITL never opens its MAVLink port. With the patch and TMPDIR set it starts normally and the other user's file is untouched. Also checked that two instances (-I 60 -n 2) with TMPDIR set write two separate logs.

### Description

sim_vehicle.py gives each instance its own working directory, but the console log path is the same for every instance, so "sim_vehicle.py -n 4" ends up with four vehicles writing one file.

The multi-user case has an additional issue: /tmp is sticky, and with fs.protected_regular=2 (the default on most current distros) a second user can't open the first user's file at all, whatever the mode bits say. The redirect fails before the binary is exec'd, the script exits 0 anyway, and SITL just never comes up, with no error output anywhere. This took us a while to track down on a shared SITL machine, since test -w on the file reports it writable.

```diff
-  filename="/tmp/$name.log"
+  filename="${TMPDIR:-/tmp}/$name.log"
```

The SITL_RITW_TERMINAL branch at the top of the same script already honors TMPDIR, so this makes the headless branch match. With TMPDIR unset nothing changes.