### PR TITLE
Tools: fix the TFS20L feature macro in the Renode driver catalog

### DIFF
--- a/Tools/renode/driver_catalog.py
+++ b/Tools/renode/driver_catalog.py
@@ -924,7 +924,7 @@ ATTACHABLE_DEVICES = {
         'model': 'Sensors.AP_TFS20L',
         'address': 0x10,
         'driver': 'AP_RangeFinder/AP_RangeFinder_Benewake_TFS20L.cpp',
-        'feature': 'AP_RANGEFINDER_BENEWAKE_TFS20L_ENABLED',
+        'feature': 'AP_RANGEFINDER_BENEWAKE_TFS20L_I2C_ENABLED',
         'coverage': COVERAGE_DYNAMIC,
         'hotplug': 'boot-probe',
         'physics': {


### PR DESCRIPTION
### Summary

The Renode driver catalog refers to `AP_RANGEFINDER_BENEWAKE_TFS20L_ENABLED`, which no longer exists — it was renamed to `AP_RANGEFINDER_BENEWAKE_TFS20L_I2C_ENABLED`. The `cubeorangeplus-quadplane` job fails on master and on every open PR as a result.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Reproduced on a pristine `master` worktree with no other changes applied:

```
$ python3 Tools/renode/driver_inventory.py --root . --check
catalog errors:
  tfs20l-i2c-rangefinder feature does not exist beside driver: AP_RANGEFINDER_BENEWAKE_TFS20L_ENABLED
exit 1
```

With this change the same command exits 0, and the three assertions that were failing all pass:

| Test | Assertion | Before | After |
|---|---|---|---|
| `test_live_catalog_is_consistent` | `validate_catalog(ROOT) == []` | fail | pass |
| `test_inventory_json_cli` | `result['catalog_errors'] == []` | fail | pass |
| `test_catalog_check_cli` | `main(['--root', ROOT, '--check']) == 0` | fail | pass |

Python-only change, so no binary is affected.

### Description

`validate_catalog()` checks that each catalogued device's `feature` macro is actually defined beside its driver. The `tfs20l-i2c-rangefinder` entry names a macro that isn't there any more, so the check errors and takes three tests, and the job that runs them, down with it.

**How it got in.** Two PRs merged 95 minutes apart on the same morning:

| Merged (UTC) | PR | Effect |
|---|---|---|
| 2026-09-05 09:09:31 | #34297, "AP_RangeFinder: rename Benewake TFS20-L macros/label to clarify I2C-only support" | renamed `AP_RANGEFINDER_BENEWAKE_TFS20L_ENABLED` to `..._TFS20L_I2C_ENABLED` |
| 2026-09-05 10:44:29 | #33975, "Add renode MCU emulation support" | added `Tools/renode/driver_catalog.py`, referencing the pre-rename name |

`Tools/renode/driver_catalog.py` did not exist at the rename commit (3b28cfd387), and that commit is an ancestor of the catalog commit (0c15a1d88d), so #33975 is where the stale reference entered master — its branch was written against a base that still had the old macro. Neither PR could have caught this in its own CI: #34297 had no catalog to update, and #33975 was green against its pre-rename base. It only breaks once both are in the same tree.

The fix is to match `libraries/AP_RangeFinder/AP_RangeFinder_config.h`:

```python
-        'feature': 'AP_RANGEFINDER_BENEWAKE_TFS20L_ENABLED',
+        'feature': 'AP_RANGEFINDER_BENEWAKE_TFS20L_I2C_ENABLED',
```

`AP_RANGEFINDER_BENEWAKE_TFS20L_ENABLED` has no remaining references anywhere in the tree. The `AP_SIM_TFS20L_ENABLED` macros in `libraries/SITL/` are a separate namespace and are unaffected. No other catalog entry references a missing macro — the check reports zero errors after this one line.

cc @tridge, @excited-electrn
