### PR TITLE
.github: do not run CI on tag pushes

### DIFF
--- a/.github/workflows/colcon.yml
+++ b/.github/workflows/colcon.yml
@@ -2,6 +2,7 @@ name: colcon build/test
 
 on:
   push:
+    branches: ['**']  # excludes tag pushes
     paths-ignore:
       # remove not tests vehicles
       - 'AntennaTracker/**'

--- a/.github/workflows/cygwin_build.yml
+++ b/.github/workflows/cygwin_build.yml
@@ -2,6 +2,7 @@ name: Cygwin Build
 
 on:
   push:
+    branches: ['**']  # excludes tag pushes
     paths-ignore:
       # remove other vehicles
       - 'AntennaTracker/**'

--- a/.github/workflows/esp32_build.yml
+++ b/.github/workflows/esp32_build.yml
@@ -2,6 +2,7 @@ name: ESP32 Build
 
 on:
   push:
+    branches: ['**']  # excludes tag pushes
     paths-ignore:
       # remove non copter and plane vehicles
       - 'AntennaTracker/**'

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -2,6 +2,7 @@ name: Macos Build
 
 on:
   push:
+    branches: ['**']  # excludes tag pushes
     paths-ignore:
       # remove other env install scripts
       - 'Tools/environment_install/install-ROS-ubuntu.sh'

--- a/.github/workflows/qurt_build.yml
+++ b/.github/workflows/qurt_build.yml
@@ -2,6 +2,7 @@ name: QURT Build
 
 on:
   push:
+    branches: ['**']  # excludes tag pushes
     paths-ignore:
       # remove other vehicles
       - 'AntennaTracker/**'

--- a/.github/workflows/test_ccache.yml
+++ b/.github/workflows/test_ccache.yml
@@ -2,6 +2,7 @@ name: test ccache
 
 on:
   push:
+    branches: ['**']  # excludes tag pushes
     paths-ignore:
       # remove other vehicles
       - 'AntennaTracker/**'

--- a/.github/workflows/test_chibios.yml
+++ b/.github/workflows/test_chibios.yml
@@ -2,6 +2,7 @@ name: test chibios
 
 on:
   push:
+    branches: ['**']  # excludes tag pushes
     paths-ignore:
       # remove non chibios HAL
       - 'libraries/AP_HAL_Linux/**'

--- a/.github/workflows/test_clang_scan_build.yml
+++ b/.github/workflows/test_clang_scan_build.yml
@@ -2,6 +2,7 @@ name: test clang-scan-build
 
 on:
   push:
+    branches: ['**']  # excludes tag pushes
     paths-ignore:
       # remove non SITL HAL
       - 'libraries/AP_HAL_ChibiOS/**'

--- a/.github/workflows/test_dds.yml
+++ b/.github/workflows/test_dds.yml
@@ -2,6 +2,7 @@ name: test dds
 
 on:
   push:
+    branches: ['**']  # excludes tag pushes
     paths-ignore:
       # remove not tests vehicles
       - 'AntennaTracker/**'

--- a/.github/workflows/test_environment.yml
+++ b/.github/workflows/test_environment.yml
@@ -4,6 +4,7 @@ on:
     - cron: '0 0 * * 6'  # every saturday at midnight
   workflow_dispatch:
   push:
+    branches: ['**']  # excludes tag pushes
     paths:
       - '.github/workflows/test_environment.yml'
       - 'Tools/environment_install/**'

--- a/.github/workflows/test_linux_sbc.yml
+++ b/.github/workflows/test_linux_sbc.yml
@@ -2,6 +2,7 @@ name: test Linux SBC
 
 on:
   push:
+    branches: ['**']  # excludes tag pushes
     paths-ignore:
       # remove non LINUX HAL
       - 'libraries/AP_HAL_ChibiOS/**'

--- a/.github/workflows/test_replay.yml
+++ b/.github/workflows/test_replay.yml
@@ -2,6 +2,7 @@ name: test replay
 
 on:
   push:
+    branches: ['**']  # excludes tag pushes
     paths-ignore:
       # remove other vehicles
       - 'AntennaTracker/**'

--- a/.github/workflows/test_scripting.yml
+++ b/.github/workflows/test_scripting.yml
@@ -2,6 +2,7 @@ name: test scripting
 
 on:
   push:
+    branches: ['**']  # excludes tag pushes
     paths: # only run for scripting changes
       - 'libraries/AP_Scripting/tests/docs_check.py'
       - 'libraries/AP_Scripting/generator/**'

--- a/.github/workflows/test_scripts.yml
+++ b/.github/workflows/test_scripts.yml
@@ -1,6 +1,10 @@
 name: test scripts
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches: ['**']  # excludes tag pushes
+  pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{github.workflow}}-${{ github.ref }}

--- a/.github/workflows/test_sitl_blimp.yml
+++ b/.github/workflows/test_sitl_blimp.yml
@@ -2,6 +2,7 @@ name: test blimp
 
 on:
   push:
+    branches: ['**']  # excludes tag pushes
     paths-ignore:
       # remove other vehicles
       - 'AntennaTracker/**'

--- a/.github/workflows/test_sitl_copter.yml
+++ b/.github/workflows/test_sitl_copter.yml
@@ -2,6 +2,7 @@ name: test copter
 
 on:
   push:
+    branches: ['**']  # excludes tag pushes
     paths-ignore:
       # remove other vehicles
       - 'AntennaTracker/**'

--- a/.github/workflows/test_sitl_periph.yml
+++ b/.github/workflows/test_sitl_periph.yml
@@ -2,6 +2,7 @@ name: test ap_periph
 
 on: 
   push:
+    branches: ['**']  # excludes tag pushes
     paths-ignore:
       # remove other vehicles than copter
       - 'AntennaTracker/**'

--- a/.github/workflows/test_sitl_plane.yml
+++ b/.github/workflows/test_sitl_plane.yml
@@ -2,6 +2,7 @@ name: test plane
 
 on:
   push:
+    branches: ['**']  # excludes tag pushes
     paths-ignore:
       # remove other vehicles
       - 'AntennaTracker/**'

--- a/.github/workflows/test_sitl_rover.yml
+++ b/.github/workflows/test_sitl_rover.yml
@@ -2,6 +2,7 @@ name: test rover
 
 on:
   push:
+    branches: ['**']  # excludes tag pushes
     paths-ignore:
       # remove other vehicles
       - 'AntennaTracker/**'

--- a/.github/workflows/test_sitl_sub.yml
+++ b/.github/workflows/test_sitl_sub.yml
@@ -2,6 +2,7 @@ name: test sub
 
 on:
   push:
+    branches: ['**']  # excludes tag pushes
     paths-ignore:
       # remove other vehicles
       - 'AntennaTracker/**'

--- a/.github/workflows/test_sitl_tracker.yml
+++ b/.github/workflows/test_sitl_tracker.yml
@@ -2,6 +2,7 @@ name: test tracker
 
 on:
   push:
+    branches: ['**']  # excludes tag pushes
     paths-ignore:
       # remove other vehicles
       - 'ArduCopter/**'

--- a/.github/workflows/test_size.yml
+++ b/.github/workflows/test_size.yml
@@ -2,6 +2,7 @@ name: test size
 
 on:
   push:
+    branches: ['**']  # excludes tag pushes
     paths-ignore:  # ignore autotest stuffs
       - 'Tools/autotest/**'
       # Remove markdown files as irrelevant

--- a/.github/workflows/test_unit_tests.yml
+++ b/.github/workflows/test_unit_tests.yml
@@ -2,6 +2,7 @@ name: test unit tests and sitl building
 
 on:
   push:
+    branches: ['**']  # excludes tag pushes
     paths-ignore:
       # Remove markdown files as irrelevant
       - '**.md'


### PR DESCRIPTION
### Summary

Filter every push trigger to branches, so pushing a tag no longer starts CI. A release pushes about twenty tags at one commit and each of them currently runs the full matrix.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Tried on a fork with the same workflows enabled, on the same afternoon. A tag pushed at a commit without this change started 19 workflow runs. A tag pushed at the commit with it started none. A branch push of that same commit started the usual 19.

- tag, before: https://github.com/Float-Cargo/ardupilot-upstream/actions?query=branch%3Aci-demo-unpatched
- tag, after: https://github.com/Float-Cargo/ardupilot-upstream/actions?query=branch%3Aci-demo-patched
- branch, after: https://github.com/Float-Cargo/ardupilot-upstream/actions?query=branch%3Agithub-no-ci-on-tag-pushes

All 30 workflow files still parse, and every push trigger now carries a branch filter (pre-commit.yml already had one).

### Description

The release procedure pushes the same commit under about twenty tag names, one git push each: the per-vehicle -stable and -beta tags, and the numbered ones like Copter-4.7.1. Apart from pre-commit.yml, no push trigger in the repo has a branch or tag filter, and a trigger with neither fires for both kinds of ref. Path filters are not evaluated for tag pushes, so the paths-ignore lists do not thin them out either. Every tag push therefore runs the whole matrix.

For 4.7.1 that came to 438 push-event runs on commit dbe792162d: 18 from the ArduPilot-4.7 branch push and 420 from the twenty tags. They are the same work. The test copter runs started by the branch and by a tag have identical jobs, matrix entries and steps, and nothing in the workflows or the build reads the ref name. 4.7.0 produced 437 runs the same way, and the pattern is there at every release back to at least 4.6.2. It is the largest single contributor to the backlog described in #32482: on the 4.7.0 release day the median wall clock for a test copter run was over 22 hours, and the queue took until the weekend to drain.

The change adds branches: ['**'] to each push trigger. '**' matches every branch and combines with the existing paths-ignore filters, so branch pushes behave exactly as they do now. Tag pushes stop triggering workflows. The tags still show the commit's checks, since check results attach to the commit. Those are the release-branch push's runs, path-filtered like any other branch push: 18 of the 21 workflows for 4.7.1, the other three having had no relevant change since the previous commit.

test_scripts.yml used the list form of on, which cannot carry a filter, so it is expanded to the mapping form with the same three triggers.

I could not find anything that depends on CI running for a tag. No workflow uses on: release, a tags: filter or github.ref_type, and the firmware builds take these tags from the autobuild server, not from Actions. If something outside the repo does rely on it, I am happy to rework this.

Two other ways to get the same result, not taken:

- Keep tags triggering but key their concurrency group on the commit, so the twenty pushes collapse to one or two runs. That gives the release commit the full matrix rather than the path-filtered set, at the cost of a cancelled run per workflow per tag on every release commit and a more involved expression in 29 files.
- Push all the tags in one git push. GitHub does not create push events when more than three tags arrive at once, but that leans on a delivery limit rather than configuration and only covers one way of pushing.
