### PR TITLE
AP_Scripting: integrate the elapsed time in the GAT example

### DIFF
--- a/libraries/AP_Scripting/examples/guided_above_terrain_posvelaccel_sub.lua
+++ b/libraries/AP_Scripting/examples/guided_above_terrain_posvelaccel_sub.lua
@@ -6,6 +6,10 @@ local PARAM_TABLE_KEY = 96
 local PARAM_TABLE_PREFIX = "GAT_"
 
 local RUN_HZ = 20
+-- the largest step the position target may be integrated over in one
+-- callback; big enough that ordinary scheduling jitter is integrated
+-- honestly, small enough to bound the lurch after a real stall
+local MAX_DT = 0.5
 local GUIDED_MODE = 4
 
 -- configuration
@@ -34,9 +38,15 @@ local function update()
     -- calculate dt
     local tnow = millis()
     local dt = (tnow - last_time_ms):tofloat() / 1000.0
-    -- cap dt to avoid large integration steps if execution was delayed
-    if (dt > 2.0 / RUN_HZ) then
-        dt = 1.0 / RUN_HZ
+    -- cap dt to avoid a large integration step if execution was badly
+    -- delayed, but otherwise integrate the time which actually elapsed.
+    -- Substituting 1/RUN_HZ for a late callback discards the excess, and
+    -- the position target then advances more slowly than the clock: under
+    -- autotest at --parallel=16 7.3% of callbacks arrived later than
+    -- 2/RUN_HZ (worst 243ms) and integrating each as 50ms threw away 5.8s
+    -- of a 60s run, so the sub covered 27.9m of an expected 30m.
+    if (dt > MAX_DT) then
+        dt = MAX_DT
     end
     last_time_ms = tnow
 


### PR DESCRIPTION
### Summary

Corrects integration of position target in Lua script used in new (slightly flakey) autotest suite.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

guided_above_terrain_posvelaccel_sub.lua integrates its position target forward by the time since the last callback.  When a callback arrived later than 2/RUN_HZ it substituted 1/RUN_HZ for the real interval:

    if (dt > 2.0 / RUN_HZ) then
        dt = 1.0 / RUN_HZ
    end

so a callback 243ms late advanced the target by 50ms and the remaining 193ms was discarded.  The position target then falls behind the clock, and the vehicle - which tracks that target accurately - covers less ground than the commanded speed implies.

Measured from a failing Sub.GuidedAboveTerrain run under autotest at --parallel=16, over the 60 simulated seconds the test watches:

    GUIP updates      1047 at 17.2Hz (nominal 20Hz)
    late callbacks    76 of 1047 (7.3%), worst 243ms
    time discarded    5.82s, so 55.08s integrated of 60.90s elapsed
    distance          27.90m of an expected 30.00m, +-1.00m -> failed

The dataflash shows the loss is upstream of the controller, not in it: the script commanded 0.495m/s and the position controller achieved 0.442m/s against a desired 0.443m/s - it tracked what it was given to within 0.001m/s, and what it was given was slow.

Cap the step at a fixed MAX_DT instead, so ordinary jitter is integrated honestly and only a real stall is bounded.  Pinning the simulation speedup was tried first and is not a fix: at context_set_speedup(10) the run still lost ground, reaching 28.93m, because it reduces how often callbacks are late without changing what happens when they are.
