### PR TITLE
Linux+SITL: Fix risk of wrong prng return

### DIFF
--- a/libraries/AP_HAL_Linux/Util.cpp
+++ b/libraries/AP_HAL_Linux/Util.cpp
@@ -254,12 +254,8 @@ bool Util::get_random_vals(uint8_t* data, size_t size)
         return false;
     }
     ssize_t result = read(dev_random, data, size);
-    if (result < 0) {
-        close(dev_random);
-        return false;
-    }
     close(dev_random);
-    return true;
+    return result >= 0 && (size_t)result == size;
 }
 
 bool Util::parse_cpu_set(const char *str, cpu_set_t *cpu_set) const

--- a/libraries/AP_HAL_SITL/Util.cpp
+++ b/libraries/AP_HAL_SITL/Util.cpp
@@ -126,12 +126,8 @@ bool HALSITL::Util::get_random_vals(uint8_t* data, size_t size)
         return false;
     }
     ssize_t result = read(dev_random, data, size);
-    if (result < 0) {
-        close(dev_random);
-        return false;
-    }
     close(dev_random);
-    return true;
+    return result >= 0 && (size_t)result == size;
 }
 
 #if HAL_UART_STATS_ENABLED


### PR DESCRIPTION
### Summary

Return false from get_random_vals() if it fails to fully populate the destination buffer.

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [X] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Testing steps:
1. instrumented existing implementation
2. used existing implementation to read random numbers into a 1MB array in a loop with a no-op SIGINT handler while mashing control-C
3. Confirmed signals can cause read() to return short reads(positive return code but less than specified size), but get_random_vals() returned true.
4. Fixed it.
5. Verified return code is now false under the above signal interruption.

### Description

Fix a footgun in get_random_vals() when read() returns early due to a signal handler(as may happen during ArduPilot shutdown on SITL or Linux). Some systems will read blocks of 4096B at a time, though the manual states early returns may occur as small as 256B. I couldn't find any mainline ArduPilot code that read()s a large enough buffer to trigger this.
