### PR TITLE
Rover: Update limits at each waypoint

### DIFF
--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -7503,6 +7503,156 @@ return update()
         if abs(Horizontaldistance - expected_distance) > 1:
             raise NotAchievedException(f"Unexpected GPS position (want {expected_distance}, got {Horizontaldistance})")
 
+    def WP_SPEED(self):
+        '''ensure changing WP_SPEED during a mission works'''
+        self.upload_simple_relhome_mission([
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 300, 0, 0),
+        ])
+        start_speed_ms = self.get_parameter('WP_SPEED')
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+        self.change_mode('AUTO')
+
+        self.wait_groundspeed(start_speed_ms-1, start_speed_ms+1, minimum_duration=10)
+
+        for speed_ms in 1, 2, 3, 4, 5:
+            self.set_parameter('WP_SPEED', speed_ms)
+            self.wait_groundspeed(speed_ms-1, speed_ms+1, minimum_duration=10)
+        self.do_RTL()
+        self.disarm_vehicle()
+
+    def AutoModeAccelChanges(self):
+        '''verify WP_ACCEL mid-mission change bakes at the next WP crossing and takes effect n+2 legs later'''
+        # Change WP_ACCEL during WP1->WP2; bakes at WP2 crossing;
+        # WP2->WP3 may still propagate old value; WP3->WP4 is the reliable measurement leg.
+        self.upload_simple_relhome_mission([
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT,  300,    0, 0),  # WP1
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT,  300,  300, 0),  # WP2
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT,  600,  300, 0),  # WP3
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT,  600,  600, 0),  # WP4
+        ])
+        wp_accel    = 0.5   # m/s^2: slow enough for a clear ~2.0 s measurement
+        accel_start = 4.0   # m/s
+        accel_stop  = 5.0   # m/s
+        high_speed  = 6.0   # m/s
+        self.set_parameters({
+            "WP_SPEED":      high_speed,
+            "WP_ACCEL":      3.0,    # initial fast rate; changed mid-mission below
+            "ATC_ACCEL_MAX": 20.0,
+        })
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+        self.change_mode('AUTO')
+
+        self.wait_current_waypoint(2, timeout=120)     # rover is now on WP1->WP2
+        self.set_parameter("WP_ACCEL", wp_accel)       # bakes at WP2 crossing
+
+        expected_time = (accel_stop - accel_start) / wp_accel  # 2.0 s
+        self.wait_current_waypoint(4, timeout=120)     # WP3->WP4: first reliable leg
+        self.wait_groundspeed(0, accel_start - 0.5, timeout=30)  # wait for WP3 corner dip
+        self.wait_groundspeed(accel_start, 100, timeout=30)
+        tstart = self.get_sim_time()
+        self.wait_groundspeed(accel_stop, 100, timeout=expected_time * 3)
+        actual_time = self.get_sim_time() - tstart
+        if actual_time > expected_time * 2.0:
+            raise NotAchievedException(
+                "WP_ACCEL=%.1f too slow: expected ~%.1fs, got %.1fs" %
+                (wp_accel, expected_time, actual_time))
+        if actual_time < expected_time * 0.3:
+            raise NotAchievedException(
+                "WP_ACCEL=%.1f too fast: expected ~%.1fs, got %.1fs" %
+                (wp_accel, expected_time, actual_time))
+        self.progress("WP_ACCEL=%.1f ramp time %.1fs (expected ~%.1fs)" %
+                      (wp_accel, actual_time, expected_time))
+        self.disarm_vehicle(force=True)
+
+    def AutoModeAccelLimiting(self):
+        '''verify ATC_ACCEL_MAX and ATC_DECEL_MAX cap WP_ACCEL'''
+
+        high_speed = 6.0  # m/s
+        low_speed  = 2.0  # m/s
+
+        self.start_subtest("ATC_ACCEL_MAX limits WP_ACCEL from standing start")
+        self.upload_simple_relhome_mission([
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 1000, 0, 0),
+        ])
+        wp_accel_high = 3.0   # m/s^2 — intentionally above the cap value
+        atc_accel_cap = 0.5   # m/s^2
+        meas_start    = 1.0   # m/s
+        meas_stop     = 3.0   # m/s
+        self.set_parameters({
+            "WP_SPEED":      high_speed,
+            "WP_ACCEL":      wp_accel_high,
+            "ATC_ACCEL_MAX": 20.0,
+            "ATC_DECEL_MAX": 5.0,
+        })
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+        self.change_mode('AUTO')
+        self.wait_groundspeed(meas_start, 100, timeout=30)
+        tstart = self.get_sim_time()
+        self.wait_groundspeed(meas_stop, 100, timeout=15)
+        time_uncapped = self.get_sim_time() - tstart
+        self.progress("ATC_ACCEL_MAX uncapped ramp %.2fs" % time_uncapped)
+        self.change_mode('HOLD')
+        self.wait_groundspeed(0, 0.5, timeout=30)
+        self.set_parameter("ATC_ACCEL_MAX", atc_accel_cap)
+        self.change_mode('AUTO')
+        self.wait_groundspeed(meas_start, 100, timeout=30)
+        tstart = self.get_sim_time()
+        self.wait_groundspeed(meas_stop, 100, timeout=30)
+        time_capped = self.get_sim_time() - tstart
+        self.progress("ATC_ACCEL_MAX=%.1f capped ramp %.2fs" % (atc_accel_cap, time_capped))
+        if time_capped < time_uncapped * 2.0:
+            raise NotAchievedException(
+                "ATC_ACCEL_MAX=%.1f did not limit WP_ACCEL as expected "
+                "(uncapped=%.2fs capped=%.2fs)" %
+                (atc_accel_cap, time_uncapped, time_capped))
+        self.disarm_vehicle(force=True)
+
+        self.start_subtest("ATC_DECEL_MAX limits WP_ACCEL via mid-leg WP_SPEED drop")
+        self.upload_simple_relhome_mission([
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT,  600, 0, 0),  # WP1
+            (mavutil.mavlink.MAV_CMD_NAV_WAYPOINT, 1200, 0, 0),  # WP2
+        ])
+        decel_trigger = high_speed - 0.7   # 5.3 m/s — confirm at cruise before triggering
+        decel_from    = high_speed - 1.0   # 5.0 m/s
+        decel_to      = 3.0               # m/s — 2 m/s band
+        atc_decel_cap = 0.5               # m/s^2
+        self.set_parameters({
+            "WP_SPEED":      high_speed,
+            "ATC_ACCEL_MAX": 20.0,
+            "ATC_DECEL_MAX": 0.0,
+        })
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+        self.change_mode('AUTO')
+        self.wait_groundspeed(decel_trigger, 100, timeout=30)
+        self.set_parameter("WP_SPEED", low_speed)
+        self.wait_groundspeed(0, decel_from, timeout=30)
+        tstart = self.get_sim_time()
+        self.wait_groundspeed(0, decel_to, timeout=30)
+        time_uncapped_decel = self.get_sim_time() - tstart
+        self.progress("ATC_DECEL_MAX uncapped decel %.2fs" % time_uncapped_decel)
+        self.set_parameters({
+            "WP_SPEED":      high_speed,
+            "ATC_DECEL_MAX": atc_decel_cap,
+        })
+        self.wait_current_waypoint(2, timeout=120)
+        self.wait_groundspeed(decel_trigger, 100, timeout=30)
+        self.set_parameter("WP_SPEED", low_speed)
+        self.wait_groundspeed(0, decel_from, timeout=30)
+        tstart = self.get_sim_time()
+        self.wait_groundspeed(0, decel_to, timeout=60)
+        time_capped_decel = self.get_sim_time() - tstart
+        self.progress("ATC_DECEL_MAX=%.1f capped decel %.2fs" % (atc_decel_cap, time_capped_decel))
+        if time_capped_decel < time_uncapped_decel * 1.5:
+            raise NotAchievedException(
+                "ATC_DECEL_MAX=%.1f did not limit decel rate "
+                "(uncapped=%.2fs capped=%.2fs)" %
+                (atc_decel_cap, time_uncapped_decel, time_capped_decel))
+        self.disarm_vehicle(force=True)
+
     def tests(self):
         '''return list of all tests'''
         ret = super(AutoTestRover, self).tests()
@@ -7628,6 +7778,9 @@ return update()
             self.GPSAntennaPositionOffset,
             self.UTMGlobalPosition,
             self.UTMGlobalPositionWaypoint,
+            self.WP_SPEED,
+            self.AutoModeAccelChanges,
+            self.AutoModeAccelLimiting,
         ])
         return ret
 

--- a/libraries/AR_WPNav/AR_WPNav.cpp
+++ b/libraries/AR_WPNav/AR_WPNav.cpp
@@ -99,6 +99,7 @@ AR_WPNav::AR_WPNav(AR_AttitudeControl& atc, AR_PosControl &pos_control) :
 void AR_WPNav::init(float speed_max)
 {
     // determine max speed, acceleration and jerk
+    _check_speed_param_change = !is_positive(speed_max);
     if (is_positive(speed_max)) {
         _base_speed_max = speed_max;
     } else {
@@ -107,6 +108,7 @@ void AR_WPNav::init(float speed_max)
     _base_speed_max = MAX(AR_WPNAV_SPEED_MIN, _base_speed_max);
     const float accel_max = get_accel_max();
     const float jerk_max = get_jerk_max();
+    _last_speed_param_ms = _speed_max;
 
     // initialise position controller
     _pos_control.set_limits(_base_speed_max, accel_max, _atc.get_turn_lat_accel_max(), jerk_max);
@@ -183,6 +185,8 @@ bool AR_WPNav::set_speed_max(float speed_max)
     }
 
     _base_speed_max = speed_max;
+    // explicit override takes precedence; disable WP_SPEED param-refresh so it cannot overwrite the override
+    _check_speed_param_change = false;
     return true;
 }
 
@@ -605,6 +609,12 @@ bool AR_WPNav::set_origin_and_destination_to_stopping_point()
 // _atc.get_turn_lat_accel_max() and update position controller limits if required
 void AR_WPNav::update_limits()
 {
+    // refresh _base_speed_max if WP_SPEED param changed since init
+    if (_check_speed_param_change && !is_equal(_speed_max.get(), _last_speed_param_ms)) {
+        _base_speed_max = MAX(AR_WPNAV_SPEED_MIN, _speed_max.get());
+        _last_speed_param_ms = _speed_max;
+    }
+
     // update limits
     // Note this won't be applied to s-curve legs until the next waypoint, or (in 
     // the case of fast waypoints, the waypoint-after-next)

--- a/libraries/AR_WPNav/AR_WPNav.cpp
+++ b/libraries/AR_WPNav/AR_WPNav.cpp
@@ -105,13 +105,8 @@ void AR_WPNav::init(float speed_max)
         _base_speed_max = _speed_max;
     }
     _base_speed_max = MAX(AR_WPNAV_SPEED_MIN, _base_speed_max);
-    float atc_accel_max = MIN(_atc.get_accel_max(), _atc.get_decel_max());
-    if (!is_positive(atc_accel_max)) {
-        // accel_max of zero means no limit so use maximum acceleration
-        atc_accel_max = AR_WPNAV_ACCEL_MAX;
-    }
-    const float accel_max = is_positive(_accel_max) ? MIN(_accel_max, atc_accel_max) : atc_accel_max;
-    const float jerk_max = is_positive(_jerk_max) ? _jerk_max : accel_max;
+    const float accel_max = get_accel_max();
+    const float jerk_max = get_jerk_max();
 
     // initialise position controller
     _pos_control.set_limits(_base_speed_max, accel_max, _atc.get_turn_lat_accel_max(), jerk_max);
@@ -159,8 +154,8 @@ void AR_WPNav::update(float dt)
 
     update_distance_and_bearing_to_destination();
 
-    // handle change in max speed
-    update_speed_max();
+    // handle change in params
+    update_limits();
 
     // advance target along path unless vehicle is pivoting
     if (!_pivot.active()) {
@@ -606,14 +601,22 @@ bool AR_WPNav::set_origin_and_destination_to_stopping_point()
     return true;
 }
 
-// check for changes in _base_speed_max or _nudge_speed_max
-// updates position controller limits and recalculate scurve path if required
-void AR_WPNav::update_speed_max()
+// check for changes in _nudge_speed_max, _base_speed_max, _accel_max, _jerk_max or
+// _atc.get_turn_lat_accel_max() and update position controller limits if required
+void AR_WPNav::update_limits()
 {
+    // update limits
+    // Note this won't be applied to s-curve legs until the next waypoint, or (in 
+    // the case of fast waypoints, the waypoint-after-next)
+    const float accel_max = get_accel_max();
+    const float jerk_max = get_jerk_max();
     const float speed_max = MAX(_base_speed_max, _nudge_speed_max);
+    const float lat_accel_max = _atc.get_turn_lat_accel_max();
 
-    // ignore calls that do not change the speed
-    if (is_equal(speed_max, _pos_control.get_speed_max())) {
+    // ignore calls that do not change the speed, accel, jerk or lateral acceleration limits
+    if (is_equal(speed_max, _pos_control.get_speed_max()) && is_equal(accel_max, _pos_control.get_accel_max()) &&
+        is_equal(jerk_max, _pos_control.get_jerk_max()) &&
+        is_equal(lat_accel_max, _pos_control.get_lat_accel_max())) {
         return;
     }
 
@@ -624,10 +627,25 @@ void AR_WPNav::update_speed_max()
     }
     _last_speed_update_ms = now_ms;
 
-    // update position controller max speed
-    _pos_control.set_limits(speed_max, _pos_control.get_accel_max(), _pos_control.get_lat_accel_max(), _pos_control.get_jerk_max());
+    // update position controller.
+    _pos_control.set_limits(speed_max, accel_max, lat_accel_max, jerk_max);
 
     // change track speed
     _scurve_this_leg.set_speed_max(_pos_control.get_speed_max(), _pos_control.get_speed_max(), _pos_control.get_speed_max());
     _scurve_next_leg.set_speed_max(_pos_control.get_speed_max(), _pos_control.get_speed_max(), _pos_control.get_speed_max());
+}
+
+float AR_WPNav::get_accel_max() const
+{
+    float atc_accel_max = MIN(_atc.get_accel_max(), _atc.get_decel_max());
+    if (!is_positive(atc_accel_max)) {
+        // accel_max of zero means no limit so use maximum acceleration
+        atc_accel_max = AR_WPNAV_ACCEL_MAX;
+    }
+    return is_positive(_accel_max) ? MIN(_accel_max, atc_accel_max) : atc_accel_max;
+}
+
+float AR_WPNav::get_jerk_max() const
+{
+    return is_positive(_jerk_max) ? _jerk_max : get_accel_max();
 }

--- a/libraries/AR_WPNav/AR_WPNav.h
+++ b/libraries/AR_WPNav/AR_WPNav.h
@@ -138,9 +138,15 @@ protected:
     // set origin and destination to stopping point
     bool set_origin_and_destination_to_stopping_point();
 
-    // check for changes in _base_speed_max or _nudge_speed_max
-    // updates position controller limits and recalculate scurve path if required
-    void update_speed_max();
+    // check for changes in _nudge_speed_max, _base_speed_max, _accel_max, _jerk_max or
+    // _atc.get_turn_lat_accel_max() and update position controller limits if required
+    void update_limits();
+
+    // get the maximum acceleration used by the position controller
+    float get_accel_max() const;
+
+    // get the maximum jerk used by the position controller
+    float get_jerk_max() const;
 
     // parameters
     AP_Float _speed_max;            // target speed between waypoints in m/s

--- a/libraries/AR_WPNav/AR_WPNav.h
+++ b/libraries/AR_WPNav/AR_WPNav.h
@@ -187,6 +187,8 @@ protected:
     float _base_speed_max;          // speed max (in m/s) derived from parameters or passed into init
     float _nudge_speed_max;         // "nudge" speed max (in m/s) normally from the pilot.  has no effect if less than _base_speed_max.  always positive.
     uint32_t _last_speed_update_ms; // system time that speed_max was last update.  used to ensure speed_max is not update too quickly
+    bool _check_speed_param_change; // true if WP_SPEED param should be monitored for changes during navigation
+    float _last_speed_param_ms;     // last recorded WP_SPEED value (m/s) for change detection
 
     // main outputs from navigation library
     float _desired_speed_limited;   // desired speed (above) but accel/decel limited


### PR DESCRIPTION
### Summary

Currently, when running rover in AUTO mode, any changes to ``WP_JERK``, ``WP_ACCEL``, ``WP_SPEED`` and ``ATC_TURN_MAX_G`` are _not_ used for s-curve track calculations until the user exits and then re-enters AUTO mode.

This PR ensures that changes to these parameters are used when ``set_desired_location()`` is called, ie when the vehicle reaches a waypoint and needs to calculate the track to the next one.

Makes tuning in AUTO mode much easier and will make things less confusing for users, as the current behavior is not documented anywhere.

Tested in SITL.

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [X] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request
