### PR TITLE
.github: allow selecting self-hosted runners via repo variables

### DIFF
--- a/.github/SELF_HOSTED_RUNNERS.md
+++ b/.github/SELF_HOSTED_RUNNERS.md
@@ -1,0 +1,187 @@
+# Running ArduPilot CI on your own (self-hosted) GitHub runners
+
+The workflows in this tree select their runner through two GitHub
+Actions *repository variables*:
+
+```yaml
+runs-on: ${{ vars.CI_RUNNER || 'ubuntu-22.04' }}        # linux jobs
+runs-on: ${{ vars.CI_WIN_RUNNER || 'windows-latest' }}  # cygwin build
+```
+
+If the variables are **not defined** (the default everywhere, including
+the upstream ArduPilot repository) every job resolves to exactly the
+original GitHub-hosted label and nothing changes. If you define them in
+your fork, your own pushes run on your own hardware instead - useful
+when the hosted queue is slow, or when your machine is simply faster.
+
+## Quick start (fork)
+
+1. Register a runner on your fork: *Settings -> Actions -> Runners ->
+   New self-hosted runner*, and give it a custom label, e.g. `mybox`.
+2. Define the variables: *Settings -> Secrets and variables -> Actions
+   -> Variables*:
+   * `CI_RUNNER` = `mybox` (routes Linux jobs)
+   * `CI_WIN_RUNNER` = `Windows` (routes the Cygwin build to a runner
+     carrying the `Windows` label)
+3. Push. Jobs dispatch to your runners; delete the variables to return
+   to GitHub-hosted at any time. No workflow edits either way.
+
+Do **not** give a self-hosted runner a GitHub-hosted image label such
+as `ubuntu-22.04` or `windows-latest`: hosted runners take precedence
+for those labels, so your runner will starve, and when it does catch a
+job you can no longer tell which environment produced a result.
+
+## Linux runner in Docker
+
+### Installing Docker first
+
+Any recent Docker works. On Debian/Ubuntu the quickest path:
+
+```bash
+curl -fsSL https://get.docker.com | sh          # docker engine + cli
+sudo usermod -aG docker $USER                   # then log out/in once
+```
+
+or, to run the daemon **rootless** (no root daemon on the machine -
+recommended for a runner box; this is also what changes the socket
+path mentioned below):
+
+```bash
+sudo apt-get install -y docker-ce-rootless-extras uidmap
+dockerd-rootless-setuptool.sh install
+systemctl --user enable --now docker
+echo "export DOCKER_HOST=unix:///run/user/$(id -u)/docker.sock" >> ~/.bashrc
+```
+
+Check it works before going further: `docker run --rm hello-world`.
+
+### Watching your runner
+
+Once the runner container (below) is up, its console - registration,
+"Listening for Jobs", every job start/finish - is just its container
+log:
+
+```bash
+docker logs gh-runner-mybox --tail 20 -f        # live tail
+docker ps --filter name=gh-runner               # is it up
+gh api repos/<you>/ardupilot/actions/runners \
+   -q '.runners[] | "\(.name) \(.status) busy=\(.busy)"'   # GitHub's view
+```
+
+### The runner container
+
+A containerised runner works well; ArduPilot jobs run inside
+`ardupilot/ardupilot-dev-*` job containers, so the runner needs access
+to a Docker daemon:
+
+```bash
+TOKEN=$(gh api -X POST repos/<you>/ardupilot/actions/runners/registration-token -q .token)
+docker run -d --restart always --name gh-runner \
+  -e REPO_URL=https://github.com/<you>/ardupilot \
+  -e RUNNER_TOKEN=$TOKEN -e RUNNER_NAME=mybox \
+  -e LABELS=self-hosted,mybox \
+  -e RUNNER_WORKDIR=/tmp/gh-runner-work \
+  -e ACTIONS_RUNNER_HOOK_JOB_STARTED=/tmp/gh-runner-work/prejob.sh \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v /tmp/gh-runner-work:/tmp/gh-runner-work \
+  --cpus 4 --memory 6g \
+  myoung34/github-runner:ubuntu-jammy
+```
+
+Hard-won details, all one-time:
+
+* **Rootless Docker**: mount the rootless socket
+  (`/run/user/<uid>/docker.sock`) as `/var/run/docker.sock` instead -
+  the rootful socket appears as `nobody:nogroup` inside the container
+  and is unusable even by root.
+* **Mount the workdir at the identical path** on host and in the
+  container (as above). The runner passes that path to the daemon when
+  starting job containers, and the daemon resolves it on the *host*.
+* **`/actions-runner/externals` and `/opt/hostedtoolcache`** must exist
+  on the host (the daemon mounts them into job containers from host
+  paths): copy `externals` out of the runner image once
+  (`docker cp gh-runner:/actions-runner/externals /actions-runner/externals`)
+  and `mkdir` a user-owned `/opt/hostedtoolcache`.
+* **Persistent-workspace poisoning**: some workflows use sparse
+  checkouts, and sparse state survives in `.git` between jobs on a
+  reused workspace, leaving later full checkouts nearly empty. Use a
+  job-started hook (`prejob.sh`) that removes
+  `.git/info/sparse-checkout` / sets `core.sparseCheckout=false` in any
+  workspace repo, and `chmod -R a+rwX` the `_temp` dir so job
+  containers running as a different uid can write runner state files.
+* Replace runner containers only when idle: killing one mid-job leaves
+  GitHub holding the runner "busy" with an orphaned job for ~10
+  minutes, blocking dispatch to the replacement.
+
+## Windows runner (for the Cygwin build)
+
+Install the runner natively (GitHub Actions cannot run Windows job
+containers; the Cygwin workflow's steps run directly on the host). Any
+Windows 10/11 or Server VM with a few cores, ~8GB RAM and ~40GB free
+disk is enough.
+
+### Registering the VM as a runner (PowerShell)
+
+Grab a registration token from your fork - either *Settings -> Actions
+-> Runners -> New self-hosted runner* (it shows the token inline), or
+from any machine with `gh`:
+
+```bash
+gh api -X POST repos/<you>/ardupilot/actions/runners/registration-token -q .token
+```
+
+Then on the VM, in PowerShell:
+
+```powershell
+mkdir C:ctions-runner ; cd C:ctions-runner
+Invoke-WebRequest -Uri https://github.com/actions/runner/releases/latest/download/actions-runner-win-x64.zip -OutFile runner.zip
+Expand-Archive runner.zip -DestinationPath .
+./config.cmd --url https://github.com/<you>/ardupilot --token <TOKEN>
+#   runner group: Enter (Default)
+#   name:         e.g. buzz-windows
+#   extra labels: Enter (the automatic self-hosted,Windows,X64 are enough;
+#                 do NOT add windows-latest - see the label warning above)
+#   work folder:  Enter (_work)
+./run.cmd            # interactive: shows "Listening for Jobs" and every job live
+```
+
+(If the `latest/download` URL 404s, take the exact
+`actions-runner-win-x64-<version>.zip` asset URL from
+<https://github.com/actions/runner/releases>.)
+
+`./run.cmd` runs in the foreground, which is ideal while setting up -
+it is the Windows equivalent of `docker logs -f`. When you are happy
+with it, install it as a service instead so it survives logouts and
+reboots (admin PowerShell):
+
+```powershell
+./svc.cmd install ; ./svc.cmd start
+```
+
+Finally set the fork variable `CI_WIN_RUNNER` = `Windows` and the
+Cygwin build dispatches to the VM on your next push.
+
+### One-time VM preparation
+
+A bare machine needs, once:
+
+* **Git for Windows** on PATH (checkout falls back to a REST download
+  that cannot fetch submodules without it), plus
+  `git config --system core.longpaths true`.
+* **PowerShell execution policy**:
+  `Set-ExecutionPolicy RemoteSigned -Scope LocalMachine` (actions
+  generate .ps1 scripts; the OS default blocks them).
+* **Firewall rules** for the built SITL binaries if you dislike
+  popups - all test traffic is loopback, which Windows permits
+  regardless, so the prompts are cosmetic.
+* Expect the first build to be slow (Cygwin install + cold compile);
+  the workspace, Cygwin and ccache persist, so later runs are much
+  faster than GitHub-hosted.
+
+## Security
+
+Self-hosted runners on a **public** fork execute whatever a workflow
+tells them to. Keep *Settings -> Actions -> "Require approval for all
+outside collaborators"* strict, prefer ephemeral runners where
+practical, and treat a runner with a mounted Docker socket as
+root-equivalent on its host.

--- a/.github/workflows/colcon.yml
+++ b/.github/workflows/colcon.yml
@@ -145,7 +145,7 @@ jobs:
     permissions:
       contents: read
       actions: write  # save/prune ccache on master
-    runs-on: ubuntu-22.04
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-22.04' }}
     timeout-minutes: 60
     container:
       image: ardupilot/ardupilot-dev-ros:latest

--- a/.github/workflows/cygwin_build.yml
+++ b/.github/workflows/cygwin_build.yml
@@ -148,7 +148,7 @@ jobs:
     permissions:
       contents: read
       actions: write  # save/prune ccache on master
-    runs-on: 'windows-latest'
+    runs-on: ${{ vars.CI_WIN_RUNNER || 'windows-latest' }}
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/esp32_build.yml
+++ b/.github/workflows/esp32_build.yml
@@ -145,7 +145,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-22.04' }}
     # ESP-IDF toolchain is baked into this image (see ardupilot_dev_docker
     # Dockerfile_dev-esp32). Keep the tag in sync with the rest of CI.
     container: ardupilot/ardupilot-dev-esp32:v0.2.0

--- a/.github/workflows/test_branch_conventions.yml
+++ b/.github/workflows/test_branch_conventions.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   check-merge-commits:
     if: github.repository == 'ArduPilot/ardupilot'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     container: ardupilot/ardupilot-dev-chibios:v0.2.0
 
     steps:

--- a/.github/workflows/test_ccache.yml
+++ b/.github/workflows/test_ccache.yml
@@ -125,7 +125,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-22.04' }}
     container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.2.0
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails

--- a/.github/workflows/test_chibios.yml
+++ b/.github/workflows/test_chibios.yml
@@ -139,7 +139,7 @@ jobs:
     permissions:
       contents: read
       actions: write  # save-ccache prunes the previous cache entry
-    runs-on: ubuntu-22.04
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-22.04' }}
     container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.2.0
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -19,7 +19,7 @@ jobs:
     permissions:
       contents: read
       actions: write  # save-ccache prunes the previous cache entry
-    runs-on: ubuntu-22.04
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-22.04' }}
     container:
       image: ardupilot/ardupilot-dev-${{ matrix.type }}:v0.2.0
       options: --privileged
@@ -88,7 +88,7 @@ jobs:
   finish:
     if: always()
     needs: build
-    runs-on: ubuntu-22.04
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-22.04' }}
     steps:
       - name: Coveralls Finished
         uses: coverallsapp/github-action@master

--- a/.github/workflows/test_dds.yml
+++ b/.github/workflows/test_dds.yml
@@ -145,7 +145,7 @@ jobs:
     permissions:
       contents: read
       actions: write  # save-ccache prunes the previous cache entry
-    runs-on: ubuntu-22.04
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-22.04' }}
     container:
       image: ardupilot/ardupilot-dev-ros:latest
       options: --user 1001

--- a/.github/workflows/test_environment.yml
+++ b/.github/workflows/test_environment.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-22.04' }}
     container:
       image: ${{matrix.os}}:${{matrix.name}}
       options: --privileged
@@ -141,7 +141,7 @@ jobs:
           ./waf plane
 
   build-alpine:  # special case for alpine as it doesn't have bash by default
-    runs-on: ubuntu-22.04
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-22.04' }}
     container:
       image: alpine:latest
       options: --privileged

--- a/.github/workflows/test_linux_sbc.yml
+++ b/.github/workflows/test_linux_sbc.yml
@@ -140,7 +140,7 @@ jobs:
     permissions:
       contents: read
       actions: write  # save-ccache prunes the previous cache entry
-    runs-on: ubuntu-22.04
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-22.04' }}
     container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.2.0
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails

--- a/.github/workflows/test_replay.yml
+++ b/.github/workflows/test_replay.yml
@@ -155,7 +155,7 @@ jobs:
     permissions:
       contents: read
       actions: write  # save-ccache prunes the previous cache entry
-    runs-on: ubuntu-22.04
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-22.04' }}
     container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.2.0
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails

--- a/.github/workflows/test_sitl_blimp.yml
+++ b/.github/workflows/test_sitl_blimp.yml
@@ -176,7 +176,7 @@ jobs:
     permissions:
       contents: read
       actions: write  # save-ccache prunes the previous cache entry
-    runs-on: ubuntu-22.04
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-22.04' }}
     container:
       image: ardupilot/ardupilot-dev-base:v0.2.0
       options: --privileged --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --security-opt seccomp=unconfined

--- a/.github/workflows/test_sitl_copter.yml
+++ b/.github/workflows/test_sitl_copter.yml
@@ -172,7 +172,7 @@ jobs:
     permissions:
       contents: read
       actions: write  # save-ccache prunes the previous cache entry
-    runs-on: ubuntu-22.04
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-22.04' }}
     container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.2.0
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
@@ -221,7 +221,7 @@ jobs:
 
   autotest:
     needs: build  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
-    runs-on: ubuntu-22.04
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-22.04' }}
     container:
       image: ardupilot/ardupilot-dev-base:v0.2.0
       options: --privileged --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --security-opt seccomp=unconfined
@@ -293,7 +293,7 @@ jobs:
     permissions:
       contents: read
       actions: write  # save-ccache prunes the previous cache entry
-    runs-on: ubuntu-22.04
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-22.04' }}
     container:
       image: ardupilot/ardupilot-dev-base:v0.2.0
       options: --privileged --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --security-opt seccomp=unconfined
@@ -320,7 +320,7 @@ jobs:
 
   autotest-heli:
     needs: build-gcc-heli  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
-    runs-on: ubuntu-22.04
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-22.04' }}
     container: ardupilot/ardupilot-dev-base:v0.2.0
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails

--- a/.github/workflows/test_sitl_periph.yml
+++ b/.github/workflows/test_sitl_periph.yml
@@ -171,7 +171,7 @@ jobs:
     permissions:
       contents: read
       actions: write  # save-ccache prunes the previous cache entry
-    runs-on: ubuntu-22.04
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-22.04' }}
     container:
       image: ardupilot/ardupilot-dev-periph:v0.2.0
       options: --privileged

--- a/.github/workflows/test_sitl_plane.yml
+++ b/.github/workflows/test_sitl_plane.yml
@@ -173,7 +173,7 @@ jobs:
     permissions:
       contents: read
       actions: write  # save-ccache prunes the previous cache entry
-    runs-on: ubuntu-22.04
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-22.04' }}
     container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.2.0
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
@@ -224,7 +224,7 @@ jobs:
 
   autotest:
     needs: build  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
-    runs-on: ubuntu-22.04
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-22.04' }}
     container:
       image: ardupilot/ardupilot-dev-base:v0.2.0
       options: --privileged --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --security-opt seccomp=unconfined

--- a/.github/workflows/test_sitl_rover.yml
+++ b/.github/workflows/test_sitl_rover.yml
@@ -171,7 +171,7 @@ jobs:
     permissions:
       contents: read
       actions: write  # save-ccache prunes the previous cache entry
-    runs-on: ubuntu-22.04
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-22.04' }}
     container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.2.0
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
@@ -219,7 +219,7 @@ jobs:
 
   autotest:
     needs: build  # don't try to launch the tests matrix if it doesn't build first, profit from caching for fast build
-    runs-on: ubuntu-22.04
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-22.04' }}
     container:
       image: ardupilot/ardupilot-dev-base:v0.2.0
       options: --privileged --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --security-opt seccomp=unconfined

--- a/.github/workflows/test_sitl_sub.yml
+++ b/.github/workflows/test_sitl_sub.yml
@@ -175,7 +175,7 @@ jobs:
     permissions:
       contents: read
       actions: write  # save-ccache prunes the previous cache entry
-    runs-on: ubuntu-22.04
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-22.04' }}
     container:
       image: ardupilot/ardupilot-dev-base:v0.2.0
       options: --privileged --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --security-opt seccomp=unconfined

--- a/.github/workflows/test_sitl_tracker.yml
+++ b/.github/workflows/test_sitl_tracker.yml
@@ -175,7 +175,7 @@ jobs:
     permissions:
       contents: read
       actions: write  # save-ccache prunes the previous cache entry
-    runs-on: ubuntu-22.04
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-22.04' }}
     container:
       image: ardupilot/ardupilot-dev-base:v0.2.0
       options: --privileged --cap-add=SYS_PTRACE --security-opt apparmor=unconfined --security-opt seccomp=unconfined

--- a/.github/workflows/test_size.yml
+++ b/.github/workflows/test_size.yml
@@ -123,7 +123,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-22.04' }}
     container: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.2.0
     permissions:
       contents: read

--- a/.github/workflows/test_unit_tests.yml
+++ b/.github/workflows/test_unit_tests.yml
@@ -108,7 +108,7 @@ jobs:
     permissions:
       contents: read
       actions: write  # save-ccache prunes the previous cache entry
-    runs-on: ubuntu-22.04
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-22.04' }}
     container:
       image: ardupilot/ardupilot-dev-${{ matrix.toolchain }}:v0.2.0
       options: --user 1001


### PR DESCRIPTION
Linux jobs' runs-on becomes ${{ vars.CI_RUNNER || 'ubuntu-<orig>' }} and the Cygwin build's becomes
${{ vars.CI_WIN_RUNNER || 'windows-latest' }}. Repositories that define no such Actions variables - including this one - resolve to exactly the original GitHub-hosted labels, so nothing changes for ArduPilot CI. A fork sets the variables (Settings -> Secrets and variables -> Actions -> Variables) to route its own pushes to self-hosted runners, e.g. CI_RUNNER=mybox after registering a runner with that label, without diverging from upstream workflow files.

### Summary

<!-- Put a one or two line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [ x ] Checked by a human programmer
- [ x] Non-functional change for most ppl  - makes self-hosted runners possible
- [x ] Infrastructure change (e.g. unit tests, helper scripts)
- [ x] Tested manually, description below (e.g. SITL)
- [ x ] Logs attached

<!-- Put additional testing description for this PR's changes here -->

### Description

read the readme.  

logs showing me starting a ubuntu runner in docker: 
    docker logs gh-runner-buzzbox --tail 20 -f
    Current runner version: '2.337.0'
    2026-08-28 20:01:48Z: Listening for Jobs
    
    √ Connected to GitHub
    
    Current runner version: '2.337.0'
    2026-08-29 20:01:48Z: Listening for Jobs
    
    √ Connected to GitHub
    
    Current runner version: '2.337.0'
    2026-08-30 20:01:49Z: Listening for Jobs
    
    √ Connected to GitHub
    
    Current runner version: '2.337.0'
    2026-08-31 20:01:50Z: Listening for Jobs
    2026-08-31 23:50:57Z: Running job: build-test
    2026-09-01 00:14:31Z: Job build-test completed with result: Succeeded
    2026-09-01 00:14:35Z: Running job: build (bhat, armhf)
    2026-09-01 00:23:00Z: Job build (bhat, armhf) completed with result: Succeeded


logs showing me starting a windows runner in my own windows VM: 
    PS C:\actions-runner>
    PS C:\actions-runner> ./run.cmd
            1 file(s) copied.
    
    √ Connected to GitHub
    
    Current runner version: '2.336.0'
    2026-08-31 23:47:01Z: Listening for Jobs
    2026-08-31 23:50:58Z: Running job: build
    2026-09-01 00:52:11Z: Job build completed with result: Canceled
    2026-09-01 00:52:16Z: Running job: build
    2026-09-01 00:56:32Z: Job build completed with result: Failed
    2026-09-01 00:56:36Z: Running job: build


<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
