### PR TITLE
Plane: apply throttle limits to tiltrotor forward thrust

### DIFF
--- a/ArduPlane/Plane.h
+++ b/ArduPlane/Plane.h
@@ -636,6 +636,17 @@ private:
     // this controls throttle suppression in auto modes
     bool throttle_suppressed;
 
+    // Throttle limits, calculated in set_throttle() and cached so that the
+    // tiltrotor forward thrust output can apply them on the next loop, from
+    // within the quadplane update. That runs ahead of set_throttle(), so it
+    // samples the throttle channel before the limits have been applied to it.
+    // See apply_cached_throttle_limits().
+    struct {
+        bool valid;     // true once the limits have been calculated
+        float min_pct;
+        float max_pct;
+    } throttle_limits;
+
 #if AP_BATTERY_WATT_MAX_ENABLED
     // reduce throttle to eliminate battery over-current
     int8_t  throttle_watt_limit_max;
@@ -1172,7 +1183,9 @@ private:
 
     // servos.cpp
     void set_servos();
-    float apply_throttle_limits(float throttle_in);
+    void calc_throttle_limits(void);
+    float apply_throttle_limits(float throttle_in) const;
+    float apply_cached_throttle_limits(float throttle_in) const;
     void set_throttle(void);
     void set_takeoff_expected(void);
     float get_auto_flap_speed() const;

--- a/ArduPlane/servos.cpp
+++ b/ArduPlane/servos.cpp
@@ -529,9 +529,14 @@ void Plane::throttle_watt_limiter(int8_t &min_throttle, int8_t &max_throttle)
 #endif // #if AP_BATTERY_WATT_MAX_ENABLED
 
 /*
-  Apply min/max safety limits to throttle.
+  Calculate the min/max safety limits to be applied to throttle.
+
+  Run once per loop from set_throttle(). The result is cached so that
+  set_servos() can apply it before the quadplane update on the next loop,
+  which is where the tiltrotor forward thrust output samples the throttle
+  channel.
  */
-float Plane::apply_throttle_limits(float throttle_in)
+void Plane::calc_throttle_limits(void)
 {
     // Pull the base throttle limits.
     // These are usually set to map the ESC operating range.
@@ -603,7 +608,64 @@ float Plane::apply_throttle_limits(float throttle_in)
     // These will be taken into account on the next iteration.
     TECS_controller.set_throttle_min(0.01f*min_throttle);
     TECS_controller.set_throttle_max(0.01f*max_throttle);
-    return constrain_float(throttle_in, min_throttle, max_throttle);
+
+    throttle_limits.min_pct = min_throttle;
+    throttle_limits.max_pct = max_throttle;
+    throttle_limits.valid = true;
+}
+
+/*
+  Apply the throttle limits calculated by calc_throttle_limits().
+ */
+float Plane::apply_throttle_limits(float throttle_in) const
+{
+    return constrain_float(throttle_in, throttle_limits.min_pct, throttle_limits.max_pct);
+}
+
+/*
+  Apply the throttle limits to a throttle sampled before set_throttle() has
+  run, using the values cached on the previous loop.  The tiltrotor forward
+  thrust output runs from quadplane.update(), which is ahead of set_throttle(),
+  so it would otherwise use an unlimited throttle.
+
+  The limits are only ever applied towards zero, so this can reduce the
+  magnitude of the throttle but never increase it, and a zero throttle stays
+  zero.  That matters because suppress_throttle() has not run yet: the tilt
+  motors are gated on is_zero(), so raising the throttle here would spin them
+  when the throttle should be suppressed.  With reverse thrust configured the
+  minimum is negative, or zero while reverse thrust is disallowed, so clamping
+  towards zero is also what keeps a reverse throttle off the tilt motors.
+
+  The throttle channel itself is deliberately left alone.  Writing the clamped
+  value back would feed an already limited throttle to the watt limiter's
+  hysteresis and to the forward battery compensation in set_throttle(), which
+  read the live channel, and would change behaviour for every plane rather than
+  only tiltrotors.
+ */
+float Plane::apply_cached_throttle_limits(float throttle_in) const
+{
+    if (!control_mode->use_throttle_limits()) {
+        return throttle_in;
+    }
+
+    float min_pct = throttle_limits.min_pct;
+    float max_pct = throttle_limits.max_pct;
+    if (!throttle_limits.valid) {
+        /*
+          The limits have not been calculated yet.  This is the first loop
+          after a mode that does not apply them, so calc_throttle_limits()
+          will run for the first time later in this same loop, from
+          set_throttle().  Fall back to the base parameters rather than
+          leaving the tiltrotor unlimited for that loop.  They can be
+          slightly stricter than the calculated limits would have been,
+          where the forward battery compensation or TKOFF_THR_MAX relax
+          them, which is the safe direction for a single loop.
+         */
+        min_pct = aparm.throttle_min.get();
+        max_pct = aparm.throttle_max.get();
+    }
+
+    return constrain_float(throttle_in, MIN(min_pct, 0.0f), MAX(max_pct, 0.0f));
 }
 
 /*
@@ -622,9 +684,18 @@ void Plane::set_throttle(void)
     }
 
     if (control_mode->use_throttle_limits()) {
-        // Apply min/max throttle limits
+        // Calculate and apply the min/max throttle limits. This is left where
+        // master applied them, after the quadplane update, so that the side
+        // effects of the calculation - the watt limiter's hysteresis, the
+        // forward battery compensation and the TECS limit setters - all see
+        // the same throttle and the same point in the loop as before. The
+        // limits are cached for set_servos() to re-use on the next loop.
+        calc_throttle_limits();
         const float limited_throttle = apply_throttle_limits(SRV_Channels::get_output_scaled(SRV_Channel::k_throttle));
         SRV_Channels::set_output_scaled(SRV_Channel::k_throttle, limited_throttle);
+    } else {
+        // the cached limits are only usable while the mode is applying them
+        throttle_limits.valid = false;
     }
 
     if (suppress_throttle()) {

--- a/ArduPlane/takeoff.cpp
+++ b/ArduPlane/takeoff.cpp
@@ -253,7 +253,7 @@ void Plane::takeoff_calc_pitch(void)
 
 /*
  * Calculate the throttle limits to run at during a takeoff.
- * These limits are meant to be used exclusively by Plane::apply_throttle_limits().
+ * These limits are meant to be used exclusively by Plane::calc_throttle_limits().
  */
 void Plane::takeoff_calc_throttle() {
     // Initialize the maximum throttle limit.

--- a/ArduPlane/tiltrotor.cpp
+++ b/ArduPlane/tiltrotor.cpp
@@ -229,7 +229,7 @@ void Tiltrotor::continuous_update(void)
 
         max_change = tilt_max_change(false);
 
-        float new_throttle = constrain_float(SRV_Channels::get_output_scaled(SRV_Channel::k_throttle)*0.01, 0, 1);
+        float new_throttle = constrain_float(plane.apply_cached_throttle_limits(SRV_Channels::get_output_scaled(SRV_Channel::k_throttle))*0.01, 0, 1);
         if (current_tilt < get_fully_forward_tilt()) {
             current_throttle = constrain_float(new_throttle,
                                                     current_throttle-max_change,
@@ -363,7 +363,7 @@ void Tiltrotor::binary_update(void)
         // all the way forward and run them as a forward motor
         binary_slew(true);
 
-        float new_throttle = SRV_Channels::get_output_scaled(SRV_Channel::k_throttle)*0.01f;
+        float new_throttle = plane.apply_cached_throttle_limits(SRV_Channels::get_output_scaled(SRV_Channel::k_throttle))*0.01f;
         if (current_tilt >= 1) {
             const uint32_t mask = is_zero(new_throttle) ? 0 : tilt_mask.get();
             // the motors are all the way forward, start using them for fwd thrust

--- a/Tools/autotest/quadplane.py
+++ b/Tools/autotest/quadplane.py
@@ -3817,6 +3817,111 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
 
         self.do_RTL()
 
+    def tiltrotor_throttle_limits(self, model, num_tilt_motors, extra_params=None):
+        '''Check that the tilt motors of the given frame honour THR_MAX'''
+
+        # A tiltrotor's forward thrust is written straight to the motors by
+        # Tiltrotor::continuous_update() or Tiltrotor::binary_update(), which
+        # run from quadplane.update().  That is before set_throttle() applies
+        # the throttle limits, so a regression here lets the motors follow the
+        # raw pilot stick in a manual throttle mode while the throttle channel,
+        # and CTUN.ThO, carry on reading a correctly limited value.
+        self.customise_SITL_commandline(
+            [],
+            model=model,
+            wipe=True,
+        )
+
+        thr_max = 60
+        params = {
+            "THR_MAX": thr_max,
+        }
+        if extra_params is not None:
+            params.update(extra_params)
+        self.set_parameters(params)
+
+        self.takeoff(30, mode='QHOVER', timeout=120)
+        self.change_mode('FBWA')
+        # full throttle stick, which is well above THR_MAX
+        self.set_rc(3, 2000)
+        # the two tilt types report the end of the transition differently, so
+        # key off the airspeed the transition waits for rather than a
+        # statustext, then let the tilt reach fully forward and settle
+        self.wait_airspeed(14, 100, timeout=180)
+        self.delay_sim_time(20, reason="tilt motors to settle in forward flight")
+
+        class CheckTiltMotorThrottle(vehicle_test_suite.TestSuite.MessageHook):
+            '''Checks the tilt motors sit at THR_MAX, neither above nor below'''
+            def __init__(self, suite, num_motors, min_pwm, max_pwm):
+                super(CheckTiltMotorThrottle, self).__init__(suite)
+                self.num_motors = num_motors
+                self.min_pwm = min_pwm
+                self.max_pwm = max_pwm
+                self.num_samples = 0
+
+            def hook_removed(self):
+                if self.num_samples == 0:
+                    raise NotAchievedException("Did not get SERVO_OUTPUT_RAW")
+
+            def process(self, mav, m):
+                if m.get_type() != 'SERVO_OUTPUT_RAW':
+                    return
+
+                self.num_samples += 1
+                # the tilt motors are SERVO5 onwards.  output_motor_mask() adds
+                # rudder differential to the individual motors, which cancels
+                # in the mean, so the mean is the commanded thrust.
+                total = 0
+                for i in range(self.num_motors):
+                    total += getattr(m, 'servo%u_raw' % (5 + i))
+                mean_pwm = total / float(self.num_motors)
+
+                if mean_pwm > self.max_pwm:
+                    raise NotAchievedException(
+                        "Tilt motors above THR_MAX (%.0f > %u)" % (mean_pwm, self.max_pwm))
+                # the stick is at maximum, so the motors should be held right
+                # at THR_MAX.  Without this a regression that left them off,
+                # or badly under-commanded, would pass the check above.
+                if mean_pwm < self.min_pwm:
+                    raise NotAchievedException(
+                        "Tilt motors below THR_MAX (%.0f < %u)" % (mean_pwm, self.min_pwm))
+
+        self.set_message_rate_hz('SERVO_OUTPUT_RAW', 200)
+
+        self.context_push()
+        # Q_M_PWM_MIN/MAX are 1000/2000, and output_motor_mask() writes the
+        # thrust into that range directly.  Allow 1% either side for rounding.
+        self.install_message_hook_context(CheckTiltMotorThrottle(self,
+                                                                 num_tilt_motors,
+                                                                 1000 + 10*(thr_max-1),
+                                                                 1000 + 10*(thr_max+1)))
+        self.delay_sim_time(10, reason="check tilt motors honour THR_MAX")
+        self.context_pop()
+
+        # the full throttle leg leaves the vehicle a long way from home, too
+        # far for the fixed timeout in do_RTL(), so land in place instead
+        self.set_rc(3, 1000)
+        self.change_mode('QLAND')
+        self.wait_disarmed(timeout=200)
+
+    def TiltrotorThrottleLimits(self):
+        '''Ensure THR_MAX is applied to vectored tiltrotor forward thrust'''
+        # Q_TILT_TYPE 2, so Tiltrotor::continuous_update().  Q_TILT_MASK is
+        # 15, so all four motors provide the forward thrust.
+        self.tiltrotor_throttle_limits("quadplane-tilthvec", 4)
+
+    def TiltrotorBinaryThrottleLimits(self):
+        '''Ensure THR_MAX is applied to binary tiltrotor forward thrust'''
+        # Q_TILT_TYPE 0, so Tiltrotor::binary_update(), which is a separate
+        # output path from the vectored case above.  Q_TILT_MASK is 3, so two
+        # motors provide the forward thrust.
+        #
+        # This frame settles around 15 m/s, below the default Q_ASSIST_SPEED,
+        # so assistance would never drop out and the transition would never
+        # complete.  Lower it so the vehicle reaches pure fixed wing flight.
+        self.tiltrotor_throttle_limits("quadplane-tilttri", 2,
+                                       extra_params={"Q_ASSIST_SPEED": 10})
+
     def CircuitStatusScript(self):
         '''test CircuitStatus lua driver against a CAN periph'''
         self.context_collect('STATUSTEXT')
@@ -3985,6 +4090,8 @@ class AutoTestQuadPlane(vehicle_test_suite.TestSuite):
             self.HighServoFunctionDefault,
             self.WPSpdChange,
             self.TECSThrSpikeOnModeChange,
+            self.TiltrotorThrottleLimits,
+            self.TiltrotorBinaryThrottleLimits,
             self.CircuitStatusScript,
             self.CompassLearnCopyFromEKFAffinity,
         ])

--- a/libraries/AP_TECS/AP_TECS.h
+++ b/libraries/AP_TECS/AP_TECS.h
@@ -373,7 +373,7 @@ private:
     // Maximum and minimum floating point throttle limits
     float _THRmaxf;
     float _THRminf;
-    // Maximum and minimum throttle safety limits, set externally, typically by servos.cpp:apply_throttle_limits()
+    // Maximum and minimum throttle safety limits, set externally, typically by servos.cpp:calc_throttle_limits()
     float _THRmaxf_ext = 1.0f;
     float _THRminf_ext = -1.0f;
     // Maximum and minimum pitch limits, set externally, typically by the takeoff logic.


### PR DESCRIPTION
### Summary

Tiltrotors output forward thrust straight to the motors from inside `quadplane.update()`, which runs *before* `set_throttle()` applies the throttle limits, so in manual-throttle fixed-wing modes the tilt motors follow the raw pilot stick and ignore `THR_MAX` completely. This splits the limit calculation from its application, caches the result, and has the tiltrotor apply it to the throttle it samples.

Fixes #34274

### Classification & Testing (check all that apply and add your own)

- [ ] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

`QuadPlane.TiltrotorThrottleLimits` covers this: with `THR_MAX=60` and the throttle stick at maximum after transition, it asserts the tilt motors sit *at* `THR_MAX` from both sides. Verified by reverting the `ArduPlane/` files to the base commit and rebuilding: fails on base with `Tilt motors above THR_MAX (2000 > 1610)`, passes with the change.

Earlier manual SITL runs on `quadplane-tilttrivec` (`Q_TILT_TYPE=2`) and `quadplane-tilttri` (`Q_TILT_TYPE=0`, binary), `THR_MAX=60`, climbing to ~100 m, transitioning, then throttle stick to maximum, showed the tilt motors going from 100% to 60.0% in FBWA on both frames, with airspeed 40.8 → 25.7 m/s. CRUISE was the control case and was unchanged, since TECS is pre-limited via `set_throttle_max()` there. Those runs were made against the original revision of this PR; the behaviour the tiltrotor sees is the same now, and the autotest is what covers it going forward.

### Description

`Plane::set_servos()` runs, in order:

1. `quadplane.update()` → `tiltrotor.update()` → `Tiltrotor::continuous_update()`, which reads `SRV_Channels::get_output_scaled(SRV_Channel::k_throttle)` and writes the motors via `motors->output_motor_mask()`. That call outputs immediately, and nothing re-runs it later in the loop.
2. `set_throttle()` → `apply_throttle_limits()`, which clamps `k_throttle`.

In a manual-throttle mode `Mode::output_pilot_throttle()` has put the raw stick into `k_throttle` during the preceding `FAST_TASK(stabilize)`, so the tiltrotor samples the unlimited value. The clamp afterwards only affects the logged scalar and any dedicated fixed-wing throttle channel — which is why `CTUN.ThO` reads a compliant value throughout and the problem is invisible on a normal throttle plot. `Tiltrotor::binary_update()` has the same ordering. Auto-throttle modes are unaffected because TECS is pre-limited via `set_throttle_max()`.

Simply moving `set_throttle()` ahead of `quadplane.update()` would regress VTOL forward thrust: `quadplane.update()` itself writes `k_throttle` when in a VTOL mode, and that write needs the limits applied after it.

**The calculation cannot move either.** `apply_throttle_limits()` on master does more than constrain a value: `throttle_watt_limiter()` reads the live throttle channel to drive its attack/release hysteresis, `g2.fwd_batt_cmp.apply_min_max()` scales the limits by the voltage ratio, and `TECS_controller.set_throttle_min()`/`set_throttle_max()` push the limits into TECS. Running that block earlier in the loop would change what the watt limiter observes and when the compensation is computed — a behaviour change for every Plane with those features enabled, not just tiltrotors.

So `apply_throttle_limits()` is split, and the calculation stays put:

- `calc_throttle_limits()` keeps the whole calculation and all of its side effects, and is still called from `set_throttle()`, after the quadplane update, exactly where the limits were applied before. Nothing it touches sees a different throttle or a different point in the loop.
- `apply_throttle_limits()` becomes a pure `constrain_float()` against the cached limits, still used by `set_throttle()`.
- `apply_cached_throttle_limits()` applies the previous loop's limits, and the tiltrotor calls it on the throttle it samples.

**The limits are applied at the point of use, not written back to the throttle channel.** An earlier revision of this PR clamped `k_throttle` in `set_servos()` ahead of the quadplane update. That is what @tridge's review caught: `throttle_watt_limiter()` decides whether to *release* by testing the live channel against its own limit (`servos.cpp:514`), so feeding it an already-capped value means the test becomes `max - wl > wl` and the limiter can attack but never let go. The forward battery compensation reads the live channel too. Applying the limits where the tiltrotor uses them leaves `k_throttle` untouched until `set_throttle()`, so both are bit-identical to master and no plane without a tiltrotor changes at all.

**The limits are only ever applied towards zero.** `apply_cached_throttle_limits()` constrains against `MIN(min_pct, 0)` and `MAX(max_pct, 0)`, so it can reduce the magnitude of the throttle but never increase it, and a zero throttle stays zero. Two reasons:

- `suppress_throttle()` has not run when the tiltrotor samples the throttle, and both tilt paths gate their motors on `is_zero()` (`tiltrotor.cpp:248`, `:368`). Applying a positive `THR_MIN` here would spin the tilt motors when the throttle should be suppressed — @IamPete1's finding on the first revision.
- With reverse thrust configured, `calc_throttle_limits()` lowers the minimum to zero whenever reverse thrust is not currently allowed (`servos.cpp:552`), which with the default `USE_REV_THRUST` is every FBWA flight. Clamping towards zero is what applies that, and what a max-only clamp missed — @IamPete1's second finding.

`THR_SLEWRATE` is still not applied to tilt-motor forward thrust — it is applied by `throttle_slew_limit()` on the throttle channel, and the tiltrotor keeps its own slew via `tilt_max_change()`. The unclamped throttle handoff at "Transition FW done" (`quadplane.cpp`) is also left alone; both are described in #34274 and are separate from this fix.

**On the one-loop lag.** The cache carries a `valid` flag that is cleared whenever the mode stops applying limits, and `control_mode->use_throttle_limits()` is re-checked live inside `apply_cached_throttle_limits()`. It is *not* cleared on a mode or flight-stage change that keeps limits enabled, so the tiltrotor can use the previous stage's limits for a single loop — leaving TAKEOFF with `TKOFF_THR_MAX` still cached is the concrete case. Since the application is towards zero only, the exposure is one loop at a stale bound on a value that is otherwise unlimited, which is strictly better than master. Most of the limits come from parameters and the flight stage, though the watt-limited maximum does depend on the live throttle demand; at the QuadPlane default `SCHED_LOOP_RATE` of 300 Hz one loop is 3.33 ms.
