### PR TITLE
AP_Baro: read bmp581 thrice to get corrected data

### DIFF
--- a/libraries/AP_Baro/AP_Baro_BMP581.cpp
+++ b/libraries/AP_Baro/AP_Baro_BMP581.cpp
@@ -157,8 +157,14 @@ void AP_Baro_BMP581::timer(void)
         return;
     }
     if (memcmp(buf, buf2, ARRAY_SIZE(buf)) != 0) {
-        // we didn't get the same data twice.  Reject.
-        return;
+        // we didn't get the same data twice.  Reject.  See if we can
+        // git a third measurement to match the second:
+        if (!_dev->read_registers(BMP581_REG_TEMP_DATA_XLSB, buf, sizeof(buf))) {
+            return;
+        }
+        if (memcmp(buf, buf2, ARRAY_SIZE(buf)) != 0) {
+            return;
+        }
     }
 
     WITH_SEMAPHORE(_sem);


### PR DESCRIPTION
### Summary

Reads bmp581 three times to find a consistent reading; the existing twice meant we could lose the device due to beat frequencies

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

original read-twice suffers from beat frequencies where the 50Hz update on the device and the 50Hz update rate of the backend drift relative to one another.  The device appears dead when that happens.
