### PR TITLE
autotest: add a test for RADIO_RC_CHANNELS support

### DIFF
--- a/Tools/autotest/rover.py
+++ b/Tools/autotest/rover.py
@@ -7525,6 +7525,153 @@ return update()
         if abs(Horizontaldistance - expected_distance) > 1:
             raise NotAchievedException(f"Unexpected GPS position (want {expected_distance}, got {Horizontaldistance})")
 
+    def RadioRCChannels(self):
+        '''test RC input supplied via the RADIO_RC_CHANNELS mavlink message'''
+
+        # channel values are in the message's centered 13-bit format;
+        # [-4096,4096] maps onto [860,2140] PWM.  Channel 8 is left where the
+        # test suite's default RC puts it so the mode switch does not move:
+        values = [
+            0,      # 1500
+            -4096,  # 860; minimum
+            4096,   # 2140; maximum
+            1600,   # 1750
+            -1600,  # 1250
+            100,    # 1515; division truncates towards zero
+            -100,   # 1485; ... in both directions
+            1920,   # 1800; mode channel
+            320,    # 1550
+            -320,   # 1450
+            800,    # 1625
+            -800,   # 1375
+            2400,   # 1875
+            -2400,  # 1125
+            3200,   # 2000
+            -3200,  # 1000
+        ]
+        expected_pwm = [self.radio_rc_channels_value_to_pwm(x) for x in values]
+
+        self.set_parameters({
+            "RC_PROTOCOLS": 1 << 16,  # MAVRadio only; excludes the SITL UDP RC input
+            "RC_FS_TIMEOUT": 3,  # we feed the frames by hand; be generous
+            "FS_ACTION": 0,  # we want the failsafe reported, not acted upon
+        })
+        # RC_PROTOCOLS is only consulted while AP_RCProtocol is searching for
+        # a protocol, and the SITL UDP input has long since been detected:
+        self.context_collect('STATUSTEXT')
+        self.reboot_sitl()
+
+        self.start_subtest("no RC input at all until a RADIO_RC_CHANNELS arrives")
+        self.delay_sim_time(5, reason="let any RC input appear")
+        self.assert_sensor_state(
+            mavutil.mavlink.MAV_SYS_STATUS_SENSOR_RC_RECEIVER,
+            present=False,
+            enabled=False,
+            healthy=False,
+        )
+        m = self.assert_receive_message('RC_CHANNELS')
+        if m.chancount != 0:
+            raise NotAchievedException("Expected no RC channels, got %u" % m.chancount)
+
+        self.start_subtest("channel values are converted to PWM")
+        self.wait_radio_rc_channels_pwm(values, expected_pwm, len(values))
+        self.wait_statustext("RCInput: decoding MAVRadio", check_context=True, timeout=10)
+        self.context_stop_collecting('STATUSTEXT')
+
+        self.start_subtest("every frame is converted, not just the first")
+        # the same count, but a different value in every channel bar the mode
+        # channel; a backend which converted the first frame it saw and then
+        # latched would still be reporting the PWMs from the subtest above.
+        # All of the values are distinct, so rotating them moves every one:
+        moved = [x for (i, x) in enumerate(values) if i != 7]
+        moved = moved[1:] + moved[0:1]
+        moved.insert(7, values[7])
+        moved_pwm = [self.radio_rc_channels_value_to_pwm(x) for x in moved]
+        self.wait_radio_rc_channels_pwm(moved, moved_pwm, len(moved))
+
+        self.start_subtest("count is honoured")
+        # the payload always carries 32 channels, so count is the only thing
+        # saying how many of them are real; send all sixteen values but claim
+        # only eight, so honouring count and honouring the payload differ:
+        self.wait_radio_rc_channels_pwm(values, expected_pwm[0:8], 8, count=8)
+
+        self.start_subtest("oversize count is clamped")
+        # the message carries 32 channels and ArduPilot takes at most
+        # MAX_RCIN_CHANNELS of them.  RC_CHANNELS is all we can see here and
+        # it reports at most NUM_RC_CHANNELS, so this demonstrates only that
+        # no more than 16 channels come back, not where the input-side clamp
+        # sits:
+        self.wait_radio_rc_channels_pwm(values + values, expected_pwm, 16)
+
+        self.start_subtest("failsafe flag is honoured")
+        self.set_parameter("FS_THR_ENABLE", 1)
+        # establish that the vehicle is happy while the frames flow:
+        self.radio_rc_channels_pump(
+            values,
+            0,
+            'SYS_STATUS',
+            lambda m: m.onboard_control_sensors_health & mavutil.mavlink.MAV_SYS_STATUS_SENSOR_RC_RECEIVER,
+            20,
+            "RC receiver to be healthy",
+        )
+        # ... then change nothing but the failsafe flag:
+        self.context_collect('STATUSTEXT')
+        self.radio_rc_channels_pump(
+            values,
+            mavutil.mavlink.RADIO_RC_CHANNELS_FLAGS_FAILSAFE,
+            'SYS_STATUS',
+            lambda m: not (m.onboard_control_sensors_health & mavutil.mavlink.MAV_SYS_STATUS_SENSOR_RC_RECEIVER),
+            30,
+            "RC receiver to go unhealthy",
+        )
+        # note that it is the SYS_STATUS assertion above - made while the
+        # frames were still flowing - which shows the flag caused this.  The
+        # statustext wait below runs after the pump has stopped, so on its own
+        # it would also be satisfied by simply losing the input:
+        self.wait_statustext("Radio Failsafe", check_context=True, timeout=30)
+        self.context_stop_collecting('STATUSTEXT')
+
+        self.start_subtest("failsafe clears when the flag clears")
+        self.context_collect('STATUSTEXT')
+        self.radio_rc_channels_pump(
+            values,
+            0,
+            'SYS_STATUS',
+            lambda m: m.onboard_control_sensors_health & mavutil.mavlink.MAV_SYS_STATUS_SENSOR_RC_RECEIVER,
+            30,
+            "RC receiver to recover",
+        )
+        self.wait_statustext("Radio Failsafe Cleared", check_context=True, timeout=30)
+        self.context_stop_collecting('STATUSTEXT')
+
+        self.start_subtest("a flag which is not FAILSAFE does not fail the vehicle")
+        # a backend testing bool(flags) rather than the FAILSAFE bit would put
+        # us into failsafe here.  Maintain for longer than RC_FS_TIMEOUT, so
+        # input which had stopped counting as valid would show up:
+        self.assert_radio_rc_channels_maintains(
+            values,
+            mavutil.mavlink.RADIO_RC_CHANNELS_FLAGS_OUTDATED,
+            'SYS_STATUS',
+            lambda m: m.onboard_control_sensors_health & mavutil.mavlink.MAV_SYS_STATUS_SENSOR_RC_RECEIVER,
+            6,  # RC_FS_TIMEOUT is 3
+            "RC receiver went unhealthy with only the OUTDATED flag set",
+        )
+
+        self.start_subtest("FAILSAFE is honoured when another flag is also set")
+        # ... while a backend comparing flags with == rather than masking
+        # would ignore FAILSAFE the moment any other bit came along, so send
+        # the pair the subtest above has just shown to be individually inert
+        # and active:
+        self.radio_rc_channels_pump(
+            values,
+            (mavutil.mavlink.RADIO_RC_CHANNELS_FLAGS_FAILSAFE |
+             mavutil.mavlink.RADIO_RC_CHANNELS_FLAGS_OUTDATED),
+            'SYS_STATUS',
+            lambda m: not (m.onboard_control_sensors_health & mavutil.mavlink.MAV_SYS_STATUS_SENSOR_RC_RECEIVER),
+            30,
+            "RC receiver to go unhealthy with FAILSAFE and OUTDATED both set",
+        )
+
     def tests(self):
         '''return list of all tests'''
         ret = super(AutoTestRover, self).tests()
@@ -7549,6 +7696,7 @@ return update()
             self.RCOverridesCancel,
             Test(self.RCOverrideEnableChannel, speedup=10),
             self.RCOverridesClearByPilotInput,
+            Test(self.RadioRCChannels, speedup=5),  # we hand-feed the RC frames
             self.MANUAL_CONTROL,
             self.Sprayer,
             self.AC_Avoidance,

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -9036,6 +9036,85 @@ class TestSuite(abc.ABC):
             raise NotAchievedException("Expected %s to be %u got %u" %
                                        (channel, value, m_value))
 
+    def radio_rc_channels_value_to_pwm(self, value):
+        '''convert a RADIO_RC_CHANNELS channel value (centered 13-bit; range
+        [-4096,4096], centre 0) into the PWM value ArduPilot derives from
+        it.  Mirrors AP_RCProtocol_MAVLinkRadio, including C's
+        truncation-towards-zero integer division.'''
+        scaled = value * 5
+        if scaled < 0:
+            return 1500 - ((-scaled) // 32)
+        return 1500 + (scaled // 32)
+
+    def send_radio_rc_channels(self, values, flags=0, count=None, time_last_update_ms=0):
+        '''send a RADIO_RC_CHANNELS message; values are in the centered
+        13-bit format the message specifies.  The message always carries 32
+        channels, so count - which defaults to the number of values supplied
+        - is the only thing saying how many of them are real.'''
+        if len(values) > 32:
+            raise ValueError("RADIO_RC_CHANNELS carries at most 32 channels")
+        if count is None:
+            count = len(values)
+        channels = list(values) + [0] * (32 - len(values))
+        self.mav.mav.radio_rc_channels_send(
+            self.mav.target_system,
+            self.mav.target_component,
+            time_last_update_ms,
+            flags,
+            count,
+            channels,
+        )
+
+    def radio_rc_channels_pump(self, values, flags, mtype, check, timeout, what, count=None):
+        '''feed RADIO_RC_CHANNELS messages to the vehicle until check()
+        returns True for a received message of type mtype.  The frames have
+        to keep flowing while we wait, or the vehicle simply loses RC.'''
+        tstart = self.get_sim_time()
+        while True:
+            if self.get_sim_time_cached() - tstart > timeout:
+                raise NotAchievedException("Timed out waiting for %s" % what)
+            self.send_radio_rc_channels(values, flags=flags, count=count)
+            m = self.mav.recv_match(type=mtype, blocking=True, timeout=0.05)
+            if m is None:
+                continue
+            if check(m):
+                return m
+
+    def assert_radio_rc_channels_maintains(self, values, flags, mtype, check, duration, what, count=None):
+        '''feed RADIO_RC_CHANNELS messages to the vehicle for duration
+        seconds, failing if check() is ever False for a received message of
+        type mtype - or if no such message turns up at all, which would
+        otherwise pass vacuously'''
+        seen = False
+        tstart = self.get_sim_time()
+        while self.get_sim_time_cached() - tstart < duration:
+            self.send_radio_rc_channels(values, flags=flags, count=count)
+            m = self.mav.recv_match(type=mtype, blocking=True, timeout=0.05)
+            if m is None:
+                continue
+            seen = True
+            if not check(m):
+                raise NotAchievedException(what)
+        if not seen:
+            raise NotAchievedException("No %s received while checking for %s" % (mtype, what))
+
+    def wait_radio_rc_channels_pwm(self, values, expected_pwm, expected_chancount, count=None, timeout=20):
+        '''feed RADIO_RC_CHANNELS until RC_CHANNELS reports expected_pwm in
+        its first len(expected_pwm) channels'''
+        def check(m):
+            if m.chancount != expected_chancount:
+                self.progress("RC_CHANNELS chancount=%u want=%u" %
+                              (m.chancount, expected_chancount))
+                return False
+            got = [getattr(m, "chan%u_raw" % (i+1)) for i in range(len(expected_pwm))]
+            if got != expected_pwm:
+                self.progress("RC_CHANNELS got=%s want=%s" % (got, expected_pwm))
+                return False
+            return True
+        return self.radio_rc_channels_pump(
+            values, 0, 'RC_CHANNELS', check, timeout,
+            "RC_CHANNELS to match RADIO_RC_CHANNELS", count=count)
+
     def _rc_overrides_send_single(self, chan, pwm):
         '''Send RC_CHANNELS_OVERRIDE targeting a single channel; others are UINT16_MAX (ignore)'''
         channels = [65535] * 18


### PR DESCRIPTION
### Summary

Adds a test for RADIO_RC_CHANNELS mavlink message

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

We added this message but didn't add tests at the same time.  So test it.
