### PR TITLE
Pr frame stretching

### DIFF
--- a/libraries/AP_Scheduler/AP_Scheduler.cpp
+++ b/libraries/AP_Scheduler/AP_Scheduler.cpp
@@ -25,6 +25,8 @@
 
 #include "AP_Scheduler.h"
 
+#include <stdlib.h>
+
 #include <AP_HAL/AP_HAL.h>
 #include <AP_Param/AP_Param.h>
 #include <AP_Vehicle/AP_Vehicle.h>
@@ -179,6 +181,17 @@ void AP_Scheduler::tick(void)
  */
 static void fill_nanf_stack(void)
 {
+    // A debug aid, and a costly one: 4KB of NaNs written before EVERY
+    // scheduler task, measured at ~4% of total CPU and scaling linearly
+    // with simulation speedup. Perf-focused runs (multi-vehicle clusters
+    // chasing high speedups) can opt out; the default is unchanged.
+    static int8_t enabled = -1;
+    if (enabled == -1) {
+        enabled = getenv("SITL_DISABLE_STACK_NANF") == nullptr;
+    }
+    if (!enabled) {
+        return;
+    }
     float v[1024];
     fill_nanf(v, ARRAY_SIZE(v));
 }

--- a/libraries/AP_TECS/AP_TECS.cpp
+++ b/libraries/AP_TECS/AP_TECS.cpp
@@ -1178,7 +1178,21 @@ void AP_TECS::_initialise_states(float hgt_afe)
     // Initialise states and variables if DT > 0.2 second or TECS is getting overridden or in climbout.
     _flags.reset = false;
 
-    if (_DT > 0.2f || _need_reset) {
+#if CONFIG_HAL_BOARD == HAL_BOARD_SITL
+    /*
+      SIMULATION ONLY: accelerated simulation can legitimately deliver
+      update intervals above 0.2s of simulated time (a stretched clock
+      makes a 10Hz scheduler-table task arrive at 0.1-0.3s of sim
+      time). Resetting on every such call re-anchored the height
+      demand to the current altitude each cycle and TECS converted the
+      resulting overspeed into an unbounded climb. Real hardware keeps
+      the 0.2s threshold unchanged.
+    */
+    const float reset_DT_threshold = 2.0f;
+#else
+    const float reset_DT_threshold = 0.2f;
+#endif
+    if (_DT > reset_DT_threshold || _need_reset) {
         _SKE_weighting        = 1.0f;
         _integTHR_state       = 0.0f;
         _integSEBdot          = 0.0f;


### PR DESCRIPTION
Summary
Two small SITL-only robustness fixes for running the simulation at high commanded speedups. Split out of #34019 (multi-instance shared-memory clustering) so they can be judged on their own; that PR's branch stacks on this one.

- [ x] Checked by a human programmer
- [x ] Automated test(s) verify changes (e.g. unit test, autotest)

Background — why a scheduler task can see > 0.2s of simulated time
In classic SITL the physics step is fixed, so a 10Hz scheduler task always sees 0.1s of sim time between calls and host CPU load can only ever stretch wall time. #34019 adds a mode (engaged only when clustering is active) where, if the host cannot afford full control density at the commanded speedup, the per-loop sim-time step stretches instead — bounded to +5ms, ramped in with altitude, disabled near the ground. This is a deliberate, declared trade of control-loop invocations per simulated second for throughput; the clustered instances themselves stay in lock-step with each other via a shared-clock barrier (which the long formation-hold results in that PR's CI demonstrate). Under maximum stretch a 10Hz task legitimately sees ~0.15s of sim time between calls, and ~0.3s if the scheduler sheds a cycle under budget pressure.

AP_TECS: SITL-only wider reset threshold
_initialise_states() performs a full reset whenever _DT > 0.2f. Under sustained frame stretch that fires on every call: the height demand is re-anchored to current altitude each cycle, the resulting overspeed is converted into climb, and the aircraft ascends without bound (we measured 20km with every TECS input individually verified sane before locating this). This commit widens the threshold to 2.0s under SITL only — real hardware keeps 0.2s untouched. The exact configuration that reproduced the runaway on every run flies its whole mission level with this change.

I'm happy to scope this tighter if preferred: (a) widen only while frame-stretching is actually engaged, keeping 0.2s for ordinary SITL, or (b) cap the stretch so a 10Hz task can never exceed 0.2s and drop this commit entirely — (b) is simplest but costs measurable speedup on slower hosts.

AP_Scheduler: allow disabling the SITL stack NaN fill
The per-task stack NaN poisoning is a debug aid that measures ~4% of total CPU in accelerated multi-vehicle runs. This adds an opt-out via the SITL_DISABLE_STACK_NANF environment variable; default behavior is unchanged.

Testing
Plane + 2 copters in FOLLOW at commanded 100x on a stock ubuntu-22.04 runner: 119.4x steady-state, formation held ~6000 sim-seconds unbroken (CI in #34019).
The previously always-reproducing TECS runaway configuration (raced clock, 10Hz tasks arriving at ~0.22 sim-s intervals) now flies level for entire missions.
Hardware code paths are untouched by both commits.



<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
