### PR TITLE
autotest: fly clear_roi on one northbound leg

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -17332,11 +17332,13 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
     def clear_roi(self):
         '''ensure three commands that clear ROI are equivalent'''
 
+        # 8000m so the vehicle never reaches the waypoint: the thirteen heading
+        # waits below are capped at 30s each and the twelve command ACKs at 10s,
+        # 5100m at the default WP_SPD, from within 500m of home.  A stopped
+        # vehicle holds its last yaw.
         self.upload_simple_relhome_mission([
-            (mavutil.mavlink.MAV_CMD_NAV_TAKEOFF,    0, 0, 20),
-            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT,   0, 0, 20),
-            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 200, 0, 20), # directly North, i.e. 0 degrees
-            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 400, 0, 20), # directly North, i.e. 0 degrees
+            (mavutil.mavlink.MAV_CMD_NAV_TAKEOFF,     0, 0, 20),
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 8000, 0, 20), # directly North, i.e. 0 degrees
         ])
 
         self.set_parameter("AUTO_OPTIONS", 3)
@@ -17345,6 +17347,9 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         self.arm_vehicle()
         home_loc = self.get_location()
 
+        self.wait_distance_to_home(150, 500, timeout=120)
+        self.wait_heading(0)
+
         cmd_ids = [
             mavutil.mavlink.MAV_CMD_DO_SET_ROI,
             mavutil.mavlink.MAV_CMD_DO_SET_ROI_LOCATION,
@@ -17352,8 +17357,6 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         ]
         for command in self.run_cmd, self.run_cmd_int:
             for cmd_id in cmd_ids:
-                self.wait_waypoint(2, 2)
-
                 # Set an ROI at the Home location, expect to point at Home
                 self.run_cmd(mavutil.mavlink.MAV_CMD_DO_SET_ROI_LOCATION,
                              p5=home_loc.lat,
@@ -17361,13 +17364,10 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                              p7=home_loc.get_alt_m(AltFrame.ABSOLUTE))
                 self.wait_heading(180)
 
-                # Clear the ROI, expect to point at the next Waypoint
+                # Clear the ROI, expect to point along the flight path again
                 self.progress("Clear ROI using %s(%d)" % (command.__name__, cmd_id))
                 command(cmd_id)
                 self.wait_heading(0)
-
-                self.wait_waypoint(4, 4)
-                self.set_current_waypoint_using_mav_cmd_do_set_mission_current(seq=2)
 
         self.land_and_disarm()
 


### PR DESCRIPTION
### Summary

`clear_roi` fails intermittently in CI, in two ways, both to do with the mission it flies rather than the ROI handling it checks. This flies it on a single northbound leg instead.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Both failures can be reproduced on master by nudging the timing. Adding one delay makes each of them fire every time:

```python
# waypoint 2 is gone before we start looking for it
self.arm_vehicle()
self.delay_sim_time(15, "miss the waypoint 2 window")

# ...and letting the mission finish before jumping back into it
self.wait_waypoint(4, 4)
self.delay_sim_time(5, "let the mission COMPLETE first")
self.set_current_waypoint_using_mav_cmd_do_set_mission_current(seq=2)
```

The first gives `WaitWaypointTimeout('Timed out waiting for waypoint 2 of 2')` and the second gives `AutoTestTimeoutException('Failed to attain Heading want 0.0, reached 180')`, matching the two failures seen in CI. Neither of those waits remains after this change.

`test.Copter.clear_roi` was then run 10 times in a row against the new version, all passing, and once more with 10 seconds of extra delay injected into every iteration, which also passed. Runtime goes from about 7.7s to 4.7s, since it no longer flies the 200m southbound leg six times. flake8 is clean.

### Description

Since 2026-08-27 this test accounts for 4 of the 7 `sitltest-copter-tests1e` failures, around 3% of completed `test copter` runs, in each case on an unrelated PR:

* `WaitWaypointTimeout('Timed out waiting for waypoint 2 of 2')` in runs [33437383581](https://github.com/ArduPilot/ardupilot/actions/runs/33437383581), [33204501405](https://github.com/ArduPilot/ardupilot/actions/runs/33204501405) and [33059577368](https://github.com/ArduPilot/ardupilot/actions/runs/33059577368)
* `AutoTestTimeoutException('Failed to attain Heading want 0.0, reached 180')` in run [33397616319](https://github.com/ArduPilot/ardupilot/actions/runs/33397616319)

As far as I can tell there are two causes behind those failures, and a third weakness that has not caused one yet.

Cause 1: Waypoint 2 is hard to observe. Mission item 2 is `(0, 0, 20)`, which `upload_simple_relhome_mission` stores as a lat/lng of zero, and a zero lat/lng waypoint means wherever the vehicle happens to be. Item 2 is therefore a zero-length leg that completes in one mission tick, sitting where the takeoff ends. `wait_waypoint(2, 2)` has to catch `MISSION_CURRENT` while it still names item 2, and if it misses that tick it treats the waypoint as skipped and spins until its 400 second timeout. The failing logs show the vehicle going straight from 1 to 3:

```
AP: Mission: 2 WP
AP: Reached command #2
AP: Mission: 3 WP
WW: Starting new waypoint 3
```

Cause 2: The jump back to item 2 can arrive after the mission has completed. `wait_waypoint(4, 4)` returns as soon as `wp_dist` drops below 2m, which is also when the mission can complete. The test then sends `MAV_CMD_DO_SET_MISSION_CURRENT` with `param2` of zero. If the mission has already completed, `AP_Mission::set_current_cmd()` loads the command without starting it and leaves the mission `MISSION_STOPPED`, and `resume()` is only reached when `param2` is 1, so nothing restarts it. The vehicle stops where it is, auto yaw holds its last target because the vehicle is no longer moving, and `wait_heading(0)` cannot be satisfied. In a failing log, `Reached command #2` never appears after the command goes out.

Additional weakness: The jump leaves little margin even when it lands in time. The vehicle spends the next twenty seconds flying south towards item 3, so 180 is the expected heading whether or not the ROI was cleared. `wait_heading(0)` only becomes meaningful once the vehicle turns north again, which uses most of that wait's 30 second budget. I have not seen this one time out in CI, and it is worth saying that it would be reported as the same `Failed to attain Heading want 0.0, reached 180` as the previous case. The two are distinguishable in the log: on a slow leg the vehicle is still making progress and `Reached command #3` eventually arrives, whereas in the failure linked above `Reached command #2` never appears at all and the heading sits at exactly 180, which is the stopped mission rather than a slow leg.

Flying one long leg due north avoids all three. The vehicle is north of home and northbound throughout, so an ROI at home points it south and clearing the ROI points it north again. The two headings never coincide, so each wait is answered by a yaw slew rather than by a leg the vehicle first has to fly, and nothing depends on a one-tick mission state or on restarting a finished mission.

The leg is 5000m so the test cannot outrun it. Thirteen heading waits capped at 30 seconds each is 3900m at the default `WP_SPD`, and they begin within 500m of home, so the vehicle can only reach the waypoint if a wait has already timed out and failed. That matters because reaching it would stop the vehicle, and a stationary vehicle holds its last yaw target, which is the same condition as the second failure above.

The test still covers what it covered before: all three clear-ROI command ids, over both `run_cmd` and `run_cmd_int`, six iterations.