### PR TITLE
AP_Bootloader: reserve board IDs 3136-3145 for MADpilot

### DIFF
--- a/Tools/AP_Bootloader/board_types.txt
+++ b/Tools/AP_Bootloader/board_types.txt
@@ -482,6 +482,8 @@ AP_HW_AET-405-Mini                   2512
 AP_HW_SakuraRC-H743                  2714
 
 AP_HW_SkyRukh_Surge_H7               2815
+# IDs 3136-3145 reserved for MADpilot
+AP_HW_MADPILOT_H7                    3141
 
 # IDs 4000-4009 reserved for Karshak Drones
 AP_HW_KRSHKF7_MINI                   4000


### PR DESCRIPTION
### Summary

Reserve bootloader board ID block 3136-3145 in \Tools/AP_Bootloader/board_types.txt\ for the MADpilot project, with ID 3141 assigned to the MADpilot-H7 flight controller.

### Classification & Testing

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually (validated registry block bounds and syntax against \oard_types.txt\ conventions)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

- **Purpose of this PR**: This PR **only** allocates a bootloader Board ID in \Tools/AP_Bootloader/board_types.txt\. It does **not** introduce any hardware definition (\hwdef\) into ArduPilot and does **not** add any build matrix targets or CI maintenance burden to upstream ArduPilot.
- **Why the ID is needed**: The board runs the ArduPilot bootloader. Registering the 16-bit \APJ_BOARD_ID\ upstream is required to avoid bootloader identification and USB/GCS firmware upload collisions with other boards across the ArduPilot ecosystem (per the guidance at the top of \oard_types.txt\).
- **Hardware & Out-of-Tree Status**: The MADpilot-H7 board definition and firmware are developed and maintained **out-of-tree**. The open project repository is public and accessible at: https://github.com/Mohameddewedar/MADpilot
- **Requested Range**: 10-ID allocation 3136–3145 (strictly adhering to the 10-ID reservation block cap), with ID 3141 assigned to \AP_HW_MADPILOT_H7\. This fills the gap between 2815 and 4000, well within the documented range guidelines.