### PR TITLE
AP_Math: speedup unit test

### DIFF
--- a/libraries/AP_Math/tests/test_math.cpp
+++ b/libraries/AP_Math/tests/test_math.cpp
@@ -710,11 +710,13 @@ TEST(CRCTest, parity)
 
 TEST(MathTest, div1000)
 {
+    uint64_t v[32];
     for (uint32_t i=0; i<1000000; i++) {
-        uint64_t v;
-        EXPECT_EQ(hal.util->get_random_vals((uint8_t*)&v, sizeof(v)), true);
-        uint64_t v1 = v / 1000ULL;
-        uint64_t v2 = uint64_div1000(v);
+        if ((i%ARRAY_SIZE(v)) == 0) {
+            EXPECT_EQ(hal.util->get_random_vals((uint8_t*)v, sizeof(v)), true);
+        }
+        uint64_t v1 = v[i%ARRAY_SIZE(v)] / 1000ULL;
+        uint64_t v2 = uint64_div1000(v[i%ARRAY_SIZE(v)]);
         EXPECT_EQ(v1, v2);
     }
 }


### PR DESCRIPTION
### Summary

Speed up test_math, which is mostly testing div1000.

### Classification & Testing (check all that apply and add your own)

- [X] Checked by a human programmer
- [X] Non-functional change
- [ ] No-binary change
- [X] Infrastructure change (e.g. unit tests, helper scripts)
- [X] Automated test(s) verify changes (e.g. unit test, autotest)
- [X] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Tested on SITL on PC and RPi4.

### Description

The div1000 test takes around 10 seconds on my RPi4, most of which is 3x OS system calls per random u64.
Fetch more random values at once to spread this overhead out.. 

| Platform | Before          | After |
|-----------|---------------|-------|
| PC           | ~4 s| ~0.25s |
| RPi3        | ~10s| ~0.5s |
| RPi4        | ~9 s| ~0.4s |