### PR TITLE
autotest: add --sitl-instance to move a run's ports

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -20123,7 +20123,7 @@ RTL_ALT_M 111
                 gdb=self.gdb,
                 valgrind=self.valgrind,
                 customisations=[
-                    '-I', str(1),
+                    '-I', str(1 + self.sitl_instance),
                     '--serial0', 'mcast:',
                     '--serial1', 'tcp:2',
                     '--serial2', 'tcp:3',
@@ -20167,7 +20167,7 @@ RTL_ALT_M 111
             self.progress("Connect to the serial port on the peripheral, which should be talking mavlink")
             self.drain_mav()
             mav2 = mavutil.mavlink_connection(
-                "tcp:localhost:5772",
+                "tcp:localhost:%u" % self.adjust_ardupilot_port(5772),
                 robust_parsing=True,
                 source_system=9,
                 source_component=9,
@@ -20178,7 +20178,7 @@ RTL_ALT_M 111
             self.progress("Connect to the other serial port on the peripheral, which should also be talking mavlink")
             self.drain_mav()
             mav3 = mavutil.mavlink_connection(
-                "tcp:localhost:5773",
+                "tcp:localhost:%u" % self.adjust_ardupilot_port(5773),
                 robust_parsing=True,
                 source_system=10,
                 source_component=10,

--- a/Tools/autotest/autotest.py
+++ b/Tools/autotest/autotest.py
@@ -379,6 +379,18 @@ tester_class_map = {
     "test.BattCAN": arducopter.AutoTestBattCAN,
 }
 
+# above 25 the rc-in ports (5501 + 10*instance) reach the SERIAL range of
+# instance 0 (5760 and up), so a run would take a lower instance's ports
+MAX_SITL_INSTANCE = 25
+
+# SITL_MCAST_PORT in SITL_State_common.h, MCAST_PORT in CAN_Multicast.cpp.
+# The state port steps by 100 rather than 10: the servo socket next to it takes
+# SITL_SERVO_PORT + instance, stepping by 1, so a 10 step would put instance 9's
+# state port on instance 1's servo port, and that bind is fatal.
+SITL_MCAST_STATE_PORT = 20721
+SITL_MCAST_STATE_STEP = 100
+SITL_CAN_MCAST_PORT = 57732
+
 supplementary_test_binary_map = {
     "test.CAN": ["sitl_periph_universal:AP_Periph:0:Tools/autotest/default_params/periph.parm,Tools/autotest/default_params/quad-periph.parm", # noqa: E501
                  "sitl_periph_universal:AP_Periph:1:Tools/autotest/default_params/periph.parm"],
@@ -507,7 +519,7 @@ def run_step(step):
                 instance_num = int(a[2])
                 param_file = a[3].split(",")
                 bin_path = util.reltopdir(os.path.join('build', config_name, 'bin', binary_name))
-                customisation = '-I {}'.format(instance_num)
+                customisation = '-I {}'.format(instance_num + opts.sitl_instance)
                 sup_binary = {"binary" : bin_path,
                               "customisation" : customisation,
                               "param_file" : param_file}
@@ -541,6 +553,7 @@ def run_step(step):
         "generate_junit": opts.junit,
         "enable_fgview": opts.enable_fgview,
         "unix_domain_socket": opts.unix_domain_socket,
+        "sitl_instance": opts.sitl_instance,
     }
     if opts.speedup is not None:
         fly_opts["speedup"] = opts.speedup
@@ -1073,6 +1086,11 @@ if __name__ == "__main__":
                          action='store_true',
                          default=False,
                          help="use Unix domain sockets for SITL UARTs")
+    group_sim.add_option("--sitl-instance",
+                         dest="sitl_instance",
+                         default=0,
+                         type='int',
+                         help='run this autotest at the given SITL instance, moving its ports by 10 per instance')
     parser.add_option_group(group_sim)
 
     group_completion = optparse.OptionGroup(parser, "Completion helpers")
@@ -1095,6 +1113,18 @@ if __name__ == "__main__":
     parser.add_option_group(group_completion)
 
     opts, args = parser.parse_args()
+
+    if opts.sitl_instance < 0 or opts.sitl_instance > MAX_SITL_INSTANCE:
+        print("--sitl-instance must be 0..%u" % MAX_SITL_INSTANCE)
+        sys.exit(1)
+
+    if opts.sitl_instance != 0:
+        # -I does not reach the multicast ports.  Overriding rather than
+        # setdefault-ing: an inherited value would put two instances back on
+        # one bus, which is the thing the instance was asked for.
+        os.environ['SITL_MCAST_STATE_PORT'] = str(SITL_MCAST_STATE_PORT +
+                                                  SITL_MCAST_STATE_STEP * opts.sitl_instance)
+        os.environ['SITL_CAN_MCAST_PORT'] = str(SITL_CAN_MCAST_PORT + 10 * opts.sitl_instance)
 
     # canonicalise on opts.debug:
     if opts.debug is None and opts.no_debug is None:

--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -6786,7 +6786,9 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.context_get().sitl_commandline_customised = True
 
         self.progress("Starting PPP daemon")
-        pppd = util.start_PPP_daemon("192.168.14.15:192.168.14.13", '127.0.0.1:5765')
+        pppd = util.start_PPP_daemon(
+            "192.168.14.15:192.168.14.13",
+            '127.0.0.1:%u' % self.adjust_ardupilot_port(5765))
 
         self.context_push()
         self.context_collect('STATUSTEXT')
@@ -7175,10 +7177,10 @@ Brakes have negligible effect (with=%0.2fm without=%0.2fm delta=%0.2fm)
         self.wait_statustext("hello, world")
         conns = {}
         endpoints = [
-            "tcp:localhost:5761",
+            "tcp:localhost:%u" % self.adjust_ardupilot_port(5761),
             self.sitl_serial_endpoint(1),
             self.sitl_serial_endpoint(2),
-            "tcp:localhost:5764",
+            "tcp:localhost:%u" % self.adjust_ardupilot_port(5764),
             self.sitl_serial_endpoint(5),
             self.sitl_serial_endpoint(6),
             self.sitl_serial_endpoint(7),

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -2133,6 +2133,7 @@ class TestSuite(abc.ABC):
                  asan=False,
                  check_parameter_leaks=True,
                  unix_domain_socket=False,
+                 sitl_instance=0,
                  ):
         if breakpoints is None:
             breakpoints = []
@@ -2215,6 +2216,7 @@ class TestSuite(abc.ABC):
         self.enable_fgview = enable_fgview
         self.unix_domain_socket = unix_domain_socket
         self.unix_domain_socket_dir = os.getcwd()
+        self.sitl_instance = sitl_instance
 
         self.rc_thread: threading.Thread | None = None
         self.rc_thread_should_quit: bool = False
@@ -2320,15 +2322,19 @@ class TestSuite(abc.ABC):
         """Allow subclasses to override SITL streamrate."""
         return 10
 
+    def instance_port_offset(self):
+        '''amount this run's ports move by; SITL uses the same 10-per-instance step'''
+        return 10 * self.sitl_instance
+
     def adjust_ardupilot_port(self, port):
-        '''adjust port in case we do not wish to use the default range (5760 and 5501 etc)'''
-        return port
+        '''shift a default SITL port (5760 and 5501 etc) to this run's instance'''
+        return port + self.instance_port_offset()
 
     def spare_network_port(self, offset=0):
         '''returns a network port which should be able to be bound'''
         if offset > 2:
             raise ValueError("offset too large")
-        return 8000 + offset
+        return 8000 + self.instance_port_offset() + offset
 
     def autotest_connection_string_to_ardupilot(self):
         return self.sitl_serial_endpoint(0)
@@ -2352,7 +2358,7 @@ class TestSuite(abc.ABC):
     def sitl_rcin_port(self, offset=0):
         if offset > 2:
             raise ValueError("offset too large")
-        return 5501 + offset
+        return 5501 + self.instance_port_offset() + offset
 
     def sitl_rcin_endpoint(self, offset=0):
         if self.unix_domain_socket:
@@ -10318,6 +10324,10 @@ Also, ignores heartbeats not from our target system'''
         start_sitl_args.update(**sitl_args)
         if "model" not in start_sitl_args or start_sitl_args["model"] is None:
             start_sitl_args["model"] = self.frame
+        if self.sitl_instance != 0:
+            customisations = list(start_sitl_args.get("customisations") or [])
+            customisations.append("-I %u" % self.sitl_instance)
+            start_sitl_args["customisations"] = customisations
         self.progress("Starting SITL", send_statustext=False)
         if binary is None:
             binary = self.binary

--- a/Tools/completion/zsh/_ap_autotest
+++ b/Tools/completion/zsh/_ap_autotest
@@ -54,6 +54,7 @@ _ap_autotest() {
         '--disable-breakpoints[disable all breakpoints before starting]' \
         '--force-ahrs-type[force a specific AHRS type (e.g. 10 for SITL-ekf)]:AHRS_TYPE:' \
         '--replay[enable replay logging for tests]' \
+        '--sitl-instance[run this autotest at the given SITL instance]:SITL_INSTANCE:' \
         '--reset-after-every-test[reset everything after every test run]' \
         '*: :_ap_autotest_cmds' \
       ;;


### PR DESCRIPTION
### Summary

Adds `autotest.py --sitl-instance N`, which moves every port a run uses so two SITL autotests can share a machine. Today the second one started anywhere on the host collides with the first.

### Classification & Testing (check all that apply and add your own)

- [ ] Checked by a human programmer
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Tested manually, description below (e.g. SITL)

Two `test.Copter.AltTypes` runs launched together from separate checkouts, one at the default instance and one at `--sitl-instance 12`. Both passed, with the two SITLs alive at the same moment on disjoint ports:

```
16:35:46: 2 arducopter processes
0.0.0.0:5760
0.0.0.0:5880
```

`test.Rover.ManyMAVLinkConnections`, which failed outright at any non-zero instance before this change, passes at instance 12 and is visibly reaching 5881/5884 rather than the literals it used to use. `test.Copter.AltTypes`, `AltEstimation` and `LoiterToAlt` also pass at instance 12, and instance 0 produces a byte-identical SITL command line to before.

### Description

SITL already moves the default ports it takes from its command line by 10 per `-I` instance, and `adjust_ardupilot_port()` has sat in the test suite as the override hook for exactly this since 2023, never overridden. This wires the two together and offsets `sitl_rcin_port()` and `spare_network_port()` to match.

The two multicast ports do not follow `-I`, so the option sets `SITL_MCAST_STATE_PORT` and `SITL_CAN_MCAST_PORT` as well; without them concurrent runs share one state bus and one set of CAN buses, and a peripheral answers whichever vehicle it hears. The state port steps by 100 rather than 10 because the servo socket beside it takes `SITL_SERVO_PORT + instance` and steps by 1: with a step of 10, instance 9's state port lands on instance 1's servo port, and that bind calls `exit(1)`. With the 100 step, no two of the eight port families overlap anywhere in the permitted instance range.

Three tests reached SITL by a port number instead of through the helpers, so they did not merely share ports at a non-zero instance, they failed: Rover's `ManyMAVLinkConnections` and `NetworkingWebServerPPP`, and Copter's `PeriphMultiUARTTunnel`, which additionally started its own peripheral at a fixed instance 1 and would have had it bind the vehicle's own 5772/5773. All four sites follow the offset now.

Above instance 25 the rc-in ports (5501 + 10 per instance) reach instance 0's SERIAL range, so a high instance would take a lower one's ports. The option refuses those rather than failing obscurely.

`sim_vehicle.py -I N` has the same multicast-bus problem and this does not fix it; the two callers could share the offset by pushing it down into `pysim/util.start_SITL`, which is worth doing separately rather than widening this change.

Two limits worth stating. Separating the autotest lock file and the log tree is still `BUILDLOGS`' job - a caller that wants two concurrent runs sets it per checkout, and baking that in here would be a second, unrelated decision. And tests that bind literal ports of their own still share them between concurrent runs: the Rover networking ports, `IBus`, the log download tests, and `PeriphMultiUARTTunnel`'s MAVLink multicast bus. Those work at any instance; they just cannot run twice at once.
