### PR TITLE
Fix various MAVFTP bugs

### DIFF
--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -9434,6 +9434,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.MAVFTPBurstEOFOffset,
             self.MAVFTPBurstMissionDat,
             self.MAVFTPParamPck,
+            self.MAVFTPListDirectoryRoot,
             self.MAVFTPShortReplyPadding,
             self.MAVFTPListDirectoryEdgeCases,
             self.MAVFTPListDirectoryLongNames,

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -9434,6 +9434,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.MAVFTPBurstEOFOffset,
             self.MAVFTPBurstMissionDat,
             self.MAVFTPParamPck,
+            self.MAVFTPShortReplyPadding,
             self.MAVFTPListDirectoryEdgeCases,
             self.MAVFTPListDirectoryLongNames,
             self.MAVFTPDuplicateRequest,

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -9434,6 +9434,7 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
             self.MAVFTPBurstEOFOffset,
             self.MAVFTPBurstMissionDat,
             self.MAVFTPParamPck,
+            self.MAVFTPListDirectoryFullPacket,
             self.MAVFTPListDirectoryRoot,
             self.MAVFTPShortReplyPadding,
             self.MAVFTPListDirectoryEdgeCases,

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -16897,6 +16897,37 @@ switch value'''
         raise NotAchievedException(
             "%s did not %s" % (path, "appear" if present else "go away"))
 
+    def MAVFTPListDirectoryRoot(self):
+        '''test listing the root, whose path already ends in a separator'''
+
+        dirname = "ftp_root_test_dir"
+        filename = "ftp_root_test.txt"
+        content = b"root listing"
+
+        if os.path.exists(dirname):
+            shutil.rmtree(dirname)
+        os.mkdir(dirname)
+        self.write_content_to_filepath(content, filename)
+
+        try:
+            (entries, _) = self.ftp_list_dir("/")
+            (files, dirs) = self.ftp_listing_files_and_dirs(entries)
+
+            # the root's path already ends in a separator; adding another gave
+            # "//name", which stat'ed a different place entirely, and an entry
+            # which cannot be stat'ed is dropped - so every file in the root
+            # went missing and the listing came back with directories only
+            if filename not in files:
+                raise NotAchievedException(f"{filename} missing from the root listing")
+            if files[filename] != len(content):
+                raise NotAchievedException(
+                    f"{filename}: size {files[filename]}, expected {len(content)}")
+            if dirname not in dirs:
+                raise NotAchievedException(f"{dirname} missing from the root listing")
+        finally:
+            shutil.rmtree(dirname)
+            os.unlink(filename)
+
     def MAVFTPShortReplyPadding(self):
         '''test a short FTP reply carries no stale bytes past its size'''
 

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -16897,6 +16897,45 @@ switch value'''
         raise NotAchievedException(
             "%s did not %s" % (path, "appear" if present else "go away"))
 
+    def MAVFTPListDirectoryFullPacket(self):
+        '''test an entry which exactly fills a listing packet is still sent'''
+
+        dirname = "ftp_full_packet_test"
+        content = b"x" * 10
+        # an entry is "F<name>\t<size>\0", and the payload of a listing reply
+        # holds 239 bytes
+        payload_len = 239
+        overhead = len("F") + len("\t") + len(str(len(content))) + len("\0")
+        names = {
+            "control": "control.txt",
+            # exactly fills the payload: sendable, and was being dropped
+            "exact": "exact_".ljust(payload_len - overhead, "x"),
+            # one byte too long for a packet of its own, so it can never be sent
+            "toolong": "toolong_".ljust(payload_len - overhead + 1, "x"),
+        }
+
+        if os.path.exists(dirname):
+            shutil.rmtree(dirname)
+        os.mkdir(dirname)
+        for name in names.values():
+            self.write_content_to_filepath(content, os.path.join(dirname, name))
+
+        try:
+            (entries, _) = self.ftp_list_dir(dirname)
+            (files, _) = self.ftp_listing_files_and_dirs(entries)
+
+            if names["exact"] not in files:
+                raise NotAchievedException(
+                    f"An entry of exactly {payload_len} bytes was not listed")
+            if names["toolong"] in files:
+                raise NotAchievedException(
+                    f"An entry of {payload_len + 1} bytes was listed")
+            # dropping the one which cannot be sent must not end the listing
+            if names["control"] not in files:
+                raise NotAchievedException("The listing ended early")
+        finally:
+            shutil.rmtree(dirname)
+
     def MAVFTPListDirectoryRoot(self):
         '''test listing the root, whose path already ends in a separator'''
 

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -16897,6 +16897,48 @@ switch value'''
         raise NotAchievedException(
             "%s did not %s" % (path, "appear" if present else "go away"))
 
+    def MAVFTPShortReplyPadding(self):
+        '''test a short FTP reply carries no stale bytes past its size'''
+
+        dirname = "ftp_padding_test"
+        self.create_ftp_listing_pages(dirname, 20)
+
+        try:
+            seq = self.ftp_reset_sessions()
+
+            # list first, so the reply buffer is left holding entries
+            reply = self.ftp_op(seq, mavftp_op.OP_ListDirectory, self.ftp_path_bytes(dirname))
+            self.assert_ftp_ack(reply, "listing to fill the reply buffer")
+
+            # then ask past the end of the listing, which is answered with a
+            # one-byte EndOfFile NAK
+            path_bytes = self.ftp_path_bytes(dirname)
+            self.ftp_send(FTP_OP(
+                seq=reply.seq, session=0, opcode=mavftp_op.OP_ListDirectory,
+                size=len(path_bytes), req_opcode=0, burst_complete=0,
+                offset=1000, payload=path_bytes,
+            ))
+            m = self.mav.recv_match(type='FILE_TRANSFER_PROTOCOL', blocking=True, timeout=5)
+            if m is None:
+                raise NotAchievedException("No reply listing past the end")
+
+            raw = bytearray(m.payload)
+            size = raw[4]
+            opcode = raw[3]
+            if opcode != mavftp_op.OP_Nack:
+                raise NotAchievedException(f"Expected a Nack past the end, got opcode {opcode}")
+            if size != 1 or raw[12] != FtpError.EndOfFile:
+                raise NotAchievedException(
+                    f"Expected a one-byte EndOfFile Nack, got size={size} error={raw[12]}")
+
+            # everything after the error byte belongs to no reply at all
+            stale = bytes(raw[12 + size:]).rstrip(b"\0")
+            if stale:
+                raise NotAchievedException(
+                    f"Reply carried {len(stale)} bytes past its size: {stale[:32]!r}")
+        finally:
+            shutil.rmtree(dirname)
+
     def MAVFTPListDirectoryEdgeCases(self):
         '''test how FTP directory listing rejects and terminates'''
 

--- a/libraries/GCS_MAVLink/GCS_FTP.cpp
+++ b/libraries/GCS_MAVLink/GCS_FTP.cpp
@@ -183,9 +183,14 @@ int GCS_FTP::Session::gen_dir_entry(char *dest, size_t space, const char *path, 
 #else
         const uint8_t max_name_len = 255U;
 #endif
-        const size_t full_path_len = strlen(path) + strnlen(entry->d_name, max_name_len);
+        const size_t path_len = strlen(path);
+        const size_t full_path_len = path_len + strnlen(entry->d_name, max_name_len);
         char full_path[full_path_len + 2];
-        hal.util->snprintf(full_path, sizeof(full_path), "%s/%s", path, entry->d_name);
+        // the path already ends in a separator when the directory being
+        // listed is the root; adding another gives "//name", which is a
+        // different place
+        const char *sep = (path_len > 0 && path[path_len - 1] != '/') ? "/" : "";
+        hal.util->snprintf(full_path, sizeof(full_path), "%s%s%s", path, sep, entry->d_name);
         struct stat st;
         if (AP::FS().stat(full_path, &st)) {
             return -1;

--- a/libraries/GCS_MAVLink/GCS_FTP.cpp
+++ b/libraries/GCS_MAVLink/GCS_FTP.cpp
@@ -120,7 +120,9 @@ bool GCS_FTP::send_reply(const Transaction &reply)
     payload[5] = static_cast<uint8_t>(reply.req_opcode);
     payload[6] = reply.burst_complete ? 1 : 0;
     put_le32_ptr(&payload[8], reply.offset);
-    memcpy(&pkt.payload[12], reply.data, sizeof(reply.data));
+    // only the first size bytes belong to this reply; the packet is zeroed,
+    // so copying just those leaves the rest of it zero
+    memcpy(&pkt.payload[12], reply.data, MIN(reply.size, sizeof(reply.data)));
     mavlink_msg_file_transfer_protocol_send_struct(reply.chan, &pkt);
     return true;
 }

--- a/libraries/GCS_MAVLink/GCS_FTP.cpp
+++ b/libraries/GCS_MAVLink/GCS_FTP.cpp
@@ -245,11 +245,10 @@ void GCS_FTP::Session::list_dir(Transaction &request, Transaction &response)
         // check how much space would be needed to emit the listing
         const int needed_space = gen_dir_entry((char *)response.data, sizeof(request.data), (char *)request.data, entry);
 
-        // an entry needing the whole packet still does not fit, as the
-        // packing loop below only takes an entry which leaves the index
-        // inside the buffer. both loops must agree on which entries are
-        // skipped or the offsets they are counting drift apart
-        if (needed_space < 0 || needed_space >= (int)sizeof(request.data)) {
+        // an entry needing more than a whole packet can never be sent. both
+        // loops must agree on which entries are skipped or the offsets they
+        // are counting drift apart
+        if (needed_space < 0 || needed_space > (int)sizeof(request.data)) {
             continue;
         }
 
@@ -272,12 +271,12 @@ void GCS_FTP::Session::list_dir(Transaction &request, Transaction &response)
         // will be able to send it either. dropping it loses one file from
         // the listing; breaking here would end the listing at an EndOfFile
         // and lose every file after it as well
-        if (required_space >= (int)sizeof(response.data)) {
+        if (required_space > (int)sizeof(response.data)) {
             continue;
         }
 
         // can't fit it in this one, leave it for the next list to send
-        if ((required_space + index) >= (int)sizeof(request.data)) {
+        if ((required_space + index) > (int)sizeof(request.data)) {
             break;
         }
 


### PR DESCRIPTION
### Summary

Three long-standing bugs in MAVLink FTP directory listings, each with an autotest which fails without its fix.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Every fix has an autotest, and every autotest was checked against the unfixed
code so that it is known to fail without the change:

| test | without the fix |
| --- | --- |
| `MAVFTPListDirectoryRoot` | `ftp_root_test.txt missing from the root listing` |
| `MAVFTPListDirectoryFullPacket` | `An entry of exactly 239 bytes was not listed` |
| `MAVFTPShortReplyPadding` | `Reply carried 15 bytes past its size: b'entry_010.txt\t1'` |

All 17 CI-enabled `MAVFTP*` autotests pass on this branch.

Manual SITL testing, over raw MAVLink FTP against `arduplane`:

- listing `/` returned **0 files and 58 directories**, where listing `.` on the
  same directory returned **98 files**. After the fix, listing `/` returns all
  98.
- a 233 character filename (a 238 byte entry) was listed and a 234 character
  one (a 239 byte entry) was not. After the fix both are listed, and a 235
  character name is still correctly refused.
- a listing followed by a request past its end produced a one byte EndOfFile
  NAK whose payload trailed `00000002.BIN\t446464\t1788926...` from the
  previous reply. After the fix everything past the error byte is zero.

### Description

Three independent bugs, all in `master` today. They were found while working on
ListDirectoryWithTime (#34229) but none of them depend on it, so they are split
out here to be reviewed and merged on their own.

**1. No file in the root directory was ever listed.**

To `stat()` an entry, `gen_dir_entry()` builds `<path>/<name>`. The root's path
is already `/`, so this produced `//name`, which is not the path that was asked
for - under SITL it resolves outside the vehicle's directory entirely. A failed
`stat()` drops the entry, so every file in the root disappeared and a listing of
`/` came back containing directories only. Directories survived because they are
not `stat()`ed in a plain listing.

**2. An entry which exactly filled a listing packet was dropped.**

An entry needing exactly as many bytes as the payload holds was treated as
unsendable. It does fit: `AP_HAL::Util::vsnprintf()` builds its `BufferPrinter`
with `size-1` and then writes the terminator itself at `str[size-1]`, and the
byte it overwrites is the entry's own trailing NUL, so what lands in the buffer
is exactly what was intended. The comparisons now allow that case in all three
places, so the offset-skip loop and the packing loop still agree on what can
never be sent.

**3. Short replies carried stale bytes on the wire.**

`send_reply()` copied the whole payload buffer whatever the reply's size, so a
short reply was padded with the tail of whatever that session sent last. The
packet is the same length either way; only the bytes beyond the reply's `size`
change, and they are now zero.

### AI assistance

This contribution was AI-assisted. Claude found the second and third bugs and
wrote the fixes, the autotests and this description under my direction; I found
the first by pointing Mission Planner at a vehicle and noticing the file list
was empty. The 239 byte off-by-one was first raised by an adversarial review
from OpenAI Codex, then confirmed against `AP_HAL::Util::vsnprintf()` and
reproduced on SITL before being fixed. Every fix and every test has been
reviewed by me.
