### PR TITLE
Reserve board IDs 716x for Viima Aerospace FCs

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -674,6 +674,10 @@ AP_HW_SED_GPS                        7151
 AP_HW_SED_AirSpeed                   7152
 AP_HW_SED_UGNSS                      7153
 
+# IDs 7160-7169 reserved for Viima Aerospace
+AP_HW_Viima-WH7-v2                   7162
+AP_HW_Viima-WH7-v3                   7163
+
 # IDs 7170-7179 reserved for Tykho Electronics
 AP_HW_TYKHO_TLS7V2                   7170
 AP_HW_TYKHO_TLS7-Wing                7171


### PR DESCRIPTION
### Summary

Reserve and assign board IDs for the Viima Aerospace flight controllers. The board definition files will follow in later pull requests too.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

This PR adds IDs for a family of fixed-wing oriented flight controllers which have been in development at Viima Aerospace for the past year, with the first customer units now being prepared.

The product page can be found here: https://viima.aero/wh7

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
