### PR TITLE
AP_Logger, add dBm unit to log structure

### DIFF
--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -70,6 +70,7 @@ const struct UnitStructure log_Units[] = {
     { 't', "N.m" },           // Newton meters, torque
     { 'q', "rpm" },           // rounds per minute. Not SI, but sometimes more intuitive than Hertz
     { 'r', "rad" },           // radians
+    { 'R', "dBm" },           // decibel-milliwatt (referenced to 1 mW)
     { 'U', "deglongitude" },  // degrees of longitude
     { 'u', "ppm" },           // pulses per minute
     { 'v', "V" },             // Volt


### PR DESCRIPTION
### Summary

I kindly ask to add a unit specifier for dBm to the log structure. It may not be used inside ArduPilot code, but Lua scripts are allowed to define their own datalog messages, where it can be highly useful. The specific application is mLRS, which provides an ArduPilot Lua script which allows us to log substantial link performance and link information metrics, among which are lots of "dBm types", such as rssi, snr and power.

### Classification & Testing (check all that apply and add your own)

- [ x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
