### PR TITLE
Fix weekly code coverage / lcov

### DIFF
--- a/Tools/ardupilotwaf/boards.py
+++ b/Tools/ardupilotwaf/boards.py
@@ -248,6 +248,24 @@ class Board:
         return (int(major) < want_major or
                 (int(major) == want_major and int(minor) <= want_minor))
 
+    def configure_coverage(self, cfg):
+        """Apply the coverage flags.
+
+        Called after the configure checks have run, rather than from
+        configure_env: cfg.check() links small probe programs, and
+        instrumenting those drags in libgcov, whose malloc call
+        -Wl,--wrap,malloc rewrites into an undefined __wrap_malloc.  The
+        probe then fails to link and waf records the feature it was
+        probing for as missing.
+        """
+        if not cfg.env.COVERAGE:
+            return
+        cfg.env.CFLAGS += ['-fprofile-arcs', '-ftest-coverage']
+        cfg.env.CXXFLAGS += ['-fprofile-arcs', '-ftest-coverage']
+        cfg.env.LINKFLAGS += ['-lgcov', '-coverage']
+        # cfg.env is post-merge, where DEFINES is a list of NAME=value
+        cfg.env.DEFINES += ['HAL_COVERAGE_BUILD=1']
+
     def configure_env(self, cfg, env):
         # Use a dictionary instead of the conventional list for definitions to
         # make easy to override them. Convert back to list before consumption.
@@ -342,23 +360,6 @@ class Board:
             env.CFLAGS += [
                 '-g',
             ]
-        if cfg.env.COVERAGE:
-            env.CFLAGS += [
-                '-fprofile-arcs',
-                '-ftest-coverage',
-            ]
-            env.CXXFLAGS += [
-                '-fprofile-arcs',
-                '-ftest-coverage',
-            ]
-            env.LINKFLAGS += [
-                '-lgcov',
-                '-coverage',
-            ]
-            env.DEFINES.update(
-                HAL_COVERAGE_BUILD = 1,
-            )
-
         if cfg.options.bootloader:
             # don't let bootloaders try and pull scripting in
             cfg.options.disable_scripting = True

--- a/Tools/scripts/run_coverage.py
+++ b/Tools/scripts/run_coverage.py
@@ -7,6 +7,7 @@ Runs tests with gcov coverage support.
 """
 import argparse
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -36,6 +37,30 @@ class CoverageRunner(object):
         self.verbose = verbose
         self.check_tests = check_tests
         self.start_time = time.time()
+
+    def lcov_ignore_errors(self, *classes):
+        """Return --ignore-errors arguments for the given lcov error classes.
+
+        lcov 2.x promotes several conditions to fatal errors which 1.x
+        merely warned about (or did not check at all):
+
+         - "mismatch": two functions defined on the same source line
+           with different end lines.  Every gtest TEST() body trips
+           this, as the macro also defines the fixture's constructor and
+           destructor on that line.
+         - "unused": an --exclude/--remove pattern which matched nothing.
+
+        lcov 1.x rejects unknown error classes outright, so the
+        arguments are only emitted for 2.x and later.
+        """
+        try:
+            output = subprocess.run(["lcov", "--version"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True).stdout
+        except OSError:
+            return []
+        match = re.search(r"version (\d+)", output)
+        if match is None or int(match.group(1)) < 2:
+            return []
+        return ["--ignore-errors", ",".join(classes)]
 
     def progress(self, text) -> None:
         """Pretty printer."""
@@ -80,6 +105,7 @@ class CoverageRunner(object):
         self.progress("Initializing Coverage with current build")
         try:
             result = subprocess.run(["lcov",
+                                     *self.lcov_ignore_errors("mismatch"),
                                      "--no-external",
                                      "--initial",
                                      "--capture",
@@ -204,6 +230,7 @@ class CoverageRunner(object):
                 try:
                     self.progress("Capturing Coverage statistics")
                     subprocess.run(["lcov",
+                                    *self.lcov_ignore_errors("mismatch"),
                                     "--no-external",
                                     "--capture",
                                     "--directory", root_dir,
@@ -230,6 +257,7 @@ class CoverageRunner(object):
                     # remove files we do not intentionally test:
                     self.progress("Removing unwanted coverage statistics")
                     subprocess.run(["lcov",
+                                    *self.lcov_ignore_errors("unused"),
                                     "--remove", self.INFO_FILE,
                                     ".waf*",
                                     root_dir + "/modules/*",

--- a/wscript
+++ b/wscript
@@ -628,6 +628,7 @@ def configure(cfg):
         else:
             cfg.end_msg('disabled', color='YELLOW')
 
+    cfg.get_board().configure_coverage(cfg)
     cfg.start_msg('Coverage build')
     if cfg.env.COVERAGE:
         cfg.end_msg('enabled')


### PR DESCRIPTION
### Summary

lcov weekly is broken in two different ways - fix both

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

coverage seems to work locally for me:
```
****** AT-7112.1: Coverage successful. Open /home/pbarker/rc/ardupilot/reports/lcov-report/index.html
real    118m32.114s
user    203m32.293s
sys     38m37.371s
```

### Description

 - bswap16 was a latent problem introduced by ordering dependency
 - update of CI machines uncovered lcov version problem