### PR TITLE
Plane: avoid skipping VTOL takeoff when home unavailable

### DIFF
--- a/ArduPlane/commands_logic.cpp
+++ b/ArduPlane/commands_logic.cpp
@@ -52,6 +52,7 @@ bool Plane::start_command(const AP_Mission::Mission_Command& cmd)
         crash_state.is_crashed = false;
 #if HAL_QUADPLANE_ENABLED
         if (quadplane.is_vtol_takeoff(cmd.id)) {
+            quadplane.reset_vtol_takeoff();
             return quadplane.do_vtol_takeoff(cmd);
         }
 #endif
@@ -103,6 +104,7 @@ bool Plane::start_command(const AP_Mission::Mission_Command& cmd)
 #if HAL_QUADPLANE_ENABLED
     case MAV_CMD_NAV_VTOL_TAKEOFF:
         crash_state.is_crashed = false;
+        quadplane.reset_vtol_takeoff();
         return quadplane.do_vtol_takeoff(cmd);
 
     case MAV_CMD_NAV_VTOL_LAND:
@@ -1353,4 +1355,3 @@ bool Plane::in_auto_mission_id(uint16_t command) const
 {
     return control_mode == &mode_auto && mission.get_current_nav_id() == command;
 }
-

--- a/ArduPlane/quadplane.cpp
+++ b/ArduPlane/quadplane.cpp
@@ -3322,12 +3322,18 @@ bool QuadPlane::do_vtol_takeoff(const AP_Mission::Mission_Command& cmd)
     plane.set_next_WP(loc);
     if (option_is_set(QuadPlane::Option::RESPECT_TAKEOFF_FRAME)) {
         // convert to absolute frame for takeoff
-        if (!plane.next_WP_loc.change_alt_frame(Location::AltFrame::ABSOLUTE) ||
-            plane.current_loc.alt >= plane.next_WP_loc.alt) {
+        if (!plane.next_WP_loc.change_alt_frame(Location::AltFrame::ABSOLUTE)) {
+            // Keep the command active until a home/origin/terrain reference is available.
+            takeoff_altitude_resolved = false;
+            return true;
+        }
+        takeoff_altitude_resolved = true;
+        if (plane.current_loc.alt >= plane.next_WP_loc.alt) {
             // we are above the takeoff already, no need to do anything
-            return false;
+            return true;
         }
     } else {
+        takeoff_altitude_resolved = true;
         plane.next_WP_loc.set_alt_cm(plane.current_loc.alt + cmd.content.location.alt,
                                      Location::AltFrame::ABSOLUTE);
     }
@@ -3367,6 +3373,11 @@ bool QuadPlane::do_vtol_takeoff(const AP_Mission::Mission_Command& cmd)
     takeoff_time_limit_ms = MAX(travel_time_s * takeoff_failure_scalar * 1000, 5000); // minimum time 5 seconds
 
     return true;
+}
+
+void QuadPlane::reset_vtol_takeoff()
+{
+    takeoff_altitude_resolved = false;
 }
 
 
@@ -3412,9 +3423,16 @@ bool QuadPlane::verify_vtol_takeoff(const AP_Mission::Mission_Command &cmd)
 
     const uint32_t now = millis();
 
+    if (!takeoff_altitude_resolved) {
+        do_vtol_takeoff(cmd);
+        return false;
+    }
+
     // reset takeoff if we aren't armed
     if (!plane.arming.is_armed_and_safety_off()) {
-        do_vtol_takeoff(cmd);
+        if (!takeoff_altitude_resolved) {
+            do_vtol_takeoff(cmd);
+        }
         return false;
     }
 

--- a/ArduPlane/quadplane.h
+++ b/ArduPlane/quadplane.h
@@ -117,6 +117,7 @@ public:
     bool handle_do_vtol_transition(enum MAV_VTOL_STATE state) const;
 
     bool do_vtol_takeoff(const AP_Mission::Mission_Command& cmd);
+    void reset_vtol_takeoff();
     bool do_vtol_land(const AP_Mission::Mission_Command& cmd);
     bool verify_vtol_takeoff(const AP_Mission::Mission_Command &cmd);
     bool verify_vtol_land(void);
@@ -611,6 +612,7 @@ private:
     AP_Float maximum_takeoff_airspeed_ms;
     uint32_t takeoff_start_time_ms;
     uint32_t takeoff_time_limit_ms;
+    bool takeoff_altitude_resolved;
 
     float last_land_final_agl_m;
 


### PR DESCRIPTION
## Summary
Prevent AUTO VTOL takeoff commands from being skipped when home is unavailable during command initialization.

## Problem
Altitude-frame conversion can fail before home is established. The failure was previously interpreted as an unnecessary/completed takeoff, allowing the mission to advance.

## Root cause
`do_vtol_takeoff()` returned `false`, which caused `AP_Mission` not to load the navigation command.

## Fix
Keep the command active and retry altitude conversion until the reference is available. Cache the resolved target for the active command and reset the resolution state for each new VTOL takeoff.

## Testing
- `./waf plane --target=bin/arduplane`
- `python3 -m py_compile Tools/autotest/quadplane.py`
- `git diff --check`

No deterministic existing SITL fixture was available for home-unavailable initialization; no timing-based flaky test was added.