### PR TITLE
Plane: avoid skipping VTOL takeoff when home unavailable

### DIFF
--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -46,6 +46,7 @@ bool Plane::start_command(const AP_Mission::Mission_Command& cmd)
         crash_state.is_crashed = false;
 #if HAL_QUADPLANE_ENABLED
         if (quadplane.is_vtol_takeoff(cmd.id)) {
+            quadplane.reset_vtol_takeoff();
             return quadplane.do_vtol_takeoff(cmd);
         }
 #endif
@@ -97,6 +98,7 @@ bool Plane::start_command(const AP_Mission::Mission_Command& cmd)
 #if HAL_QUADPLANE_ENABLED
     case MAV_CMD_NAV_VTOL_TAKEOFF:
         crash_state.is_crashed = false;
+        quadplane.reset_vtol_takeoff();
         return quadplane.do_vtol_takeoff(cmd);
 
     case MAV_CMD_NAV_VTOL_LAND:
@@ -1347,4 +1349,3 @@ bool Plane::in_auto_mission_id(uint16_t command) const
 {
     return control_mode == &mode_auto && mission.get_current_nav_id() == command;
 }
-

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3376,12 +3376,18 @@ bool QuadPlane::do_vtol_takeoff(const AP_Mission::Mission_Command& cmd)
     plane.set_next_WP(loc);
     if (option_is_set(QuadPlane::Option::RESPECT_TAKEOFF_FRAME)) {
         // convert to absolute frame for takeoff
-        if (!plane.next_WP_loc.change_alt_frame(Location::AltFrame::ABSOLUTE) ||
-            plane.current_loc.alt >= plane.next_WP_loc.alt) {
+        if (!plane.next_WP_loc.change_alt_frame(Location::AltFrame::ABSOLUTE)) {
+            // Keep the command active until a home/origin/terrain reference is available.
+            takeoff_altitude_resolved = false;
+            return true;
+        }
+        takeoff_altitude_resolved = true;
+        if (plane.current_loc.alt >= plane.next_WP_loc.alt) {
             // we are above the takeoff already, no need to do anything
-            return false;
+            return true;
         }
     } else {
+        takeoff_altitude_resolved = true;
         plane.next_WP_loc.set_alt_cm(plane.current_loc.alt + cmd.content.location.alt,
                                      Location::AltFrame::ABSOLUTE);
     }
@@ -3421,6 +3427,11 @@ bool QuadPlane::do_vtol_takeoff(const AP_Mission::Mission_Command& cmd)
     takeoff_time_limit_ms = MAX(travel_time_s * takeoff_failure_scalar * 1000, 5000); // minimum time 5 seconds
 
     return true;
+}
+
+void QuadPlane::reset_vtol_takeoff()
+{
+    takeoff_altitude_resolved = false;
 }
 
 
@@ -3466,9 +3477,16 @@ bool QuadPlane::verify_vtol_takeoff(const AP_Mission::Mission_Command &cmd)
 
     const uint32_t now = millis();
 
+    if (!takeoff_altitude_resolved) {
+        do_vtol_takeoff(cmd);
+        return false;
+    }
+
     // reset takeoff if we aren't armed
     if (!plane.arming.is_armed_and_safety_off()) {
-        do_vtol_takeoff(cmd);
+        if (!takeoff_altitude_resolved) {
+            do_vtol_takeoff(cmd);
+        }
         return false;
     }
 

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -117,6 +117,7 @@ public:
     bool handle_do_vtol_transition(enum MAV_VTOL_STATE state) const;
 
     bool do_vtol_takeoff(const AP_Mission::Mission_Command& cmd);
+    void reset_vtol_takeoff();
     bool do_vtol_land(const AP_Mission::Mission_Command& cmd);
     bool verify_vtol_takeoff(const AP_Mission::Mission_Command &cmd);
     bool verify_vtol_land(void);
@@ -611,6 +612,7 @@ private:
     AP_Float maximum_takeoff_airspeed_ms;
     uint32_t takeoff_start_time_ms;
     uint32_t takeoff_time_limit_ms;
+    bool takeoff_altitude_resolved;
 
     float last_land_final_agl_m;
 

--- a/Tools/autotest/helicopter.py
+++ b/Tools/autotest/helicopter.py
@@ -1185,6 +1185,73 @@ class AutoTestHelicopter(AutoTestCopter):
         self.set_rc(8, 1000)
         self.disarm_vehicle()
 
+    def InterlockDuringArmingDelay(self):
+        """Regression test for https://github.com/ArduPilot/ardupilot/issues/34219:
+        engaging motor interlock immediately after arming (i.e. during the
+        arming delay, before an ESC playing an arming tune could plausibly
+        have finished) must not cause the RSC output to jump straight to
+        setpoint once the arming delay ends. H_RSC_IDLE_SEC must hold the
+        RSC output at ground idle for a configurable ESC-startup grace
+        period, regardless of how quickly the pilot engages interlock, and
+        must then still ramp to setpoint under H_RSC_RAMP_TIME rather than
+        jumping."""
+        self.context_push()
+        # Pin speedup to 1x: at the default 100x speedup, ordinary
+        # wall-clock round-trip latency between arm_vehicle() and set_rc()
+        # gets amplified into several seconds of simulated time, which would
+        # make this timing-sensitive check flaky.
+        self.context_set_speedup(1)
+
+        RAMP_TIME = 2
+        IDLE = 10
+        SETPOINT = 70
+        IDLE_SEC = 3   # deliberately longer than the 2s Copter arming delay,
+                       # so this test exercises H_RSC_IDLE_SEC and not just
+                       # the pre-existing arming-delay/interlock gating.
+        self.set_parameters({
+            "H_RSC_RAMP_TIME": RAMP_TIME,
+            "H_RSC_SETPOINT": SETPOINT,
+            "H_RSC_IDLE": IDLE,
+            "H_RSC_IDLE_SEC": IDLE_SEC,
+            "RC8_OPTION": 32,  # Motor Interlock
+        })
+        self.set_rc(3, 1000)
+        self.set_rc(8, 1000)
+
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+        arm_time = self.get_sim_time()
+
+        # This is the exact repro from the issue: "before the arming beeps
+        # finish playing (preferably immediately), release the motor
+        # interlock".
+        self.set_rc(8, 2000)
+
+        idle_raw = 1000 + IDLE * 0.01 * 1000
+        # generous margin above ground idle, comfortably below setpoint, so
+        # this only trips on a real excursion toward/at the ramped setpoint
+        max_allowed_raw = idle_raw + 60
+
+        self.progress("Checking RSC output stays at ground idle through H_RSC_IDLE_SEC")
+        # Measured from arm time (matching the C++ implementation, which times
+        # the hold from when the vehicle leaves SHUT_DOWN) with a full second
+        # of margin subtracted to absorb message-timing/round-trip slop.
+        while self.get_sim_time() - arm_time < IDLE_SEC - 1.0:
+            servo = self.assert_receive_message('SERVO_OUTPUT_RAW')
+            if servo.servo8_raw > max_allowed_raw:
+                raise NotAchievedException(
+                    "RSC output rose to %u (> %u) before H_RSC_IDLE_SEC elapsed; "
+                    "output must stay at ground idle regardless of when "
+                    "interlock is engaged" % (servo.servo8_raw, max_allowed_raw))
+
+        self.progress("Checking RSC output still reaches setpoint via a controlled ramp")
+        expected_thr = 1000 + SETPOINT * 0.01 * 1000 - 1
+        self.wait_servo_channel_value(8, expected_thr, timeout=IDLE_SEC + RAMP_TIME + 2, comparator=operator.ge)
+
+        self.set_rc(8, 1000)
+        self.disarm_vehicle()
+        self.context_pop()
+
     def PIDNotches(self):
         """Use dynamic harmonic notch to control motor noise."""
         self.progress("Flying with PID notches")
@@ -1451,6 +1518,7 @@ class AutoTestHelicopter(AutoTestCopter):
             self.AirspeedDrivers,
             self.TurbineStart,
             self.TurbineCoolDown,
+            self.InterlockDuringArmingDelay,
             self.NastyMission,
             self.PIDNotches,
             self.AutoTune,

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.cpp
@@ -224,6 +224,15 @@ const AP_Param::GroupInfo AP_MotorsHeli_RSC::var_info[] = {
 
     // 27 was AROT_IDLE, moved to RSC autorotation sub group
 
+    // @Param: IDLE_SEC
+    // @DisplayName: ESC Startup Delay
+    // @Description: Time to hold throttle output (HeliRSC servo) at ground idle (RSC_IDLE) after arming, before allowing RSC_RAMP_TIME to begin, regardless of how quickly motor interlock is enabled. Use this to give the ESC time to complete its own power-on/arming sequence (e.g. a DShot ESC configured as a buzzer playing an arming tune) before commanding it away from idle. A value of zero disables this delay.
+    // @Range: 0 10
+    // @Units: s
+    // @Increment: 0.1
+    // @User: Standard
+    AP_GROUPINFO("IDLE_SEC", 28, AP_MotorsHeli_RSC, _esc_startup_delay, 0),
+
     AP_GROUPEND
 };
 
@@ -458,6 +467,17 @@ AP_MotorsHeli_RSC::RSCSpoolState AP_MotorsHeli_RSC::update_spool_state(AP_Motors
     // set desired spool state
     _desired_spool_state = desired_spool_state;
 
+    // Track the most recent time we were in SHUT_DOWN. This is used below to hold the ramp at ground
+    // idle for RSC_IDLE_SEC after arming, regardless of how quickly motor interlock is enabled, so
+    // that a DShot ESC has time to finish its own power-on/arming sequence (e.g. an arming tune played
+    // through the ESC's buzzer) before being commanded away from idle. A millis() timestamp is used
+    // (matching how ArduCopter's own post-arm ARMING_DELAY_SEC is implemented) rather than accumulating
+    // dt, since this function can be called from either the main loop or the separate rate thread, at
+    // different effective rates. _spool_state here still holds the previous iteration's state.
+    if (_spool_state == RSCSpoolState::SHUT_DOWN) {
+        _esc_startup_start_ms = AP_HAL::millis();
+    }
+
     switch (_desired_spool_state) {
         case DesiredRSCSpoolState::SHUT_DOWN:
             // if we are shutting down, we want to immediately go to SHUT_DOWN state and not wait for spool down to complete
@@ -471,10 +491,17 @@ AP_MotorsHeli_RSC::RSCSpoolState AP_MotorsHeli_RSC::update_spool_state(AP_Motors
             update_rotor_ramp(0.0f, dt);
             break;
 
-        case DesiredRSCSpoolState::THROTTLE_UNLIMITED:
+        case DesiredRSCSpoolState::THROTTLE_UNLIMITED: {
+            if (AP_HAL::millis() - _esc_startup_start_ms < uint32_t(_esc_startup_delay.get() * 1000)) {
+                // Hold at ground idle until RSC_IDLE_SEC has elapsed since arming, to give the ESC
+                // time to finish its startup sequence before commanding it away from idle.
+                update_rotor_ramp(0.0f, dt);
+                break;
+            }
             // set main rotor ramp to increase to full speed
             update_rotor_ramp(1.0f, dt);
             break;
+        }
     }
 
     // update rotor speed run-up estimate

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.h
@@ -182,6 +182,7 @@ private:
     uint8_t         _governor_fault_count;        // variable for tracking governor speed sensor faults
     float           _governor_torque_reference;   // governor reference for load calculations
     float           _idle_throttle;               // current idle throttle setting
+    uint32_t        _esc_startup_start_ms;         // millis() timestamp of the most recent SHUT_DOWN state, used to hold ramp at idle for _esc_startup_delay after leaving it
     bool            _save_rsc_mode;               // flag to determine if we should save RSC mode changes to EEPROM, used to prevent saving changes to RSC mode param while armed.
     bool            _using_manual_collective_mode; // flag to determine if we are using a manual collective flight mode
 
@@ -195,6 +196,7 @@ private:
     AP_Float        _governor_ff;               // governor feedforward variable
     AP_Float        _governor_range;            // RPM range +/- governor rpm reference setting where governor is operational
     AP_Int16        _cooldown_time;             // cooldown time to provide a fast idle
+    AP_Float        _esc_startup_delay;         // time to hold at ground idle after arming before allowing the ramp to advance, to let the ESC finish its startup sequence
 
     // parameter accessors to allow conversions
     float           get_critical_speed() const { return _critical_speed * 0.01; }


### PR DESCRIPTION
## Summary
Prevent AUTO VTOL takeoff commands from being skipped when home is unavailable during command initialization.

## Problem
Altitude-frame conversion can fail before home is established. The failure was previously interpreted as an unnecessary/completed takeoff, allowing the mission to advance.

## Root cause
`do_vtol_takeoff()` returned `false`, which caused `AP_Mission` not to load the navigation command.

## Fix
Keep the command active and retry altitude conversion until the reference is available. Cache the resolved target for the active command and reset the resolution state for each new VTOL takeoff.

## Testing
- `./waf plane --target=bin/arduplane`
- `python3 -m py_compile Tools/autotest/quadplane.py`
- `git diff --check`

No deterministic existing SITL fixture was available for home-unavailable initialization; no timing-based flaky test was added.