### PR TITLE
Remove airspeed index circularity from AP_AHRS/AP_AHRS_NavEKF3

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -4384,6 +4384,250 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
 
         self.disarm_vehicle(force=True)
 
+    def _EKF3AirspeedAffinity(self, force_dcm=False):
+        '''shared body for EKF3AirspeedAffinity and
+        EKF3AirspeedAffinityDCM; see those for what is asserted'''
+        self.set_parameters({
+            "EK3_ENABLE": 1,
+            "EK2_ENABLE": 0,
+            "AHRS_EKF_TYPE": 3,
+            "EK3_AFFINITY": 8,  # airspeed affinity only
+            "EK3_IMU_MASK": 3,  # two IMUs, so two cores
+            "ARSPD2_TYPE": 2,
+            "ARSPD2_USE": 1,
+            "ARSPD2_PIN": 2,
+            # the airspeed library's own failure handling would, with
+            # EKF3 active, disable a sensor the EKF keeps rejecting
+            # after a few seconds and move ARSPD_PRIMARY off it, at
+            # which point both cores fall back to the same sensor and
+            # there is no affinity left to test.  This test is about
+            # the EKF's per-core behaviour, so turn that off:
+            "ARSPD_OPTIONS": 0,
+        })
+        self.reboot_sitl()
+
+        # AIRSPEED.flags bit 1 is AIRSPEED_SENSOR_USING, set on the
+        # sensor the AHRS is taking its airspeed from; with affinity
+        # that is the sensor selected by the EKF3 primary core.
+        AIRSPEED_SENSOR_USING = 2
+
+        def wait_airspeed_condition(description, condition, minimum_duration=0, timeout=30):
+            '''wait for condition(sensor1_msg, sensor2_msg) to hold
+            continuously for minimum_duration seconds of sim time,
+            sampling a fresh AIRSPEED message from each sensor each
+            time'''
+            self.progress("Waiting for %s" % description)
+            tstart = self.get_sim_time()
+            pass_start = None
+            while True:
+                now = self.get_sim_time_cached()
+                if now - tstart > timeout:
+                    raise NotAchievedException("Did not get %s" % description)
+                a0 = self.assert_receive_message('AIRSPEED', instance=0)
+                a1 = self.assert_receive_message('AIRSPEED', instance=1)
+                if not condition(a0, a1):
+                    pass_start = None
+                    continue
+                if pass_start is None:
+                    pass_start = now
+                if now - pass_start >= minimum_duration:
+                    return
+
+        def wait_ahrs_using_airspeed_sensor(instance, minimum_duration=0):
+            '''wait for the AHRS to be using airspeed sensor instance and
+            not the other one, both holding for minimum_duration'''
+            flags = [0, 0]
+            flags[instance] = AIRSPEED_SENSOR_USING
+            wait_airspeed_condition(
+                "AHRS using airspeed sensor %u only" % (instance+1),
+                lambda a0, a1: a0.flags == flags[0] and a1.flags == flags[1],
+                minimum_duration=minimum_duration)
+
+        def wait_airspeed_sensors_agree(minimum_duration):
+            '''wait for the two airspeed sensors to read within 1m/s of
+            each other for minimum_duration seconds'''
+            wait_airspeed_condition(
+                "airspeed sensors agreeing",
+                lambda a0, a1: abs(a0.airspeed - a1.airspeed) <= 1,
+                minimum_duration=minimum_duration,
+                timeout=60)
+
+        def fail_airspeed_sensor(instance, error=10):
+            '''freeze airspeed sensor instance at error m/s above the
+            reading of the other, healthy, sensor'''
+            good = self.assert_receive_message('AIRSPEED', instance=1-instance)
+            name = "SIM_ARSPD_FAIL" if instance == 0 else "SIM_ARSPD2_FAIL"
+            self.set_parameter(name, good.airspeed + error)
+
+        def restore_airspeed_sensor(instance):
+            name = "SIM_ARSPD_FAIL" if instance == 0 else "SIM_ARSPD2_FAIL"
+            self.set_parameter(name, 0)
+
+        self.context_collect("STATUSTEXT")
+
+        try:
+            self.takeoff(alt=50)
+            self.change_mode('CIRCLE')
+            if force_dcm:
+                # the AHRS reports the sensor its *active* backend
+                # consumes.  EKF3 keeps running and lane-switching while
+                # DCM is active, but DCM has no per-core selection, so the
+                # AHRS must stay on ARSPD_PRIMARY (sensor 1) throughout:
+                self.start_subtest("Force DCM as the active AHRS; EKF3 keeps running")
+                self.set_parameter("AHRS_EKF_TYPE", 0)
+                self.wait_statustext("DCM active", timeout=10, check_context=True)
+            t_start = self.get_sim_time()
+
+            self.start_subtest("Both sensors healthy: core 0 is primary and the AHRS uses sensor 1")
+            wait_airspeed_sensors_agree(minimum_duration=5)
+            wait_ahrs_using_airspeed_sensor(0)
+
+            # (fault start, fault end, faulty core) for the log checks:
+            fault_windows = []
+
+            for (faulty, healthy) in [(0, 1), (1, 0)]:
+                self.start_subtest("Fail airspeed sensor %u: lane moves to core %u" %
+                                   (faulty+1, healthy))
+                self.context_clear_collection("STATUSTEXT")
+                t_fault = self.get_sim_time()
+                fail_airspeed_sensor(faulty)
+                # a 10m/s step is rejected outright, so the switch follows
+                # within a few filter updates (observed 0.1-0.2s); 5s
+                # leaves a wide margin while still catching a regression
+                # to the slow error-score path
+                self.wait_statustext("EKF3 lane switch %u" % healthy, timeout=5, check_context=True)
+                self.context_clear_collection("STATUSTEXT")
+                # with EKF3 active the AHRS follows the new primary core's
+                # sensor; with DCM active it stays on ARSPD_PRIMARY.  Hold
+                # the fault so the lane must stay with the healthy core and
+                # the log has a decent window to check; longer than the 5s
+                # the EKF takes to declare an airspeed timeout, so the
+                # healthy core silently ceasing to fuse would show up in
+                # the log:
+                ahrs_sensor = 0 if force_dcm else healthy
+                wait_ahrs_using_airspeed_sensor(ahrs_sensor, minimum_duration=8)
+                t_restore = self.get_sim_time()
+                restore_airspeed_sensor(faulty)
+                fault_windows.append((t_fault, t_restore, faulty))
+
+                self.start_subtest("Sensor %u restored: lane stays with core %u" % (faulty+1, healthy))
+                # 15s of agreement comfortably exceeds the 10s a core must
+                # have been off-primary before it can be selected again,
+                # so a spurious switch back would be seen here:
+                wait_airspeed_sensors_agree(minimum_duration=15)
+                if self.statustext_in_collections("EKF3 lane switch"):
+                    raise NotAchievedException("Unexpected lane switch after sensor restored")
+                wait_ahrs_using_airspeed_sensor(ahrs_sensor)
+
+            t_end = self.get_sim_time()
+        except Exception:
+            # get the vehicle on the ground so the framework can
+            # reboot it during context cleanup:
+            self.disarm_vehicle(force=True)
+            raise
+        self.disarm_vehicle(force=True)
+
+        self.start_subtest("Check onboard log for per-core airspeed selection and fusion")
+        dfreader = self.dfreader_for_current_onboard_log()
+        # per-core count of XKFS samples seen, and the set of the
+        # non-airspeed selection indexes each core used; these must be
+        # constant and identical across cores as only airspeed affinity
+        # is on:
+        xkfs_count = {0: 0, 1: 0}
+        other_selections = {0: set(), 1: set()}
+        # per-window, per-core peak airspeed innovation (XKF3.IVT, m/s)
+        # and count of samples failing the innovation gate (XKF4.SVT
+        # is sqrt of the airspeed innovation test ratio):
+        peak_innov = [{0: 0.0, 1: 0.0} for _ in fault_windows]
+        rejected = [{0: 0, 1: 0} for _ in fault_windows]
+        xkf4_count = [{0: 0, 1: 0} for _ in fault_windows]
+        # XKF4.TS bit 4 is the airspeed timeout: 5s without a sample
+        # passing the innovation gate
+        timed_out = [{0: False, 1: False} for _ in fault_windows]
+        while True:
+            m = dfreader.recv_match(type=['XKFS', 'XKF3', 'XKF4'])
+            if m is None:
+                break
+            t = m.TimeUS * 1e-6
+            if t < t_start or t > t_end:
+                continue
+            if m.get_type() == 'XKFS':
+                if m.AI != m.C:
+                    raise NotAchievedException(
+                        "Core %u selected airspeed sensor %u at t=%.1f, expected %u" %
+                        (m.C, m.AI, t, m.C))
+                xkfs_count[m.C] += 1
+                other_selections[m.C].add((m.MI, m.BI, m.GI))
+                continue
+            for (i, (t_fault, t_restore, faulty)) in enumerate(fault_windows):
+                if t < t_fault or t > t_restore:
+                    continue
+                if m.get_type() == 'XKF3':
+                    peak_innov[i][m.C] = max(peak_innov[i][m.C], abs(m.IVT))
+                    continue
+                xkf4_count[i][m.C] += 1
+                if m.SVT >= 1.0:
+                    rejected[i][m.C] += 1
+                if m.TS & (1 << 4):
+                    timed_out[i][m.C] = True
+
+        for core in (0, 1):
+            if xkfs_count[core] == 0:
+                raise NotAchievedException("No XKFS sensor-selection samples for core %u" % core)
+            if len(other_selections[core]) != 1:
+                raise NotAchievedException(
+                    "Core %u changed compass/baro/GPS selection during the test (%s)" %
+                    (core, other_selections[core]))
+        if other_selections[0] != other_selections[1]:
+            raise NotAchievedException(
+                "Compass/baro/GPS selection differs between cores (%s vs %s)" %
+                (other_selections[0], other_selections[1]))
+
+        for (i, (t_fault, t_restore, faulty)) in enumerate(fault_windows):
+            healthy = 1 - faulty
+            self.progress("Fault window %u (sensor %u failed): "
+                          "peak innovation core0=%.1f core1=%.1f rejected core0=%u/%u core1=%u/%u" %
+                          (i, faulty+1, peak_innov[i][0], peak_innov[i][1],
+                           rejected[i][0], xkf4_count[i][0], rejected[i][1], xkf4_count[i][1]))
+            if peak_innov[i][faulty] < 5:
+                raise NotAchievedException(
+                    "Core %u did not see the fault on its sensor (peak innovation %.1f)" %
+                    (faulty, peak_innov[i][faulty]))
+            # the faulty core must keep reading and gating its own sensor
+            # for the whole hold, not just see it once: XKF4 is logged
+            # every filter update, so most samples must show rejection
+            if rejected[i][faulty] < xkf4_count[i][faulty] / 2:
+                raise NotAchievedException(
+                    "Core %u rejected only %u of %u samples from its faulty sensor" %
+                    (faulty, rejected[i][faulty], xkf4_count[i][faulty]))
+            if xkf4_count[i][healthy] == 0:
+                raise NotAchievedException("No XKF4 samples for healthy core %u in fault window" % healthy)
+            if peak_innov[i][healthy] > 2.5:
+                raise NotAchievedException(
+                    "Core %u fusing the healthy sensor was disturbed (peak innovation %.1f)" %
+                    (healthy, peak_innov[i][healthy]))
+            if rejected[i][healthy] != 0:
+                raise NotAchievedException(
+                    "Core %u rejected %u healthy airspeed samples" %
+                    (healthy, rejected[i][healthy]))
+            if timed_out[i][healthy]:
+                raise NotAchievedException(
+                    "Core %u stopped fusing its healthy airspeed sensor" % healthy)
+
+    def EKF3AirspeedAffinity(self):
+        '''Test EKF3 airspeed affinity: each core fuses its own airspeed
+        sensor, a fault on either sensor moves the primary lane to the
+        core fusing the healthy sensor, the AHRS follows the primary
+        core's selection, and the other affinity bits are unaffected'''
+        self._EKF3AirspeedAffinity()
+
+    def EKF3AirspeedAffinityDCM(self):
+        '''EKF3AirspeedAffinity with DCM forced as the active AHRS after
+        takeoff: EKF3 still lane-switches on its own sensors but the
+        AHRS keeps reporting ARSPD_PRIMARY in use, as its active backend
+        has no per-core selection'''
+        self._EKF3AirspeedAffinity(force_dcm=True)
+
     def FenceAltCeilFloor(self):
         '''Tests the fence ceiling and floor'''
         self.set_parameters({
@@ -9139,6 +9383,8 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.EKF_STATUS_REPORT,
             self.Deadreckoning,
             self.EKFlaneswitch,
+            self.EKF3AirspeedAffinity,
+            self.EKF3AirspeedAffinityDCM,
             self.AirspeedDrivers,
             self.RTL_CLIMB_MIN,
             self.ClimbBeforeTurn,

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -5561,11 +5561,9 @@ class TestSuite(abc.ABC):
         tstart = time.time()  # timeout in wallclock
         while True:
             m = mav.recv_match(type=type, blocking=True, timeout=0.05, condition=condition)
-            if instance is not None:
-                if getattr(m, m._instance_field) != instance:
-                    continue
             if m is not None:
-                break
+                if instance is None or getattr(m, m._instance_field) == instance:
+                    break
             elapsed_time = time.time() - tstart
             if elapsed_time > timeout:
                 raise NotAchievedException("Did not get %s after %s seconds" %

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -2055,6 +2055,21 @@ uint8_t AP_AHRS::get_active_airspeed_index() const
 #endif // AP_AIRSPEED_ENABLED
 }
 
+#if AP_AIRSPEED_ENABLED
+// returns true if airspeed sensor data is being consumed by the
+// active backend.  Note that this does *not* indicate the results
+// are derived from the airspeed data, just that the backend is
+// attempting to use the data
+bool AP_AHRS::airspeed_sensor_data_being_consumed(void) const
+{
+    // This is obviously a lie, we should be looking in the
+    // backend results to see if it truly is using the data.
+    const AP_Airspeed *_airspeed = AP::airspeed();
+    return _airspeed != nullptr && _airspeed->use() && _airspeed->healthy();
+}
+
+#endif  // AP_AIRSPEED_ENABLED
+
 #if AP_AHRS_EKF_RESET_ENABLED
 // request full backend reset, currently only implemented for EKF3
 // returns true if the reset was performed

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -729,12 +729,14 @@ bool AP_AHRS::using_airspeed_sensor() const
     return state.airspeed_estimate_type == AirspeedEstimateType::AIRSPEED_SENSOR;
 }
 
+#if AP_AIRSPEED_ENABLED
 /*
     Return true if a airspeed sensor should be used for the AHRS airspeed estimate
  */
 bool AP_AHRS::_should_use_airspeed_sensor(uint8_t airspeed_index) const
 {
-    if (!airspeed_sensor_enabled(airspeed_index)) {
+    const auto *airspeed = AP::airspeed();
+    if (airspeed == nullptr || !airspeed->healthy(airspeed_index) || !airspeed->use(airspeed_index)) {
         return false;
     }
     nav_filter_status filter_status;
@@ -751,6 +753,7 @@ bool AP_AHRS::_should_use_airspeed_sensor(uint8_t airspeed_index) const
     }
     return true;
 }
+#endif  // AP_AIRSPEED_ENABLED
 
 // return an airspeed estimate if available. return true
 // if we have an estimate

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -192,6 +192,10 @@ public:
     // returns false if the data is unavailable
     bool airspeed_health_data(uint8_t instance, float &innovation, float &innovationVariance, uint32_t &age_ms) const;
 
+    // returns true if airspeed sensor data is being consumed by the
+    // active backend
+    bool airspeed_sensor_data_being_consumed(void) const;
+
     // return true if a airspeed sensor is enabled
     bool airspeed_sensor_enabled(void) const {
         // FIXME: make this a method on the active backend

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -196,18 +196,6 @@ public:
     // active backend
     bool airspeed_sensor_data_being_consumed(void) const;
 
-    // return true if a airspeed sensor is enabled
-    bool airspeed_sensor_enabled(void) const {
-        // FIXME: make this a method on the active backend
-        return AP_AHRS_Backend::airspeed_sensor_enabled();
-    }
-
-    // return true if a airspeed from a specific airspeed sensor is enabled
-    bool airspeed_sensor_enabled(uint8_t airspeed_index) const {
-        // FIXME: make this a method on the active backend
-        return AP_AHRS_Backend::airspeed_sensor_enabled(airspeed_index);
-    }
-
     // true if compass is being used
     bool use_compass();
 

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -292,28 +292,6 @@ public:
     static float get_EAS2TAS(void);
     static float get_TAS2EAS(void) { return 1.0/get_EAS2TAS(); }
 
-    // return true if airspeed comes from an airspeed sensor, as
-    // opposed to an IMU estimate
-    static bool airspeed_sensor_enabled(void) {
-    #if AP_AIRSPEED_ENABLED
-        const AP_Airspeed *_airspeed = AP::airspeed();
-        return _airspeed != nullptr && _airspeed->use() && _airspeed->healthy();
-    #else
-        return false;
-    #endif
-    }
-
-    // return true if airspeed comes from a specific airspeed sensor, as
-    // opposed to an IMU estimate
-    static bool airspeed_sensor_enabled(uint8_t airspeed_index) {
-    #if AP_AIRSPEED_ENABLED
-        const AP_Airspeed *_airspeed = AP::airspeed();
-        return _airspeed != nullptr && _airspeed->use(airspeed_index) && _airspeed->healthy(airspeed_index);
-    #else
-        return false;
-    #endif
-    }
-
     virtual bool set_origin(const Location &loc) {
         return false;
     }

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -152,6 +152,26 @@ private:
     // update our wind estimate from the latest GPS velocity and attitude:
     void estimate_wind(void);
 
+    // returns true if DCM should consume airspeed data
+    static bool airspeed_sensor_enabled(void) {
+    #if AP_AIRSPEED_ENABLED
+        const AP_Airspeed *_airspeed = AP::airspeed();
+        return _airspeed != nullptr && _airspeed->use() && _airspeed->healthy();
+    #else
+        return false;
+    #endif
+    }
+
+    // returns true if DCM should consume airspeed data
+    static bool airspeed_sensor_enabled(uint8_t airspeed_index) {
+    #if AP_AIRSPEED_ENABLED
+        const AP_Airspeed *_airspeed = AP::airspeed();
+        return _airspeed != nullptr && _airspeed->use(airspeed_index) && _airspeed->healthy(airspeed_index);
+    #else
+        return false;
+    #endif
+    }
+
     // airspeed_ret: will always be filled-in by get_unconstrained_airspeed_EAS which fills in airspeed_ret in this order:
     //               airspeed as filled-in by an enabled airspeed sensor
     //               if no airspeed sensor: airspeed estimated using the GPS speed & wind_speed_estimation

--- a/libraries/AP_DAL/AP_DAL.cpp
+++ b/libraries/AP_DAL/AP_DAL.cpp
@@ -76,7 +76,6 @@ void AP_DAL::start_frame(AP_DAL::FrameType frametype)
     _RFRN.fly_forward = ahrs.get_fly_forward();
     _RFRN.takeoff_expected = ahrs.get_takeoff_expected();
     _RFRN.touchdown_expected = ahrs.get_touchdown_expected();
-    _RFRN.ahrs_airspeed_sensor_enabled = ahrs.airspeed_sensor_enabled(ahrs.get_active_airspeed_index());
     _RFRN.available_memory = hal.util->available_memory();
     _RFRN.ahrs_trim = ahrs.get_trim();
 #if AP_OPTICALFLOW_ENABLED

--- a/libraries/AP_DAL/AP_DAL.h
+++ b/libraries/AP_DAL/AP_DAL.h
@@ -105,7 +105,7 @@ public:
         ARMED = (1U<<0),
         UNUSED = (1U<<1),
         FLY_FORWARD = (1U<<2),
-        AHRS_AIRSPEED_SENSOR_ENABLED = (1U<<3),
+        AHRS_AIRSPEED_SENSOR_ENABLED_UNUSED = (1U<<3),
         OPTICALFLOW_ENABLED = (1U<<4),
         WHEELENCODER_ENABLED = (1U<<5),
         TAKEOFF_EXPECTED = (1U<<6),
@@ -174,11 +174,6 @@ public:
 #endif
 
     AP_DAL_Compass &compass() { return _compass; }
-
-    // random methods that AP_NavEKF3 wants to call on AHRS:
-    bool airspeed_sensor_enabled(void) const {
-        return _RFRN.ahrs_airspeed_sensor_enabled;
-    }
 
     // get apparent to true airspeed ratio; this is a sensor input
     // to the EKFs, captured from the barometer's atmosphere model

--- a/libraries/AP_DAL/LogStructure.h
+++ b/libraries/AP_DAL/LogStructure.h
@@ -104,7 +104,7 @@ struct log_RFRN {
     uint8_t armed:1;
     uint8_t unused:1;  // was get_compass_is_null
     uint8_t fly_forward:1;
-    uint8_t ahrs_airspeed_sensor_enabled:1;
+    uint8_t ahrs_airspeed_sensor_enabled_unused:1;
     uint8_t opticalflow_enabled:1;
     uint8_t wheelencoder_enabled:1;
     uint8_t takeoff_expected:1;

--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -369,7 +369,8 @@ void NavEKF2_core::checkAttitudeAlignmentStatus()
 // return true if we should use the airspeed sensor
 bool NavEKF2_core::useAirspeed(void) const
 {
-    return dal.airspeed_sensor_enabled();
+    const auto *airspeed = dal.airspeed();
+    return airspeed != nullptr && airspeed->healthy() && airspeed->use();
 }
 
 // return true if we should use the range finder sensor

--- a/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_VehicleStatus.cpp
@@ -311,7 +311,7 @@ void NavEKF2_core::detectFlight()
         bool largeHgtChange = false;
 
         // trigger at 8 m/s airspeed
-        if (dal.airspeed_sensor_enabled()) {
+        if (useAirspeed()) {
             const auto *airspeed = dal.airspeed();
             if (airspeed->get_airspeed() * dal.get_EAS2TAS() > 10.0f) {
                 highAirSpd = true;

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -534,7 +534,8 @@ void NavEKF3_core::checkAttitudeAlignmentStatus()
 // return true if we should use the airspeed sensor
 bool NavEKF3_core::useAirspeed(void) const
 {
-    return dal.airspeed_sensor_enabled();
+    const auto *airspeed = dal.airspeed();
+    return airspeed != nullptr && airspeed->healthy() && airspeed->use();
 }
 
 // return true if we should use the range finder sensor

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Control.cpp
@@ -535,7 +535,7 @@ void NavEKF3_core::checkAttitudeAlignmentStatus()
 bool NavEKF3_core::useAirspeed(void) const
 {
     const auto *airspeed = dal.airspeed();
-    return airspeed != nullptr && airspeed->healthy() && airspeed->use();
+    return airspeed != nullptr && airspeed->healthy(selected_airspeed) && airspeed->use(selected_airspeed);
 }
 
 // return true if we should use the range finder sensor

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.cpp
@@ -71,8 +71,11 @@ bool NavEKF3_core::setup_core(uint8_t _imu_index, uint8_t _core_index)
         maxTimeDelay_ms = MAX(maxTimeDelay_ms , MIN((uint16_t)(gps_delay_sec * 1000.0f),250));
     }
 
-    // airspeed sensing can have large delays and should not be included if disabled
-    if (dal.airspeed_sensor_enabled()) {
+    // airspeed sensing can have large delays and should not be
+    // included if disabled.  This check requires airspeed sensors to
+    // already have been probed.
+    const auto *airspeed = dal.airspeed();
+    if (airspeed != nullptr && airspeed->get_num_sensors() > 0) {
         maxTimeDelay_ms = MAX(maxTimeDelay_ms , frontend->tasDelay_ms);
     }
 

--- a/libraries/GCS_MAVLink/GCS.cpp
+++ b/libraries/GCS_MAVLink/GCS.cpp
@@ -592,7 +592,7 @@ void GCS::update_sensor_status_flags()
         control_sensors_present |= MAV_SYS_STATUS_SENSOR_DIFFERENTIAL_PRESSURE;
         const bool use = airspeed->use();
 #if AP_AHRS_ENABLED
-        const bool enabled = AP::ahrs().airspeed_sensor_enabled();
+        const bool enabled = AP::ahrs().airspeed_sensor_data_being_consumed();
 #else
         const AP_Airspeed *_airspeed = AP::airspeed();
         const bool enabled = (_airspeed != nullptr && _airspeed->use());


### PR DESCRIPTION
### Summary

EKF3 cores gated their airspeed fusion on a flag derived from the AHRS's idea of the active airspeed sensor rather than on the sensor each core actually reads; make every EKF3 core gate on its own selected sensor, remove the AHRS-derived flag from AP_DAL, and add autotests for EKF3 airspeed affinity.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

Two new Plane autotests, `EKF3AirspeedAffinity` and `EKF3AirspeedAffinityDCM`, exercise the property the fix protects: with only the airspeed affinity bit set and two simulated sensors, each core reads and gate-rejects its own sensor when that sensor is frozen 10 m/s high, the primary lane moves to the core fusing the healthy sensor within 0.2 s, the AHRS reports that sensor in use (`AIRSPEED.flags` USING) for the whole of an 8 s hold, the lane holds after the sensor is restored, and the onboard log shows each core selected its own sensor throughout, compass/baro/GPS selection stayed constant and identical across cores, the faulty core rejected most samples from its own sensor, and the healthy core saw small innovations with no rejections and no airspeed timeout. The DCM variant forces DCM after takeoff and asserts EKF3 keeps lane-switching underneath while the AHRS keeps reporting `ARSPD_PRIMARY` in use, since the AHRS reports the sensor of its *active* backend and DCM has no per-core selection.

To be explicit: these tests pass on master and on every commit of this branch. The per-core gate change is not observable in a SITL flight, because `AP_Airspeed::select_primary()` moves the library primary onto any healthy, in-use sensor in the same `update()` that refreshes health, so "primary usable" and "own selected sensor usable" agree whenever any sensor is usable. The only divergence is a window of at most one airspeed-library update (100 ms) around a `use()` transition (an `ARSPD_USE` parameter change, or throttle-gated `ARSPD_USE=2`), affecting at most one delayed sample on one core. The tests are regression coverage for per-core affinity fusion and selection, not a before/after demonstration of the gate change.

Testing performed (SITL, x86-64):

| Check | Result |
|---|---|
| `test.Plane.EKF3AirspeedAffinity` at the branch tip | pass, identical numbers across runs |
| `test.Plane.EKF3AirspeedAffinityDCM` at the branch tip | pass |
| Both tests against master and against the commit before the EKF3 fix | pass (as expected, see above) |
| `test.Plane.EKFlaneswitch` at the branch tip | pass |
| `test.Copter.PosHoldTakeOff` at the branch tip (no airspeed sensor; exercises the null `dal.airspeed()` path) | pass |
| Plane and Copter SITL build at every firmware commit | pass |
| `Tools/scripts/check_branch_conventions.py` | all checks pass |

Both tests ran deterministically across more than ten runs during development; the faulty core rejects 68 to 70 of 73 logged samples per fault window against a required half, and the healthy core's peak innovation is 0.3 to 0.8 m/s against a bound of 2.5 m/s.

### Description

On master `AP_DAL::start_frame()` captured

```
_RFRN.ahrs_airspeed_sensor_enabled = ahrs.airspeed_sensor_enabled(ahrs.get_active_airspeed_index());
```

and every EKF3 core consumed that single flag in `NavEKF3_core::useAirspeed()`, which gates `readAirSpdData()`, the airspeed-delay term in `setup_core()`, and the have-airspeed check in `controlFilterModes()`. With `EK3_AFFINITY` bit 3 set, core N reads airspeed sensor N (`selected_airspeed`), but its gate came from the AHRS's active index, which is the *primary* core's selection when EKF3 is the active backend and the library primary otherwise. Every core was therefore gated on a sensor most of them were not reading, and the gate depended circularly on the frontend's view of EKF3's own output. It stayed correct only because `get_active_airspeed_index()` validates its return and `AP_Airspeed::select_primary()` keeps the primary usable, two unrelated guarantees that a change to either would silently break.

The branch, in order:

- `AP_AHRS`, `GCS_MAVLink`: add `AP_AHRS::airspeed_sensor_data_being_consumed()` for the SYS_STATUS differential-pressure health bit. Same expression as the helper it replaces; behaviour-preserving. Its comment is honest that it reports the library primary rather than what the active backend truly consumes.
- `AP_DAL`, `AP_NavEKF2`, `AP_NavEKF3`: retire the RFRN flag in place (bit 3 renamed `_UNUSED`, log layout unchanged) and have `useAirspeed()` read the DAL airspeed object directly, guarded for null since AP_DAL only allocates it when at least one airspeed sensor is configured. Replay of pre-existing logs is unaffected because RASH/RASI already carry the primary and per-instance health/use.
- `AP_AHRS`: `_should_use_airspeed_sensor(idx)` checks health and use of the index it was given, as before, and the two static helpers move into `AP_AHRS_DCM` as the only remaining user.
- `AP_NavEKF3`: the fix. `useAirspeed()` gates on `selected_airspeed`, the sensor `readAirSpdData()` and the fusion gate already use. `selected_airspeed` is only ever the library primary or a bounds-checked core index, `update_sensor_selection()` runs before the first read in `InitialiseFilterBootstrap()` and every `UpdateFilter()`, and the one pre-selection consumer in `setup_core()` sees the zero-initialised default (the core array comes from `malloc_type`, which zeroes on every HAL), i.e. instance 0, the same as before.
- `autotest`: fix `assert_receive_message()` dereferencing a `None` message when an instance was requested and nothing arrived within one 50 ms receive window. Pre-existing; the new tests exercise that path continuously.
- `autotest`: the two tests described above. `ARSPD_OPTIONS` is set to 0 in the test because the library's EKF-consistency failure handling, on by default, disables a sensor EKF3 keeps rejecting after roughly 5 to 8 s and moves the primary off it, at which point both cores fall back to the same sensor and there is no affinity left to observe.

Two things noticed along the way that this PR does not address:

- With default `ARSPD_OPTIONS`, affinity provides redundancy only until the library disables the rejected sensor; after that both cores share the surviving sensor and a second failure cannot be lane-switched away from.
- Under DCM, `airspeed_health_data()` returns nothing, so the library's EKF-consistency check never fires and a frozen sensor is flown on until some other mechanism intervenes. That is the active-backend semantics working as designed, but worth knowing.

### AI assistance disclosure

This PR was developed with AI assistance (Claude Code). The firmware commits were written by the human author; the AI evaluated each commit, found and reported the null-pointer dereference and the dropped index argument that were then fixed by the author, performed the behaviour-preservation analysis above, and wrote and hardened the two autotests and the framework fix. Two independent adversarial reviews of the tests and of the whole branch were also run with OpenAI Codex, and their findings folded in. All testing listed above was actually executed in SITL; no test result is inferred.
