### PR TITLE
SIM: 3D mode for ESC and unit test for SIM_moter.cpp

### DIFF
--- a/libraries/SITL/SIM_Frame.cpp
+++ b/libraries/SITL/SIM_Frame.cpp
@@ -167,6 +167,12 @@ const AP_Param::GroupInfo Frame::var_info[] = {
     // @Description: scaling of the bluff body drag derived from the reference test, zero for no bluff body drag. Defaults to zero on planes where the plane model handles drag
     AP_GROUPINFO("BBDRAG", 21, Frame, model.bbdrag_coef, SIM_FRAME_BBDRAG_DEFAULT),
 
+    // @Param: REV_THR_MSK
+    // @DisplayName: reversible thrust motor mask
+    // @Description: bitmask of motors modelled as reversible (3D) ESCs, where 1500 PWM is zero thrust and below 1500 is reverse thrust
+    // @Bitmask: 0: Servo 1, 1: Servo 2, 2: Servo 3, 3: Servo 4, 4: Servo 5, 5: Servo 6, 6: Servo 7, 7: Servo 8, 8: Servo 9, 9: Servo 10, 10: Servo 11, 11: Servo 12, 12: Servo 13, 13: Servo 14, 14: Servo 15, 15: Servo 16, 16: Servo 17, 17: Servo 18, 18: Servo 19, 19: Servo 20, 20: Servo 21, 21: Servo 22, 22: Servo 23, 23: Servo 24, 24: Servo 25, 25: Servo 26, 26: Servo 27, 27: Servo 28, 28: Servo 29, 29: Servo 30, 30: Servo 31, 31: Servo 32
+    AP_GROUPINFO("REV_THR_MSK", 22, Frame, model.reversible_mask, 0),
+
     AP_GROUPEND
 };
 #endif // AP_SIM_ENABLED
@@ -815,7 +821,7 @@ void Frame::update_parameters(void)
         motors[i].setup_params(model.pwmMin.get(), model.pwmMax.get(), model.spin_min, model.spin_max, model.propExpo, model.slew_max,
                                model.diagonal_size, power_factor, model.maxVoltage, effective_prop_area, velocity_max,
                                model.motor_pos[i], model.motor_thrust_vec[i], model.yaw_factor[i], true_prop_area,
-                               mdrag_coef);
+                               mdrag_coef, model.reversible_mask, motor_offset);
     }
 
     if (is_zero(model.moment_of_inertia.x) || is_zero(model.moment_of_inertia.y) || is_zero(model.moment_of_inertia.z)) {

--- a/libraries/SITL/SIM_Frame.h
+++ b/libraries/SITL/SIM_Frame.h
@@ -156,6 +156,9 @@ private:
 
         // number of motors
         float num_motors = 4;
+
+        // bit mask of 3d motors
+        AP_Int32 reversible_mask;
     };
 
 protected:

--- a/libraries/SITL/SIM_Motor.cpp
+++ b/libraries/SITL/SIM_Motor.cpp
@@ -33,9 +33,23 @@ void Motor::calculate_forces(const struct sitl_input &input,
                              bool use_drag)
 {
 
-    const float pwm = input.servos[motor_offset+servo];
+    float pwm = input.servos[motor_offset+servo];
     float command;
-    float thrust_sign = 1;
+
+    int8_t collective_thrust_sign = 1;
+    int8_t mot_3d_thrust_sign = 1;
+    int8_t thrust_sign = 1;
+
+    if (pwm <= 1500 && mot_3d_enable){
+        mot_3d_thrust_sign = mot_3d_thrust_sign * -1;
+    }
+
+    // this is to remap it back to normal
+    // 3D is 1000 = full reverse thrust; 1500 = no thrust; 2000 = full thrust
+    if (mot_3d_enable && !is_zero(pwm)) { // stop max pwm = 0 from commanding max thrust
+        pwm = fabsf((pwm - 1500)*2) + mot_pwm_min;
+    }
+
     if (rsc_servo >= 0) {
         // variable-pitch rotor; the motor's servo channel commands
         // blade pitch about mid-PWM and rotor speed comes from the
@@ -46,12 +60,14 @@ void Motor::calculate_forces(const struct sitl_input &input,
         const float rotor_speed = constrain_float((input.servos[motor_offset+rsc_servo]-1000)*0.002, 0, 1);
         const float collective = constrain_float((pwm-1500)*0.002, -1, 1);
         if (is_negative(collective)) {
-            thrust_sign = -1;
+            collective_thrust_sign = -1;
         }
         command = fabsf(collective) * sq(rotor_speed);
     } else {
         command = pwm_to_command(pwm);
     }
+    thrust_sign = collective_thrust_sign * mot_3d_thrust_sign;
+
     float voltage_scale = voltage / voltage_max;
 
     if (voltage_scale < 0.1) {
@@ -93,6 +109,8 @@ void Motor::calculate_forces(const struct sitl_input &input,
 
     // thrust in bodyframe NED
     thrust = thrust_vector * motor_thrust;
+    
+    rotor_torque = rotor_torque * mot_3d_thrust_sign;
 
     // work out roll and pitch of motor relative to it pointing straight up
     float roll = 0, pitch = 0;
@@ -184,7 +202,7 @@ float Motor::get_current(void) const
 void Motor::setup_params(uint16_t _pwm_min, uint16_t _pwm_max, float _spin_min, float _spin_max, float _expo, float _slew_max,
                          float _diagonal_size, float _power_factor, float _voltage_max, float _effective_prop_area,
                          float _velocity_max, Vector3f _position, Vector3f _thrust_vector, float _yaw_factor, 
-                         float _true_prop_area, float _momentum_drag_coefficient)
+                         float _true_prop_area, float _momentum_drag_coefficient, int32_t _rev_msk, uint8_t motor_offset)
 {
     mot_pwm_min = _pwm_min;
     mot_pwm_max = _pwm_max;
@@ -199,6 +217,10 @@ void Motor::setup_params(uint16_t _pwm_min, uint16_t _pwm_max, float _spin_min, 
     true_prop_area = _true_prop_area;
     momentum_drag_coefficient = _momentum_drag_coefficient;
     diagonal_size = _diagonal_size;
+
+    // on a variable-pitch rotor this motor's channel carries blade pitch,
+    // which is already signed
+    mot_3d_enable = ((rsc_servo < 0) && (_rev_msk & (1U << (motor_offset + servo)))) != 0;
 
     if (!_position.is_zero()) {
         position = _position;

--- a/libraries/SITL/SIM_Motor.h
+++ b/libraries/SITL/SIM_Motor.h
@@ -133,7 +133,8 @@ public:
     void setup_params(uint16_t _pwm_min, uint16_t _pwm_max, float _spin_min, float _spin_max, float _expo, float _slew_max,
                       float _diagonal_size, float _power_factor, float _voltage_max, float _effective_prop_area,
                       float _velocity_max, Vector3f _position, Vector3f _thrust_vector, float _yaw_factor,
-                      float _true_prop_area, float _momentum_drag_coefficient);
+                      float _true_prop_area, float _momentum_drag_coefficient, int32_t _rev_msk,
+                      uint8_t motor_offset);
 
     // override slew limit
     void set_slew_max(float _slew_max) {
@@ -152,6 +153,7 @@ private:
     float mot_pwm_max;
     float mot_spin_min;
     float mot_spin_max;
+    bool mot_3d_enable;
     float mot_expo;
     float slew_max;
     float current;

--- a/libraries/SITL/examples/EvaluateMotorModel/EvaluateMotorModel.cpp
+++ b/libraries/SITL/examples/EvaluateMotorModel/EvaluateMotorModel.cpp
@@ -79,7 +79,7 @@ void setup(void)
 
     motor.setup_params(frame.get_pwm_min(), frame.get_pwm_max(), frame.get_spin_min(), frame.get_spin_max(), frame.get_prop_expo(), frame.get_slew_max(),
                        0, power_factor, frame.get_max_voltage(), effective_prop_area, velocity_max,
-                       Vector3f {}, Vector3f {}, 1, true_prop_area, frame.get_mdrag_coef());
+                       Vector3f {}, Vector3f {}, 1, true_prop_area, frame.get_mdrag_coef(), 0, 0);
 
     // parse inflow velocity and voltage
     const float velocity = strtof(argv[2], NULL);

--- a/libraries/SITL/tests/test_sim_motor.cpp
+++ b/libraries/SITL/tests/test_sim_motor.cpp
@@ -1,0 +1,145 @@
+#include <AP_gtest.h>
+
+#include <SITL/SIM_Motor.h>
+#include <SITL/SITL_Input.h>
+#include <AP_Motors/AP_Motors.h>
+
+const AP_HAL::HAL& hal = AP_HAL::get_HAL();
+
+using namespace SITL;
+
+/*
+  These tests exercise Motor::calculate_forces directly. Reversible
+  (3D) thrust cannot be flown in SITL yet because no vehicle code
+  emits a 1500-centred motor output, so the model is verified here
+  instead.
+
+  Assertions are on the thrust that comes out for a given PWM in,
+  rather than on how it is computed, so they stay valid if the
+  internals change.
+
+  Thrust is in body-frame NED, so a motor pointing up produces
+  NEGATIVE Z.
+*/
+
+static const uint16_t PWM_MIN = 1000;
+static const uint16_t PWM_MAX = 2000;
+static const float VOLTAGE = 12.6;
+
+/*
+  run a single calculate_forces call on a freshly configured motor and
+  return the resulting thrust
+*/
+static Vector3f thrust_for_pwm(uint16_t pwm, int32_t rev_mask)
+{
+    Motor motor(AP_MOTORS_MOT_1, 45, AP_MOTORS_MATRIX_YAW_FACTOR_CCW, 1);
+
+    motor.setup_params(PWM_MIN, PWM_MAX,
+                       0.15,               // spin min
+                       0.95,               // spin max
+                       0.65,               // expo
+                       0,                  // slew max, zero disables the slew limiter
+                       0.35,               // diagonal size
+                       1.0,                // power factor
+                       VOLTAGE,            // voltage max
+                       0.05,               // effective prop area
+                       30.0,               // velocity max
+                       Vector3f {},        // position, derived from angle
+                       Vector3f {0, 0, -1},// thrust vector, straight up
+                       1.0,                // yaw factor
+                       0.05,               // true prop area
+                       0.0,                // momentum drag coefficient
+                       rev_mask,
+                       0);                 // motor offset
+
+    sitl_input input {};
+    input.servos[0] = pwm;
+
+    Vector3f torque, thrust;
+    motor.calculate_forces(input, 0, torque, thrust,
+                           Vector3f {},    // still air
+                           Vector3f {},    // no rotation
+                           1.225,          // sea level air density
+                           VOLTAGE,
+                           false);         // no momentum drag
+
+    return thrust;
+}
+
+/*
+  with no bit set the motor must behave conventionally: no thrust at
+  or below minimum PWM, thrust upwards above it, and never reversed
+*/
+TEST(SIM_Motor, conventional_when_mask_clear)
+{
+    const float accuracy = 0.001;
+
+    EXPECT_NEAR(thrust_for_pwm(PWM_MIN, 0).z, 0, accuracy);
+
+    const float mid = thrust_for_pwm(1500, 0).z;
+    const float full = thrust_for_pwm(PWM_MAX, 0).z;
+
+    // negative Z is up
+    EXPECT_LT(mid, 0);
+    EXPECT_LT(full, mid);
+
+    // a conventional motor never produces downward thrust
+    for (uint16_t pwm = PWM_MIN; pwm <= PWM_MAX; pwm += 100) {
+        EXPECT_LE(thrust_for_pwm(pwm, 0).z, accuracy);
+    }
+}
+
+/*
+  with the bit set, mid PWM is the zero-thrust point
+*/
+TEST(SIM_Motor, reversible_neutral_is_mid_pwm)
+{
+    EXPECT_NEAR(thrust_for_pwm(1500, 1).z, 0, 0.001);
+}
+
+/*
+  above neutral the thrust is up, below neutral it is down
+*/
+TEST(SIM_Motor, reversible_direction_follows_pwm)
+{
+    // negative Z is up
+    EXPECT_LT(thrust_for_pwm(PWM_MAX, 1).z, 0);
+    EXPECT_GT(thrust_for_pwm(PWM_MIN, 1).z, 0);
+}
+
+/*
+  a reversible motor is symmetric about neutral: full reverse must
+  produce the same magnitude of thrust as full forward
+*/
+TEST(SIM_Motor, reversible_is_symmetric)
+{
+    const float forward = thrust_for_pwm(PWM_MAX, 1).z;
+    const float reverse = thrust_for_pwm(PWM_MIN, 1).z;
+
+    EXPECT_NEAR(fabsf(forward), fabsf(reverse), 0.001);
+}
+
+/*
+  a zero PWM means the channel is not being driven rather than a pulse
+  width, and must produce no thrust in either direction
+*/
+TEST(SIM_Motor, undriven_channel_produces_no_thrust)
+{
+    EXPECT_NEAR(thrust_for_pwm(0, 1).z, 0, 0.001);
+    EXPECT_NEAR(thrust_for_pwm(0, 0).z, 0, 0.001);
+}
+
+/*
+  only the motors named in the mask are reversible; a motor whose bit
+  is clear keeps conventional behaviour even when other bits are set
+*/
+TEST(SIM_Motor, mask_selects_individual_motors)
+{
+    // motor under test drives servo 0, so bit 0 selects it
+    EXPECT_GT(thrust_for_pwm(PWM_MIN, 1).z, 0);
+
+    // bits 1..3 set, bit 0 clear, so this motor stays conventional
+    EXPECT_NEAR(thrust_for_pwm(PWM_MIN, 14).z, 0, 0.001);
+}
+
+AP_GTEST_MAIN()


### PR DESCRIPTION
### Summary
This add the ability to simulate 3D mode on ESCs. As we don't support this yet it can't be verified in SITL so there was a unit test added.
<!-- Put a one or two line summary of what your PR does here -->

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer (the main SITL change not the unit test)
- [ ] No-binary change
- [ ] Non-functional change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

<!-- Put additional testing description for this PR's changes here -->
Given that it is param gated that means that there will be no functionality change for all users. I will be adding 3D acro so when that is in place this will be used to test it with FlightGear sim. If it works in the sim but not in flight testing then this will indicate that the sim may be wrong.

### Description
Motors selected by SIM_REV_THR_MSK are modelled as reversible ESCs:
1500us is zero thrust, above it is forward, below it is reverse.
That matches what ArduPilot outputs for a reversible channel, which
SRV_Channels forces to min 1000, max 2000, trim 1500.

The mask indexes servo channels and accounts for the frame's motor
offset, so it works on quadplane VTOL motors as well as multicopters.
Variable-pitch rotors are excluded because their channel already
carries signed blade pitch.

Default is 0, so every existing frame is unchanged.

Nothing in Copter emits a 1500-centred motor output yet, so this
can't be flown. SITL_State.cpp already carries a note about this gap
in the FETtec ESC handling. The unit tests cover the neutral point,
direction, symmetry, undriven channels and mask selection.


<!-- Describe the PR's content here -->

<!--
Don't overlook our community's expectations for creating a PR:
https://ardupilot.org/dev/docs/style-guide.html
https://ardupilot.org/dev/docs/submitting-patches-back-to-master.html
https://ardupilot.org/dev/docs/porting.html
-->
