### PR TITLE
Tools: environment_install: add if clauses to avoid churn on add/remove OS

### DIFF
--- a/Tools/environment_install/install-prereqs-ubuntu.sh
+++ b/Tools/environment_install/install-prereqs-ubuntu.sh
@@ -72,16 +72,31 @@ case ${RELEASE_DISTRIBUTOR} in
     linuxmint)
         # translate Mint-codenames to Ubuntu-codenames based on https://www.linuxmint.com/download_all.php
         case ${RELEASE_CODENAME} in
-            zena | wilma | xia)
+            zena)     ;&
+            wilma)    ;&
+            xia)      ;&
+            _LISTENDA)
                 RELEASE_CODENAME='noble'
                 ;;
-            vanessa | vera | victoria | virginia)
+            vanessa)  ;&
+            vera)     ;&
+            victoria) ;&
+            virginia) ;&
+            _LISTENDB)
                 RELEASE_CODENAME='jammy'
                 ;;
-            una | uma | ulyssa | ulyana)
+            una)      ;&
+            uma)      ;&
+            ulyssa)   ;&
+            ulyana)   ;&
+            _LISTENDC)
                 RELEASE_CODENAME='focal'
                 ;;
-            tricia | tina | tessa | tara)
+            tricia)   ;&
+            tina)     ;&
+            tessa)    ;&
+            tara)     ;&
+            _LISTENDD)
                 RELEASE_CODENAME='bionic'
                 ;;
             elsie)
@@ -105,7 +120,8 @@ case "${RELEASE_CODENAME}" in
     lunar)    ;&
     mantic)   ;&
     bullseye) ;&
-    oracular)
+    oracular) ;&
+    _LISTENDA)
         echo "ArduPilot no longer supports developing on this operating system that has reached end of standard support."
         exit 1
         ;;
@@ -116,7 +132,8 @@ case "${RELEASE_CODENAME}" in
     noble)    ;&
     plucky)   ;&
     questing) ;&
-    resolute)
+    resolute) ;&
+    _LISTENDB)
         echo "${RELEASE_CODENAME} is supported"
         ;;
 
@@ -126,7 +143,8 @@ case "${RELEASE_CODENAME}" in
         ;;
 esac
 
-if [ ${RELEASE_CODENAME} == 'trixie' ]; then
+if false; then :
+elif [ ${RELEASE_CODENAME} == 'trixie' ]; then
     SITLFML_VERSION="2.6"
     SITLCFML_VERSION="2.6"
     PYTHON_V="python3"
@@ -211,7 +229,8 @@ fi
 ARM_LINUX_PKGS="g++-arm-linux-gnueabihf $INSTALL_PKG_CONFIG"
 # python-wxgtk packages are added to SITL_PKGS below
 
-if [ ${RELEASE_CODENAME} == 'trixie' ] ||
+if false ||
+   [ ${RELEASE_CODENAME} == 'trixie' ] ||
    [ ${RELEASE_CODENAME} == 'bookworm' ] ||
    [ ${RELEASE_CODENAME} == 'noble' ] ||
    [ ${RELEASE_CODENAME} == 'plucky' ] ||
@@ -227,7 +246,8 @@ fi
 
 # add some packages required for commonly-used MAVProxy modules:
 if [[ $SKIP_AP_GRAPHIC_ENV -ne 1 ]]; then
-    if [ ${RELEASE_CODENAME} == 'trixie' ] ||
+    if false ||
+       [ ${RELEASE_CODENAME} == 'trixie' ] ||
        [ ${RELEASE_CODENAME} == 'bookworm' ] ||
        [ ${RELEASE_CODENAME} == 'noble' ] ||
        [ ${RELEASE_CODENAME} == 'plucky' ] ||
@@ -311,14 +331,16 @@ sudo usermod -a -G dialout $USER
 echo "Done!"
 
 # Add back python symlink to python interpreter on Ubuntu >= 20.04
-if [ ${RELEASE_CODENAME} == 'jammy' ]; then
+if false; then :
+elif [ ${RELEASE_CODENAME} == 'jammy' ]; then
     BASE_PKGS+=" python-is-python3"
     SITL_PKGS+=" libpython3-stdlib" # for argparse
 elif [ ${RELEASE_CODENAME} == 'trixie' ]; then
     SITL_PKGS+=" libpython3-stdlib" # for argparse
 elif [ ${RELEASE_CODENAME} == 'bookworm' ]; then
     SITL_PKGS+=" libpython3-stdlib" # for argparse
-elif [ ${RELEASE_CODENAME} != 'noble' ] &&
+elif true &&
+     [ ${RELEASE_CODENAME} != 'noble' ] &&
      [ ${RELEASE_CODENAME} != 'plucky' ] &&
      [ ${RELEASE_CODENAME} != 'questing' ] &&
      [ ${RELEASE_CODENAME} != 'resolute' ] &&
@@ -332,7 +354,8 @@ fi
 
 # Check for graphical package for MAVProxy
 if [[ $SKIP_AP_GRAPHIC_ENV -ne 1 ]]; then
-  if [ ${RELEASE_CODENAME} == 'trixie' ]; then
+  if false; then :
+  elif [ ${RELEASE_CODENAME} == 'trixie' ]; then
     SITL_PKGS+=" libgtk-3-dev libwxgtk3.2-dev "
   elif [ ${RELEASE_CODENAME} == 'bookworm' ]; then
     SITL_PKGS+=" libgtk-3-dev libwxgtk3.2-dev "
@@ -360,7 +383,8 @@ if [[ $SKIP_AP_GRAPHIC_ENV -ne 1 ]]; then
       SITL_PKGS+=" fonts-freefont-ttf libfreetype6-dev libjpeg8-dev libpng12-0 libportmidi-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl1.2-dev"  # for pygame
   fi
 
-  if [ ${RELEASE_CODENAME} == 'trixie' ]; then
+  if false; then :
+  elif [ ${RELEASE_CODENAME} == 'trixie' ]; then
       PYTHON_PKGS+=" opencv-python"
       SITL_PKGS+=" python3-wxgtk4.0"
       SITL_PKGS+=" fonts-freefont-ttf libfreetype6-dev libpng16-16 libportmidi-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl1.2-dev"  # for pygame
@@ -368,7 +392,8 @@ if [[ $SKIP_AP_GRAPHIC_ENV -ne 1 ]]; then
       PYTHON_PKGS+=" opencv-python"
       SITL_PKGS+=" python3-wxgtk4.0"
       SITL_PKGS+=" fonts-freefont-ttf libfreetype6-dev libpng16-16 libportmidi-dev libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl1.2-dev"  # for pygame
-  elif [ ${RELEASE_CODENAME} == 'noble' ] ||
+  elif false ||
+       [ ${RELEASE_CODENAME} == 'noble' ] ||
        [ ${RELEASE_CODENAME} == 'plucky' ] ||
        [ ${RELEASE_CODENAME} == 'questing' ] ||
        [ ${RELEASE_CODENAME} == 'resolute' ] ||
@@ -425,7 +450,8 @@ ARDUPILOT_ROOT=$(realpath "$SCRIPT_DIR/../../")
 PIP_USER_ARGUMENT="--user"
 
 # create a Python venv on more recent releases:
-if [ ${RELEASE_CODENAME} == 'bookworm' ] ||
+if false ||
+     [ ${RELEASE_CODENAME} == 'bookworm' ] ||
      [ ${RELEASE_CODENAME} == 'trixie' ] ||
      [ ${RELEASE_CODENAME} == 'noble' ] ||
      [ ${RELEASE_CODENAME} == 'plucky' ] ||
@@ -476,7 +502,8 @@ if [ "$GITHUB_ACTIONS" == "true" ]; then
     PIP_USER_ARGUMENT+=" --progress-bar off"
 fi
 
-if [ ${RELEASE_CODENAME} == 'trixie' ] ||
+if false ||
+   [ ${RELEASE_CODENAME} == 'trixie' ] ||
    [ ${RELEASE_CODENAME} == 'bookworm' ] ||
    [ ${RELEASE_CODENAME} == 'noble' ] ||
    [ ${RELEASE_CODENAME} == 'plucky' ] ||


### PR DESCRIPTION
### Summary

Adds lines t o prevent churn in the file when adding or removing a supported OS

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

previously adding or removing support for an OS meant changing lines unrelated to that OS.

Add a bit of cruft to the file so that adds/removes are just clean line additions or removal
