### PR TITLE
SITL: add Unix domain socket support to sim_vehicle

### DIFF
--- a/Tools/autotest/pysim/util.py
+++ b/Tools/autotest/pysim/util.py
@@ -507,6 +507,29 @@ class PSpawnStdPrettyPrinter(object):
         pass
 
 
+def unix_domain_socket_path(serial, cwd=None):
+    if cwd is None:
+        cwd = os.getcwd()
+    return os.path.join(cwd, "APM-UDS-serial%u" % serial)
+
+
+def unix_domain_socket_serial_args():
+    ret = []
+    for serial in [0, 1, 2, 5, 6, 7, 8]:
+        path = "uds:APM-UDS-serial%u" % serial
+        if serial == 0:
+            path += ":wait"
+        ret.append("--serial%u=%s" % (serial, path))
+    return ret
+
+
+def unix_domain_socket_rcin_path(cwd=None, offset=0):
+    if cwd is None:
+        cwd = os.getcwd()
+    suffix = "" if offset == 0 else str(offset)
+    return os.path.join(cwd, "APM-UDS-rcin%s" % suffix)
+
+
 def start_SITL(binary,
                valgrind=False,
                callgrind=False,

--- a/Tools/autotest/sim_vehicle.py
+++ b/Tools/autotest/sim_vehicle.py
@@ -857,17 +857,22 @@ def start_antenna_tracker(opts):
     tracker_instance = 1
     oldpwd = os.getcwd()
     os.chdir(vehicledir)
-    tracker_serial0 = "tcp:127.0.0.1:" + str(5760 + 10 * tracker_instance)
+    if opts.unix_domain_socket:
+        tracker_serial0 = "uds:" + util.unix_domain_socket_path(0, vehicledir)
+    else:
+        tracker_serial0 = "tcp:127.0.0.1:" + str(5760 + 10 * tracker_instance)
     binary_basedir = "build/sitl"
     exe = os.path.join(root_dir,
                        binary_basedir,
                        "bin/antennatracker")
-    run_in_terminal_window("AntennaTracker",
-                           ["nice",
-                            exe,
-                            "-I" + str(tracker_instance),
-                            "--model=tracker",
-                            "--home=" + ",".join([str(x) for x in tracker_home])])
+    cmd = ["nice",
+           exe,
+           "-I" + str(tracker_instance),
+           "--model=tracker",
+           "--home=" + ",".join([str(x) for x in tracker_home])]
+    if opts.unix_domain_socket:
+        cmd.extend(util.unix_domain_socket_serial_args())
+    run_in_terminal_window("AntennaTracker", cmd)
     os.chdir(oldpwd)
 
 
@@ -985,6 +990,9 @@ def start_vehicle(binary, opts, stuff, spawns=None):
         cmd.extend(["--slave", str(opts.slave)])
     if opts.enable_fgview:
         cmd.extend(["--enable-fgview"])
+    if opts.unix_domain_socket:
+        cmd.extend(util.unix_domain_socket_serial_args())
+        cmd.append("--rc-in-port=uds:APM-UDS-rcin")
     if opts.sitl_instance_args:
         # this could be a lot better:
         cmd.extend(opts.sitl_instance_args)
@@ -1107,7 +1115,7 @@ def start_mavproxy(opts, stuff):
     # This is run before the loop so it only runs once
     wsl2_host_ip_str = wsl2_host_ip()
 
-    for i in instances:
+    for i, i_dir in zip(instances, instance_dir):
         if not opts.no_extra_ports:
             ports = [14550 + 10 * i]
             for port in ports:
@@ -1125,10 +1133,15 @@ def start_mavproxy(opts, stuff):
         if not opts.mcast:
             if opts.udp:
                 cmd.extend(["--master", ":" + str(5760 + 10 * i)])
+            elif opts.unix_domain_socket:
+                cmd.extend(["--master", "uds:" + util.unix_domain_socket_path(0, i_dir)])
             else:
                 cmd.extend(["--master", "tcp:127.0.0.1:" + str(5760 + 10 * i)])
         if stuff["sitl-port"] and not opts.no_rcin:
-            cmd.extend(["--sitl", "127.0.0.1:" + str(5501 + 10 * i)])
+            if opts.unix_domain_socket:
+                cmd.extend(["--sitl", "uds:" + util.unix_domain_socket_rcin_path(i_dir)])
+            else:
+                cmd.extend(["--sitl", "127.0.0.1:" + str(5501 + 10 * i)])
 
     if opts.tracker:
         cmd.extend(["--load-module", "tracker"])
@@ -1506,6 +1519,10 @@ group_sim.add_option("", "--udp",
                      action="store_true",
                      default=False,
                      help="Use UDP on 127.0.0.1:5760")
+group_sim.add_option("--unix-domain-socket", "--uds",
+                     action="store_true",
+                     default=False,
+                     help="Use Unix domain sockets; each instance requires a separate working directory")
 group_sim.add_option("", "--osd",
                      action='store_true',
                      dest='OSD',
@@ -1739,6 +1756,10 @@ if cmd_opts.strace and cmd_opts.callgrind:
 
 if cmd_opts.sysid and cmd_opts.auto_sysid:
     print("Cannot use auto-sysid together with sysid")
+    sys.exit(1)
+
+if cmd_opts.unix_domain_socket and (cmd_opts.mcast or cmd_opts.udp):
+    print("Cannot use unix domain sockets together with multicast or UDP")
     sys.exit(1)
 
 # magically determine vehicle type (if required):

--- a/libraries/AP_HAL/utility/Socket.cpp
+++ b/libraries/AP_HAL/utility/Socket.cpp
@@ -36,6 +36,10 @@
 #include <unistd.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
+#if defined(AP_SOCKET_NATIVE_ENABLED)
+#include <sys/stat.h>
+#include <sys/un.h>
+#endif
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <arpa/inet.h>
@@ -44,6 +48,7 @@
 #endif
 
 #include <errno.h>
+#include <stdlib.h>
 
 #if AP_NETWORKING_BACKEND_CHIBIOS || AP_NETWORKING_BACKEND_PPP
 #define CALL_PREFIX(x) ::lwip_##x
@@ -53,6 +58,81 @@
 
 #ifndef MSG_NOSIGNAL
 #define MSG_NOSIGNAL 0
+#endif
+
+#if defined(AP_SOCKET_NATIVE_ENABLED)
+struct UnixSocketPath {
+    int fd;
+    char *path;
+    dev_t device;
+    ino_t inode;
+    UnixSocketPath *next;
+};
+
+static UnixSocketPath *unix_socket_paths;
+static bool unix_socket_cleanup_registered;
+
+static bool unix_path_matches(const char *path, dev_t device, ino_t inode)
+{
+    struct stat path_stat;
+    return lstat(path, &path_stat) == 0 &&
+           S_ISSOCK(path_stat.st_mode) &&
+           path_stat.st_dev == device &&
+           path_stat.st_ino == inode;
+}
+
+static void unlink_unix_path(const UnixSocketPath &socket_path)
+{
+    if (unix_path_matches(socket_path.path, socket_path.device, socket_path.inode)) {
+        unlink(socket_path.path);
+    }
+}
+
+static void forget_unix_path(int fd)
+{
+    UnixSocketPath **entry = &unix_socket_paths;
+    while (*entry != nullptr) {
+        if ((*entry)->fd == fd) {
+            UnixSocketPath *removed = *entry;
+            *entry = removed->next;
+            unlink_unix_path(*removed);
+            free(removed->path);
+            free(removed);
+            return;
+        }
+        entry = &(*entry)->next;
+    }
+}
+
+static void remember_unix_path(int fd, const char *path)
+{
+    if (!unix_socket_cleanup_registered) {
+        if (atexit(SOCKET_CLASS_NAME::cleanup_unix_paths) != 0) {
+            return;
+        }
+        unix_socket_cleanup_registered = true;
+    }
+
+    struct stat path_stat;
+    if (lstat(path, &path_stat) != 0 || !S_ISSOCK(path_stat.st_mode)) {
+        return;
+    }
+
+    char *path_copy = strdup(path);
+    UnixSocketPath *entry = (UnixSocketPath *)calloc(1, sizeof(*entry));
+    if (path_copy == nullptr || entry == nullptr) {
+        free(path_copy);
+        free(entry);
+        return;
+    }
+
+    entry->fd = fd;
+    entry->path = path_copy;
+    entry->device = path_stat.st_dev;
+    entry->inode = path_stat.st_ino;
+    entry->next = unix_socket_paths;
+    unix_socket_paths = entry;
+}
 #endif
 
 /*
@@ -81,12 +161,7 @@ SOCKET_CLASS_NAME::SOCKET_CLASS_NAME(bool _datagram, int _fd) :
 
 SOCKET_CLASS_NAME::~SOCKET_CLASS_NAME()
 {
-    if (fd != -1) {
-        CALL_PREFIX(close)(fd);
-    }
-    if (fd_in != -1) {
-        CALL_PREFIX(close)(fd_in);
-    }
+    close();
 }
 
 void SOCKET_CLASS_NAME::make_sockaddr(const char *address, uint16_t port, struct sockaddr_in &sockaddr)
@@ -261,6 +336,124 @@ bool SOCKET_CLASS_NAME::bind(const char *address, uint16_t port)
     }
     return true;
 }
+
+#if defined(AP_SOCKET_NATIVE_ENABLED)
+/*
+  connect a native Unix domain socket
+ */
+bool SOCKET_CLASS_NAME::connect_unix(const char *path)
+{
+    if (path == nullptr || path[0] == '\0') {
+        errno = EINVAL;
+        return false;
+    }
+
+    struct sockaddr_un sockaddr {};
+    if (strlen(path) >= sizeof(sockaddr.sun_path)) {
+        errno = ENAMETOOLONG;
+        return false;
+    }
+    sockaddr.sun_family = AF_UNIX;
+    strncpy(sockaddr.sun_path, path, sizeof(sockaddr.sun_path) - 1);
+
+    const int unix_fd = CALL_PREFIX(socket)(AF_UNIX, datagram ? SOCK_DGRAM : SOCK_STREAM, 0);
+    if (unix_fd == -1) {
+        return false;
+    }
+#ifdef FD_CLOEXEC
+    CALL_PREFIX(fcntl)(unix_fd, F_SETFD, FD_CLOEXEC);
+#endif
+
+    if (CALL_PREFIX(connect)(unix_fd, (struct sockaddr *)&sockaddr, sizeof(sockaddr)) == -1) {
+        const int connect_errno = errno;
+        CALL_PREFIX(close)(unix_fd);
+        errno = connect_errno;
+        return false;
+    }
+
+    close();
+    fd = unix_fd;
+    connected = true;
+    pending_connect = false;
+    return true;
+}
+
+/*
+  bind a native Unix domain datagram socket
+ */
+bool SOCKET_CLASS_NAME::bind_unix(const char *path)
+{
+    if (!datagram || path == nullptr || path[0] == '\0') {
+        errno = EINVAL;
+        return false;
+    }
+
+    struct sockaddr_un sockaddr {};
+    if (strlen(path) >= sizeof(sockaddr.sun_path)) {
+        errno = ENAMETOOLONG;
+        return false;
+    }
+    sockaddr.sun_family = AF_UNIX;
+    strncpy(sockaddr.sun_path, path, sizeof(sockaddr.sun_path) - 1);
+
+    const int unix_fd = CALL_PREFIX(socket)(AF_UNIX, SOCK_DGRAM, 0);
+    if (unix_fd == -1) {
+        return false;
+    }
+#ifdef FD_CLOEXEC
+    CALL_PREFIX(fcntl)(unix_fd, F_SETFD, FD_CLOEXEC);
+#endif
+
+    int ret = CALL_PREFIX(bind)(unix_fd, (struct sockaddr *)&sockaddr, sizeof(sockaddr));
+    if (ret == -1 && errno == EADDRINUSE) {
+        struct stat path_stat;
+        if (lstat(path, &path_stat) == 0 && S_ISSOCK(path_stat.st_mode)) {
+            const int probe_fd = CALL_PREFIX(socket)(AF_UNIX, SOCK_DGRAM, 0);
+            const int connect_ret = probe_fd == -1 ? -1 : CALL_PREFIX(connect)(
+                probe_fd,
+                (struct sockaddr *)&sockaddr,
+                sizeof(sockaddr));
+            const int connect_errno = errno;
+            if (probe_fd != -1) {
+                CALL_PREFIX(close)(probe_fd);
+            }
+            if (connect_ret == -1 && connect_errno == ECONNREFUSED &&
+                unix_path_matches(path, path_stat.st_dev, path_stat.st_ino) &&
+                unlink(path) == 0) {
+                ret = CALL_PREFIX(bind)(unix_fd, (struct sockaddr *)&sockaddr, sizeof(sockaddr));
+            }
+        }
+    }
+    if (ret == -1) {
+        const int bind_errno = errno;
+        CALL_PREFIX(close)(unix_fd);
+        errno = bind_errno;
+        return false;
+    }
+
+    if (fd != -1) {
+#if defined(AP_SOCKET_NATIVE_ENABLED)
+        forget_unix_path(fd);
+#endif
+        CALL_PREFIX(close)(fd);
+    }
+    fd = unix_fd;
+    remember_unix_path(fd, path);
+    return true;
+}
+
+void SOCKET_CLASS_NAME::register_unix_path(int fd, const char *path)
+{
+    remember_unix_path(fd, path);
+}
+
+void SOCKET_CLASS_NAME::cleanup_unix_paths()
+{
+    for (UnixSocketPath *entry = unix_socket_paths; entry != nullptr; entry = entry->next) {
+        unlink_unix_path(*entry);
+    }
+}
+#endif
 
 
 /*
@@ -564,6 +757,9 @@ bool SOCKET_CLASS_NAME::is_multicast_address(struct sockaddr_in &addr) const
 void SOCKET_CLASS_NAME::close(void)
 {
     if (fd != -1) {
+#if defined(AP_SOCKET_NATIVE_ENABLED)
+        forget_unix_path(fd);
+#endif
         CALL_PREFIX(close)(fd);
         fd = -1;
     }

--- a/libraries/AP_HAL/utility/Socket.hpp
+++ b/libraries/AP_HAL/utility/Socket.hpp
@@ -36,6 +36,12 @@ public:
     bool connect(const char *address, uint16_t port);
     bool connect_timeout(const char *address, uint16_t port, uint32_t timeout_ms);
     bool bind(const char *address, uint16_t port);
+#if defined(AP_SOCKET_NATIVE_ENABLED)
+    bool connect_unix(const char *path);
+    bool bind_unix(const char *path);
+    static void register_unix_path(int fd, const char *path);
+    static void cleanup_unix_paths();
+#endif
     bool reuseaddress() const;
     bool set_blocking(bool blocking) const;
     bool set_cloexec() const;

--- a/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
+++ b/libraries/AP_HAL_SITL/HAL_SITL_Class.cpp
@@ -34,6 +34,7 @@
 #include <AP_Logger/AP_Logger.h>
 #include <AP_RCProtocol/AP_RCProtocol_config.h>
 #include <AP_HAL/SIMState.h>
+#include <AP_HAL/utility/Socket_native.h>
 
 using namespace HALSITL;
 
@@ -173,6 +174,7 @@ static void sig_alrm(int signum)
     static char env[] = "SITL_WATCHDOG_RESET=1";
     putenv(env);
     printf("GOT SIGALRM\n");
+    SocketAPM_native::cleanup_unix_paths();
     execv(new_argv[0], new_argv);
 }
 
@@ -319,6 +321,7 @@ void HAL_SITL::run(int argc, char * const argv[], Callbacks* callbacks) const
 
 void HAL_SITL::actually_reboot()
 {
+    SocketAPM_native::cleanup_unix_paths();
     execv(new_argv[0], new_argv);
     AP_HAL::panic("PANIC: REBOOT FAILED: %s", strerror(errno));
 }

--- a/libraries/AP_HAL_SITL/SITL_State.cpp
+++ b/libraries/AP_HAL_SITL/SITL_State.cpp
@@ -14,6 +14,7 @@
 #include <signal.h>
 #include <unistd.h>
 #include <stdlib.h>
+#include <string.h>
 #include <errno.h>
 #include <sys/types.h>
 #include <sys/select.h>
@@ -52,9 +53,13 @@ void SITL_State::_sitl_setup()
         _update_airspeed(0);
 #if AP_SIM_SOLOGIMBAL_ENABLED
         if (enable_gimbal) {
-            // the gimbal connects back to the vehicle's SERIAL2 MAVLink
-            // port, which is base_port + 2 (offset by the SITL instance):
-            gimbal = NEW_NOTHROW SITL::SoloGimbal(base_port() + 2);
+            // the gimbal connects back to the vehicle's SERIAL1 MAVLink endpoint
+            const char *serial1_path = _serial_path[1];
+            if (strncmp(serial1_path, "uds:", 4) == 0) {
+                gimbal = NEW_NOTHROW SITL::SoloGimbal(serial1_path + 4);
+            } else {
+                gimbal = NEW_NOTHROW SITL::SoloGimbal(base_port() + 2);
+            }
         }
 #endif
 
@@ -77,6 +82,7 @@ void SITL_State::_sitl_setup()
         _sitl->irlock_port = _irlock_port;
 
         _sitl->rcin_port = _rcin_port;
+        _sitl->rcin_path = _rcin_path;
 
         fprintf(stdout, "Using \\clock topic for DDS timing: %s\n", _use_dds_sim_time ? "enabled" : "disabled");
         _sitl->use_dds_sim_time = _use_dds_sim_time;
@@ -166,7 +172,7 @@ void SITL_State::wait_clock(uint64_t wait_time_usec)
             HALSITL::UARTDriver *uart = (HALSITL::UARTDriver*)hal.serial(0);
             const int queue_length = uart->get_system_outqueue_length();
             // ::fprintf(stderr, "queue_length=%d\n", (signed)queue_length);
-            if (queue_length < 1024) {
+            if (queue_length < uart->get_system_outqueue_limit()) {
                 break;
             }
             _serial_0_outqueue_full_count++;

--- a/libraries/AP_HAL_SITL/SITL_State.h
+++ b/libraries/AP_HAL_SITL/SITL_State.h
@@ -93,6 +93,7 @@ private:
     Scheduler *_scheduler;
 
     uint16_t _rcin_port;
+    const char *_rcin_path;
     uint16_t _fg_view_port;
     uint16_t _irlock_port;
 

--- a/libraries/AP_HAL_SITL/SITL_cmdline.cpp
+++ b/libraries/AP_HAL_SITL/SITL_cmdline.cpp
@@ -111,7 +111,7 @@ void SITL_State::_usage(void)
            "\t--uartA device           alias for --serial0 (do not use)\n"
            "\t--net-device NAME:PORT   attach simulated device NAME to TCP port PORT rather than to a serial port\n"
            "\t--base-port PORT         set port num for base port(default 5670) must be before -I option\n"
-           "\t--rc-in-port PORT        set port num for rc in\n"
+           "\t--rc-in-port PORT|uds:PATH set UDP port or Unix datagram path for rc in\n"
            "\t--sim-address ADDR       set address string for simulator\n"
            "\t--sim-port-in PORT       set port num for simulator in\n"
            "\t--sim-port-out PORT      set port num for simulator out\n"
@@ -255,6 +255,7 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
     const int FG_VIEW_PORT = 5503;
     _base_port = BASE_PORT;
     _rcin_port = RCIN_PORT;
+    _rcin_path = nullptr;
     _fg_view_port = FG_VIEW_PORT;
 
     const int SIM_IN_PORT = 9003;
@@ -451,7 +452,7 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
             if (_base_port == BASE_PORT) {
                 _base_port += _instance * 10;
             }
-            if (_rcin_port == RCIN_PORT) {
+            if (_rcin_path == nullptr && _rcin_port == RCIN_PORT) {
                 _rcin_port += _instance * 10;
             }
             if (_fg_view_port == FG_VIEW_PORT) {
@@ -546,7 +547,16 @@ void SITL_State::_parse_command_line(int argc, char * const argv[])
             _base_port = atoi(gopt.optarg);
             break;
         case CMDLINE_RCIN_PORT:
-            _rcin_port = atoi(gopt.optarg);
+            if (strncmp(gopt.optarg, "uds:", 4) == 0) {
+                _rcin_path = &gopt.optarg[4];
+                if (_rcin_path[0] == '\0') {
+                    printf("--rc-in-port requires a path after uds:\n");
+                    exit(1);
+                }
+            } else {
+                _rcin_path = nullptr;
+                _rcin_port = atoi(gopt.optarg);
+            }
             break;
         case CMDLINE_SIM_ADDRESS:
             simulator_address = gopt.optarg;

--- a/libraries/AP_HAL_SITL/UARTDriver.cpp
+++ b/libraries/AP_HAL_SITL/UARTDriver.cpp
@@ -29,8 +29,10 @@
 
 #include <errno.h>
 #include <sys/ioctl.h>
+#include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <sys/un.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <sys/select.h>
@@ -47,6 +49,7 @@
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 #include <AP_Filesystem/AP_Filesystem.h>
 #include <AP_Common/ExpandingString.h>
+#include <AP_HAL/utility/Socket_native.h>
 
 extern const AP_HAL::HAL& hal;
 
@@ -87,6 +90,7 @@ void UARTDriver::_begin(uint32_t baud, uint16_t rxSpace, uint16_t txSpace)
            For example:
              tcp:5760:wait    // tcp listen on port 5760
              tcp:0:wait       // tcp listen on use base_port + 0
+             uds:APM-UDS-serial0:wait
              tcpclient:192.168.2.15:5762
              udpclient:127.0.0.1
              udpclient:127.0.0.1:14550
@@ -116,6 +120,12 @@ void UARTDriver::_begin(uint32_t baud, uint16_t rxSpace, uint16_t txSpace)
             uint16_t port = atoi(args1);
             bool wait = (args2 && strcmp(args2, "wait") == 0);
             _tcp_start_connection(port, wait);
+        } else if (strcmp(devtype, "uds") == 0) {
+            if (args1 == nullptr || args1[0] == '\0') {
+                AP_HAL::panic("Invalid Unix domain socket path: %s", path);
+            }
+            bool wait = (args2 && strcmp(args2, "wait") == 0);
+            _unix_start_connection(args1, wait);
         } else if (strcmp(devtype, "tcpclient") == 0) {
             if (args2 == nullptr) {
                 AP_HAL::panic("Invalid tcp client path: %s", path);
@@ -428,6 +438,125 @@ void UARTDriver::_tcp_start_connection(uint16_t port, bool wait_for_connection)
 
 
 /*
+  start a Unix domain socket connection for the serial port. If
+  wait_for_connection is true then block until a client connects
+ */
+void UARTDriver::_unix_start_connection(const char *path, bool wait_for_connection)
+{
+    struct sockaddr_un listen_sockaddr {};
+
+    if (_connected) {
+        return;
+    }
+
+    _use_send_recv = true;
+    _is_unix_socket = true;
+
+    if (_console) {
+        _connected = true;
+        _use_send_recv = false;
+        _listen_fd = -1;
+        _fd = 1;
+        return;
+    }
+
+    if (_fd != -1) {
+        close(_fd);
+    }
+
+    if (_listen_fd == -1) {
+        if (strlen(path) >= sizeof(listen_sockaddr.sun_path)) {
+            fprintf(stderr, "Unix domain socket path is too long: %s\n", path);
+            exit(1);
+        }
+
+        listen_sockaddr.sun_family = AF_UNIX;
+        strncpy(listen_sockaddr.sun_path, path, sizeof(listen_sockaddr.sun_path) - 1);
+
+        _listen_fd = socket(AF_UNIX, SOCK_STREAM, 0);
+        if (_listen_fd == -1) {
+            fprintf(stderr, "socket failed - %s\n", strerror(errno));
+            exit(1);
+        }
+        if (fcntl(_listen_fd, F_SETFD, FD_CLOEXEC) == -1) {
+            fprintf(stderr, "fcntl failed on setting FD_CLOEXEC - %s\n", strerror(errno));
+            exit(1);
+        }
+
+        int ret = bind(_listen_fd, (struct sockaddr *)&listen_sockaddr, sizeof(listen_sockaddr));
+        if (ret == -1 && errno == EADDRINUSE) {
+            struct stat path_stat;
+            if (lstat(path, &path_stat) == 0 && S_ISSOCK(path_stat.st_mode)) {
+                int probe_fd = socket(AF_UNIX, SOCK_STREAM, 0);
+                int connect_ret = probe_fd == -1 ? -1 : connect(
+                    probe_fd,
+                    (struct sockaddr *)&listen_sockaddr,
+                    sizeof(listen_sockaddr));
+                int connect_errno = errno;
+                if (probe_fd != -1) {
+                    close(probe_fd);
+                }
+                if (connect_ret == -1 && connect_errno == ECONNREFUSED) {
+                    // A newly bound stream socket also refuses connections in
+                    // the brief interval before listen(). Give it time to
+                    // become live before treating the path as stale.
+                    usleep(100000);
+                    probe_fd = socket(AF_UNIX, SOCK_STREAM, 0);
+                    connect_ret = probe_fd == -1 ? -1 : connect(
+                        probe_fd,
+                        (struct sockaddr *)&listen_sockaddr,
+                        sizeof(listen_sockaddr));
+                    connect_errno = errno;
+                    if (probe_fd != -1) {
+                        close(probe_fd);
+                    }
+
+                    struct stat current_path_stat;
+                    if (connect_ret == -1 && connect_errno == ECONNREFUSED &&
+                        lstat(path, &current_path_stat) == 0 &&
+                        S_ISSOCK(current_path_stat.st_mode) &&
+                        current_path_stat.st_dev == path_stat.st_dev &&
+                        current_path_stat.st_ino == path_stat.st_ino &&
+                        unlink(path) == 0) {
+                        ret = bind(_listen_fd, (struct sockaddr *)&listen_sockaddr, sizeof(listen_sockaddr));
+                    }
+                }
+            }
+        }
+        if (ret == -1) {
+            fprintf(stderr, "bind failed on Unix domain socket %s - %s\n", path, strerror(errno));
+            exit(1);
+        }
+        SocketAPM_native::register_unix_path(_listen_fd, path);
+
+        if (listen(_listen_fd, 5) == -1) {
+            fprintf(stderr, "listen failed - %s\n", strerror(errno));
+            exit(1);
+        }
+
+        fprintf(stderr, "SERIAL%u on Unix domain socket %s\n", _portNumber, path);
+        fflush(stdout);
+    }
+
+    if (wait_for_connection) {
+        fprintf(stdout, "Waiting for connection ....\n");
+        fflush(stdout);
+        _fd = accept(_listen_fd, nullptr, nullptr);
+        if (_fd == -1) {
+            fprintf(stderr, "accept() error - %s", strerror(errno));
+            exit(1);
+        }
+        if (fcntl(_fd, F_SETFD, FD_CLOEXEC) == -1) {
+            fprintf(stderr, "fcntl failed on setting FD_CLOEXEC - %s\n", strerror(errno));
+            exit(1);
+        }
+        _connected = true;
+        fprintf(stdout, "Connection on Unix domain socket for SERIAL%u\n", _portNumber);
+    }
+}
+
+
+/*
   start a TCP client connection for the serial port. 
  */
 void UARTDriver::_tcp_start_client(const char *address, uint16_t port)
@@ -697,10 +826,17 @@ void UARTDriver::_check_connection(void)
         _fd = accept(_listen_fd, nullptr, nullptr);
         if (_fd != -1) {
             int one = 1;
-            _connected = true;
-            setsockopt(_fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
+            if (!_is_unix_socket) {
+                setsockopt(_fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
+            }
             setsockopt(_fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
-            fcntl(_fd, F_SETFD, FD_CLOEXEC);
+            if (fcntl(_fd, F_SETFD, FD_CLOEXEC) == -1) {
+                fprintf(stderr, "fcntl failed on setting FD_CLOEXEC - %s\n", strerror(errno));
+                close(_fd);
+                _fd = -1;
+                return;
+            }
+            _connected = true;
             fprintf(stdout, "New connection on SERIAL%u\n", _portNumber);
         }
     }
@@ -1088,6 +1224,14 @@ ssize_t UARTDriver::get_system_outqueue_length() const
 #endif
 }
 
+ssize_t UARTDriver::get_system_outqueue_limit() const
+{
+    // AF_UNIX TIOCOUTQ includes per-write kernel accounting and data already
+    // delivered to the peer. Allow enough room for several full UART writes
+    // before applying the anti-lag throttle, while retaining the TCP limit.
+    return _is_unix_socket ? 65536 : 1024;
+}
+
 uint32_t UARTDriver::bw_in_bytes_per_second() const
 {
     // if connected, assume at least a 10/100Mbps connection if not limited
@@ -1118,4 +1262,3 @@ void UARTDriver::uart_info(ExpandingString &str, StatsTracker &stats, const uint
 #endif
 
 #endif // CONFIG_HAL_BOARD
-

--- a/libraries/AP_HAL_SITL/UARTDriver.h
+++ b/libraries/AP_HAL_SITL/UARTDriver.h
@@ -31,6 +31,7 @@ public:
     }
 
     ssize_t get_system_outqueue_length() const;
+    ssize_t get_system_outqueue_limit() const;
 
     bool tx_pending() override {
         return false;
@@ -84,6 +85,7 @@ private:
     uint8_t _portNumber;
     bool _connected = false; // true if a client has connected
     bool _use_send_recv = false;
+    bool _is_unix_socket = false;
     int _listen_fd;  // socket we are listening on
     int _serial_port;
     static bool _console;
@@ -101,6 +103,7 @@ private:
     bool _auto_flow_detected;   // true once CTS confirmed active in AUTO mode
 
     void _tcp_start_connection(uint16_t port, bool wait_for_connection);
+    void _unix_start_connection(const char *path, bool wait_for_connection);
     void _uart_start_connection(void);
     void _check_reconnect();
     void _tcp_start_client(const char *address, uint16_t port);

--- a/libraries/AP_RCProtocol/AP_RCProtocol_UDP.cpp
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_UDP.cpp
@@ -8,6 +8,9 @@
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 #include <SITL/SITL.h>
 
+#include <errno.h>
+#include <string.h>
+
 #if AP_RCPROTOCOL_FDM_ENABLED
 #include "AP_RCProtocol_FDM.h"
 #endif
@@ -43,11 +46,22 @@ bool AP_RCProtocol_UDP::init()
     if (sitl == nullptr) {
         return false;
     }
-    if (!rc_in.reuseaddress()) {
-        return false;
-    }
-    if (!rc_in.bind("0.0.0.0", sitl->rcin_port)) {
-        return false;
+    if (sitl->rcin_path != nullptr) {
+        if (!rc_in.bind_unix(sitl->rcin_path)) {
+            if (!init_error_reported) {
+                hal.console->printf("RCInput: failed to bind Unix domain socket %s: %s\n",
+                                    sitl->rcin_path, strerror(errno));
+                init_error_reported = true;
+            }
+            return false;
+        }
+    } else {
+        if (!rc_in.reuseaddress()) {
+            return false;
+        }
+        if (!rc_in.bind("0.0.0.0", sitl->rcin_port)) {
+            return false;
+        }
     }
     if (!rc_in.set_blocking(false)) {
         return false;

--- a/libraries/AP_RCProtocol/AP_RCProtocol_UDP.h
+++ b/libraries/AP_RCProtocol/AP_RCProtocol_UDP.h
@@ -31,6 +31,7 @@ private:
 
     bool init();
     bool init_done;
+    bool init_error_reported = false;
 
     uint32_t last_input_ms;
 

--- a/libraries/SITL/SIM_SoloGimbal.cpp
+++ b/libraries/SITL/SIM_SoloGimbal.cpp
@@ -122,9 +122,14 @@ void SoloGimbal::send_report(void)
         // and the initial wait on SERIAL0
         return;
     }
-    if (!mavlink.connected && mav_socket.connect(target_address, target_port)) {
-        ::printf("SoloGimbal connected to %s:%u\n", target_address, (unsigned)target_port);
-        mavlink.connected = true;
+    if (!mavlink.connected) {
+        if (target_path != nullptr && mav_socket.connect_unix(target_path)) {
+            ::printf("SoloGimbal connected to Unix domain socket %s\n", target_path);
+            mavlink.connected = true;
+        } else if (target_path == nullptr && mav_socket.connect(target_address, target_port)) {
+            ::printf("SoloGimbal connected to %s:%u\n", target_address, (unsigned)target_port);
+            mavlink.connected = true;
+        }
     }
     if (!mavlink.connected) {
         return;

--- a/libraries/SITL/SIM_SoloGimbal.h
+++ b/libraries/SITL/SIM_SoloGimbal.h
@@ -38,15 +38,15 @@ namespace SITL {
 class SoloGimbal {
 public:
 
-    // target_port is the vehicle's MAVLink port the gimbal connects back
-    // to (SERIAL2).  It is offset by the SITL instance number, so it must
-    // be supplied rather than hard-coded.
-    SoloGimbal(uint16_t _target_port = 5762) : target_port(_target_port) {}
+    // endpoint for the vehicle's SERIAL1 MAVLink connection
+    explicit SoloGimbal(uint16_t _target_port) : target_path(nullptr), target_port(_target_port) {}
+    explicit SoloGimbal(const char *_target_path) : target_path(_target_path), target_port(0) {}
     void update(const Aircraft &aicraft);
 
 private:
 
     const char *target_address = "127.0.0.1";
+    const char *const target_path;
     const uint16_t target_port;
 
     // physic simulation of gimbal:
@@ -88,4 +88,3 @@ private:
 }  // namespace SITL
 
 #endif  // AP_SIM_SOLOGIMBAL_ENABLED
-

--- a/libraries/SITL/SITL.h
+++ b/libraries/SITL/SITL.h
@@ -532,6 +532,7 @@ public:
 
     uint16_t irlock_port;
     uint16_t rcin_port;
+    const char *rcin_path = nullptr;
 
     time_t start_time_UTC;
 


### PR DESCRIPTION
### Summary

Add Unix domain socket transport for SITL UARTs and expose it through `sim_vehicle.py` as a step toward #34129.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Testing performed:

- Python syntax compilation for `Tools/autotest/pysim/util.py` and `Tools/autotest/sim_vehicle.py`
- `python3 -m flake8 Tools/autotest/pysim/util.py`
- `Tools/scripts/check_branch_conventions.py --base-branch origin/master`


### Description

This adds `uds:<path>[:wait]` support to the AP_HAL_SITL UART driver, including reconnect handling, stale socket recovery, cleanup, and output-queue throttling. RC input gains Unix datagram socket binding.

`sim_vehicle.py` gains `--unix-domain-socket` and `--uds`. When selected, the TCP-backed SITL UARTs are exposed as `APM-UDS-serialN` in each SITL working directory, and MAVProxy connects to the corresponding UART and RC input socket paths.

This is intentionally a smaller first step toward the broader integration in #34129. It does not add the `autotest.py` option or convert the vehicle test suite to Unix domain sockets.

RC input over Unix domain sockets requires ArduPilot/MAVProxy#1735.
