### PR TITLE
Tools: AP_Periph: init rangefinder without serial port

### DIFF
--- a/Tools/AP_Periph/AP_Periph.cpp
+++ b/Tools/AP_Periph/AP_Periph.cpp
@@ -243,7 +243,6 @@ void AP_Periph_FW::init()
 #endif
 
 #if AP_PERIPH_RANGEFINDER_ENABLED
-    bool have_rangefinder = false;
     for (uint8_t i=0; i<RANGEFINDER_MAX_INSTANCES; i++) {
         if ((rangefinder.get_type(i) != RangeFinder::Type::NONE) && (g.rangefinder_port[i] >= 0)) {
             // init uart for serial rangefinders
@@ -251,14 +250,10 @@ void AP_Periph_FW::init()
             if (uart != nullptr) {
                 uart->begin(g.rangefinder_baud[i]);
                 serial_manager.set_protocol_and_baud(g.rangefinder_port[i], AP_SerialManager::SerialProtocol_Rangefinder, g.rangefinder_baud[i]);
-                have_rangefinder = true;
             }
         }
     }
-    if (have_rangefinder) {
-        // Can only call rangefinder init once, subsequent inits are blocked
-        rangefinder.init(ROTATION_NONE);
-    }
+    rangefinder.init(ROTATION_NONE);
 #endif
 
 #if AP_PERIPH_PROXIMITY_ENABLED


### PR DESCRIPTION
### Summary

Currently the Periph rangefinder init is gated on the rangefinder port being set. However, not all rangefinders need a serial port, some are i2c. The current code means you have to waste a serial port on a i2c rangefinder. 

<!-- Put a one or two line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->

### Description

<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
I have tested that a I2C driver works with this patch and does not work on master.

Note that you could get around this by setting the continuous detection define.
