### PR TITLE
AP_Baro: fix MS5837 stamping BARO_DEVID with devtype 0

### DIFF
--- a/libraries/AP_Baro/AP_Baro_MS5611.cpp
+++ b/libraries/AP_Baro/AP_Baro_MS5611.cpp
@@ -115,15 +115,6 @@ bool AP_Baro_MS5837::_init()
         return false;
     }
     _frontend.set_type(_instance, AP_Baro::BARO_TYPE_WATER);
-    // Use pressure sensitivity as a proxy for range determination
-    // High sensitivity for the same number size implies the lower-range sensor variant
-    // Threshold determined from datasheet example values and some sample sensors
-    uint16_t pressure_sensitivity = _cal_reg.c1;
-    if (pressure_sensitivity > MS5837_30BA_02BA_SELECTION_THRESHOLD) {
-        _subtype = DEVTYPE_BARO_MS5837_02BA;
-    } else {
-        _subtype = DEVTYPE_BARO_MS5837_30BA;
-    }
     return true;
 }
 #endif // AP_BARO_MS5837_ENABLED
@@ -484,7 +475,7 @@ void AP_Baro_MS5637::_calculate()
 // Calculate Temperature and compensated Pressure in real units (Celsius degrees*100, mbar*100).
 void AP_Baro_MS5837::_calculate()
 {
-    if (_subtype == DEVTYPE_BARO_MS5837_02BA) {
+    if (devtype() == DEVTYPE_BARO_MS5837_02BA) {
         _calculate_5837_02ba();
     } else {
         _calculate_5837_30ba();
@@ -559,8 +550,14 @@ void AP_Baro_MS5837::_calculate_5837_02ba() {
     _copy_to_frontend(_instance, (float)pressure, (float)TEMP / 100);
 }
 
+// Use pressure sensitivity as a proxy for range determination
+// High sensitivity for the same number size implies the lower-range sensor variant
+// Threshold determined from datasheet example values and some sample sensors
 AP_Baro_Backend::DevTypes AP_Baro_MS5837::devtype() const {
-    return _subtype;
+    if (_cal_reg.c1 > MS5837_30BA_02BA_SELECTION_THRESHOLD) {
+        return DEVTYPE_BARO_MS5837_02BA;
+    }
+    return DEVTYPE_BARO_MS5837_30BA;
 }
 
 #endif  // AP_BARO_MS5837_ENABLED

--- a/libraries/AP_Baro/AP_Baro_MS5611.h
+++ b/libraries/AP_Baro/AP_Baro_MS5611.h
@@ -155,8 +155,6 @@ protected:
     void _calculate() override;
     void _calculate_5837_02ba();
     void _calculate_5837_30ba();
-
-    DevTypes _subtype;
 };
 #endif  // AP_BARO_MS5837_ENABLED
 


### PR DESCRIPTION
AP_Baro_MS56XX::_init() fills in the device ID from devtype() before AP_Baro_MS5837::_init() gets a chance to assign _subtype, so the devtype byte of BARO*_DEVID was taken from an uninitialised member. In practice it read back as 0, which ground stations decode as an UNKNOWN sensor. Pressure was unaffected because _calculate() only runs once _subtype has been set.

Pick the variant in devtype() from _cal_reg.c1, which the parent has already read out of PROM by the time it stamps the ID, and drop _subtype so there is only one source of truth.

### Summary

<!-- Put a one or two line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Tested on Navigator with a Bar02 and on Navigator64 with Bar30
<img width="721" height="61" alt="Screenshot 2026-09-08 at 15 29 04" src="https://github.com/user-attachments/assets/0c763bff-d712-475e-b8bc-684271a10854" />
<img width="693" height="57" alt="Screenshot 2026-09-08 at 15 29 29" src="https://github.com/user-attachments/assets/77559179-b657-43f7-bcc4-f65e0bddc9bc" />
