### PR TITLE
.github: run the workflows that use problem matchers when those change

### DIFF
--- a/.github/workflows/test_scripting.yml
+++ b/.github/workflows/test_scripting.yml
@@ -11,6 +11,7 @@ on:
       - 'Tools/scripts/run_luacheck.sh'
       - 'Tools/scripts/generate_lua_docs.sh'
       - '.github/workflows/test_scripting.yml'
+      - '.github/problem-matchers/Lua.json'
 
   pull_request:
     paths: # only run for scripting changes
@@ -21,6 +22,7 @@ on:
       - 'Tools/scripts/run_luacheck.sh'
       - 'Tools/scripts/generate_lua_docs.sh'
       - '.github/workflows/test_scripting.yml'
+      - '.github/problem-matchers/Lua.json'
 
   workflow_dispatch:
 

--- a/.github/workflows/test_sitl_copter.yml
+++ b/.github/workflows/test_sitl_copter.yml
@@ -81,6 +81,7 @@ on:
       # Remove change on other workflows
       - '.github/**'
       - '!.github/actions/**'  # except actions
+      - '!.github/problem-matchers/**'  # except problem matchers
       - '!.github/workflows/test_sitl_copter.yml'  # except this one
 
 
@@ -163,6 +164,7 @@ on:
       # Remove change on other workflows
       - '.github/**'
       - '!.github/actions/**'  # except actions
+      - '!.github/problem-matchers/**'  # except problem matchers
       - '!.github/workflows/test_sitl_copter.yml'  # except this one
 
   workflow_dispatch:

--- a/.github/workflows/test_sitl_rover.yml
+++ b/.github/workflows/test_sitl_rover.yml
@@ -80,6 +80,7 @@ on:
       # Remove change on other workflows
       - '.github/**'
       - '!.github/actions/**'  # except actions
+      - '!.github/problem-matchers/**'  # except problem matchers
       - '!.github/workflows/test_sitl_rover.yml'  # except this one
 
   pull_request:
@@ -160,6 +161,7 @@ on:
       # Remove change on other workflows
       - '.github/**'
       - '!.github/actions/**'  # except actions
+      - '!.github/problem-matchers/**'  # except problem matchers
       - '!.github/workflows/test_sitl_rover.yml'  # except this one
 
   workflow_dispatch:

--- a/.github/workflows/test_sitl_sub.yml
+++ b/.github/workflows/test_sitl_sub.yml
@@ -82,6 +82,7 @@ on:
       # Remove change on other workflows
       - '.github/**'
       - '!.github/actions/**'  # except actions
+      - '!.github/problem-matchers/**'  # except problem matchers
       - '!.github/workflows/test_sitl_sub.yml'  # except this one
 
   pull_request:
@@ -164,6 +165,7 @@ on:
       # Remove change on other workflows
       - '.github/**'
       - '!.github/actions/**'  # except actions
+      - '!.github/problem-matchers/**'  # except problem matchers
       - '!.github/workflows/test_sitl_sub.yml'  # except this one
 
   workflow_dispatch:


### PR DESCRIPTION
test_sitl_copter, test_sitl_rover and test_sitl_sub register four matchers from .github/problem-matchers/ but ignored all of .github/ bar actions and their own file, so a matcher edit never reached the workflow it was written for.  They gain the negation esp32_build.yml already carries.  test_scripting.yml filters on an allowlist instead, so Lua.json has to be named there.

### Summary

<!-- Put a one or two line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
