### PR TITLE
GitHub clang scan build portability

### DIFF
--- a/.github/workflows/test_clang_scan_build.yml
+++ b/.github/workflows/test_clang_scan_build.yml
@@ -178,7 +178,7 @@ jobs:
           sudo apt update
           sudo apt-get -y install clang-tools
           export PATH="/github/home/.local/bin:$PATH"
-          mkdir -p /__w/ardupilot/ardupilot/tmp
+          mkdir -p "$GITHUB_WORKSPACE/tmp"
           CI_BUILD_TARGET="clang_scan_build" Tools/scripts/build_ci.sh  >$HOME/scan-build-stdout.txt
 
           ccache -s
@@ -202,5 +202,5 @@ jobs:
         if: always()
         with:
            name: clang-scan-build
-           path: /__w/ardupilot/ardupilot/tmp/scan-build
+           path: ${{ github.workspace }}/tmp/scan-build
            retention-days: 7

--- a/Tools/autotest/process_scan_build_output.py
+++ b/Tools/autotest/process_scan_build_output.py
@@ -129,11 +129,30 @@ class ProcessScanBuildOutput():
         '''in CI, move the report dir to a fixed path so it can be archived.
 
         Done before the pass/fail check so the artifacts are available even
-        when the check fails.  A no-op outside CI.
+        when the check fails.
+
+        Only done under GitHub Actions, where the workflow creates
+        $GITHUB_WORKSPACE/tmp for scan-build to write into and archives
+        tmp/scan-build beneath it.  A developer's checkout has a tmp
+        directory too (autotest.py points TMPDIR at it), so the archive is
+        not keyed on that directory existing: moving a second run onto an
+        existing tmp/scan-build would nest its reports beneath the first
+        run's, where findings_from_plists() would not see them.
+
+        GITHUB_WORKSPACE must be an absolute path: an empty one would put
+        the archive relative to the current directory, and the upload step
+        only warns when it finds nothing there.
         '''
-        dest = "/__w/ardupilot/ardupilot/tmp/scan-build"
-        if not os.path.isdir(os.path.dirname(dest)):
+        if os.environ.get("GITHUB_ACTIONS") != "true":
             return scan_build_dir
+        workspace = os.environ.get("GITHUB_WORKSPACE", "")
+        if not os.path.isabs(workspace):
+            self.progress(f"FAIL: GITHUB_WORKSPACE is not an absolute path: {workspace!r}")
+            sys.exit(1)
+        dest = os.path.join(workspace, "tmp", "scan-build")
+        if os.path.exists(dest):
+            self.progress(f"FAIL: {dest} already exists; refusing to nest this run's reports beneath it")
+            sys.exit(1)
         self.progress(f"Renaming {scan_build_dir} to {dest}")
         shutil.move(scan_build_dir, dest)
         new_stdout_filepath = os.path.join(dest, os.path.basename(self.stdout_filepath))

--- a/tests/test_process_scan_build_output.py
+++ b/tests/test_process_scan_build_output.py
@@ -1,0 +1,110 @@
+"""Tests for Tools/autotest/process_scan_build_output.py."""
+
+import os
+import plistlib
+
+import pytest
+
+from Tools.autotest.process_scan_build_output import ProcessScanBuildOutput
+
+
+def write_plist(report_dir, file_rel, issue_hash):
+    """One scan-build report carrying a single finding."""
+    data = {
+        "clang_version": "Ubuntu clang version 14.0.0",
+        "files": [file_rel],
+        "diagnostics": [{
+            "location": {"file": 0},
+            "issue_hash_content_of_line_in_context": issue_hash,
+            "type": "Dead assignment",
+        }],
+    }
+    with open(report_dir / "report-1.plist", "wb") as f:
+        plistlib.dump(data, f)
+
+
+@pytest.fixture
+def checkout(tmp_path, monkeypatch):
+    """A checkout whose tmp directory exists, as it must for scan-build to run.
+
+    autotest.py points TMPDIR at <checkout>/tmp, so any checkout that has run
+    scan-build locally has one.  The name avoids "ardupilot" so that a path
+    derived from the canonical repository name cannot pass by accident.
+    """
+    root = tmp_path / "renamed-fork"
+    (root / "tmp").mkdir(parents=True)
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
+    return root
+
+
+def scan_build_run(checkout, n):
+    """Simulate one scan-build run: its report directory and captured stdout."""
+    report = checkout / "tmp" / f"scan-build-2026-09-07-{n}"
+    report.mkdir()
+    write_plist(report, "libraries/AP_X/AP_X.cpp", f"hash{n}")
+    stdout = checkout / f"stdout-{n}.txt"
+    stdout.write_text(f"scan-build: Run 'scan-view {report}' to examine bug reports.\n")
+    return ProcessScanBuildOutput(str(stdout)), str(report)
+
+
+def in_github_actions(monkeypatch, workspace):
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    monkeypatch.setenv("GITHUB_WORKSPACE", str(workspace))
+
+
+def test_local_run_leaves_reports_where_scan_build_put_them(checkout):
+    p, report = scan_build_run(checkout, 1)
+    assert p.archive_rename(report) == report
+    assert os.path.isdir(report)
+    assert not (checkout / "tmp" / "scan-build").exists()
+
+
+def test_second_local_run_reads_its_own_reports(checkout):
+    """Moving a run onto an existing tmp/scan-build would nest its reports
+    beneath the previous run's, where the non-recursive plist glob does not
+    look, and the previous run's findings would be reported instead."""
+    p1, r1 = scan_build_run(checkout, 1)
+    p1.archive_rename(r1)
+    p2, r2 = scan_build_run(checkout, 2)
+    findings = p2.findings_from_plists(p2.archive_rename(r2))
+    assert {issue_hash for (_, issue_hash) in findings} == {"hash2"}
+
+
+def test_github_actions_archives_to_the_workspace(checkout, monkeypatch):
+    in_github_actions(monkeypatch, checkout)
+    p, report = scan_build_run(checkout, 1)
+    dest = checkout / "tmp" / "scan-build"
+    assert p.archive_rename(report) == str(dest)
+    assert (dest / "report-1.plist").is_file()
+    assert p.stdout_filepath == str(dest / "stdout-1.txt")
+    assert not os.path.exists(report)
+
+
+def test_github_actions_refuses_an_existing_archive(checkout, monkeypatch):
+    in_github_actions(monkeypatch, checkout)
+    p1, r1 = scan_build_run(checkout, 1)
+    p1.archive_rename(r1)
+    p2, r2 = scan_build_run(checkout, 2)
+    with pytest.raises(SystemExit):
+        p2.archive_rename(r2)
+    assert os.path.isdir(r2)
+
+
+@pytest.mark.parametrize("workspace", [None, "", "relative/workspace"])
+def test_github_actions_requires_an_absolute_workspace(checkout, monkeypatch, workspace):
+    """An empty or relative workspace would archive relative to the current
+    directory, where the upload step would only warn that nothing was found."""
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    if workspace is None:
+        monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
+    else:
+        monkeypatch.setenv("GITHUB_WORKSPACE", workspace)
+    elsewhere = checkout.parent / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+    p, report = scan_build_run(checkout, 1)
+    with pytest.raises(SystemExit):
+        p.archive_rename(report)
+    assert os.path.isdir(report)
+    assert os.listdir(elsewhere) == []


### PR DESCRIPTION
### Summary

Make clang-scan-build CI derive temporary and artifact paths from the current checkout so the workflow also runs in renamed forks.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

The configured pre-commit hooks pass for both changed files, including YAML validation, flake8, Ruff and codespell. `Tools/scripts/check_branch_conventions.py --base-branch origin/master` also passes.

`tests/test_process_scan_build_output.py` covers the archive step, run by the `pre-commit` workflow's `pytest tests/`: outside GitHub Actions the reports stay where scan-build put them and a repeat run reads its own findings; under GitHub Actions they are archived beneath `$GITHUB_WORKSPACE/tmp/scan-build`; an existing archive, or a `GITHUB_WORKSPACE` that is unset, empty or relative, fails the run rather than losing the reports. Five of the seven cases fail against the script at the earlier head 000e933.

The failure is also demonstrated by the same commit running in two repositories: [the renamed fork fails](https://github.com/Float-Cargo/ardupilot-upstream/actions/runs/33576460326), while [ArduPilot/ardupilot succeeds](https://github.com/ArduPilot/ardupilot/actions/runs/33576462939). The patched run at 000e933 completed green and uploaded the `clang-scan-build` artifact (11.19 MB, against 11.20 MB from the current master run).

### Description

`autotest.py` exports `TMPDIR` as the checkout's `tmp` directory. The clang-scan-build workflow instead created that directory under `/__w/ardupilot/ardupilot`, and the report processor and artifact upload repeated the same canonical-repository path. A fork with another repository name therefore gave scan-build a `TMPDIR` that did not exist. LLVM's scan-build diagnostic misleadingly reports this as an inaccessible `/tmp` directory even when another `TMPDIR` was selected.

Use `GITHUB_WORKSPACE` for the workflow paths and, under GitHub Actions only, for the report processor's archive destination. The archive step was a no-op on developer machines only because its hardcoded path never existed there; deriving the path from the checkout would have turned it on locally, where a second run moves its reports beneath the first run's and the plist glob then reads stale reports. It is therefore gated on `GITHUB_ACTIONS` and refuses an existing destination. Canonical-repository behavior is unchanged, while renamed forks keep all reports inside their own checkout.