### PR TITLE
Tools: fix Java path for arm64 Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ ARG SKIP_AP_GRAPHIC_ENV=1
 ARG SKIP_AP_COV_ENV=1
 ARG SKIP_AP_GIT_CHECK=1
 ARG DO_AP_STM_ENV=1
+ARG TARGETARCH
 
 WORKDIR /${USER_NAME}
 
@@ -46,7 +47,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 
 # Ensure Gradle uses a supported JDK (Ubuntu 24.04 defaults to Java 21, which
 # Gradle 7.6 does not support). This is only needed for the Docker build.
-ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-${TARGETARCH}
 ENV PATH="$JAVA_HOME/bin:$PATH"
 
 COPY Tools/environment_install/install-prereqs-ubuntu.sh /${USER_NAME}/Tools/environment_install/


### PR DESCRIPTION
### Summary

Fix ARM64 Docker image builds by selecting the Java 17 installation path for the target architecture instead of assuming AMD64.

### Classification & Testing

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Ubuntu installs OpenJDK in an architecture-specific directory. The Dockerfile previously set JAVA_HOME to /usr/lib/jvm/java-17-openjdk-amd64, causing ARM64 builds to fail when Gradle started.

Use Docker BuildKit's predefined TARGETARCH build argument to select the correct Java installation directory. This preserves the existing AMD64 behavior while supporting ARM64 builds.