### PR TITLE
ArduSub: reject force inputs to Guided_PosVelAccel; other fixes

### DIFF
--- a/ArduSub/GCS_MAVLink_Sub.cpp
+++ b/ArduSub/GCS_MAVLink_Sub.cpp
@@ -639,8 +639,14 @@ void GCS_MAVLINK_Sub::handle_message(const mavlink_message_t &msg)
         bool pos_ignore      = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_POS_IGNORE;
         bool vel_ignore      = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_VEL_IGNORE;
         bool acc_ignore      = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_ACC_IGNORE;
+        bool force_set       = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_FORCE;
         bool yaw_ignore      = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_YAW_IGNORE;
         bool yaw_rate_ignore = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_YAW_RATE_IGNORE;
+
+        // Force inputs are not supported
+        if (force_set && !acc_ignore) {
+            break;
+        }
 
         // prepare position
         Vector3f pos_vector_neu_cm;
@@ -726,13 +732,18 @@ void GCS_MAVLINK_Sub::handle_message(const mavlink_message_t &msg)
         bool pos_ignore      = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_POS_IGNORE;
         bool vel_ignore      = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_VEL_IGNORE;
         bool acc_ignore      = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_ACC_IGNORE;
+        bool force_set       = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_FORCE;
 
         /*
          * for future use:
-         * bool force           = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_FORCE;
          * bool yaw_ignore      = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_YAW_IGNORE;
          * bool yaw_rate_ignore = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_YAW_RATE_IGNORE;
          */
+
+        // Force inputs are not supported
+        if (force_set && !acc_ignore) {
+            break;
+        }
 
         if (!z_ignore && sub.control_mode == Mode::Number::ALT_HOLD) { // Control only target depth when in ALT_HOLD
             sub.pos_control.set_pos_desired_U_cm(packet.alt*100);

--- a/ArduSub/mode_guided.cpp
+++ b/ArduSub/mode_guided.cpp
@@ -198,7 +198,7 @@ bool ModeGuided::guided_set_destination(const Location& dest_loc)
 
 #if HAL_LOGGING_ENABLED
     // log target
-    sub.Log_Write_GuidedTarget(sub.guided_mode, Vector3f(dest_loc.lat, dest_loc.lng, dest_loc.alt), Vector3f(), Vector3f());
+    sub.Log_Write_GuidedTarget(sub.guided_mode, sub.wp_nav.get_wp_destination_NEU_cm(), Vector3f(), Vector3f());
 #endif
 
     return true;

--- a/Tools/autotest/ardusub.py
+++ b/Tools/autotest/ardusub.py
@@ -7,6 +7,7 @@ Parameters are in-code defaults plus default_params/sub.parm
 AP_FLAKE8_CLEAN
 '''
 
+import math
 import os
 import re
 
@@ -173,7 +174,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
             self.arm_vehicle()
         pwm = 1300 if self.get_altitude(relative=True) > alt else 1700
         self.set_rc(Joystick.Throttle, pwm)
-        self.wait_altitude(altitude_min=alt - 1, altitude_max=alt, relative=False, timeout=timeout)
+        self.wait_altitude(altitude_min=alt - 1, altitude_max=alt, relative=True, timeout=timeout)
         self.set_rc(Joystick.Throttle, 1500)
         self.delay_sim_time(1, reason="altitude to stabilise")
         self.progress("DIVE COMPLETE")
@@ -1754,7 +1755,6 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         # Stay in GUIDED mode for the duration
         self.change_mode('GUIDED')
 
-        import math
         for run in runs:
             msg = self.assert_receive_message('LOCAL_POSITION_NED')
             start_x = msg.x
@@ -1766,6 +1766,11 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
             dest_y = start_y + dy
             dest_z = -run['target_alt']
 
+            accel_mag = 0.2
+            acc_x = accel_mag * math.cos(math.radians(run['bearing']))
+            acc_y = accel_mag * math.sin(math.radians(run['bearing']))
+            acc_z = 0.0
+
             self.progress(f"Sending target: x={dest_x:.2f}, y={dest_y:.2f}, z={dest_z:.2f} (bearing={run['bearing']})")
 
             self.mav.mav.set_position_target_local_ned_send(
@@ -1775,7 +1780,7 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
                 pva_mode,
                 dest_x, dest_y, dest_z,  # position target
                 0, 0, 0,  # velocity target
-                0, 0, 0,  # acceleration target
+                acc_x, acc_y, acc_z,  # acceleration target
                 0, 0  # yaw, yawrate
             )
 
@@ -1806,9 +1811,6 @@ class AutoTestSub(vehicle_test_suite.TestSuite):
         # Minimize vertical oscillation due to sensor delay
         self.set_parameter('PSC_D_JERK', 4.0)
         self.set_parameter('WP_ACC_Z', 5.0)
-
-        # Aim south (180 deg) so the sub travels over the simulated ridge
-        # self.reach_heading_manual(180)
 
         self.dive(-seafloor_depth + match_distance, mode="ALT_HOLD")
 

--- a/libraries/AP_Scripting/examples/guided_above_terrain_posvelaccel_sub.lua
+++ b/libraries/AP_Scripting/examples/guided_above_terrain_posvelaccel_sub.lua
@@ -38,6 +38,9 @@ local function update()
     -- calculate dt
     local tnow = millis()
     local dt = (tnow - last_time_ms):tofloat() / 1000.0
+    if dt <= 0 then
+        return update, 1000 / RUN_HZ
+    end
     -- cap dt to avoid a large integration step if execution was badly
     -- delayed, but otherwise integrate the time which actually elapsed.
     -- Substituting 1/RUN_HZ for a late callback discards the excess, and


### PR DESCRIPTION
### Summary

The AI review of backport PR https://github.com/ArduPilot/ardupilot/pull/34298 caught a few bugs in the original Sub Guided_PosVelAccel PR (https://github.com/ArduPilot/ardupilot/pull/33609) and in the surrounding code. These are addressed in this PR.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

See the backport PR for details. A summary of the problems and fixes:
* MAVLink allows the caller to send force inputs in the accel fields by setting the `MAVLINK_SET_POS_TYPE_MASK_FORCE` bit. Sub does not support this. Fix: reject targets when this bit is set. (Copied from Copter.)
* The `guided_above_terrain_posvelaccel_sub.lua` script doesn't check for dt <= 0, so it can divide by zero. Fix: check for dt <= 0.
* * Sub mixes local (x, y) and global (lat, lon) pos targets when logging to the GUIP table. Fix: convert to local coordinates for logging. This is a long-standing bug.

For the autotests:
* IMHO the `Sub.GuidedAboveTerrain` test does a good job testing the acceleration targets. I don't think it is worth repeating in `Sub.GuidedPosVelAccel`.
* I did pick up the other autotest suggestions from the review.