### PR TITLE
Tools: document waf alias for shell completion

### DIFF
--- a/Tools/completion/completion.md
+++ b/Tools/completion/completion.md
@@ -28,6 +28,16 @@ where PATH_TO_ARDUPILOT_DIRECTORY is the path to ArduPilot directory.
 
 You can now abuse of your TAB key on `waf` and `sim_vehicle.py` call ! See the video at the end.
 
+Note: completion is registered for the `waf` command. Since ArduPilot's
+`waf` is called as `./waf` from the root directory, add the following alias
+to your `.bashrc` so you can call it as `waf` and get completion:
+
+```bash
+alias waf="./waf"
+```
+
+After adding the alias, use `waf` (without `./`) to benefit from TAB completion.
+
 ## On ZSH
 
 Zsh don't allow live loading of completion. So you have to source the completion script in your `.zshrc` file. Like for Bash, you will find it hiding on your home !


### PR DESCRIPTION
### Summary

Documents an alias for the `waf` command so that TAB completion works when
ArduPilot's waf is invoked as `./waf` from the root directory.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Tested manually on Bash: sourced `Tools/completion/completion.bash`, added
`alias waf="./waf"`, and confirmed that `waf configure --board <TAB>` lists
the available boards and `waf <TAB>` lists commands and options.

<img width="1716" height="365" alt="image" src="https://github.com/user-attachments/assets/05ffb519-cc29-4e13-a1f2-b94506ea241f" />

### Description

The shell completion is registered for the `waf` command, but ArduPilot's
waf is normally invoked as `./waf` from the repository root. When called that
way, Bash falls back to default path/file completion instead of the waf
completion function, so TAB does not list boards, targets, or options.

This is a documentation-only change: it adds a note to
`Tools/completion/completion.md` recommending users add `alias waf="./waf"`
to their shell configuration, so they can call `waf` (without `./`) and get
working TAB completion. No scripts or build logic are changed.
