### PR TITLE
AP_ExternalAHRS: fix intermittent AeronEAHRS bad health

### DIFF
--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_Aeron_plx.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_Aeron_plx.cpp
@@ -1061,15 +1061,25 @@ bool AP_ExternalAHRS_Aeron_plx::healthy() const
         return false;
     }
 
+    // Snapshot the stamps BEFORE sampling the clock. The reader thread runs
+    // at higher priority and can stamp a newer millisecond between the two
+    // reads; sampled the other way round, (now - stamp) underflows to ~2^32
+    // and health flickers false for one loop, bouncing AP_AHRS to DCM and
+    // back ("AHRS: DCM active"). millis() is monotonic, so reading the
+    // stamps first guarantees now >= stamp.
+    const uint32_t sens_ms = last_sens_ms;
+    const uint32_t nav1_ms = last_nav1_ms;
+    const uint32_t nav2_ms = last_nav2_ms;
+    const uint32_t gnss_ms = last_gnss_ms;
     const uint32_t now = AP_HAL::millis();
     // Both NAV streams are checked independently: NAV_PARA1 carries
     // position/velocity/attitude and NAV_PARA2 the quaternion + hw_status.
     // Losing either must trip unhealthy, otherwise stale data from the
     // lost stream would keep publishing at arbitrary age.
-    return (now - last_sens_ms)  < SENS_TIMEOUT_MS
-        && (now - last_nav1_ms)  < NAV_TIMEOUT_MS
-        && (now - last_nav2_ms)  < NAV_TIMEOUT_MS
-        && (now - last_gnss_ms)  < GNSS_TIMEOUT_MS;
+    return (now - sens_ms)  < SENS_TIMEOUT_MS
+        && (now - nav1_ms)  < NAV_TIMEOUT_MS
+        && (now - nav2_ms)  < NAV_TIMEOUT_MS
+        && (now - gnss_ms)  < GNSS_TIMEOUT_MS;
 }
 
 /*

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_Aeron_plx.cpp
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_Aeron_plx.cpp
@@ -107,10 +107,30 @@ void AP_ExternalAHRS_Aeron_plx::check_and_decode()
         return;
     }
 
-    // Drain buffer, stack-local. 256 B is ~3x the max bytes that arrive
-    // in one 1 ms tick at 921600 baud (~92 B), and still clears a full
-    // UART RX backlog within a few ticks if the thread is briefly
-    // preempted.
+    // Both callers reach this, so the readiness guard lives here rather than
+    // being duplicated in each. update_thread() sets setup_complete after
+    // uart->begin(), before its first call.
+    if (!setup_complete) {
+        return;
+    }
+
+    // Nothing buffered: return before taking parse_sem. This is the normal
+    // path for the main-thread caller on HALs that serve reads only to the
+    // thread that claimed the port, and it keeps that caller from blocking
+    // behind a reader-thread parse to then read nothing. Racing with the
+    // reader thread here is harmless: the worst case is taking the lock and
+    // finding the ring already drained.
+    if (uart->available() == 0) {
+        return;
+    }
+
+    WITH_SEMAPHORE(parse_sem);
+
+    // Drain buffer, stack-local. Sized for the 1 ms reader thread: ~92 B
+    // arrive per tick at 921600 baud, so 256 B is ~3x headroom and still
+    // clears a full UART RX backlog within a few ticks after a preemption.
+    // The main-thread caller shares the quantum, and normally finds the ring
+    // already drained by the reader thread.
     uint8_t chunk_buf[256];
     const uint16_t avail = MIN(uart->available(), uint16_t(sizeof(chunk_buf)));
     if (avail == 0) {

--- a/libraries/AP_ExternalAHRS/AP_ExternalAHRS_Aeron_plx.h
+++ b/libraries/AP_ExternalAHRS/AP_ExternalAHRS_Aeron_plx.h
@@ -63,7 +63,17 @@ public:
     void        get_filter_status(nav_filter_status &status) const override;
     bool        get_variances(float &velVar, float &posVar, float &hgtVar,
                               Vector3f &magVar, float &tasVar) const override;
-    void        update() override {}    // all work happens in update_thread()
+    // Parse on the main thread as well as the reader thread. last_sens_ms is
+    // stamped at parse time, so if only the reader thread parses, healthy()
+    // reports "time since that thread was scheduled" rather than how recently
+    // the PLX sent anything. Mirrors MicroStrain5/7 and VectorNav, which also
+    // parse from update().
+    //
+    // On HALs that serve reads only to the thread that claimed the port
+    // (ChibiOS, ESP32) the reader thread owns it and this returns having read
+    // nothing. That is intentional - those targets schedule the reader thread
+    // in real time and do not exhibit the starvation this addresses.
+    void        update() override { check_and_decode(); }
 
 protected:
     uint8_t num_gps_sensors() const override
@@ -231,6 +241,12 @@ private:
     // this by snapshotting `shared` under arn_sem and RELEASING it before
     // acquiring state.sem to write `state`.
     mutable HAL_Semaphore arn_sem;
+
+    // Serialises check_and_decode() between the reader thread and the main
+    // thread. Held across the publish path, so arn_sem and state.sem are taken
+    // beneath it. Note the main-thread caller arrives already holding
+    // AP_AHRS::_rsem, so this is not the outermost lock on that path.
+    HAL_Semaphore parse_sem;
 
     void update_thread();
     void check_and_decode();


### PR DESCRIPTION
### Summary

Fixes intermittent `AeronEAHRS` autotest failures. The Aeron PLX3 backend measured sensor freshness by when its reader thread last ran rather than when the PLX3 last sent data, producing spurious AHRS fallbacks to DCM and failed arming checks.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

**SITL, A/B against this branch's base.** 8 alternating runs per variant of `test.Plane.AeronEAHRS` under CPU contention (2 busy loops pinned to the same cores as the autotest). Binaries were rebuilt per variant and verified before each run.

| | without patch | with patch |
|---|---|---|
| `test.Plane.AeronEAHRS` passed | 1 / 8 | **8 / 8** |
| `AHRS: DCM active` per run | 116, 199, 200, 208, 228, 231, 236, 274 | **0 in every run** |
| `PreArm: AHRS: Aeron Unhealthy` | 6 of 8 runs | **0** |

**Autotest suites, all passing with the patch:** `AeronEAHRS`, `VectorNavEAHRS`, `MicroStrainEAHRS5`, `MicroStrainEAHRS7`, `InertialLabsEAHRS`, `GpsSensorPreArmEAHRS`, `Copter.CommonOriginExternalAHRS`, `Copter.CommonOriginExternalAHRSReceives`.

**Builds:** SITL plane and copter, and CubeOrangePlus plane and copter.

**Hardware:** bench tested and flight tested on a PLX3-equipped airframe.

### Description

`AP_ExternalAHRS_Aeron_plx` stamps `last_sens_ms` (and the NAV/GNSS equivalents) at *parse* time, and `update()` was an empty stub, so only the driver's reader thread ever parsed. `healthy()` consequently reported "time since that thread was scheduled" rather than "time since the driver last parsed a packet". The two agree while the thread is scheduled promptly and diverge when it is not. Note the stamp remains a parse-time stamp either way: this removes the dependency on reader-thread scheduling, it does not make the stamp track transmission time, and a deep RX backlog can still restamp older packets.

Under SITL that divergence is routine: a non-main thread's wall-clock scheduling delay is multiplied by the speedup factor when expressed in simulated time, so an ordinary 1-2 ms preemption at `SIM_SPEEDUP=20` exceeds the 40 ms `SENS_PARA` deadline. `healthy()` returns false, `get_filter_status()` reports no usable solution, `AP_AHRS::_active_EKF_type()` falls back to DCM for fixed wing, and the arming check then fails.

From the reported CI run:

```
AT-0130.7: Took 3 seconds to become armable
AT-0130.7: Arm motors with MAVLink cmd
AT-0130.7: ACK received: COMMAND_ACK {command : 400, result : 4, ...}
AT-0130.7: AP: AHRS: DCM active
AT-0130.7: AP: Arm: AHRS: not using configured AHRS type
AT-0130.7: AP: AHRS: External active
AT-0133.7: FAILED: "AeronEAHRS": ValueError('Expected MAV_RESULT_ACCEPTED got MAV_RESULT_FAILED')
```

In that run the Aeron backend was the only external AHRS backend to fall back to DCM. The others parse from `update()` in addition to their reader thread, so their freshness stamps do not depend on when that thread was last scheduled.

This is still reproducible on current master. The seven unpatched failures above were `AHRS position lags simulator truth`, the DCM fallback seen from the position check. In an earlier series of eight unpatched runs on the previous base, one failed with the same `MAV_RESULT_FAILED` as CI, reported as `AP: Arm: AHRS: Aeron Unhealthy` — the same root cause surfacing through the live health check instead of the cached AHRS type, depending on whether the reader thread recovers between the AHRS update and the arm handler.

### Fix

**First commit** makes `update()` call `check_and_decode()`, serialised against the reader thread by a new `parse_sem`, matching the pattern used by the other EAHRS backends. `available()` is read inside `parse_sem`: on SITL it can reach a blocking `accept()` via `_check_connection()`, which two unserialised callers could race into. `SENS_TIMEOUT_MS` is unchanged; the fix is to measure freshness correctly, not to widen the deadline. On ChibiOS and ESP32, which serve UART reads only to the thread that claimed the port, the reader thread owns it and the main-thread call returns having read nothing — intentional, as those targets schedule the reader thread in real time and do not exhibit this starvation.

**Second commit** is an independent race found while reviewing the same function. `healthy()` sampled `millis()` before reading the timestamps; since the reader thread runs at `PRIORITY_SPI` (above the main thread) it can stamp a newer millisecond between those two reads, making `now - stamp` underflow and flicker health false for one loop. Reading the timestamps first removes it.

