### PR TITLE
AP_RCTelemetry: thread safety for CRSF

### DIFF
--- a/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
+++ b/libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp
@@ -75,6 +75,7 @@
  * user-interactive elements.
  */
 
+#include "AP_HAL/Semaphores.h"
 #include "AP_RCTelemetry_config.h"
 
 #if HAL_CRSF_TELEM_ENABLED
@@ -113,6 +114,7 @@ const uint8_t AP_CRSF_Telem::PASSTHROUGH_MULTI_PACKET_FRAME_MAX_SIZE;
 const uint8_t AP_CRSF_Telem::CRSF_RX_DEVICE_PING_MAX_RETRY;
 
 AP_CRSF_Telem *AP_CRSF_Telem::singleton;
+HAL_Semaphore AP_CRSF_Telem::sem;
 
 AP_CRSF_Telem::AP_CRSF_Telem() : AP_RCTelemetry(0)
 {
@@ -140,7 +142,8 @@ bool AP_CRSF_Telem::init(void)
     }
 #endif
 
-    return AP_RCTelemetry::init();
+    _initialized = AP_RCTelemetry::init();
+    return _initialized;
 }
 
 /*
@@ -2312,15 +2315,19 @@ bool AP_CRSF_Telem::get_telem_data(AP_RCProtocol_CRSF::Frame* data, bool is_tx_a
 }
 
 AP_CRSF_Telem *AP_CRSF_Telem::get_singleton(void) {
+    WITH_SEMAPHORE(sem);
+
     if (!singleton && !hal.util->get_soft_armed()) {
         // if telem data is requested when we are disarmed and don't
         // yet have a AP_CRSF_Telem object then try to allocate one
         NEW_NOTHROW AP_CRSF_Telem();
-        // initialize the passthrough scheduler
-        if (singleton) {
-            singleton->init();
-        }
     }
+
+    // initialize the passthrough scheduler
+    if (singleton && !singleton->_initialized) {
+        singleton->init();
+    }
+
     return singleton;
 }
 

--- a/libraries/AP_RCTelemetry/AP_CRSF_Telem.h
+++ b/libraries/AP_RCTelemetry/AP_CRSF_Telem.h
@@ -468,6 +468,8 @@ private:
 
     bool _bind_request_pending;
 
+    bool _initialized;
+
     // vtx state
     bool _vtx_freq_update;  // update using the frequency method or not
     bool _vtx_dbm_update; // update using the dbm method or not
@@ -478,6 +480,7 @@ private:
     bool _noted_lq_as_rssi_active;
 
     static AP_CRSF_Telem *singleton;
+    static HAL_Semaphore sem;
 };
 
 namespace AP {


### PR DESCRIPTION
### Summary

WIP: Ensuring thread safety with the lazy initialization of `AP_CRSF_Telem`

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Will be testing on Linux hardware in a couple of days.

### Description

More of a draft and an invitation to discussion how to patch the issue properly in spirit of the codebase that a final form of PR. I've noticed that 4.7 broke RC telemetry for me (Linux HAL) and I debugged it down to this commit: https://github.com/ArduPilot/ardupilot/commit/beb6a0be0a14dff76a61663bf421333acaa1048f

The changes in the commit call `AP_RCProtocol_CRSF::bind_in_progress` which may implicitly create an `AP_CRSF_Telem` singleton object. In Linux this is problematic, because the HAL spins a separate OS thread to handle RC input which does eventually call this method. Because of reasons that might or might not (according to the comment) relate to https://github.com/ArduPilot/ardupilot/commit/9f5b4ffca49335b75ed504e40803a572d577e7e1 in the Linux HAL the scheduler is started before the `setup()` callback. On practice this means that the first time the singleton is created, there is no `SerialManager` avaiable to check if the system has a RC telemetry UART and the `AP_CRSF_Telem` singleton gets created, but fails to do its internal scheduler initialization which means it's essentially stuck. 

Stacktrace on 4.7.0 for the first `AP_CRSF_Telem::get_singleton()` hit:
```
(gdb) bt
#0  AP_CRSF_Telem::get_singleton () at ../../libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp:2313
#1  0x000000000051b0c8 in AP::crsf_telem () at ../../libraries/AP_RCTelemetry/AP_CRSF_Telem.cpp:2330
#2  0x00000000004f5d14 in AP_RCProtocol_CRSF::bind_in_progress (this=0x6f9c80) at ../../libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp:729
#3  AP_RCProtocol_CRSF::update (this=0x6f9c80) at ../../libraries/AP_RCProtocol/AP_RCProtocol_CRSF.cpp:321
#4  0x00000000004f4b70 in AP_RCProtocol::new_input (this=0x6dc910 <AP::RC()::rcprot>) at ../../libraries/AP_RCProtocol/AP_RCProtocol.cpp:500
#5  0x0000000000566438 in Linux::RCInput_RCProtocol::_timer_tick (this=0x6ddb38 <rcinDriver>) at ../../libraries/AP_HAL_Linux/RCInput_RCProtocol.cpp:162
#6  0x00000000005683c4 in Functor<void>::operator() (this=0x6dd998 <schedulerInstance+584>) at ../../libraries/AP_HAL/utility/functor.h:52
#7  Linux::PeriodicThread::_run (this=0x6dd990 <schedulerInstance+576>) at ../../libraries/AP_HAL_Linux/Thread.cpp:271
#8  Linux::PeriodicThread::_run (this=0x6dd990 <schedulerInstance+576>) at ../../libraries/AP_HAL_Linux/Thread.cpp:253
#9  0x0000000000568528 in Linux::Thread::_run_trampoline (arg=0x6dd990 <schedulerInstance+576>) at ../../libraries/AP_HAL_Linux/Thread.cpp:41
#10 0x0000fffff7b810c4 in ?? () from /usr/lib/libc.so.6
#11 0x0000fffff7be384c in ?? () from /usr/lib/libc.so.6
```

Furthermore, because `ap-rcin` is a parallel thread, it can enter `AP_CRSF_Telem::get_singleton()` concurrently with the main thread (e.g. from `GCS_Common` etc) so it's possible to have the singleton created twice and thus produce a bit of garbage too. 

My current bandaid against this is twofold:
1. Protect the singleton getter with a semaphore;
2. Introduce a flag to keep track of whether the telemetry singleton has passed its initialization or not.

The downside is that each invocation we're doing a few additional checks and there's a slight change in behaviour, i.e. if the user sets RC telemetry UARTS the singleton would pick it up on the next `get_singleton` call and activate whereas earlier it would need a reboot.

I'm additionally a bit confused by the "don't create if armed" bit of logic. Especially since in `AP_Scripting` there are a few `get_singleton()` calls that never bother to check if the result was `nullptr` or not and if the arming clause ever activates, a `nullptr` return is entirely possible. 

The same issue will manifest in `AP_GHST_Telem` eventually if it's likewise somehow created before `SerialManager`. I'll be adding a similar fix there when there's an agreement on the course of action.