### PR TITLE
fix(GCS_MAVLink): compare compid against last_src_component in statustext chunk tracking

### DIFF
--- a/libraries/GCS_MAVLink/GCS_Common.cpp
+++ b/libraries/GCS_MAVLink/GCS_Common.cpp
@@ -3876,7 +3876,7 @@ void GCS_MAVLINK::handle_statustext(const mavlink_message_t &msg)
     const uint8_t max_prefix_len = 14;
     const uint8_t text_len = MAVLINK_MSG_STATUSTEXT_FIELD_TEXT_LEN+1+max_prefix_len;
     if (msg.sysid != statustext_chunking.last_src_system ||
-        msg.compid != statustext_chunking.last_src_system ||
+        msg.compid != statustext_chunking.last_src_component ||
         packet.id != statustext_chunking.last_id) {
         statustext_chunking.last_src_system = msg.sysid;
         statustext_chunking.last_src_component = msg.compid;


### PR DESCRIPTION
The chunk-grouping condition in `handle_statustext()` compares `msg.compid`
against `statustext_chunking.last_src_system` instead of
`statustext_chunking.last_src_component`. `last_src_component` is assigned
but never read anywhere else in the tree.

Effect: `MSG` records are grouped for reassembly by their `ID` field. Because
the condition compares two unrelated fields, it evaluates true whenever a
sender's compid differs from its sysid — which is the common case — so a new
`ID` is allocated on every chunk and the chunks of one long STATUSTEXT never
reassemble. It only happens to work when a sender's compid equals its sysid.

Verified with a two-chunk STATUSTEXT sent from a sender with mismatched
sysid/compid, read back from the SITL dataflash log:

- before: chunks logged under different `MSG.ID` values (broken)
- after: both chunks share the same `MSG.ID` (correct)

Fixes #34281