### PR TITLE
Fix CI colcon install issue

### DIFF
--- a/.github/workflows/colcon.yml
+++ b/.github/workflows/colcon.yml
@@ -182,7 +182,7 @@ jobs:
           apt update
           rosdep update
           source /opt/ros/humble/setup.bash
-          rosdep install --from-paths src --ignore-src --default-yes
+          rosdep install --from-paths src --ignore-src --default-yes --skip-keys microxrcedds_agent
       - name: Install MAVProxy
         run: |
           # Install this specific version just to prevent rolling updates.

--- a/Tools/ros2/README.md
+++ b/Tools/ros2/README.md
@@ -80,7 +80,7 @@ cd ~/ros2_ws
 source /opt/ros/humble/setup.bash
 sudo apt update
 rosdep update
-rosdep install --rosdistro ${ROS_DISTRO} --from-paths src --ignore-src
+rosdep install --rosdistro ${ROS_DISTRO} --from-paths src --ignore-src --skip-keys microxrcedds_agent
 ```
 
 ### ROS 2 Jazzy dependencies
@@ -90,7 +90,7 @@ cd ~/ros2_ws
 source /opt/ros/jazzy/setup.bash
 sudo apt update
 rosdep update
-rosdep install --rosdistro ${ROS_DISTRO} --from-paths src --ignore-src
+rosdep install --rosdistro ${ROS_DISTRO} --from-paths src --ignore-src --skip-keys microxrcedds_agent
 ```
 
 ### 4. Build


### PR DESCRIPTION
### Summary

The colcon test will fail forever-more until it is patched.  This also affects the 4.7-beta

Skip the `microxrcedds_agent` rosdep key so the `colcon build/test` workflow (and the documented ROS 2 setup) stop failing at `rosdep install`.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Not tested locally (no ROS install here). On my fork the `colcon build/test` run for this branch passes the "Install rosdep dependencies" step: https://github.com/peterbarker/ardupilot/actions/runs/33819886624 . The run on this PR is the full test: it should get past the "Install rosdep dependencies" step, which has failed on every run since 2026-09-03 (e.g. https://github.com/ArduPilot/ardupilot/actions/runs/33711956370/job/100513168003).

### Description

Every `colcon build/test` run since 2026-09-03 fails with:

```
ERROR: the following packages/stacks could not have their rosdep keys resolved
to system dependencies:
micro_ros_agent: Cannot locate rosdep definition for [microxrcedds_agent]
```

`Tools/ros2/ros2.repos` tracks the tip of micro-ROS-Agent's `humble` branch. micro-ROS/micro-ROS-Agent#279 (backported to humble in #282, jazzy in #281, kilted in #280) added `<depend>microxrcedds_agent</depend>` to the agent's package.xml so colcon orders the build correctly when the XRCE agent is a workspace package. That name is not a rosdep key in humble, jazzy or rolling, so plain `rosdep install` aborts.

Nothing is actually missing: the agent's `SuperBuild.cmake` still clones and builds Micro-XRCE-DDS-Agent itself when it is not found. micro-ROS's own install tool (`micro_ros_setup`'s `create_agent_ws.sh`) already runs rosdep with `--skip-keys` including `microxrcedds_agent`, and micro-ROS-Agent's CI passes only because action-ros-ci uses `rosdep install -r`. This PR does the same skip in the workflow and in the README's humble and jazzy instructions. The explicit skip is preferred over `-r` so that any other missing key still fails loudly.

The `install-ROS-ubuntu.sh` rosdep call is a ROS 1 catkin workspace without micro_ros_agent and is unaffected.

The `.github` commit cherry-picks cleanly onto the `ArduCopter-beta` tag (Copter-4.7 also fetches `ros2.repos` from master and runs the same rosdep line, so it is broken the same way); the README commit needs a trivial hand-merge there because 4.7's README predates #34248.

This PR was AI-assisted: Claude (Claude Code) did the CI-log investigation, root-cause tracing to the upstream commit, and authored the change and this description under direction; the diff was reviewed by the submitter.
