### PR TITLE
ArduCopter: fix PosHold brake-to-loiter speed threshold units

### DIFF
--- a/ArduCopter/mode_poshold.cpp
+++ b/ArduCopter/mode_poshold.cpp
@@ -7,7 +7,7 @@
  *     PosHold tries to improve upon regular loiter by mixing the pilot input with the loiter controller
  */
 
-#define POSHOLD_SPEED_0                         10      // speed below which it is always safe to switch to loiter
+#define POSHOLD_SPEED_0_MS                      0.10    // speed (m/s) below which it is always safe to switch to loiter
 
 #define POSHOLD_BRAKE_TIME_ESTIMATE_MAX_MS      6000    // Maximum duration (ms) allowed for braking before transitioning to loiter
 #define POSHOLD_BRAKE_TO_LOITER_TIME_MS         1500    // Duration (ms) over which braking is blended into loiter control during BRAKE_TO_LOITER phase
@@ -269,7 +269,7 @@ void ModePosHold::run()
                 const uint32_t brake_timeout_roll_ms = MIN(POSHOLD_BRAKE_TIME_ESTIMATE_MAX_MS, (1.5f * 1000.0f * (brake.angle_max_roll_rad / radians(g.poshold_brake_rate_degs))));
 
                 // if velocity is very low reduce braking time to 0.5 s
-                if ((fabsf(vel_right_ms) <= POSHOLD_SPEED_0) && (now_ms - brake.start_time_roll_ms > 500) && (brake_timeout_roll_ms > 500)) {
+                if ((fabsf(vel_right_ms) <= POSHOLD_SPEED_0_MS) && (now_ms - brake.start_time_roll_ms > 500) && (brake_timeout_roll_ms > 500)) {
                     brake.start_time_roll_ms = now_ms - brake_timeout_roll_ms + 500;
                 }
 
@@ -362,7 +362,7 @@ void ModePosHold::run()
                 const uint32_t brake_timeout_pitch_ms = MIN(POSHOLD_BRAKE_TIME_ESTIMATE_MAX_MS, (1.5 * 1000.0 * (brake.angle_max_pitch_rad / radians(g.poshold_brake_rate_degs))));
 
                 // if velocity is very low reduce braking time to 0.5 seconds
-                if ((fabsf(vel_fw_ms) <= POSHOLD_SPEED_0) && (now_ms - brake.start_time_pitch_ms > 500) && (brake_timeout_pitch_ms > 500)) {
+                if ((fabsf(vel_fw_ms) <= POSHOLD_SPEED_0_MS) && (now_ms - brake.start_time_pitch_ms > 500) && (brake_timeout_pitch_ms > 500)) {
                     brake.start_time_pitch_ms = now_ms - brake_timeout_pitch_ms + 500;
                 }
 


### PR DESCRIPTION
### Summary

`POSHOLD_SPEED_0` was left at `10` when the values it is compared against were
converted from cm/s to m/s, silently changing PosHold's brake-to-loiter speed
threshold from 10cm/s to 10m/s.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

Tested in SITL on a QUAD/PLUS, flying PosHold forward at full pitch stick until
the speed settles, then centring the stick and measuring how far the vehicle
travels past its furthest point and comes back.  Six runs per arm, alternating
only the value of the constant:

| release speed | shipped (`10`) | fixed (`0.10`) |
| --- | --- | --- |
| 10.28-10.29 m/s | 0.67, 0.68, 0.68, 0.68, 0.68 m | 0.47, 0.47, 0.46, 0.47 m |
| 9.97-9.98 m/s | 1.81, 1.84, 1.90 m | 0.69 m |
| 7.63 m/s | 0.48, 0.49, 0.49, 0.49 m | 0.36, 0.36, 0.37, 0.37 m |

The distance travelled before stopping is unchanged (~16m in the top row for
both arms) - what changes is how far the vehicle comes back afterwards.

### Description

`d56e91bbe2` ("Copter: Convert Mode PosHold to meters and radians") renamed
`vel_right_cms`/`vel_fw_cms` to `vel_right_ms`/`vel_fw_ms` at both sites which
compare them against `POSHOLD_SPEED_0`, but left the constant itself at `10`.
The threshold therefore went from 10cm/s to 10m/s.

That this was an oversight rather than a deliberate change is visible in the
same diff hunk: the sibling constant, with the same value and the same units,
*was* rescaled and renamed -

```
-#define POSHOLD_WIND_COMP_ESTIMATE_SPEED_MAX    10      // ... this speed in cm/s
+#define POSHOLD_WIND_COMP_ESTIMATE_SPEED_MAX_MS 0.10    // ... this speed in cm/s
```

`POSHOLD_SPEED_0` got neither the rescale nor the `_MS` suffix, and was left as
the only speed constant in the file without a unit suffix.  This PR restores the
intended value and adds the suffix to match.

The constant guards a shortcut which truncates the remaining braking time to
0.5s once the vehicle has essentially stopped:

```c
// if velocity is very low reduce braking time to 0.5 s
if ((fabsf(vel_right_ms) <= POSHOLD_SPEED_0) && (now_ms - brake.start_time_roll_ms > 500) && (brake_timeout_roll_ms > 500)) {
    brake.start_time_roll_ms = now_ms - brake_timeout_roll_ms + 500;
}
```

At 10m/s that condition is true at any speed a copter reaches in PosHold, so the
shortcut fires unconditionally and braking is always cut short instead of
running for the estimated `1.5 * angle_max / brake_rate`.  PosHold then reaches
`BRAKE_READY_TO_LOITER` while still travelling, and
`AC_Loiter::init_target_m()` sets the loiter target to the position *at that
moment*, so the vehicle sails past the target and flies back to it.  That is the
back-up measured above.

Shipped in Copter-4.7.0 and 4.7.1.

#### No autotest

I could not write a non-flaky autotest for this and would rather say so than
add a flaky one.  The quantity that actually discriminates - the vehicle's speed
at the instant loiter engages - is not observable: PosHold logs no state
transitions, and `PSCN`/`PSCE` are not written during PosHold's hold.  The
observable proxy above is real but strongly entry-dependent: a 3% change in
release speed (9.97 -> 10.28 m/s) moves the shipped-constant result from 1.85m
to 0.67m, so no single threshold separates the two arms across entry
conditions.  The release speed cannot be pinned from a test either, because
PosHold adds its own learned `wind_comp` lean angle to the pilot's stick and
that varies with what the vehicle did beforehand.

Making this testable would mean logging PosHold's roll/pitch mode transitions,
which is a firmware change in its own right rather than a test-only one.  Happy
to add it if that is wanted.
