### PR TITLE
.github: test_location_ratchet: run on changes to itself

### DIFF
--- a/.github/workflows/test_location_ratchet.yml
+++ b/.github/workflows/test_location_ratchet.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'Tools/autotest/**'
       - 'Tools/scripts/check_mavutil_location_ratchet.py'
+      - '.github/workflows/test_location_ratchet.yml'
 
 concurrency:
   group: ci-${{github.workflow}}-${{ github.ref }}


### PR DESCRIPTION
Its allowlist named the ratchet script and Tools/autotest but not the workflow file, so an edit to the workflow was never exercised by the workflow.

### Summary

<!-- Put a one or two line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
