### PR TITLE
AP_Follow: document FOLL_OPTIONS as the bitmask it is

### DIFF
--- a/libraries/AP_Follow/AP_Follow.cpp
+++ b/libraries/AP_Follow/AP_Follow.cpp
@@ -158,7 +158,7 @@ const AP_Param::GroupInfo AP_Follow::var_info[] = {
     // @Param: _OPTIONS
     // @DisplayName: Follow options
     // @Description: Follow options bitmask
-    // @Values: 0:None,1: Mount Follows lead vehicle on mode enter
+    // @Bitmask: 0:Mount follows lead vehicle on mode enter
     // @User: Standard
     AP_GROUPINFO("_OPTIONS", 11, AP_Follow, _options, 0),
 


### PR DESCRIPTION
### Summary

`FOLL_OPTIONS` is read with `option_is_enabled()`, which masks the parameter
against the `Option` enum, so it is a bitmask. It was annotated `@Values`,
which makes a ground station present it as a list of mutually exclusive
choices offering only "0:None" and "1: Mount Follows lead vehicle on mode
enter".

Annotate it `@Bitmask` instead, so the one option that exists is presented as
the checkbox it is, and any option added later appears alongside it rather
than requiring the operator to work out the arithmetic.

Documentation only; no functional change.

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request