### PR TITLE
AP_Mount: add follow sensitivity parameter for CADDX gimbals

### DIFF
--- a/libraries/AP_Mount/AP_Mount_CADDX.cpp
+++ b/libraries/AP_Mount/AP_Mount_CADDX.cpp
@@ -72,7 +72,12 @@ void AP_Mount_CADDX::send_target_angles(const MountAngleTarget& angle_target_rad
     if (angle_target_rad.roll_is_ef) {
         mode |= (uint8_t)LockMode::ROLL_LOCK;
     }
-    set_attitude_cmd_buf[2] = mode & 0x07;
+    // follow sensitivity (MNT_CADDX_SENS, -1.0 to +1.0) is packed into the signed
+    // 5-bit field (-16 to +15) in the upper bits of byte 2. +1 = most lock, -1 = least.
+    // Field range per the CADDX/XFRobot protocol (cf. INAV gimbal_serial: int16_t sensibility:5).
+    const float sens = constrain_float(_params.caddx_sens, -1.0f, 1.0f);
+    const int8_t sensitivity = constrain_int16(lroundf((sens + 1.0f) * 0.5f * 31.0f) - 16, -16, 15);
+    set_attitude_cmd_buf[2] = (mode & 0x07) | ((uint8_t)(sensitivity & 0x1F) << 3);
 
     // byte 3's lower 4 bits are reserved
     // upper 4 bits are roll's lower 4 bits

--- a/libraries/AP_Mount/AP_Mount_Params.cpp
+++ b/libraries/AP_Mount/AP_Mount_Params.cpp
@@ -173,6 +173,14 @@ const AP_Param::GroupInfo AP_Mount_Params::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("_OPTIONS", 16, AP_Mount_Params, options, 0),
 
+    // @Param: _CADDX_SENS
+    // @DisplayName: Mount CADDX/XFRobot follow sensitivity
+    // @Description: Follow sensitivity for CADDX and XFRobot gimbals. Higher values hold the camera more firmly (more lock), lower values follow the vehicle more loosely. Has no effect on other mount types.
+    // @Range: -1.0 1.0
+    // @Increment: 0.1
+    // @User: Standard
+    AP_GROUPINFO("_CADDX_SENS", 17, AP_Mount_Params, caddx_sens, 0),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_Mount/AP_Mount_Params.h
+++ b/libraries/AP_Mount/AP_Mount_Params.h
@@ -32,4 +32,5 @@ public:
     AP_Int8     sysid_default;      // target sysid for mount to follow
     AP_Int32    dev_id;             // Device id taking into account bus
     AP_Int8     options;            // mount options bitmask
+    AP_Float    caddx_sens;         // CADDX/XFRobot gimbal follow sensitivity, -1.0 (least lock) to +1.0 (most lock)
 };


### PR DESCRIPTION
What this does

Adds a new parameter, MNT1_CADDX_SENS (and MNT2_CADDX_SENS), that sets the follow sensitivity sent to CADDX / XFRobot gimbals over the serial protocol. Range is -1.0 to +1.0: +1.0 requests the most lock (tightest hold), -1.0 the least (loosest follow), 0 is neutral. It has no effect on any other mount type.

Testing

Tested on real hardware and working, on two gimbal firmware versions:

CADDX GM3 / XFRobot C-20T gimbal, tested on gimbal firmware 3.4 and 3.8, on a Matek H743 running ArduPlane.
Built and flashed a custom firmware with this change; the parameter appears in the GCS and takes effect immediately.
Swept the parameter across its full range and confirmed the value tracked on the gimbal's own configurator readout (full -1.0 .. +1.0), and the follow behaviour changed accordingly — looser follow at the low end, firmer hold at the high end.
Ran astyle with the repo's Tools/CodeStyle/astylerc: no formatting changes on the added lines.
Why

The CADDX / XFRobot set-attitude command carries a signed 5-bit follow sensitivity value, but the driver currently hardcodes it to zero on every command (see the existing comment in AP_Mount_CADDX.cpp: "lower 5 bits are sensitivity but always left as zero"). With a real gimbal this means ArduPilot always requests one fixed sensitivity, regardless of what the user wants — and on my unit the zeroed default was not usable for FPV follow.

Sensitivity control was raised repeatedly during #31461 (which added the roll/pitch earth-frame lock options) and in #30640, but was deferred there in favour of the GimbalConfig "set the sensitivity channel to Null" workaround. This PR implements the deferred piece.

Why a parameter, rather than just the "Null" workaround

The Null workaround does work, and this PR doesn't remove it — but a parameter avoids its limitations:

The Null method sets one fixed value, configured on the gimbal itself via the Windows GimbalConfig app and a serial/FTDI cable. Changing it means going back to the bench with the cable each time.
A parameter lets the value be set from the GCS that's already connected, per vehicle, live, alongside every other mount parameter — no cable, no GimbalConfig round-trip.
Implementation notes
Parameter lives in the shared AP_Mount_Params group, following the existing precedent for backend-specific params (e.g. the servo-only _LEAD_RLL / _LEAD_PTCH).
The -1.0 .. +1.0 value is mapped to the protocol's signed 5-bit field (-16 .. +15) and packed into the upper bits of byte 2, alongside the existing lock-mode bits.
The -16 .. +15 range was cross-referenced against the INAV serial gimbal driver, which drives the same gimbals and declares the field as int16_t sensibility : 5 with a documented range of -16 .. +15.
Related
#31461 (roll/pitch EF lock options — sensitivity deferred there)
#30640 (CADDX GM3 FPV mode support)
Notes
Wiki update needed: the CADDX gimbal page currently states ArduPilot forces sensitivity to zero and documents the Null workaround; that note should be updated to mention this parameter. Happy to do this as a follow-up in ardupilot_wiki.
First-time contributor — feedback welcome on placement and naming.