### PR TITLE
AP_VideoTX: Accept variable-length SmartAudio 2.1 settings

### DIFF
--- a/libraries/AP_VideoTX/AP_SmartAudio.cpp
+++ b/libraries/AP_VideoTX/AP_SmartAudio.cpp
@@ -593,16 +593,27 @@ bool  AP_SmartAudio::parse_response_buffer(const uint8_t *buffer, uint8_t buffer
         update_vtx_settings(settings);
         break;
 
-    case SMARTAUDIO_RSP_GET_SETTINGS_V21:
-        if (buffer_length < sizeof(SettingsExtendedResponseFrame)) {
+    case SMARTAUDIO_RSP_GET_SETTINGS_V21: {
+        // The power level list is variable length. num_power_levels is the
+        // final power-level index, followed by the frame CRC.
+        const SettingsExtendedResponseFrame *frame =
+            (const SettingsExtendedResponseFrame *)buffer;
+        const uint8_t fixed_response_length = sizeof(frame->settings) + 2U;
+        if (buffer_length < fixed_response_length) {
+            return false;
+        }
+        const uint16_t response_length =
+            fixed_response_length + uint16_t(frame->num_power_levels) + 1U /* level */ + 1U /* CRC */;
+        if (buffer_length < response_length) {
             return false;
         }
         _protocol_version = SMARTAUDIO_SPEC_PROTOCOL_v21;
-        unpack_settings(&settings, (const SettingsExtendedResponseFrame *)buffer);
+        unpack_settings(&settings, frame);
         settings.version = SMARTAUDIO_SPEC_PROTOCOL_v21;
         print_settings(&settings);
         update_vtx_settings(settings);
         break;
+    }
 
     case SMARTAUDIO_RSP_SET_FREQUENCY: {
         if (buffer_length < sizeof(U16ResponseFrame)) {


### PR DESCRIPTION
### Summary

Accept valid SA 2.1 GET_SETTINGS responses whose power-level list has fewer than eight entries.

### Classification & Testing

- [x] No-binary change
- [x] Tested on hardware
- [x] Logs available on request

While setting up an unlocked TBS Unify Pro32 Nano on a F405 FC I couldn't get SA to work; none of the params helped.

After hooking up a logic analyzer we found out the VTX returned a valid 17-byte SA 2.1 response containing five power levels.

Before this change, the fixed-size response validation rejected it, leaving `VTX_FREQ` at zero and the VTX on A1. 

After this change, SA initialises properly and applies the configured VTX settings.

Validated against the [TBS SA Rev. 0.9](https://www.team-blacksheep.com/media/files/tbs_smartaudio_rev09.pdf) GET_SETTINGS example and the captured Pro32 response. 

`git diff --check` passes.

### Description

SA 2.1 reports a variable-length list of supported power levels. 

This change validate the fixed fields, advertised list length, and CRC rather than requiring the maximum-size response struct.