### PR TITLE
ArduSub: add acceleration target to Guided_PosVel (backport to 4.7)

### DIFF
--- a/ArduSub/GCS_MAVLink_Sub.cpp
+++ b/ArduSub/GCS_MAVLink_Sub.cpp
@@ -649,6 +649,17 @@ void GCS_MAVLINK_Sub::handle_message(const mavlink_message_t &msg)
             }
         }
 
+        // prepare acceleration
+        Vector3f acc_vector;
+        if (!acc_ignore) {
+            // convert to cm/s/s
+            acc_vector = Vector3f(packet.afx * 100.0f, packet.afy * 100.0f, -packet.afz * 100.0f);
+            // rotate from body-frame if necessary
+            if (packet.coordinate_frame == MAV_FRAME_BODY_NED || packet.coordinate_frame == MAV_FRAME_BODY_FRD || packet.coordinate_frame == MAV_FRAME_BODY_OFFSET_NED) {
+                sub.rotate_body_frame_to_NE(acc_vector.x, acc_vector.y);
+            }
+        }
+
         // prepare yaw
         float yaw_cd =  0.0f;
         bool yaw_relative = false;
@@ -662,8 +673,8 @@ void GCS_MAVLINK_Sub::handle_message(const mavlink_message_t &msg)
         }
 
         // send request
-        if (!pos_ignore && !vel_ignore && acc_ignore) {
-            sub.mode_guided.guided_set_destination_posvel(pos_vector, vel_vector, !yaw_ignore, yaw_cd, !yaw_rate_ignore, yaw_rate_cds, yaw_relative);
+        if (!pos_ignore && !vel_ignore) {
+            sub.mode_guided.guided_set_posvelaccel(pos_vector, vel_vector, acc_vector, !yaw_ignore, yaw_cd, !yaw_rate_ignore, yaw_rate_cds, yaw_relative);
         } else if (pos_ignore && !vel_ignore && acc_ignore) {
             sub.mode_guided.guided_set_velocity(vel_vector, !yaw_ignore, yaw_cd, !yaw_rate_ignore, yaw_rate_cds, yaw_relative);
         } else if (!pos_ignore && vel_ignore && acc_ignore) {
@@ -721,12 +732,17 @@ void GCS_MAVLINK_Sub::handle_message(const mavlink_message_t &msg)
             };
         }
 
-        if (!pos_ignore && !vel_ignore && acc_ignore) {
+        Vector3f acc_vector_neu_cmss;
+        if (!acc_ignore) {
+            acc_vector_neu_cmss = Vector3f(packet.afx * 100.0f, packet.afy * 100.0f, -packet.afz * 100.0f);
+        }
+
+        if (!pos_ignore && !vel_ignore) {
             Vector3f pos_neu_cm;
             if (!loc.get_vector_from_origin_NEU_cm(pos_neu_cm)) {
                 break;
             }
-            sub.mode_guided.guided_set_destination_posvel(pos_neu_cm, Vector3f(packet.vx * 100.0f, packet.vy * 100.0f, -packet.vz * 100.0f));
+            sub.mode_guided.guided_set_posvelaccel(pos_neu_cm, Vector3f(packet.vx * 100.0f, packet.vy * 100.0f, -packet.vz * 100.0f), acc_vector_neu_cmss);
         } else if (pos_ignore && !vel_ignore && acc_ignore) {
             sub.mode_guided.guided_set_velocity(Vector3f(packet.vx * 100.0f, packet.vy * 100.0f, -packet.vz * 100.0f));
         } else if (!pos_ignore && vel_ignore && acc_ignore) {

--- a/ArduSub/GCS_MAVLink_Sub.cpp
+++ b/ArduSub/GCS_MAVLink_Sub.cpp
@@ -702,8 +702,7 @@ void GCS_MAVLINK_Sub::handle_message(const mavlink_message_t &msg)
             break;
         }
 
-        Vector3f pos_neu_cm;  // position (North, East, Up coordinates) in centimeters
-
+        Location loc;
         if (!pos_ignore) {
             // sanity check location
             if (!check_latlng(packet.lat_int, packet.lon_int)) {
@@ -714,23 +713,24 @@ void GCS_MAVLINK_Sub::handle_message(const mavlink_message_t &msg)
                 // unknown coordinate frame
                 break;
             }
-            const Location loc{
+            loc = {
                 packet.lat_int,
                 packet.lon_int,
                 int32_t(packet.alt*100),
                 frame,
             };
-            if (!loc.get_vector_from_origin_NEU_cm(pos_neu_cm)) {
-                break;
-            }
         }
 
         if (!pos_ignore && !vel_ignore && acc_ignore) {
+            Vector3f pos_neu_cm;
+            if (!loc.get_vector_from_origin_NEU_cm(pos_neu_cm)) {
+                break;
+            }
             sub.mode_guided.guided_set_destination_posvel(pos_neu_cm, Vector3f(packet.vx * 100.0f, packet.vy * 100.0f, -packet.vz * 100.0f));
         } else if (pos_ignore && !vel_ignore && acc_ignore) {
             sub.mode_guided.guided_set_velocity(Vector3f(packet.vx * 100.0f, packet.vy * 100.0f, -packet.vz * 100.0f));
         } else if (!pos_ignore && vel_ignore && acc_ignore) {
-            sub.mode_guided.guided_set_destination(pos_neu_cm);
+            sub.mode_guided.guided_set_destination(loc);
         }
 
         break;

--- a/ArduSub/Log.cpp
+++ b/ArduSub/Log.cpp
@@ -182,21 +182,27 @@ struct PACKED log_GuidedTarget {
     float vel_target_x;
     float vel_target_y;
     float vel_target_z;
+    float acc_target_x;
+    float acc_target_y;
+    float acc_target_z;
 };
 
 // Write a Guided mode target
-void Sub::Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target, const Vector3f& vel_target)
+void Sub::Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target, const Vector3f& vel_target, const Vector3f& acc_target)
 {
     struct log_GuidedTarget pkt = {
         LOG_PACKET_HEADER_INIT(LOG_GUIDEDTARGET_MSG),
         time_us         : AP_HAL::micros64(),
         type            : target_type,
-        pos_target_x    : pos_target.x,
-        pos_target_y    : pos_target.y,
-        pos_target_z    : pos_target.z,
-        vel_target_x    : vel_target.x,
-        vel_target_y    : vel_target.y,
-        vel_target_z    : vel_target.z
+        pos_target_x    : pos_target.x * 0.01f,
+        pos_target_y    : pos_target.y * 0.01f,
+        pos_target_z    : pos_target.z * 0.01f,
+        vel_target_x    : vel_target.x * 0.01f,
+        vel_target_y    : vel_target.y * 0.01f,
+        vel_target_z    : vel_target.z * 0.01f,
+        acc_target_x    : acc_target.x * 0.01f,
+        acc_target_y    : acc_target.y * 0.01f,
+        acc_target_z    : acc_target.z * 0.01f
     };
     logger.WriteBlock(&pkt, sizeof(pkt));
 }
@@ -257,6 +263,9 @@ void Sub::Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target
 // @Field: vX: Target velocity, X-Axis
 // @Field: vY: Target velocity, Y-Axis
 // @Field: vZ: Target velocity, Z-Axis
+// @Field: aX: Target acceleration, X-Axis
+// @Field: aY: Target acceleration, Y-Axis
+// @Field: aZ: Target acceleration, Z-Axis
 
 // type and unit information can be found in
 // libraries/AP_Logger/Logstructure.h; search for "log_Units" for
@@ -276,7 +285,7 @@ const struct LogStructure Sub::log_structure[] = {
     { LOG_DATA_FLOAT_MSG, sizeof(log_Data_Float),         
       "DFLT",  "QBf",         "TimeUS,Id,Value", "s--", "F--" },
     { LOG_GUIDEDTARGET_MSG, sizeof(log_GuidedTarget),
-      "GUIP",  "QBffffff",    "TimeUS,Type,pX,pY,pZ,vX,vY,vZ", "s-mmmnnn", "F-000000" },
+      "GUIP",  "QBfffffffff",    "TimeUS,Type,pX,pY,pZ,vX,vY,vZ,aX,aY,aZ", "s-mmmnnnooo", "F-000000000" },
 };
 
 uint8_t Sub::get_num_log_structures() const

--- a/ArduSub/Sub.cpp
+++ b/ArduSub/Sub.cpp
@@ -468,6 +468,23 @@ void Sub::rc_loop()
 }
 #endif
 
+#if AP_SCRIPTING_ENABLED
+// set target position, velocity and acceleration (for use by scripting)
+bool Sub::set_target_posvelaccel_NED(const Vector3f& target_pos_ned_m, const Vector3f& target_vel_ned_ms, const Vector3f& target_accel_ned_mss, bool use_yaw, float yaw_deg, bool use_yaw_rate, float yaw_rate_degs, bool yaw_relative)
+{
+    // exit if vehicle is not in Guided mode or Auto-Guided mode
+    if ((control_mode != Mode::Number::GUIDED) && !(control_mode == Mode::Number::AUTO && auto_mode == Auto_NavGuided)) {
+        return false;
+    }
+
+    const Vector3f pos_neu_cm(target_pos_ned_m.x * 100.0f, target_pos_ned_m.y * 100.0f, -target_pos_ned_m.z * 100.0f);
+    const Vector3f vel_neu_cms(target_vel_ned_ms.x * 100.0f, target_vel_ned_ms.y * 100.0f, -target_vel_ned_ms.z * 100.0f);
+    const Vector3f accel_neu_cmss(target_accel_ned_mss.x * 100.0f, target_accel_ned_mss.y * 100.0f, -target_accel_ned_mss.z * 100.0f);
+
+    return mode_guided.guided_set_posvelaccel(pos_neu_cm, vel_neu_cms, accel_neu_cmss, use_yaw, yaw_deg * 100.0f, use_yaw_rate, yaw_rate_degs * 100.0f, yaw_relative);
+}
+#endif
+
 Sub *Sub::_singleton = nullptr;
 
 Sub sub;

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -431,7 +431,7 @@ private:
     void Log_Write_Data(LogDataID id, int16_t value);
     void Log_Write_Data(LogDataID id, uint16_t value);
     void Log_Write_Data(LogDataID id, float value);
-    void Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target, const Vector3f& vel_target);
+    void Log_Write_GuidedTarget(uint8_t target_type, const Vector3f& pos_target, const Vector3f& vel_target, const Vector3f& acc_target);
     void Log_Write_Vehicle_Startup_Messages();
 #endif
     void load_parameters(void) override;
@@ -655,6 +655,9 @@ public:
 
     // For Lua scripting, so index is 1..4, not 0..3
     uint8_t get_and_clear_button_count(uint8_t index);
+
+    // Set targets in GUIDED mode
+    bool set_target_posvelaccel_NED(const Vector3f& target_pos_ned_m, const Vector3f& target_vel_ned_ms, const Vector3f& target_accel_ned_mss, bool use_yaw, float yaw_deg, bool use_yaw_rate, float yaw_rate_degs, bool yaw_relative) override;
 
 #if AP_RANGEFINDER_ENABLED
     float get_rangefinder_target_cm() const WARN_IF_UNUSED { return mode_surftrak.get_rangefinder_target_cm(); }

--- a/ArduSub/mode.h
+++ b/ArduSub/mode.h
@@ -10,7 +10,7 @@ class GCS_Sub;
 enum GuidedSubMode {
     Guided_WP,
     Guided_Velocity,
-    Guided_PosVel,
+    Guided_PosVelAccel,
     Guided_Angle,
 };
 
@@ -267,8 +267,8 @@ public:
     void guided_set_angle(const Quaternion &q, float climb_rate_cms, bool use_yaw_rate, float yaw_rate_rads);
     void guided_set_angle(const Quaternion&, float);
     void guided_limit_set(uint32_t timeout_ms, float alt_min_cm, float alt_max_cm, float horiz_max_cm);
-    bool guided_set_destination_posvel(const Vector3f& destination, const Vector3f& velocity);
-    bool guided_set_destination_posvel(const Vector3f& destination, const Vector3f& velocity, bool use_yaw, float yaw_cd, bool use_yaw_rate, float yaw_rate_cds, bool relative_yaw);
+    bool guided_set_posvelaccel(const Vector3f& destination, const Vector3f& velocity, const Vector3f& accel);
+    bool guided_set_posvelaccel(const Vector3f& destination, const Vector3f& velocity, const Vector3f& accel, bool use_yaw, float yaw_cd, bool use_yaw_rate, float yaw_rate_cds, bool relative_yaw);
     bool guided_set_destination(const Vector3f& destination);
     bool guided_set_destination(const Location&);
     bool guided_set_destination(const Vector3f& destination, bool use_yaw, float yaw_cd, bool use_yaw_rate, float yaw_rate_cds, bool relative_yaw);
@@ -290,12 +290,12 @@ protected:
 private:
     void guided_pos_control_run();
     void guided_vel_control_run();
-    void guided_posvel_control_run();
+    void guided_posvelaccel_control_run();
     void guided_angle_control_run();
     void guided_takeoff_run();
     void guided_pos_control_start();
     void guided_vel_control_start();
-    void guided_posvel_control_start();
+    void guided_posvelaccel_control_start();
     void guided_angle_control_start();
 };
 

--- a/ArduSub/mode_guided.cpp
+++ b/ArduSub/mode_guided.cpp
@@ -4,11 +4,13 @@
  * Init and run calls for guided flight mode
  */
 
-#define GUIDED_POSVEL_TIMEOUT_MS    3000    // guided mode's position-velocity controller times out after 3seconds with no new updates
-#define GUIDED_ATTITUDE_TIMEOUT_MS  1000    // guided mode's attitude controller times out after 1 second with no new updates
+#define GUIDED_VEL_TIMEOUT_MS       3000    // velocity controllers time out after 3 seconds with no new updates
+#define GUIDED_ATTITUDE_TIMEOUT_MS  1000    // attitude controller times out after 1 second with no new updates
 
-static Vector3p posvel_pos_target_cm;
-static Vector3f posvel_vel_target_cms;
+// targets for Guided_PosVelAccel mode
+static Vector3p posvelaccel_pos_target_cm;
+static Vector3f posvelaccel_vel_target_cms;
+static Vector3f posvelaccel_accel_target_cmss;
 static uint32_t update_time_ms;
 
 struct {
@@ -117,11 +119,15 @@ void ModeGuided::guided_vel_control_start()
     set_auto_yaw_mode(AUTO_YAW_HOLD);
 }
 
-// initialise guided mode's posvel controller
-void ModeGuided::guided_posvel_control_start()
+// initialise guided mode's posvelaccel controller
+void ModeGuided::guided_posvelaccel_control_start()
 {
-    // set guided_mode to velocity controller
-    sub.guided_mode = Guided_PosVel;
+    // set guided_mode to posvelaccel controller
+    sub.guided_mode = Guided_PosVelAccel;
+
+    // initialise horizontal speed, acceleration
+    position_control->NE_set_max_speed_accel_cm(sub.wp_nav.get_default_speed_NE_cms(), sub.wp_nav.get_wp_acceleration_cmss());
+    position_control->NE_set_correction_speed_accel_cm(sub.wp_nav.get_default_speed_NE_cms(), sub.wp_nav.get_wp_acceleration_cmss());
 
     // set vertical speed and acceleration
     // All limits must be positive
@@ -188,7 +194,7 @@ bool ModeGuided::guided_set_destination(const Vector3f& destination)
 
 #if HAL_LOGGING_ENABLED
     // log target
-    sub.Log_Write_GuidedTarget(sub.guided_mode, destination, Vector3f());
+    sub.Log_Write_GuidedTarget(sub.guided_mode, destination, Vector3f(), Vector3f());
 #endif
 
     return true;
@@ -223,7 +229,7 @@ bool ModeGuided::guided_set_destination(const Location& dest_loc)
 
 #if HAL_LOGGING_ENABLED
     // log target
-    sub.Log_Write_GuidedTarget(sub.guided_mode, Vector3f(dest_loc.lat, dest_loc.lng, dest_loc.alt),Vector3f());
+    sub.Log_Write_GuidedTarget(sub.guided_mode, Vector3f(dest_loc.lat, dest_loc.lng, dest_loc.alt), Vector3f(), Vector3f());
 #endif
 
     return true;
@@ -259,7 +265,7 @@ bool ModeGuided::guided_set_destination(const Vector3f& destination, bool use_ya
 
 #if HAL_LOGGING_ENABLED
     // log target
-    sub.Log_Write_GuidedTarget(sub.guided_mode, destination, Vector3f());
+    sub.Log_Write_GuidedTarget(sub.guided_mode, destination, Vector3f(), Vector3f());
 #endif
 
     return true;
@@ -297,8 +303,8 @@ void ModeGuided::guided_set_velocity(const Vector3f& velocity, bool use_yaw, flo
 
 }
 
-// set guided mode posvel target
-bool ModeGuided::guided_set_destination_posvel(const Vector3f& destination, const Vector3f& velocity)
+// set guided mode posvelaccel target
+bool ModeGuided::guided_set_posvelaccel(const Vector3f& destination, const Vector3f& velocity, const Vector3f& accel)
 {
 #if AP_FENCE_ENABLED
     // reject destination if outside the fence
@@ -310,30 +316,31 @@ bool ModeGuided::guided_set_destination_posvel(const Vector3f& destination, cons
     }
 #endif
 
-    // check we are in posvel control mode
-    if (sub.guided_mode != Guided_PosVel) {
-        guided_posvel_control_start();
+    // check we are in posvelaccel control mode
+    if (sub.guided_mode != Guided_PosVelAccel) {
+        guided_posvelaccel_control_start();
     }
 
     update_time_ms = AP_HAL::millis();
-    posvel_pos_target_cm = destination.topostype();
-    posvel_vel_target_cms = velocity;
+    posvelaccel_pos_target_cm = destination.topostype();
+    posvelaccel_vel_target_cms = velocity;
+    posvelaccel_accel_target_cmss = accel;
 
-    position_control->input_pos_vel_accel_NE_cm(posvel_pos_target_cm.xy(), posvel_vel_target_cms.xy(), Vector2f());
-    float dz = posvel_pos_target_cm.z;
-    position_control->input_pos_vel_accel_U_cm(dz, posvel_vel_target_cms.z, 0);
-    posvel_pos_target_cm.z = dz;
+    position_control->input_pos_vel_accel_NE_cm(posvelaccel_pos_target_cm.xy(), posvelaccel_vel_target_cms.xy(), posvelaccel_accel_target_cmss.xy());
+    float dz = posvelaccel_pos_target_cm.z;
+    position_control->input_pos_vel_accel_U_cm(dz, posvelaccel_vel_target_cms.z, posvelaccel_accel_target_cmss.z);
+    posvelaccel_pos_target_cm.z = dz;
 
 #if HAL_LOGGING_ENABLED
     // log target
-    sub.Log_Write_GuidedTarget(sub.guided_mode, destination, velocity);
+    sub.Log_Write_GuidedTarget(sub.guided_mode, destination, velocity, accel);
 #endif
 
     return true;
 }
 
-// set guided mode posvel target
-bool ModeGuided::guided_set_destination_posvel(const Vector3f& destination, const Vector3f& velocity, bool use_yaw, float yaw_cd, bool use_yaw_rate, float yaw_rate_cds, bool relative_yaw)
+// set guided mode posvelaccel target
+bool ModeGuided::guided_set_posvelaccel(const Vector3f& destination, const Vector3f& velocity, const Vector3f& accel, bool use_yaw, float yaw_cd, bool use_yaw_rate, float yaw_rate_cds, bool relative_yaw)
 {
     #if AP_FENCE_ENABLED
     // reject destination if outside the fence
@@ -345,9 +352,9 @@ bool ModeGuided::guided_set_destination_posvel(const Vector3f& destination, cons
     }
     #endif
 
-    // check we are in posvel control mode
-    if (sub.guided_mode != Guided_PosVel) {
-        guided_posvel_control_start();
+    // check we are in posvelaccel control mode
+    if (sub.guided_mode != Guided_PosVelAccel) {
+        guided_posvelaccel_control_start();
     }
 
     // set yaw state
@@ -355,17 +362,18 @@ bool ModeGuided::guided_set_destination_posvel(const Vector3f& destination, cons
 
     update_time_ms = AP_HAL::millis();
 
-    posvel_pos_target_cm = destination.topostype();
-    posvel_vel_target_cms = velocity;
+    posvelaccel_pos_target_cm = destination.topostype();
+    posvelaccel_vel_target_cms = velocity;
+    posvelaccel_accel_target_cmss = accel;
 
-    position_control->input_pos_vel_accel_NE_cm(posvel_pos_target_cm.xy(), posvel_vel_target_cms.xy(), Vector2f());
-    float dz = posvel_pos_target_cm.z;
-    position_control->input_pos_vel_accel_U_cm(dz, posvel_vel_target_cms.z, 0);
-    posvel_pos_target_cm.z = dz;
+    position_control->input_pos_vel_accel_NE_cm(posvelaccel_pos_target_cm.xy(), posvelaccel_vel_target_cms.xy(), posvelaccel_accel_target_cmss.xy());
+    float dz = posvelaccel_pos_target_cm.z;
+    position_control->input_pos_vel_accel_U_cm(dz, posvelaccel_vel_target_cms.z, posvelaccel_accel_target_cmss.z);
+    posvelaccel_pos_target_cm.z = dz;
 
 #if HAL_LOGGING_ENABLED
     // log target
-    sub.Log_Write_GuidedTarget(sub.guided_mode, destination, velocity);
+    sub.Log_Write_GuidedTarget(sub.guided_mode, destination, velocity, accel);
 #endif
 
     return true;
@@ -444,9 +452,9 @@ void ModeGuided::run()
         guided_vel_control_run();
         break;
 
-    case Guided_PosVel:
-        // run position-velocity controller
-        guided_posvel_control_run();
+    case Guided_PosVelAccel:
+        // run position-velocity-acceleration controller
+        guided_posvelaccel_control_run();
         break;
 
     case Guided_Angle:
@@ -558,7 +566,7 @@ void ModeGuided::guided_vel_control_run()
 
     // set velocity to zero if no updates received for 3 seconds
     uint32_t tnow = AP_HAL::millis();
-    if (tnow - update_time_ms > GUIDED_POSVEL_TIMEOUT_MS && !position_control->get_vel_desired_NEU_cms().is_zero()) {
+    if (tnow - update_time_ms > GUIDED_VEL_TIMEOUT_MS && !position_control->get_vel_desired_NEU_cms().is_zero()) {
         position_control->set_vel_desired_NEU_cms(Vector3f(0,0,0));
     }
 
@@ -594,9 +602,9 @@ void ModeGuided::guided_vel_control_run()
     }
 }
 
-// guided_posvel_control_run - runs the guided posvel controller
+// guided_posvelaccel_control_run - runs the guided posvelaccel controller
 // called from guided_run
-void ModeGuided::guided_posvel_control_run()
+void ModeGuided::guided_posvelaccel_control_run()
 {
     // if motors not enabled set throttle to zero and exit immediately
     if (!motors.armed()) {
@@ -632,18 +640,16 @@ void ModeGuided::guided_posvel_control_run()
 
     // set velocity to zero if no updates received for 3 seconds
     uint32_t tnow = AP_HAL::millis();
-    if (tnow - update_time_ms > GUIDED_POSVEL_TIMEOUT_MS && !posvel_vel_target_cms.is_zero()) {
-        posvel_vel_target_cms.zero();
+    if (tnow - update_time_ms > GUIDED_VEL_TIMEOUT_MS && !posvelaccel_vel_target_cms.is_zero()) {
+        posvelaccel_vel_target_cms.zero();
+        posvelaccel_accel_target_cmss.zero();
     }
 
-    // advance position target using velocity target
-    posvel_pos_target_cm += (posvel_vel_target_cms * position_control->get_dt_s()).topostype();
-
     // send position and velocity targets to position controller
-    position_control->input_pos_vel_accel_NE_cm(posvel_pos_target_cm.xy(), posvel_vel_target_cms.xy(), Vector2f());
-    float pz = posvel_pos_target_cm.z;
-    position_control->input_pos_vel_accel_U_cm(pz, posvel_vel_target_cms.z, 0);
-    posvel_pos_target_cm.z = pz;
+    position_control->input_pos_vel_accel_NE_cm(posvelaccel_pos_target_cm.xy(), posvelaccel_vel_target_cms.xy(), posvelaccel_accel_target_cmss.xy());
+    float pz = posvelaccel_pos_target_cm.z;
+    position_control->input_pos_vel_accel_U_cm(pz, posvelaccel_vel_target_cms.z, posvelaccel_accel_target_cmss.z);
+    posvelaccel_pos_target_cm.z = pz;
 
     // run position controller
     position_control->NE_update_controller();

--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -155,24 +155,23 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
                     "Altitude not maintained: want %.2f (+/- %.2f) got=%.2f" %
                     (previous_altitude, delta, m.alt))
 
+    def dive(self, alt, mode='MANUAL', timeout=120):
+        """Dive to a target altitude."""
+        self.progress("DIVE")
+        self.change_mode(mode)
+        if not self.armed():
+            self.wait_ready_to_arm()
+            self.arm_vehicle()
+        pwm = 1300 if self.get_altitude(relative=True) > alt else 1700
+        self.set_rc(Joystick.Throttle, pwm)
+        self.wait_altitude(altitude_min=alt - 1, altitude_max=alt, relative=False, timeout=timeout)
+        self.set_rc(Joystick.Throttle, 1500)
+        self.delay_sim_time(1)
+        self.progress("DIVE COMPLETE")
+
     def AltitudeHold(self):
         """Test ALT_HOLD mode"""
-        self.wait_ready_to_arm()
-        self.arm_vehicle()
-        self.change_mode('ALT_HOLD')
-
-        msg = self.assert_receive_message('GLOBAL_POSITION_INT', timeout=5)
-        pwm = 1300
-        if msg.relative_alt/1000.0 < -6.0:
-            # need to go up, not down!
-            pwm = 1700
-        self.set_rc(Joystick.Throttle, pwm)
-        self.wait_altitude(altitude_min=-6, altitude_max=-5)
-        self.set_rc(Joystick.Throttle, 1500)
-
-        # let the vehicle settle (momentum / stopping point shenanigans....)
-        self.delay_sim_time(1)
-
+        self.dive(-5, mode='ALT_HOLD')
         self.watch_altitude_maintained()
 
         self.set_rc(Joystick.Throttle, 1000)
@@ -309,16 +308,8 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.context_push()
         self.set_parameter("SIM_BARO_RND", 0.01)
 
-        self.wait_ready_to_arm()
-        self.arm_vehicle()
-        self.change_mode('MANUAL')
-
         # Dive to -5m, outside of rangefinder range, will act like ALT_HOLD
-        pwm = 1300 if self.get_altitude(relative=True) > -6 else 1700
-        self.set_rc(Joystick.Throttle, pwm)
-        self.wait_altitude(altitude_min=-6, altitude_max=-5, relative=False, timeout=60)
-        self.set_rc(Joystick.Throttle, 1500)
-        self.delay_sim_time(1)
+        self.dive(-5, timeout=60)
         self.context_collect('STATUSTEXT')
         self.change_mode(21)
         self.wait_statustext('waiting for a rangefinder reading', check_context=True)
@@ -427,15 +418,9 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
 
         self.context_push()
         self.prepare_synthetic_seafloor_test(sea_floor_depth, match_distance)
-        self.change_mode('MANUAL')
-        self.arm_vehicle()
 
         # Dive to match_distance off the bottom in preparation for the mission
-        pwm = 1300 if self.get_altitude(relative=True) > start_altitude else 1700
-        self.set_rc(Joystick.Throttle, pwm)
-        self.wait_altitude(altitude_min=start_altitude-1, altitude_max=start_altitude, relative=False, timeout=120)
-        self.set_rc(Joystick.Throttle, 1500)
-        self.delay_sim_time(1)
+        self.dive(start_altitude)
 
         # Turn on surftrak and move around
         self.change_mode(21)
@@ -486,16 +471,8 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         filename = "terrain_mission.txt"
         self.load_mission(filename)
 
-        self.change_mode('MANUAL')
-        self.arm_vehicle()
-
         # Dive to match_distance off the bottom in preparation for the mission
-        pwm = 1300 if self.get_altitude(relative=True) > start_altitude else 1700
-        self.set_rc(Joystick.Throttle, pwm)
-        self.wait_altitude(altitude_min=start_altitude-1, altitude_max=start_altitude, relative=False, timeout=120)
-        self.set_rc(Joystick.Throttle, 1500)
-        self.delay_sim_time(1)
-
+        self.dive(start_altitude)
         self.change_mode('AUTO')
         self.watch_true_distance_maintained(match_distance, delta=validation_delta, timeout=500.0, final_waypoint=4)
 
@@ -884,15 +861,9 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
 
     def MAV_CMD_DO_REPOSITION(self):
         """Move vehicle using MAV_CMD_DO_REPOSITION"""
-        self.wait_ready_to_arm()
-        self.arm_vehicle()
-
         # Dive so that rangefinder is in range, required for MAV_FRAME_GLOBAL_TERRAIN_ALT
         start_altitude = -25
-        pwm = 1300 if self.get_altitude(relative=True) > start_altitude else 1700
-        self.set_rc(Joystick.Throttle, pwm)
-        self.wait_altitude(altitude_min=start_altitude-1, altitude_max=start_altitude, relative=False, timeout=120)
-        self.set_rc(Joystick.Throttle, 1500)
+        self.dive(start_altitude)
         self.change_mode('GUIDED')
 
         loc = self.mav.location()

--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -1285,6 +1285,111 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         self.disarm_vehicle()
         self.context_pop()
 
+    def GuidedPosVelAccel(self):
+        """Test Guided_PosVelAccel mode via SET_POSITION_TARGET_LOCAL_NED"""
+
+        pva_mode = (mavutil.mavlink.POSITION_TARGET_TYPEMASK_YAW_IGNORE |
+                    mavutil.mavlink.POSITION_TARGET_TYPEMASK_YAW_RATE_IGNORE)
+
+        speed = 0.5
+
+        self.set_parameter('WP_SPD', speed)
+
+        self.dive(-15)
+
+        # Run back and forth between 2 locations
+        distance = 30
+        timeout = distance / speed + 20  # Add time to accelerate and decelerate
+
+        runs = [{
+            'bearing': 180,
+            'target_alt': -15,
+        }, {
+            'bearing': 0,
+            'target_alt': -15,
+        }]
+
+        # Stay in GUIDED mode for the duration
+        self.change_mode('GUIDED')
+
+        import math
+        for run in runs:
+            msg = self.assert_receive_message('LOCAL_POSITION_NED')
+            start_x = msg.x
+            start_y = msg.y
+
+            dx = distance * math.cos(math.radians(run['bearing']))
+            dy = distance * math.sin(math.radians(run['bearing']))
+            dest_x = start_x + dx
+            dest_y = start_y + dy
+            dest_z = -run['target_alt']
+
+            self.progress(f"Sending target: x={dest_x:.2f}, y={dest_y:.2f}, z={dest_z:.2f} (bearing={run['bearing']})")
+
+            self.mav.mav.set_position_target_local_ned_send(
+                0,  # timestamp
+                1, 1,  # target system/component IDs
+                mavutil.mavlink.MAV_FRAME_LOCAL_NED,
+                pva_mode,
+                dest_x, dest_y, dest_z,  # position target
+                0, 0, 0,  # velocity target
+                0, 0, 0,  # acceleration target
+                0, 0  # yaw, yawrate
+            )
+
+            self.wait_distance_to_local_position((dest_x, dest_y, dest_z), 0, 0.5, timeout=timeout)
+
+        self.disarm_vehicle()
+
+    def GuidedAboveTerrain(self):
+        """Test Guided_PosVelAccel mode and position offsets via Lua"""
+        self.context_collect("STATUSTEXT")
+
+        seafloor_depth = 15
+        match_distance = 2    # Target distance from seafloor (HAGL)
+        xy_margin = 1         # Allowed error horizontal
+        z_margin = 2          # Allowed error vertical
+
+        # Install the GAT PVA script
+        # This will send rapid updates to Guided_PosVelAccel and poscontrol
+        self.install_example_script_context("guided_above_terrain_posvelaccel_sub.lua")
+
+        # Install the synthetic seafloor rangefinder script and reboot
+        self.prepare_synthetic_seafloor_test(seafloor_depth, match_distance)
+
+        # Set the desired forward speed
+        speed = 0.5
+        self.set_parameter('GAT_SPEED', speed)
+
+        # Minimize vertical oscillation due to sensor delay
+        self.set_parameter('PSC_D_JERK', 4.0)
+        self.set_parameter('WP_ACC_Z', 5.0)
+
+        # Aim south (180 deg) so the sub travels over the simulated ridge
+        # self.reach_heading_manual(180)
+
+        self.dive(-seafloor_depth + match_distance, mode="ALT_HOLD")
+
+        start_loc = self.get_location()
+        timeout = 60
+
+        # Activate the GAT script
+        self.change_mode("GUIDED")
+        self.wait_text("GAT: active", check_context=True)
+
+        # Verify the sub maintains the target distance over the terrain
+        self.watch_true_distance_maintained(match_distance, delta=z_margin, timeout=timeout)
+
+        # Verify that we moved the expected distance
+        end_loc = self.get_location()
+        distance_travelled = self.get_distance(start_loc, end_loc)
+        expected_distance = speed * timeout
+        self.progress(f"Expected distance {expected_distance}m, got {distance_travelled}m")
+        if abs(distance_travelled - expected_distance) > xy_margin:
+            raise NotAchievedException("Failed to achieve distance")
+
+        self.disarm_vehicle()
+
     def tests(self):
         '''return list of all tests'''
         ret = super(AutoTestSub, self).tests()
@@ -1326,6 +1431,8 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
             self.GPSForYaw,
             self.WaterDepth,
             self.VisoForYaw,
+            self.GuidedPosVelAccel,
+            self.GuidedAboveTerrain,
         ])
 
         return ret

--- a/libraries/AP_Scripting/examples/guided_above_terrain_posvelaccel_sub.lua
+++ b/libraries/AP_Scripting/examples/guided_above_terrain_posvelaccel_sub.lua
@@ -1,0 +1,191 @@
+-- GAT (Guided Above Terrain) PVA Example Script
+-- Move forward at a constant velocity while following the terrain
+-- The pilot can set the heading, and the script will maintain it (similar to stabilize)
+
+local PARAM_TABLE_KEY = 96
+local PARAM_TABLE_PREFIX = "GAT_"
+
+local RUN_HZ = 20
+local GUIDED_MODE = 4
+
+-- configuration
+local ACC_XY = 0.5                  -- xy acceleration in m/s^2
+local P_GAIN_Z = 1.0                -- gain for vertical correction
+local MAX_VEL_Z = 2.0               -- max vertical velocity correction in m/s
+
+-- create and initialise parameters
+assert(param:add_table(PARAM_TABLE_KEY, PARAM_TABLE_PREFIX, 1), 'could not add param table')
+assert(param:add_param(PARAM_TABLE_KEY, 1, 'SPEED', 0.5), 'could not add SPEED param')
+
+local GAT_SPEED = Parameter("GAT_SPEED")
+
+-- control variables
+local active = false
+local last_time_ms = millis()
+local yaw_target_rad = 0
+local hagl_target = 0               -- height above ground level target in m
+local pos_target = Vector3f()       -- position target in m
+local vel_target = Vector3f()       -- velocity target in m/s
+local acc_target = Vector3f()       -- acceleration target in m/s^2
+local pos_offset = Vector3f()       -- position offset in m
+local vel_offset = Vector3f()       -- velocity offset in m/s
+
+local function update()
+    -- calculate dt
+    local tnow = millis()
+    local dt = (tnow - last_time_ms):tofloat() / 1000.0
+    -- cap dt to avoid large integration steps if execution was delayed
+    if (dt > 2.0 / RUN_HZ) then
+        dt = 1.0 / RUN_HZ
+    end
+    last_time_ms = tnow
+
+    local current_mode = vehicle:get_mode()
+    if current_mode ~= GUIDED_MODE then
+        if active then
+            active = false
+            gcs:send_text(6, "GAT: not active")
+        end
+        return update, 1000 / RUN_HZ
+    end
+
+    if not active then
+        -- check EKF
+        local current_pos = ahrs:get_relative_position_NED_origin()
+        local current_vel = ahrs:get_velocity_NED()
+        if not current_pos or not current_vel then
+            gcs:send_text(4, "GAT: waiting for relative position")
+            return update, 1000 / RUN_HZ
+        end
+
+        -- check rangefinder
+        if not rangefinder:has_data_orient(25) or rangefinder:status_orient(25) ~= 4 then -- 4 is RangeFinder_Good
+            gcs:send_text(4, "GAT: downward rangefinder not healthy")
+            return update, 1000 / RUN_HZ
+        end
+
+        -- reset control variables
+        yaw_target_rad = ahrs:get_yaw_rad()
+        hagl_target = rangefinder:distance_orient(25)
+
+        pos_target:x(current_pos:x())
+        pos_target:y(current_pos:y())
+        pos_target:z(current_pos:z())
+
+        vel_target:x(current_vel:x())
+        vel_target:y(current_vel:y())
+        vel_target:z(0)
+
+        acc_target:x(0)
+        acc_target:y(0)
+        acc_target:z(0)
+
+        pos_offset:x(0)
+        pos_offset:y(0)
+        pos_offset:z(0)
+
+        vel_offset:x(0)
+        vel_offset:y(0)
+        vel_offset:z(0)
+
+        active = true
+        gcs:send_text(6, string.format("GAT: active, target HAGL %.1fm", hagl_target))
+    end
+
+    -- get the pilot yaw intent semantically via RCMAP_YAW parameter (defaulting to channel 4)
+    local yaw_channel_num = param:get('RCMAP_YAW') or 4
+    local yaw_chan = rc:get_channel(yaw_channel_num)
+    local yaw_input = yaw_chan and yaw_chan:norm_input_dz() or 0
+
+    -- get the current yaw rate
+    local gyro = ahrs:get_gyro()
+    local yaw_rate_rads = gyro and gyro:z() or 0
+
+    -- if the stick is not in deadband, or rotation has not stopped, update yaw_target_rad
+    if yaw_input ~= 0 or math.abs(yaw_rate_rads) >= 0.05 then
+        yaw_target_rad = ahrs:get_yaw_rad()
+    end
+
+    -- get the desired horizontal speed
+    local speed_ms = GAT_SPEED:get()
+
+    -- calculate the desired horizontal velocity in north and east
+    local vel_desired_ne = Vector2f()
+    vel_desired_ne:x(math.cos(yaw_target_rad) * speed_ms)
+    vel_desired_ne:y(math.sin(yaw_target_rad) * speed_ms)
+
+    -- apply ACC_XY to ramp the speed up / down and limit cornering acceleration
+    local vel_diff_ne = Vector2f()
+    vel_diff_ne:x(vel_desired_ne:x() - vel_target:x())
+    vel_diff_ne:y(vel_desired_ne:y() - vel_target:y())
+
+    local vel_diff_len = vel_diff_ne:length()
+    local step_max = ACC_XY * dt
+    if vel_diff_len > step_max then
+        local scale = step_max / vel_diff_len
+        vel_diff_ne:x(vel_diff_ne:x() * scale)
+        vel_diff_ne:y(vel_diff_ne:y() * scale)
+    end
+
+    -- capture the old velocity for position integration
+    local vel_target_old_ne = Vector2f()
+    vel_target_old_ne:x(vel_target:x())
+    vel_target_old_ne:y(vel_target:y())
+
+    -- update the velocity target
+    vel_target:x(vel_target:x() + vel_diff_ne:x())
+    vel_target:y(vel_target:y() + vel_diff_ne:y())
+
+    -- update the acceleration target
+    acc_target:x(vel_diff_ne:x() / dt)
+    acc_target:y(vel_diff_ne:y() / dt)
+
+    -- update the position target
+    pos_target:x(pos_target:x() + (vel_target_old_ne:x() + vel_target:x()) * 0.5 * dt)
+    pos_target:y(pos_target:y() + (vel_target_old_ne:y() + vel_target:y()) * 0.5 * dt)
+
+    -- get the current HAGL
+    local hagl_current
+    if rangefinder:has_data_orient(25) and rangefinder:status_orient(25) == 4 then
+        hagl_current = rangefinder:distance_orient(25)
+    else
+        -- fallback if rangefinder lost: maintain current offset
+        hagl_current = hagl_target
+    end
+
+    -- calculate the vertical error
+    local hagl_error = hagl_target - hagl_current
+
+    -- set the velocity offset
+    vel_offset:z(-1.0 * (hagl_error * P_GAIN_Z))
+
+    -- limit the vertical velocity correction
+    if vel_offset:z() > MAX_VEL_Z then
+        vel_offset:z(MAX_VEL_Z)
+    elseif vel_offset:z() < -MAX_VEL_Z then
+        vel_offset:z(-MAX_VEL_Z)
+    end
+
+    -- integrate the vertical offset
+    pos_offset:z(pos_offset:z() + vel_offset:z() * dt)
+
+    -- send the targets to the controllers
+    -- set_target_posvelaccel_NED arguments: pos, vel, accel, use_yaw, yaw_deg, use_yaw_rate, yaw_rate_degs, yaw_relative
+    vehicle:set_target_posvelaccel_NED(pos_target, vel_target, acc_target, false, 0, false, 0, false)
+    poscontrol:set_posvelaccel_offset(pos_offset, vel_offset, Vector3f())
+
+    -- calculate the horizontal position error
+    local current_pos = ahrs:get_relative_position_NED_origin()
+    local distance = 0
+    if current_pos then
+        distance = (pos_target:xy() - current_pos:xy()):length()
+    end
+
+    -- log key metrics
+    logger:write('GATD', 'HAGL,Offset,TargZ,YInp,YRat,TYaw,PErr,VDL', 'ffffffff', 'mmm-rrmn', '--------', hagl_current, pos_offset:z(), pos_target:z(), yaw_input, yaw_rate_rads, yaw_target_rad, distance, vel_diff_len)
+
+    return update, 1000 / RUN_HZ
+end
+
+gcs:send_text(6, "GAT: script loaded")
+return update, 1000

--- a/libraries/AP_Scripting/generator/description/bindings.desc
+++ b/libraries/AP_Scripting/generator/description/bindings.desc
@@ -840,8 +840,8 @@ singleton AC_AttitudeControl depends APM_BUILD_TYPE(APM_BUILD_ArduPlane)||APM_BU
 singleton AC_AttitudeControl method get_rpy_srate void float'Ref float'Ref float'Ref
 singleton AC_AttitudeControl method get_att_error_angle_deg float
 
-include AC_AttitudeControl/AC_PosControl.h depends APM_BUILD_COPTER_OR_HELI
-singleton AC_PosControl depends APM_BUILD_COPTER_OR_HELI
+include AC_AttitudeControl/AC_PosControl.h depends APM_BUILD_COPTER_OR_HELI||APM_BUILD_TYPE(APM_BUILD_ArduSub)
+singleton AC_PosControl depends APM_BUILD_COPTER_OR_HELI||APM_BUILD_TYPE(APM_BUILD_ArduSub)
 singleton AC_PosControl rename poscontrol
 singleton AC_PosControl method set_posvelaccel_offset boolean Vector3f Vector3f Vector3f
 singleton AC_PosControl method get_posvelaccel_offset boolean Vector3f'Null Vector3f'Null Vector3f'Null


### PR DESCRIPTION
### Summary

Add acceleration target to Guided_PosVel in ArduSub, turning it into Guided_PosVelAccel.

Backport of https://github.com/ArduPilot/ardupilot/pull/33609.

The backport was tricky. I ended up pulling in 2 more commits, one each from:
* https://github.com/ArduPilot/ardupilot/pull/32858
* https://github.com/ArduPilot/ardupilot/pull/33412 (skipped the new autotest)

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

See original PRs.