### PR TITLE
autotest: wait for something observable in clear_roi

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -17173,7 +17173,12 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         ]
         for command in self.run_cmd, self.run_cmd_int:
             for cmd_id in cmd_ids:
-                self.wait_waypoint(2, 2)
+                # these checks need home to the south and the next
+                # waypoint to the north.  Waypoint 2 is directly above
+                # the takeoff point, so it is never reliably the current
+                # waypoint; wait for the geometry instead:
+                self.wait_current_waypoint(3, timeout=120)
+                self.wait_distance_to_home(30, 1000, timeout=30)
 
                 # Set an ROI at the Home location, expect to point at Home
                 self.run_cmd(mavutil.mavlink.MAV_CMD_DO_SET_ROI_LOCATION,


### PR DESCRIPTION
### Summary

Adjusts test so that the geometry is clear for testing

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

The test waited on waypoint 2, which it can never rely on seeing: waypoint 2 sits directly above the takeoff point, so the vehicle is already there when the mission advances to it and moves straight on to waypoint 3.  From a failing run:

    wait for waypoint ranges start=2 end=2
    WP 1 (wp_dist_m=0 Alt=584.09), current_wp: 1, wpnum_end: 2
    WP 1 (wp_dist_m=0 Alt=604.07), current_wp: 1, wpnum_end: 2
    AP: Mission: 2 WP
    AP: Reached command #2
    AP: Mission: 3 WP
    WW: Starting new waypoint 3

- 1 to 3 with nothing in between, so whether wait_waypoint() ever sees waypoint 2 is down to when NAV_CONTROLLER_OUTPUT happens to arrive.  Once missed it cannot recover: current_wp follows the sequence upwards and can then never equal 2 again, so it spends its whole timeout and fails with "Timed out waiting for waypoint 2 of 2".

What the ROI checks need is home to the south and the next waypoint to the north, so wait for that instead.  Waypoint 3 is 200m north and stays current long enough to be seen.

Seen at --parallel=36; 24 parallel copies of the test now pass 24/24 where the failure had been showing roughly one run in three.
