### PR TITLE
autotest: let the context remove SDCardWPTest's script

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -6896,7 +6896,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         spiral_script = "mission_spiral.lua"
 
         self.context_push()
-        self.install_example_script(spiral_script)
+        self.install_example_script_context(spiral_script)
         self.context_collect('STATUSTEXT')
         self.set_parameters({
             "BRD_SD_MISSION" : 64,
@@ -6932,8 +6932,6 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         self.progress("Checking spiral after reboot")
         self.set_parameter("SCR_USER6", count)
         self.wait_text("Compared spiral of size %u OK" % count, check_context=True)
-
-        self.remove_installed_script(spiral_script)
 
         self.context_pop()
         self.wait_ready_to_arm()


### PR DESCRIPTION
### Summary

Use a context to install/remove scripts in SDCardWPTest

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

SDCardWPTest installed mission_spiral.lua with the non-context install_example_script() and removed it with a bare remove_installed_script() thirty lines later, with no try/finally between them.  Every wait_text() and set_parameter() in that stretch can raise, and any of them leaves the script installed: the removal is simply skipped.

That matters more here than for a leaked trick file, because mission_spiral.lua ends in .lua - lua_scripts.cpp loads every .lua in scripts/ - so the leftover is picked up and run by the next test to start a vehicle with scripting enabled.

The test already pushes a context, and the harness pops any the test leaves behind when it fails, so install_example_script_context() cleans up on both paths.  Every other install site in Tools/autotest already uses the _context form.
