### PR TITLE
AP_HAL_ChibiOS: fix F4 SD crash dump build

### DIFF
--- a/libraries/AP_HAL_ChibiOS/CrashDump_SD.cpp
+++ b/libraries/AP_HAL_ChibiOS/CrashDump_SD.cpp
@@ -84,6 +84,10 @@
                                 SDMMC_STA_TXUNDERR | SDMMC_STA_RXOVERR | \
                                 SDMMC_STA_STBITERR)
 #elif CRASHDUMP_SD_SDIOV1
+// Some STM32F4 CMSIS headers omit the unsupported start-bit error definition.
+#ifndef SDIO_STA_STBITERR
+#define SDIO_STA_STBITERR 0U
+#endif
 #define SDIO_DATA_ERROR_FLAGS (SDIO_STA_DCRCFAIL | SDIO_STA_DTIMEOUT | \
                                SDIO_STA_TXUNDERR | SDIO_STA_RXOVERR | \
                                SDIO_STA_STBITERR)


### PR DESCRIPTION
Some STM32F4 CMSIS headers omit the unsupported SDIO start-bit error flag. Define it as zero when absent, matching the ChibiOS SDIO driver and allowing DrotekP3Pro builds to compile.

