### PR TITLE
AP_Relay: add message to array size static_assert

### DIFF
--- a/libraries/AP_Relay/AP_Relay.cpp
+++ b/libraries/AP_Relay/AP_Relay.cpp
@@ -345,7 +345,7 @@ void AP_Relay::set_defaults() {
                                       RELAY5_DEFAULT,
                                       RELAY6_DEFAULT };
 
-    static_assert(ARRAY_SIZE(pins) == ARRAY_SIZE(default_states));
+    static_assert(ARRAY_SIZE(pins) == ARRAY_SIZE(default_states), "Relay pin and default state counts must match");
 
     for (uint8_t i = 0; i < MIN(ARRAY_SIZE(_params), ARRAY_SIZE(pins)); i++) {
         // set the default


### PR DESCRIPTION
### Summary

  Fix the -Wc++17-extensions warning in the Qurt build in AP_Relay::set_defaults() by adding a
  message to static_assert.

  ### Classification & Testing (check all that apply and add your own)

  - [x] Checked by a human programmer
  - [x] Non-functional change
  - [ ] No-binary change
  - [ ] Infrastructure change (e.g. unit tests, helper scripts)
  - [ ] Automated test(s) verify changes (e.g. unit test, autotest)
  - [x] Tested manually, description below (e.g. SITL)
  - [ ] Tested on hardware
  - [ ] Logs attached
  - [ ] Logs available on request

  Confirmed the original compiler warning is resolved.

  ### Description

  Add the diagnostic message required before C++17 to the assertion comparing
  the relay pin and default state array sizes. The assertion condition and
  runtime behavior remain unchanged.

  AI-assisted: the one-line fix and PR description were prepared with AI
  assistance.
