### PR TITLE
Copter: decouple save_trim() from RC_Channel_Copter and move to Copte…

### DIFF
--- a/ArduCopter/Copter.cpp
+++ b/ArduCopter/Copter.cpp
@@ -969,3 +969,28 @@ Copter copter;
 AP_Vehicle& vehicle = copter;
 
 AP_HAL_MAIN_CALLBACKS(&copter);
+
+// save_trim - adds roll and pitch trims from the radio to ahrs
+void Copter::save_trim()
+{
+    float roll_trim_rad = 0.0;
+    float pitch_trim_rad = 0.0;
+
+#if AP_COPTER_AHRS_AUTO_TRIM_ENABLED
+    if (g2.rc_channels.auto_trim.running) {
+        g2.rc_channels.auto_trim.running = false;
+    } else {
+#endif
+
+    // get roll and pitch trim adjustment
+    flightmode->get_pilot_desired_lean_angles_rad(roll_trim_rad, pitch_trim_rad, attitude_control->lean_angle_max_rad(), attitude_control->get_althold_lean_angle_max_rad());
+
+#if AP_COPTER_AHRS_AUTO_TRIM_ENABLED
+    }
+#endif
+
+    // save roll and pitch trim
+    AP::ahrs().add_trim(roll_trim_rad, pitch_trim_rad);
+    LOGGER_WRITE_EVENT(LogEvent::SAVE_TRIM);
+    gcs().send_text(MAV_SEVERITY_INFO, "Trim saved");
+}

--- a/ArduCopter/Copter.h
+++ b/ArduCopter/Copter.h
@@ -663,6 +663,7 @@ private:
     void update_using_interlock();
 
     // Copter.cpp
+    void save_trim();
     void get_scheduler_tasks(const AP_Scheduler::Task *&tasks,
                              uint8_t &task_count,
                              uint32_t &log_bit) override;

--- a/ArduCopter/RC_Channel_Copter.cpp
+++ b/ArduCopter/RC_Channel_Copter.cpp
@@ -226,7 +226,7 @@ bool RC_Channel_Copter::do_aux_function(const AuxFuncTrigger &trigger)
             if ((ch_flag == AuxSwitchPos::HIGH) &&
                 (copter.flightmode->allows_save_trim()) &&
                 (copter.channel_throttle->get_control_in() == 0)) {
-                copter.g2.rc_channels.save_trim();
+                copter.save_trim();
             }
             break;
 
@@ -730,32 +730,7 @@ void RC_Channel_Copter::do_aux_function_change_force_flying(const AuxSwitchPos c
     }
 }
 
-// note that this is a method on the RC_Channels object, not the
-// individual channel
-// save_trim - adds roll and pitch trims from the radio to ahrs
-void RC_Channels_Copter::save_trim()
-{
-    float roll_trim_rad = 0.0;
-    float pitch_trim_rad = 0.0;
 
-#if AP_COPTER_AHRS_AUTO_TRIM_ENABLED
-    if (auto_trim.running) {
-        auto_trim.running = false;
-    } else {
-#endif
-
-    // get roll and pitch trim adjustment
-    copter.flightmode->get_pilot_desired_lean_angles_rad(roll_trim_rad, pitch_trim_rad, copter.attitude_control->lean_angle_max_rad(), copter.attitude_control->get_althold_lean_angle_max_rad());
-
-#if AP_COPTER_AHRS_AUTO_TRIM_ENABLED
-    }
-#endif
-
-    // save roll and pitch trim
-    AP::ahrs().add_trim(roll_trim_rad, pitch_trim_rad);
-    LOGGER_WRITE_EVENT(LogEvent::SAVE_TRIM);
-    gcs().send_text(MAV_SEVERITY_INFO, "Trim saved");
-}
 
 #if AP_COPTER_AHRS_AUTO_TRIM_ENABLED
 // start/stop ahrs auto trim
@@ -777,7 +752,7 @@ void RC_Channels_Copter::do_aux_function_ahrs_auto_trim(const RC_Channel::AuxSwi
     case RC_Channel::AuxSwitchPos::LOW:
         if (auto_trim.running) {
             AP_Notify::flags.save_trim = false;
-            save_trim();
+            copter.save_trim();
         }
         break;
     }

--- a/ArduCopter/RC_Channel_Copter.h
+++ b/ArduCopter/RC_Channel_Copter.h
@@ -62,7 +62,7 @@ public:
     void auto_trim_run();
     void auto_trim_cancel();
 #endif  // AP_COPTER_AHRS_AUTO_TRIM_ENABLED
-    void save_trim();
+    
 
 protected:
 


### PR DESCRIPTION
…r class

### Summary

<!-- Put a one or two line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

Decoupled save_trim() from RC_Channel_Copter and moved it into the core Copter class. Verified successfully using ArduPilot SITL simulation.
<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
