### PR TITLE
RC_Channel: add ARM auxiliary switch option (188)

### DIFF
--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -253,6 +253,7 @@ const AP_Param::GroupInfo RC_Channel::var_info[] = {
     // @Values{Copter, Rover, Plane, Blimp, Sub}: 185:Mount Roll/Pitch Lock
     // @Values{Copter, Rover, Plane, Blimp, Sub}: 186:Mount POI Lock
     // @Values{Copter, Rover, Plane, Blimp, Sub}: 187:EKF Reset
+    // @Values{Copter, Rover, Plane, Blimp, Sub}: 188:Arm
     // @Values{Rover}: 201:Roll
     // @Values{Rover}: 202:Pitch
     // @Values{Rover}: 207:MainSail
@@ -699,6 +700,7 @@ void RC_Channel::init_aux_function(const AUX_FUNC ch_option, const AuxSwitchPos 
     case AUX_FUNC::COMPASS_LEARN:
 #if AP_ARMING_ENABLED
     case AUX_FUNC::DISARM:
+    case AUX_FUNC::ARM:
 #endif
     case AUX_FUNC::DO_NOTHING:
 #if AP_GRIPPER_ENABLED
@@ -1057,6 +1059,7 @@ bool RC_Channel::init_position_on_first_radio_read(AUX_FUNC func) const
     case AUX_FUNC::ARMDISARM_AIRMODE:
     case AUX_FUNC::ARMDISARM:
     case AUX_FUNC::ARM_EMERGENCY_STOP:
+    case AUX_FUNC::ARM:
 #endif
 #if HAL_PARACHUTE_ENABLED
     case AUX_FUNC::PARACHUTE_RELEASE:
@@ -1611,6 +1614,12 @@ bool RC_Channel::do_aux_function(const AuxFuncTrigger &trigger)
     case AUX_FUNC::DISARM:
         if (ch_flag == AuxSwitchPos::HIGH) {
             AP::arming().disarm(AP_Arming::Method::AUXSWITCH);
+        }
+        break;
+
+    case AUX_FUNC::ARM:
+        if (ch_flag == AuxSwitchPos::HIGH) {
+            AP::arming().arm(AP_Arming::Method::AUXSWITCH, true);
         }
         break;
 #endif

--- a/libraries/RC_Channel/RC_Channel.h
+++ b/libraries/RC_Channel/RC_Channel.h
@@ -375,6 +375,9 @@ public:
 #if AP_AHRS_EKF_RESET_ENABLED
         EKF_RESET =          187, // trigger full EKF bootstrap reset
 #endif  // AP_AHRS_EKF_RESET_ENABLED
+#if AP_ARMING_ENABLED
+        ARM =                188, // arm vehicle on high, nothing on low
+#endif  // AP_ARMING_ENABLED
         // inputs from 200 will eventually used to replace RCMAP
         ROLL =               201, // roll input
         PITCH =              202, // pitch input


### PR DESCRIPTION
### Summary

Add a standalone `ARM` auxiliary switch option (`AUX_FUNC::ARM = 188`) to allow arming the vehicle when the switch is high, without performing any action when low.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

**Testing description:**
- **Hardware test (StampFly + Game Controller):**
  Verified on actual hardware using an M5StampFly controlled with a game controller. Because gamepad buttons only produce momentary binary states (HIGH when pressed, LOW when released), this `ARM` function reliably arms the drone when pressed, and keeping it armed when released (unlike `ARMDISARM` which would immediately disarm upon release).
- **SITL test (Copter):**
  Assigned RC channel option to `188 (Arm)`. Verified that setting the channel to HIGH triggers arming (via `AP_Arming::Method::AUXSWITCH`), and returning to LOW leaves the vehicle safely armed.

### Description

#### Motivation
Currently, ArduPilot provides several arm/disarm auxiliary switch functions:
- `DISARM = 81`: Disarm on HIGH, nothing on LOW.
- `ARMDISARM = 153`: Arm on HIGH, disarm on LOW.
- `ARMDISARM_AIRMODE = 154`: Arm on HIGH (with airmode), disarm on LOW.
- `ARM_EMERGENCY_STOP = 165`: Arm on HIGH, emergency motor stop on LOW.

However, there is no direct counterpart to `DISARM = 81`. 

When controlling a vehicle with a **game controller or gamepad**, there are no physical latching toggle switches—only momentary buttons (HIGH when pushed, LOW when released). If a gamepad button is mapped to `ARMDISARM (153)`, the vehicle will arm when the button is pressed, but will immediately disarm as soon as the pilot releases the button.

This dedicated `ARM` option (arm on HIGH, do nothing on LOW) solves this problem, allowing pilots to safely arm with a momentary button on gamepads, custom transmitters, or GCS screen buttons without the risk of unintentional in-flight disarming when released.

#### Changes
- `libraries/RC_Channel/RC_Channel.h`:
  - Added `ARM = 188` to `AUX_FUNC` enum (guarded by `AP_ARMING_ENABLED`).
- `libraries/RC_Channel/RC_Channel.cpp`:
  - Documented `@Values: 188:Arm`.
  - Added `case AUX_FUNC::ARM:` handling to invoke `AP::arming().arm(AP_Arming::Method::AUXSWITCH, true)` when `ch_flag == AuxSwitchPos::HIGH`.

#### AI Assistance
- This contribution was developed with AI assistance (Claude / Gemini), and reviewed, tested, and verified on real hardware by a human developer.
