### PR TITLE
AP_Compass: AF9838: set rotation after registering the compass

### DIFF
--- a/libraries/AP_Compass/AP_Compass_AF9838.cpp
+++ b/libraries/AP_Compass/AP_Compass_AF9838.cpp
@@ -35,8 +35,8 @@ AP_Compass_AF9838::AP_Compass_AF9838(AP_HAL::OwnPtr<AP_HAL::Device> dev,
     : AP_Compass_Backend()
     , _dev(std::move(dev))
     , _force_external(force_external)
+    , _rotation(rotation)
 {
-    set_rotation(rotation);
 }
 
 AP_Compass_Backend *AP_Compass_AF9838::probe(AP_HAL::OwnPtr<AP_HAL::Device> dev,
@@ -100,6 +100,8 @@ bool AP_Compass_AF9838::init()
     if (_force_external) {
         set_external(true);
     }
+
+    set_rotation(_rotation);
 
     _dev->set_retries(3);
 

--- a/libraries/AP_Compass/AP_Compass_AF9838.h
+++ b/libraries/AP_Compass/AP_Compass_AF9838.h
@@ -47,6 +47,7 @@ private:
     AP_HAL::OwnPtr<AP_HAL::Device> _dev;
 
     bool _force_external;
+    enum Rotation _rotation;
     bool _single_pending = false;
     uint32_t _single_start_us = 0;
 


### PR DESCRIPTION
The constructor called set_rotation() before register_compass() had assigned the backend instance, so it wrote the rotation of compass instance 0. Every AF9838 probe on an external bus constructs a backend, so on boards without an AF9838 each failed probe cleared the rotation of whichever compass was already registered as instance 0. An external IST8310 lost its PITCH_180 rotation this way.

@peterbarker this is why the renode PR quadplane flight failed. The IST8310 ended up with the wrong rotation as it first looked for (and didn't find) an AF9838. This is an extremely nasty bug as this could crash any aircraft with only one compass that isn't an AF9838
