### PR TITLE
.github: harden workflow permissions and small fixs

### DIFF
--- a/.github/workflows/cygwin_build.yml
+++ b/.github/workflows/cygwin_build.yml
@@ -211,6 +211,8 @@ jobs:
           Tools/scripts/cygwin_build.sh &&
           ccache -s
       - uses: ./.github/actions/save-ccache
+        with:
+          key-suffix: cygwin-sitl
 
       - name: Check build files
         id: check_files

--- a/.github/workflows/qurt_build.yml
+++ b/.github/workflows/qurt_build.yml
@@ -144,6 +144,9 @@ concurrency:
   group: ci-${{github.workflow}}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     if: github.repository == 'ArduPilot/ardupilot'

--- a/.github/workflows/test_ccache.yml
+++ b/.github/workflows/test_ccache.yml
@@ -130,6 +130,9 @@ concurrency:
   group: ci-${{github.workflow}}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-22.04

--- a/.github/workflows/test_chibios.yml
+++ b/.github/workflows/test_chibios.yml
@@ -177,12 +177,8 @@ jobs:
         ]
         toolchain: [
             chibios,
-            #chibios-clang,
         ]
         gcc: [10]
-        exclude:
-          - gcc: 10
-            toolchain: chibios-clang
 
     steps:
       # git checkout the PR
@@ -198,10 +194,6 @@ jobs:
         shell: bash
         run: |
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
-          if [[ ${{ matrix.toolchain }} == "chibios-clang" ]]; then
-            export CC=clang
-            export CXX=clang++
-          fi
           PATH="/usr/lib/ccache:/opt/gcc-arm-none-eabi-${{matrix.gcc}}/bin:$PATH"
           PATH="/github/home/.local/bin:$PATH"
           Tools/scripts/build_ci.sh


### PR DESCRIPTION
Add an explicit `permissions: contents: read` to the workflows that were still relying on the (broader) default token permissions.
remove old chibios-clang things
add key-suffix for cygwin as require to pass linting


### Summary

<!-- Put a one or two line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
