### PR TITLE
.github: add actionlint CI check

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+# actionlint configuration -- https://github.com/rhysd/actionlint
+# see .github/workflows/test_workflow_lint.yml for how CI invokes it
+
+self-hosted-runner:
+  # runners actionlint cannot know about; keep in sync with the runs-on: values
+  labels:
+    - ardupilot-qurt

--- a/.github/workflows/esp32_build.yml
+++ b/.github/workflows/esp32_build.yml
@@ -205,19 +205,23 @@ jobs:
           source $IDF_PATH/export.sh
           which cmake
           ./waf configure --board ${{matrix.config}}
-          echo './waf configure --board ${{matrix.config}}' >> $GITHUB_STEP_SUMMARY  
-          echo "### Build Plane ${{matrix.config}} :rocket:" >> $GITHUB_STEP_SUMMARY
-          echo './waf plane' >> $GITHUB_STEP_SUMMARY  
-          ./waf plane | tee >( grep -vE 'Compiling|Generat|includes.list|Parsing|Validation|Building|Linking|Detecting|linker|\*\*\*\*\*\*\*|Partition|SubType|Checking|esp-idf' --color=never --line-buffered > summary.log)  
-          cat summary.log >> $GITHUB_STEP_SUMMARY 
+          {
+            echo './waf configure --board ${{matrix.config}}'
+            echo "### Build Plane ${{matrix.config}} :rocket:"
+            echo './waf plane'
+          } >> $GITHUB_STEP_SUMMARY
+          ./waf plane | tee >( grep -vE 'Compiling|Generat|includes.list|Parsing|Validation|Building|Linking|Detecting|linker|\*\*\*\*\*\*\*|Partition|SubType|Checking|esp-idf' --color=never --line-buffered > summary.log)
+          cat summary.log >> $GITHUB_STEP_SUMMARY
 
           cp build/${{matrix.config}}/esp-idf_build/ardupilot.bin ./ArduPlane.${{matrix.config}}.bin
           cp build/${{matrix.config}}/esp-idf_build/ardupilot.elf ./ArduPlane.${{matrix.config}}.elf
-          echo "### Build Copter ${{matrix.config}} :rocket:" >> $GITHUB_STEP_SUMMARY
-          echo './waf copter' >> $GITHUB_STEP_SUMMARY  
-          ./waf copter | tee >( grep -vE 'Compiling|Generat|includes.list|Parsing|Validation|Building|Linking|Detecting|linker|\*\*\*\*\*\*\*|Partition|SubType|Checking|esp-idf' --color=never --line-buffered > summary2.log)  
+          {
+            echo "### Build Copter ${{matrix.config}} :rocket:"
+            echo './waf copter'
+          } >> $GITHUB_STEP_SUMMARY
+          ./waf copter | tee >( grep -vE 'Compiling|Generat|includes.list|Parsing|Validation|Building|Linking|Detecting|linker|\*\*\*\*\*\*\*|Partition|SubType|Checking|esp-idf' --color=never --line-buffered > summary2.log)
 
-          cat summary2.log >> $GITHUB_STEP_SUMMARY  
+          cat summary2.log >> $GITHUB_STEP_SUMMARY
 
           cp build/${{matrix.config}}/esp-idf_build/ardupilot.bin ./ArduCopter.${{matrix.config}}.bin
           cp build/${{matrix.config}}/esp-idf_build/ardupilot.elf ./ArduCopter.${{matrix.config}}.elf

--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -167,6 +167,7 @@ jobs:
             export DO_AP_STM_ENV=0
           fi
           Tools/environment_install/install-prereqs-mac.sh -y
+          # shellcheck source=/dev/null
           source ~/.bash_profile
       - uses: ./.github/actions/setup-ccache
         with:
@@ -176,6 +177,7 @@ jobs:
           CI_BUILD_TARGET: ${{matrix.config}}
         shell: bash
         run: |
+          # shellcheck source=/dev/null
           source ~/.bash_profile
           PATH="/github/home/.local/bin:$PATH"
           echo $PATH

--- a/.github/workflows/test_sitl_periph.yml
+++ b/.github/workflows/test_sitl_periph.yml
@@ -214,7 +214,7 @@ jobs:
         shell: bash
         run: |
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
-          kernel_ver=`uname -r`
+          kernel_ver=$(uname -r)
           if [ "$kernel_ver" = "5.4.0-1032-azure" ] || [ "$kernel_ver" = "5.11.4-051104-generic" ]; then echo "Unsupported Kernel $kernel_ver" && exit 0; fi;
           PATH="/github/home/.local/bin:$PATH"
           Tools/scripts/build_ci.sh

--- a/.github/workflows/workflows_lint.yml
+++ b/.github/workflows/workflows_lint.yml
@@ -1,0 +1,49 @@
+name: workflows lint
+
+on:
+  push:
+    branches: ['**']  # excludes tag pushes
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+      - '.github/actionlint.yaml'
+
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+      - '.github/actionlint.yaml'
+
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{github.workflow}}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-slim
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: 'false'
+          persist-credentials: false
+
+      - name: Install actionlint
+        id: actionlint
+        run: bash <(curl -s https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash) 1.7.12
+        shell: bash
+
+      # workflow syntax, action inputs, matrix and runner labels; see
+      # .github/actionlint.yaml.  SC2086 (unquoted expansions) is pre-existing
+      # quoting style across the build scripts, not something a workflow edit
+      # should be blocked on.
+      - name: actionlint
+        run: ${{ steps.actionlint.outputs.executable }} -color
+        shell: bash
+        env:
+          SHELLCHECK_OPTS: -e SC2086


### PR DESCRIPTION


### Summary

Add linter for CI workflow

Lints workflow syntax, action inputs, and runner labels/matrix on every push and pull request touching the workflows or composite actions.
close https://github.com/ArduPilot/ardupilot/pull/33213
needs https://github.com/ArduPilot/ardupilot/pulls

This is runable locally with actionlint. 
This add a new workflow to enforce the workflow correctness !

To follow zizmor and a python script to check even more stuff


### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
