### PR TITLE
SITL: honour SIM_RATE_HZ in the remaining internally-modelled vehicles

### DIFF
--- a/libraries/SITL/SIM_BalanceBot.cpp
+++ b/libraries/SITL/SIM_BalanceBot.cpp
@@ -172,6 +172,9 @@ void BalanceBot::update(const struct sitl_input &input)
     use_smoothing = true;
 
     // update lat/lon/altitude
+    // allow for changes in physics step
+    adjust_frame_time(constrain_float(sitl->loop_rate_hz, rate_hz-1, rate_hz+1));
+
     update_position();
     time_advance();
 

--- a/libraries/SITL/SIM_Blimp.cpp
+++ b/libraries/SITL/SIM_Blimp.cpp
@@ -401,7 +401,8 @@ void Blimp::update(const struct sitl_input &input)
   update_position(); //updates the position from the Vector3f position
   time_advance();
   update_mag_field_bf();
-  rate_hz = sitl->loop_rate_hz;
+  // allow for changes in physics step
+  adjust_frame_time(constrain_float(sitl->loop_rate_hz, rate_hz-1, rate_hz+1));
 
   update_battery();
 }

--- a/libraries/SITL/SIM_Rover.cpp
+++ b/libraries/SITL/SIM_Rover.cpp
@@ -137,6 +137,9 @@ void SimRover::update(const struct sitl_input &input)
 
     update_external_payload(input);
 
+    // allow for changes in physics step
+    adjust_frame_time(constrain_float(sitl->loop_rate_hz, rate_hz-1, rate_hz+1));
+
     // update lat/lon/altitude
     update_position();
     time_advance();

--- a/libraries/SITL/SIM_Sailboat.cpp
+++ b/libraries/SITL/SIM_Sailboat.cpp
@@ -323,6 +323,9 @@ void Sailboat::update(const struct sitl_input &input)
     position += (velocity_ef * delta_time).todouble();
 
     // update lat/lon/altitude
+    // allow for changes in physics step
+    adjust_frame_time(constrain_float(sitl->loop_rate_hz, rate_hz-1, rate_hz+1));
+
     update_position();
     time_advance();
 

--- a/libraries/SITL/SIM_Tracker.cpp
+++ b/libraries/SITL/SIM_Tracker.cpp
@@ -128,6 +128,9 @@ void Tracker::update(const struct sitl_input &input)
 
     // new velocity vector
     velocity_ef.zero();
+    // allow for changes in physics step
+    adjust_frame_time(constrain_float(sitl->loop_rate_hz, rate_hz-1, rate_hz+1));
+
     update_position();
     time_advance();
 


### PR DESCRIPTION
### Summary

Five SITL vehicle models silently ignored `SIM_RATE_HZ` (and the `--rate`
command line option built on it), because the only code that reads it lives in
a function they never call.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

Measured by running each SITL binary standalone for 20s at a requested speedup
far above what the machine can deliver, with a client draining the MAVLink
socket throughout, and recording how much *simulated* time advanced per second
of CPU.  Halving the physics rate should buy roughly half the physics work; if
the rate is ignored the two are identical.

Before this change (rover):

| `--rate` | sim seconds per CPU second |
| --- | --- |
| 1200 | 55 |
| 600 | 55 |

After, with the same measurement:

| model | 1200 | 600 |
| --- | --- | --- |
| rover | 231.6 | 348.6 |
| sailboat | 243.5 | 380.1 |
| balancebot | 237.0 | 366.2 |

(The gain is ~1.5x rather than 2x because only the physics half of the work
scales with the step rate; the vehicle's own loop-rate work, EKF and MAVLink
scale with simulated time.)

`SIM_RATE_HZ` read back as exactly `600.0` over MAVLink both before and after,
which is what made this quiet: the parameter was always set correctly, it just
was not connected to anything.  A `fprintf` added to `update_dynamics()`
produced no output at all on a rover, confirming that line never runs there.

`./waf rover`, `./waf blimp` and `./waf antennatracker` all build.

### Description

`SIM_RATE_HZ` reaches the physics step in exactly one place, the last line of
`Aircraft::update_dynamics()`:

```c
// allow for changes in physics step
adjust_frame_time(constrain_float(sitl->loop_rate_hz, rate_hz-1, rate_hz+1));
```

Four models derive from `Aircraft` without ever calling `update_dynamics()` -
they integrate their own simpler models and go straight to
`update_position(); time_advance()`.  For `SimRover`, `BalanceBot`, `Sailboat`
and `Tracker`, `rate_hz` therefore stayed at its 1200 default for the life of
the process no matter what `SIM_RATE_HZ` said.

`Blimp` is a third variant of the same bug.  It did assign
`rate_hz = sitl->loop_rate_hz`, but nothing recomputed `frame_time_us`, so
`time_advance()` kept adding the stale step while `rate_hz` reported the new
value - an inconsistent state rather than an honest omission.  It now uses the
same call, which updates both.

#### Why not just move the line to `update_model()`

Every model reaches `Aircraft::update_model()`, so that looks like the obvious
single-point fix.  It is not safe: `SIM_FlightAxis` sets `rate_hz` in its
**constructor** (`rate_hz = 250 / target_speedup`), and a per-frame adjustment
there would slew it away from the value FlightAxis deliberately chose.

The external-FDM backends (JSBSim, Gazebo, XPlane, Webots, Morse, SilentWings,
Scrimmage, CRRCSim, JSON) pace themselves and are deliberately left alone for
the same reason.

#### Note for anyone reaching for this as a speed lever in autotest

It is not one.  On the models fixed here the parameter previously did nothing
at all; on Copter, where `update_dynamics()` *is* called, `--rate 600` really
does halve the rate and the vehicle then fails to arm ("Prearm bit never went
true", 3 runs out of 3).  Lowering the physics rate trades simulation fidelity
for throughput and can break vehicles outright.  This PR makes the parameter
behave as documented; it does not make it advisable.
