### PR TITLE
Fixes for flakey WindEstimates

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -3427,16 +3427,29 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.takeoff(70)  # default wind sim wind is a sqrt function up to 60m
         self.change_mode('LOITER')
         # use default estimator to determine when to check others:
-        self.wait_and_maintain_wind_estimate(5, 45, timeout=120)
+        self.wait_and_maintain_wind_estimate(
+            5, 45, timeout=120, minimum_duration=10)
 
         for ahrs_type in 0, 2, 3, 10:
             self.start_subtest("Checking AHRS_EKF_TYPE=%u" % ahrs_type)
             self.set_parameter("AHRS_EKF_TYPE", ahrs_type)
-            self.wait_and_maintain_wind_estimate(
-                5, 45,
-                speed_tolerance=1,
-                timeout=30
-            )
+            if ahrs_type == 0:
+                # DCM's wind triangle assumes the airflow lies along the fuselage, so the
+                # angle of attack and turn-direction-dependent sideslip it ignores cost it degrees.
+                self.wait_and_maintain_wind_estimate(
+                    5, 45,
+                    speed_tolerance=1,
+                    dir_tolerance=6,
+                    minimum_duration=10,
+                    timeout=90,
+                )
+            else:
+                self.wait_and_maintain_wind_estimate(
+                    5, 45,
+                    speed_tolerance=1,
+                    minimum_duration=10,
+                    timeout=60,
+                )
         self.fly_home_land_and_disarm()
 
     def WindEstimatesTrim(self):

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -3397,7 +3397,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
                     self.dir_average = di
                 else:
                     self.speed_average += spd
-                    self.di_average += spd
+                    self.dir_average += di
                 self.count += 1
                 return (self.speed_average/self.count, self.dir_average/self.count)
 


### PR DESCRIPTION
### Summary

Make `Plane.WindEstimates` assert a *settled* wind estimate instead of one merely passing through the acceptance window, and give DCM a tolerance matching what it can actually deliver.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

`Plane.WindEstimates` is the test being changed. Measured in SITL after the
change: 30 runs each on three machines with the tighter DCM expectation, plus
12 more with the tolerance as proposed here — 0 failures, against 8/30 and
6/30 on the two machines which previously failed.

### Description

`WindEstimates` checks each AHRS backend's wind estimate against 45±5 degrees,
but `wait_and_maintain_range()` was called with `minimum_duration` left at 0,
so it returned on the **first** sample to enter the window. For an estimate
converging on the window from outside, that is by construction a value sitting
on the bound: the test recorded how the estimate crossed a line rather than
where it came to rest.

That matters because the backends are not comparable:

| Backend | Behaviour |
|---|---|
| EKF2, EKF3, SIM | Already correct when asked — satisfy the check in 0.3 s, settle at 44.6°, hold to ±0.12° |
| DCM | Settles several degrees off, and the sign depends on circling direction: **41.2°** loitering one way, **48.8°** the other, straddling the truth |

DCM's wind triangle assumes the air-relative velocity lies along the fuselage
axis. The simulated aircraft flies at −2.7° of angle of attack with ±0.43° of
sideslip whose sign follows the turn, so DCM cannot do better than this.

The DCM subtest was therefore accepted at the instant its estimate grazed 40,
and whether that landed inside the timeout came down to timing: measured
across three machines it failed **20–27% of runs on two of them**, and it
failed 4 times in 20 at the 2022 commit which introduced it.

This PR requires the estimate to be *maintained* rather than merely touched
(`minimum_duration=10`), and widens DCM's direction tolerance to 6° — which is
what its own geometry permits — while leaving the EKF and SIM backends on the
original tight expectation.

#### Why two commits

The first commit is a prerequisite, not a drive-by. `ValueAverager.add_value()`
added the speed into `self.di_average` — an attribute which does not exist, and
the wrong quantity even if it did:

```python
-                    self.di_average += spd
+                    self.dir_average += di
```

It raises `AttributeError` on the second sample. Nothing reached it because
`WindEstimates`, its only user, left `minimum_duration` at 0 and so never asked
for a second sample. Setting `minimum_duration=10` in the second commit is
exactly what would have found it, so the fix has to land first for the series
to be bisectable.
