### PR TITLE
StorageManager: add IO rate profiling to StorageTest

### DIFF
--- a/libraries/StorageManager/examples/StorageTest/StorageTest.cpp
+++ b/libraries/StorageManager/examples/StorageTest/StorageTest.cpp
@@ -59,6 +59,9 @@ void setup(void)
 void loop(void)
 {
     static uint32_t count;
+    static uint32_t total_bytes_read;
+    static uint32_t total_bytes_written;
+    static uint32_t last_print_ms = AP_HAL::millis();
     uint8_t type = get_random() % 4;
     const StorageAccess &storage = all_storage[type];
     uint16_t offset = get_random() % storage.size();
@@ -78,12 +81,16 @@ void loop(void)
         if (!storage.write_block(offset, b, length)) {
             hal.console->printf("write failed at offset %u length %u\n",
                                 (unsigned)offset, (unsigned)length);
+        } else {
+            total_bytes_written += length;
         }
     } else {
         uint8_t b2[length];
         if (!storage.read_block(b2, offset, length)) {
             hal.console->printf("read failed at offset %u length %u\n",
                                 (unsigned)offset, (unsigned)length);
+        } else {
+            total_bytes_read += length;
         }
         if (memcmp(b, b2, length) != 0) {
             hal.console->printf("bad data at offset %u length %u\n",
@@ -92,8 +99,26 @@ void loop(void)
     }
 
     count++;
-    if (count % 10000 == 0) {
-        hal.console->printf("%u ops\n", (unsigned)count);
+
+    uint32_t now = AP_HAL::millis();
+    if (now - last_print_ms >= 1000) {
+        /*
+          Reference test results:
+          Board: custom STM32H7 board (HAL_STORAGE_SIZE=16384, onboard flash pages 14-15)
+          MCU clock speed: 400Mhz
+          Storage backend: onboard flash (no SD card involved)
+          Measured rate: ~139-141 kB/s read, ~137-141 kB/s write, ~278-281 kB/s combined (stable over 180k+ ops)
+        */
+        float elapsed_s = (now - last_print_ms) / 1000.0f;
+        float read_rate  = (total_bytes_read  / 1024.0f) / elapsed_s;
+        float write_rate = (total_bytes_written / 1024.0f) / elapsed_s;
+        float total_rate = read_rate + write_rate;
+
+        hal.console->printf("%u ops: read=%.2f kB/s write=%.2f kB/s total=%.2f kB/s\n", (unsigned)count, read_rate, write_rate, total_rate);
+
+        total_bytes_read = 0;
+        total_bytes_written = 0;
+        last_print_ms = now;
     }
 }
 


### PR DESCRIPTION
### Summary

Add read/write/total IO rate (kB/s) profiling output to the StorageTest example sketch. 

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Built and ran in CubeOrange. Console output prints roughly once per second. -->

### Description
As mentioned in the ArduPilot docs (Learning ArduPilot: Storage and EEPROM management page), the StorageTest example was missing IO rate profiling, so I added this. It tracks bytes read and written in the existing random read/write test loop, and prints read/write/total rate in kB/s once per second, alongside the existing op counter.

Tested on custom STM32H7 hardware with onboard flash (pages 14-15).

Console output:
17968 ops: read=139.27 kB/s write=140.50 kB/s total=279.77 kB/s
35984 ops: read=141.30 kB/s write=138.37 kB/s total=279.67 kB/s
53960 ops: read=138.84 kB/s write=140.37 kB/s total=279.21 kB/s
71963 ops: read=139.74 kB/s write=140.60 kB/s total=280.33 kB/s
90031 ops: read=139.71 kB/s write=141.01 kB/s total=280.72 kB/s
108012 ops: read=138.78 kB/s write=140.47 kB/s total=279.25 kB/s
126037 ops: read=141.15 kB/s write=139.86 kB/s total=281.01 kB/s
144034 ops: read=140.91 kB/s write=138.52 kB/s total=279.44 kB/s
162019 ops: read=144.09 kB/s write=136.92 kB/s total=281.01 kB/s
179999 ops: read=138.44 kB/s write=138.88 kB/s total=277.32 kB/s
...
...

P.S. This is my first commit to ArduPilot, feedback welcome :)

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
