### PR TITLE
AP_NavEKF3: do not test flow data the terrain estimator does not have

### DIFF
--- a/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
@@ -54,7 +54,7 @@ void NavEKF3_core::SelectFlowFusion()
     // if have valid flow or range measurements, fuse data into a 1-state EKF to estimate terrain height
     if (((flowDataToFuse && (frontend->_flowUse == FLOW_USE_TERRAIN)) || rangeDataToFuse) && tiltOK) {
         // Estimate the terrain offset (runs a one state EKF)
-        EstimateTerrainOffset(ofDataDelayed);
+        EstimateTerrainOffset(ofDataDelayed, flowDataToFuse);
     }
 
 #if EK3_FEATURE_OPTFLOW_AGL_KF
@@ -79,15 +79,19 @@ Estimation of terrain offset using a single state EKF
 The filter can fuse motion compensated optical flow rates and range finder measurements
 Equations generated using https://github.com/PX4/ecl/tree/master/EKF/matlab/scripts/Terrain%20Estimator
 */
-void NavEKF3_core::EstimateTerrainOffset(const of_elements &ofDataDelayed)
+void NavEKF3_core::EstimateTerrainOffset(const of_elements &ofDataDelayed, bool flowDataToFuse)
 {
     // horizontal velocity squared
     ftype velHorizSq = sq(stateStruct.velocity.x) + sq(stateStruct.velocity.y);
 
+    // don't fuse flow data if there is no sample at the fusion time horizon: storedOF.recall()
+    // leaves ofDataDelayed untouched when it fails, so the tests below would read uninitialised
+    // stack. This must stay first so that the || short circuits before flowRadXY is touched
     // don't fuse flow data if LOS rate is misaligned, without GPS, or insufficient velocity, as it is poorly observable
     // don't fuse flow data if it exceeds validity limits
     // don't update terrain offset if ground is being used as the zero height datum in the main filter
-    bool cantFuseFlowData = ((frontend->_flowUse != FLOW_USE_TERRAIN)
+    bool cantFuseFlowData = (!flowDataToFuse
+    || (frontend->_flowUse != FLOW_USE_TERRAIN)
     || !gpsIsInUse
     || PV_AidingMode == AID_RELATIVE 
     || velHorizSq < 25.0f 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -936,7 +936,7 @@ private:
     void SelectBodyOdomFusion();
 
     // Estimate terrain offset using a single state EKF
-    void EstimateTerrainOffset(const of_elements &ofDataDelayed);
+    void EstimateTerrainOffset(const of_elements &ofDataDelayed, bool flowDataToFuse);
 
 #if EK3_FEATURE_OPTFLOW_AGL_KF
     // Update the 2-state IMU-aided AGL Kalman filter (height + vertical velocity above ground)


### PR DESCRIPTION
### Summary

`EstimateTerrainOffset()` tests `ofDataDelayed.flowRadXY` without knowing whether a flow sample was actually recalled, so on a Plane with a rangefinder and no optical flow sensor it reads uninitialised stack on most EKF steps.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Tested manually, description below (e.g. SITL)

`storedOF.recall()` only `memcpy`s into the caller's element on success, so when it returns false `ofDataDelayed` holds whatever was on the stack. `SelectFlowFusion()` calls `EstimateTerrainOffset()` when *either* flow *or* rangefinder data is available, and `cantFuseFlowData` reaches `MAX(ofDataDelayed.flowRadXY[0], flowRadXY[1]) > _maxFlowRate` before anything has established that a flow sample exists.

Whether it faults depends on the stack, so there is no reliable autotest to add. I demonstrated it deterministically instead, by poisoning the struct immediately after its declaration so the value does not depend on luck:

```c
    of_elements ofDataDelayed;
    memset(&ofDataDelayed, 0xFF, sizeof(ofDataDelayed)); // 0xFFFFFFFF is a NaN
```

Same build, one variable, `Tools/autotest/autotest.py test.Plane.RangeFinder`:

| `!flowDataToFuse` term | result |
|---|---|
| absent (master) | SITL dies, `_sig_fpe` -> `EstimateTerrainOffset` -> `SelectFlowFusion` |
| present (this PR) | passes |

Without the poison, `Plane.RangeFinder` and `Copter.OpticalFlowLimits` both pass on this branch.

### Description

Adding `!flowDataToFuse` as the first term of the `||` chain short-circuits the whole expression before `flowRadXY` is touched. It has to stay first for that reason, which the comment says.

Reachability is wider than it looks, and does not need a flow sensor:

- `EK3_FLOW_USE` defaults to **2** (`FLOW_USE_TERRAIN`) on Plane, so the existing first term does not short-circuit. Copter escapes only because its default is 1.
- `EstimateTerrainOffset()` is entered on `rangeDataToFuse` alone.
- The remaining terms - `gpsIsInUse`, `PV_AidingMode != AID_RELATIVE`, `velHorizSq >= 25` - are all satisfied by an ordinary GPS-aided plane above 5 m/s.

So the read happens whenever a rangefinder is returning data and the aircraft is above 5 m/s, which on a plane with a rangefinder fitted is most of every takeoff and landing.

SITL enables `FE_INVALID` (`AP_HAL_SITL/Scheduler.cpp`), and `>` is a signalling comparison, so a NaN there is an immediate `SIGFPE`. On hardware there is no trap: the consequence is instead a fabricated flow rate fused into the terrain estimate, or a spurious rejection of a good rangefinder update, depending on what happened to be on the stack.

Zero-initialising `ofDataDelayed` looks like the smaller fix and I do not think it is the right one. `{}` silences the fault but makes `MAX(0,0) > _maxFlowRate` false, so `cantFuseFlowData` comes out false where garbage would often have made it true, and the terrain estimator then fuses an invented zero flow rate every time a rangefinder sample arrives without a flow one. That trades a visible crash for a silent wrong measurement.

No behaviour change when a flow sample does exist: the added term is false and the rest of the expression is evaluated exactly as before. When there is no sample, the only paths affected are ones that were reading indeterminate values.
