### PR TITLE
AP_Bootloader: update board IDs for SparkNavi flight controllers

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -389,7 +389,10 @@ AP_HW_FlysparkF4                     1361
 
 # IDs 1362-1369 reserved for SparkNavi
 AP_HW_SPARKNAVI_BLUE                 1362
-AP_HW_SPARKNAVI_BLUE2                1363
+AP_HW_SPARKNAVI_BLUEv2               1363
+AP_HW_SPARKNAVI_F405                 1364
+AP_HW_SPARKNAVI_H743_R45             1365
+AP_HW_SPARKNAVI_ETH                  1366
 
 AP_HW_CUBEORANGE_PERIPH              1400
 AP_HW_CUBEBLACK_PERIPH               1401


### PR DESCRIPTION
### Summary

Rename the reserved board ID `AP_HW_SPARKNAVI_BLUE2` to `AP_HW_SPARKNAVI_BLUEv2` to match the naming convention used by the corresponding board port, and reserve additional IDs within the already-allocated 1362-1369 SparkNavi range for boards currently under internal development.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Confirmed that `./waf configure --board sparknavi-bluev2` and `./waf copter` build successfully with the renamed board ID definition.

### Description

This PR corrects the board ID name reserved in commit 22c91d4d69 (`AP_HW_SPARKNAVI_BLUE2` to `AP_HW_SPARKNAVI_BLUEv2`), which will be used by an upcoming SparkNavi Blue2 board port submitted separately.

It also reserves `AP_HW_SPARKNAVI_F405`, `AP_HW_SPARKNAVI_H743_R45`, and `AP_HW_SPARKNAVI_ETH` within the same previously-allocated ID range for internal SparkNavi hardware still under development. These boards have no associated hwdef in this PR and are not being submitted at this time.

This change only touches `Tools/AP_Bootloader/board_types.txt` and has no effect on runtime behavior.