### PR TITLE
Small airspeed-related changes

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -18838,6 +18838,74 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         if not saw_prearm:
             raise NotAchievedException("pre-arm checks did not run")
 
+    def AHRSExternalNoAttitudeAirspeedIndex(self):
+        '''the External AHRS backend reports which airspeed sensor is in
+        use even when it has no attitude.  Unlike Plane, Copter does not
+        fall back to DCM when the External backend has no attitude, so
+        here the External backend's index is the one reported'''
+        # AIRSPEED.flags bit 1 is AIRSPEED_SENSOR_USING, set on the
+        # sensor the AHRS is taking its airspeed from:
+        AIRSPEED_SENSOR_USING = 2
+
+        # a VectorNav external AHRS is configured on serial4 but
+        # nothing is attached, so it never supplies an attitude:
+        self.set_parameters({
+            "EAHRS_TYPE": 1,            # VectorNav
+            "SERIAL4_PROTOCOL": 36,
+            "SERIAL4_BAUD": 230400,
+            "ARSPD_ENABLE": 1,
+            "ARSPD_TYPE": 100,          # SITL
+            "ARSPD_USE": 1,
+            "ARSPD2_TYPE": 2,           # analog
+            "ARSPD2_USE": 1,
+            "ARSPD2_PIN": 2,
+        })
+        self.reboot_sitl()
+        self.set_message_rate_hz('AIRSPEED', 10)
+
+        # the change of backend is only announced if it happens after
+        # boot, so select External now rather than before the reboot:
+        self.context_collect("STATUSTEXT")
+        self.set_parameter("AHRS_EKF_TYPE", 11)
+        self.wait_statustext("AHRS: External active", timeout=60, check_context=True)
+
+        # the External backend really has no attitude; the vehicle's
+        # true attitude is never exactly zero on all three axes:
+        m = self.assert_receive_message('ATTITUDE', verbose=True)
+        if m.roll != 0 or m.pitch != 0 or m.yaw != 0:
+            raise NotAchievedException("External AHRS unexpectedly has an attitude")
+
+        def wait_ahrs_using_airspeed_sensor(instance, minimum_duration=2, timeout=30):
+            '''wait for the AIRSPEED messages from both sensors to show
+            the AHRS using sensor instance and not the other one,
+            continuously for minimum_duration seconds'''
+            description = "AHRS using airspeed sensor %u only" % (instance+1)
+            self.progress("Waiting for %s" % description)
+            flags = [0, 0]
+            flags[instance] = AIRSPEED_SENSOR_USING
+            tstart = self.get_sim_time()
+            pass_start = None
+            while True:
+                now = self.get_sim_time_cached()
+                if now - tstart > timeout:
+                    raise NotAchievedException("Did not get %s" % description)
+                a0 = self.assert_receive_message('AIRSPEED', instance=0)
+                a1 = self.assert_receive_message('AIRSPEED', instance=1)
+                if a0.flags != flags[0] or a1.flags != flags[1]:
+                    pass_start = None
+                    continue
+                if pass_start is None:
+                    pass_start = now
+                if now - pass_start >= minimum_duration:
+                    return
+
+        # ARSPD_PRIMARY=1 selects the second sensor, 0 the first.
+        # Start and end on the second sensor so a backend reporting a
+        # constant zero is caught:
+        for primary in 1, 0, 1:
+            self.set_parameter("ARSPD_PRIMARY", primary)
+            wait_ahrs_using_airspeed_sensor(primary)
+
     def AHRSOriginRecorded(self):
         """Test AHRS option to record and reuse origin"""
         self.context_push()
@@ -20691,6 +20759,7 @@ return update, 1000
             self.CommonOrigin,
             self.CommonOriginExternalAHRS,
             self.CommonOriginExternalAHRSReceives,
+            self.AHRSExternalNoAttitudeAirspeedIndex,
             self.AHRSOriginRecorded,
             self.TestTetherStuck,
             self.ScriptingFlipMode,

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -7,6 +7,7 @@ AP_FLAKE8_CLEAN
 import math
 import operator
 import os
+import re
 import signal
 import time
 
@@ -4644,6 +4645,99 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         AHRS keeps reporting ARSPD_PRIMARY in use, as its active backend
         has no per-core selection'''
         self._EKF3AirspeedAffinity(force_dcm=True)
+
+    def AHRSActiveAirspeedIndex(self):
+        '''every AHRS backend reports which airspeed sensor it is taking
+        its airspeed from, and that follows ARSPD_PRIMARY.  Each backend
+        fills in that index itself, and one which forgets is
+        indistinguishable from one reporting the first sensor at the
+        default ARSPD_PRIMARY, so the second sensor is made primary here'''
+        # AIRSPEED.flags bit 1 is AIRSPEED_SENSOR_USING, set on the
+        # sensor the AHRS is taking its airspeed from:
+        AIRSPEED_SENSOR_USING = 2
+
+        # bring up a VectorNav external AHRS on serial4 so that
+        # AHRS_EKF_TYPE=11 (External) is a valid selection, and enable
+        # EKF2 so that it too has a running backend:
+        self.customise_SITL_commandline(["--serial4=sim:VectorNav"])
+        self.set_parameters({
+            "EAHRS_TYPE": 1,            # VectorNav
+            "SERIAL4_PROTOCOL": 36,
+            "SERIAL4_BAUD": 230400,
+            "EK2_ENABLE": 1,
+            "EK3_ENABLE": 1,
+            "AHRS_EKF_TYPE": 3,
+            "ARSPD2_TYPE": 2,
+            "ARSPD2_USE": 1,
+            "ARSPD2_PIN": 2,
+        })
+        self.context_collect("STATUSTEXT")
+        self.reboot_sitl()
+
+        def wait_ahrs_using_airspeed_sensor(instance, minimum_duration=2, timeout=30):
+            '''wait for the AIRSPEED messages from both sensors to show
+            the AHRS using sensor instance and not the other one,
+            continuously for minimum_duration seconds'''
+            description = "AHRS using airspeed sensor %u only" % (instance+1)
+            self.progress("Waiting for %s" % description)
+            flags = [0, 0]
+            flags[instance] = AIRSPEED_SENSOR_USING
+            tstart = self.get_sim_time()
+            pass_start = None
+            while True:
+                now = self.get_sim_time_cached()
+                if now - tstart > timeout:
+                    raise NotAchievedException("Did not get %s" % description)
+                a0 = self.assert_receive_message('AIRSPEED', instance=0)
+                a1 = self.assert_receive_message('AIRSPEED', instance=1)
+                if a0.flags != flags[0] or a1.flags != flags[1]:
+                    pass_start = None
+                    continue
+                if pass_start is None:
+                    pass_start = now
+                if now - pass_start >= minimum_duration:
+                    return
+
+        def last_announced_backend():
+            '''the backend named by the most recent "AHRS: <name> active"
+            statustext, or None if none has been collected'''
+            ret = None
+            for m in self.context_collection("STATUSTEXT"):
+                match = re.match(r"AHRS: (\S+) active", m.text)
+                if match is not None:
+                    ret = match.group(1)
+            return ret
+
+        # EKF3 is the boot selection, announced during boot; it comes
+        # round again last so that it too is checked after a change of
+        # backend, where only a fresh announcement will do:
+        for (ahrs_type, shortname) in [
+                (3, "EKF3"),
+                (0, "DCM"),
+                (2, "EKF2"),
+                (10, "SIM"),
+                (11, "External"),
+                (3, "EKF3"),
+        ]:
+            self.start_subtest("%s (AHRS_EKF_TYPE=%u) reports the sensor it uses" %
+                               (shortname, ahrs_type))
+            self.set_parameter("AHRS_EKF_TYPE", ahrs_type)
+            self.wait_statustext("AHRS: %s active" % shortname, timeout=60, check_context=True)
+            # ARSPD_PRIMARY=1 selects the second sensor, 0 the first.
+            # Start and end on the second sensor so a backend reporting
+            # a constant zero is caught whether or not it has been
+            # updated in the meantime:
+            for primary in 1, 0, 1:
+                self.set_parameter("ARSPD_PRIMARY", primary)
+                wait_ahrs_using_airspeed_sensor(primary)
+            # the flags must have come from the backend under test, not
+            # from a fallback to DCM in the meantime:
+            announced = last_announced_backend()
+            if announced != shortname:
+                raise NotAchievedException(
+                    "Active backend is %s, expected %s" % (announced, shortname))
+            # announcements from this stage are not evidence for the next:
+            self.context_clear_collection("STATUSTEXT")
 
     def FenceAltCeilFloor(self):
         '''Tests the fence ceiling and floor'''
@@ -9399,6 +9493,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.EKFlaneswitch,
             self.EKF3AirspeedAffinity,
             self.EKF3AirspeedAffinityDCM,
+            self.AHRSActiveAirspeedIndex,
             self.AirspeedDrivers,
             self.RTL_CLIMB_MIN,
             self.ClimbBeforeTurn,

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -2034,33 +2034,6 @@ bool AP_AHRS::get_vel_innovations_and_variances_for_source(uint8_t source, Vecto
     return false;
 }
 
-//get the index of the active airspeed sensor, wrt the primary core
-uint8_t AP_AHRS::get_active_airspeed_index() const
-{
-#if AP_AIRSPEED_ENABLED
-    const auto *airspeed = AP::airspeed();
-    if (airspeed == nullptr) {
-        return 0;
-    }
-
-// we only have affinity for EKF3 as of now
-#if HAL_NAVEKF3_AVAILABLE
-    if (active_EKF_type() == EKFType::THREE) {
-        uint8_t ret = ekf3.EKF3.getActiveAirspeed();
-        if (ret != UINT8_MAX && airspeed->healthy(ret) && airspeed->use(ret)) {
-            return ret;
-        }
-    }
-#endif
-
-    // for the rest, let the primary airspeed sensor be used
-    return airspeed->get_primary();
-#else
-
-    return 0;
-#endif // AP_AIRSPEED_ENABLED
-}
-
 #if AP_AIRSPEED_ENABLED
 // returns true if airspeed sensor data is being consumed by the
 // active backend.  Note that this does *not* indicate the results

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -759,13 +759,14 @@ bool AP_AHRS::_should_use_airspeed_sensor(uint8_t airspeed_index) const
 // if we have an estimate
 bool AP_AHRS::_airspeed_EAS(float &airspeed_ret, AirspeedEstimateType &airspeed_estimate_type) const
 {
-#if AP_AHRS_DCM_ENABLED || (AP_AIRSPEED_ENABLED && AP_GPS_ENABLED)
+#if AP_AHRS_DCM_ENABLED || AP_AIRSPEED_ENABLED
     const uint8_t idx = get_active_airspeed_index();
 #endif
-#if AP_AIRSPEED_ENABLED && AP_GPS_ENABLED
+#if AP_AIRSPEED_ENABLED
     if (_should_use_airspeed_sensor(idx)) {
         airspeed_ret = AP::airspeed()->get_airspeed(idx);
 
+#if AP_GPS_ENABLED
         if (_wind_max > 0 && AP::gps().status() >= AP_GPS_FixType::FIX_2D) {
             // constrain the airspeed by the ground speed
             // and AHRS_WIND_MAX
@@ -776,10 +777,12 @@ bool AP_AHRS::_airspeed_EAS(float &airspeed_ret, AirspeedEstimateType &airspeed_
                                             gnd_speed + _wind_max);
             airspeed_ret = true_airspeed / get_EAS2TAS();
         }
+#endif  // AP_GPS_ENABLED
+
         airspeed_estimate_type = AirspeedEstimateType::AIRSPEED_SENSOR;
         return true;
     }
-#endif
+#endif  // AP_AIRSPEED_ENABLED
 
     if (!get_wind_estimation_enabled()) {
         airspeed_estimate_type = AirspeedEstimateType::NO_NEW_ESTIMATE;

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -450,12 +450,16 @@ public:
     }
 #endif  // AP_AHRS_GET_MAG_DATA_ENABLED
 
-    // return the index of the airspeed we should use for airspeed measurements
-    // with multiple airspeed sensors and airspeed affinity in EKF3, it is possible to have switched
-    // over to a lane not using the primary airspeed sensor, so AHRS should know which airspeed sensor
-    // to use, i.e, the one being used by the primary lane. A lane switch could have happened due to an 
-    // airspeed sensor fault, which makes this even more necessary
-    uint8_t get_active_airspeed_index() const;
+    // return the index of the airspeed sensor the active backend is
+    // using for airspeed measurements.  Backends which do not track
+    // which sensor they are using report the primary sensor.
+    uint8_t get_active_airspeed_index() const {
+#if AP_AIRSPEED_ENABLED
+        return active_estimates->active_airspeed_index;
+#else
+        return 0;
+#endif
+    }
 
     // get the index of the current primary accelerometer sensor
     uint8_t get_primary_accel_index(void) const { return state.primary_accel; }

--- a/libraries/AP_AHRS/AP_AHRS_Backend.h
+++ b/libraries/AP_AHRS/AP_AHRS_Backend.h
@@ -190,6 +190,9 @@ public:
         /*
          * Sensor-related information
          */
+#if AP_AIRSPEED_ENABLED
+        uint8_t active_airspeed_index;
+#endif  // AP_AIRSPEED_ENABLED
 
         // configured_to_use_gps will be true if the estimator will
         // use GPS data in creating its estimate when the data is good
@@ -337,6 +340,18 @@ public:
     }
 
 protected:
+
+#if AP_AIRSPEED_ENABLED
+    // returns the index of the primary airspeed sensor, or zero if
+    // there is no airspeed library
+    static uint8_t primary_airspeed_index() {
+        const auto *airspeed = AP::airspeed();
+        if (airspeed != nullptr) {
+            return airspeed->get_primary();
+        }
+        return 0;
+    }
+#endif  // AP_AIRSPEED_ENABLED
 
     // update our wind speed estimate.  velocity is a current velocity
     // estimate in m/s in NED frame.  fuselageDirection is the vehicle's

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -249,6 +249,14 @@ void AP_AHRS_DCM::get_results(AP_AHRS_Backend::Estimates &results)
     /*
      * Sensor-related information
      */
+
+#if AP_AIRSPEED_ENABLED
+    // we always use the primary airspeed instance.  We don't have
+    // a single place which actually updates that, so this *might*
+    // be a little stale:
+    results.active_airspeed_index = primary_airspeed_index();
+#endif  // AP_AIRSPEED_ENABLED
+
     // true if the estimator will use GPS data in creating its
     // estimate when the data is good:
     results.configured_to_use_gps = _gps_use != GPSUse::Disable;
@@ -1254,14 +1262,12 @@ bool AP_AHRS_DCM::get_location(Location &loc) const
 bool AP_AHRS_Backend::airspeed_EAS(bool have_velocity_source, float &airspeed_ret) const
 {
 #if AP_AIRSPEED_ENABLED
-    const auto *airspeed = AP::airspeed();
-    if (airspeed != nullptr) {
-        return airspeed_EAS(have_velocity_source, airspeed->get_primary(), airspeed_ret);
-    }
-#endif
-    // airspeed_estimate will also make this nullptr check and act
+    return airspeed_EAS(have_velocity_source, primary_airspeed_index(), airspeed_ret);
+#else
+    // airspeed_estimate will also make the nullptr check and act
     // appropriately when we call it with a dummy sensor ID.
     return airspeed_EAS(have_velocity_source, 0, airspeed_ret);
+#endif
 }
 
 // return an (equivalent) airspeed estimate:

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -1277,6 +1277,7 @@ bool AP_AHRS_Backend::airspeed_EAS(bool have_velocity_source, uint8_t airspeed_i
         return false;
     }
 
+#if AP_GPS_ENABLED
     const float _wind_max = AP::ahrs().get_max_wind();
     if (_wind_max > 0 && AP::gps().status() >= AP_GPS_FixType::FIX_2D) {
         // constrain the airspeed by the ground speed
@@ -1288,6 +1289,7 @@ bool AP_AHRS_Backend::airspeed_EAS(bool have_velocity_source, uint8_t airspeed_i
                                         gnd_speed + _wind_max);
         airspeed_ret = true_airspeed / get_EAS2TAS();
     }
+#endif  // AP_GPS_ENABLED
 
     return true;
 }

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -857,11 +857,13 @@ AP_AHRS_DCM::drift_correction(float deltat)
         }
 
         float airspeed_TAS = _last_airspeed_TAS;
+
 #if AP_AIRSPEED_ENABLED
-        if (airspeed_sensor_enabled()) {
-            airspeed_TAS = AP::airspeed()->get_airspeed() * get_EAS2TAS();
+        const auto *airspeed = AP::airspeed();
+        if (airspeed != nullptr && airspeed->use() && airspeed->healthy()) {
+            airspeed_TAS = airspeed->get_airspeed() * get_EAS2TAS();
         }
-#endif
+#endif  // AP_AIRSPEED_ENABLED
 
         // use airspeed to estimate our ground velocity in
         // earth frame by subtracting the wind

--- a/libraries/AP_AHRS/AP_AHRS_DCM.h
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.h
@@ -140,26 +140,6 @@ private:
     // update our wind estimate from the latest GPS velocity and attitude:
     void estimate_wind(void);
 
-    // returns true if DCM should consume airspeed data
-    static bool airspeed_sensor_enabled(void) {
-    #if AP_AIRSPEED_ENABLED
-        const AP_Airspeed *_airspeed = AP::airspeed();
-        return _airspeed != nullptr && _airspeed->use() && _airspeed->healthy();
-    #else
-        return false;
-    #endif
-    }
-
-    // returns true if DCM should consume airspeed data
-    static bool airspeed_sensor_enabled(uint8_t airspeed_index) {
-    #if AP_AIRSPEED_ENABLED
-        const AP_Airspeed *_airspeed = AP::airspeed();
-        return _airspeed != nullptr && _airspeed->use(airspeed_index) && _airspeed->healthy(airspeed_index);
-    #else
-        return false;
-    #endif
-    }
-
     // primary representation of attitude of board used for all inertial calculations
     Matrix3f _dcm_matrix;
 

--- a/libraries/AP_AHRS/AP_AHRS_External.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_External.cpp
@@ -34,6 +34,14 @@ void AP_AHRS_External::get_results(AP_AHRS_Backend::Estimates &results)
     // results.control_height_limit_valid = false;
     // results.control_height_limit_m = 0;
 
+#if AP_AIRSPEED_ENABLED
+    // External may or may not be using this sensor; we don't
+    // currently have this information.  This must be filled in
+    // even when we have no attitude, so do it before the early
+    // return below:
+    results.active_airspeed_index = primary_airspeed_index();
+#endif  // AP_AIRSPEED_ENABLED
+
     if (!extahrs.get_quaternion(results.quaternion)) {
         results.attitude_valid = false;
         return;

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF2.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF2.cpp
@@ -179,6 +179,13 @@ void AP_AHRS_NavEKF2::get_results(AP_AHRS_Backend::Estimates &results)
     /*
      * Sensor-related information
      */
+
+#if AP_AIRSPEED_ENABLED
+    // EKF2 doesn't actually report what it's trying to use, so assume
+    // it's the primary:
+    results.active_airspeed_index = primary_airspeed_index();
+#endif  // AP_AIRSPEED_ENABLED
+
     // true if the estimator will use GPS data in creating its
     // estimate when the data is good:
     results.configured_to_use_gps = EKF2.using_gps();

--- a/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_NavEKF3.cpp
@@ -181,6 +181,22 @@ void AP_AHRS_NavEKF3::get_results(AP_AHRS_Backend::Estimates &results)
     /*
      * Sensor-related information
      */
+#if AP_AIRSPEED_ENABLED
+    // with multiple airspeed sensors and airspeed affinity in EKF3,
+    // it is possible to have switched over to a lane not using the
+    // primary airspeed sensor, so AHRS should know which airspeed
+    // sensor to use, i.e, the one being used by the primary lane. A
+    // lane switch could have happened due to an airspeed sensor
+    // fault, which makes this even more necessary
+    results.active_airspeed_index = primary_airspeed_index();
+    {
+        const auto *airspeed = AP::airspeed();
+        const uint8_t ret = EKF3.getActiveAirspeed();
+        if (airspeed != nullptr && ret != UINT8_MAX && airspeed->healthy(ret) && airspeed->use(ret)) {
+            results.active_airspeed_index = ret;
+        }
+    }
+#endif  // AP_AIRSPEED_ENABLED
     // true if the estimator will use GPS data in creating its
     // estimate when the data is good:
     results.configured_to_use_gps = EKF3.using_gps();

--- a/libraries/AP_AHRS/AP_AHRS_SIM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_SIM.cpp
@@ -110,6 +110,13 @@ bool AP_AHRS_SIM::get_innovations(Vector3f &velInnov, Vector3f &posInnov, Vector
 
 void AP_AHRS_SIM::get_results(AP_AHRS_Backend::Estimates &results)
 {
+#if AP_AIRSPEED_ENABLED
+    // SIM doesn't really use an airspeed sensor... but whatever.
+    // This must be filled in even when we have no SITL pointer
+    // yet, so do it before the early return below:
+    results.active_airspeed_index = primary_airspeed_index();
+#endif  // AP_AIRSPEED_ENABLED
+
     if (_sitl == nullptr) {
         _sitl = AP::sitl();
         if (_sitl == nullptr) {


### PR DESCRIPTION
### Summary

Several small patches to tidy up airspeed use in the AHRS

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Fixes a small issue where if you didn't have GPS compiled in then we wouldn't return airspeed data where we could.

Removes methods which just get in the way.

Stores the airspeed sensor that the backend is currently trying to fuse into the results structure.
