### PR TITLE
AP_OpenDroneID: preserve speed precision

### DIFF
--- a/libraries/AP_OpenDroneID/AP_OpenDroneID.cpp
+++ b/libraries/AP_OpenDroneID/AP_OpenDroneID.cpp
@@ -702,7 +702,7 @@ MAV_ODID_TIME_ACC AP_OpenDroneID::create_enum_timestamp_accuracy(float accuracy)
 }
 
 // make sure value is within limits of remote ID standard
-uint16_t AP_OpenDroneID::create_speed_horizontal(uint16_t speed) const
+float AP_OpenDroneID::create_speed_horizontal(float speed) const
 {
     if (speed > ODID_MAX_SPEED_H) { // constraint function can't be used, because out of range value is invalid
         speed = ODID_INV_SPEED_H;
@@ -712,7 +712,7 @@ uint16_t AP_OpenDroneID::create_speed_horizontal(uint16_t speed) const
 }
 
 // make sure value is within limits of remote ID standard
-int16_t AP_OpenDroneID::create_speed_vertical(int16_t speed) const
+float AP_OpenDroneID::create_speed_vertical(float speed) const
 {
     if (speed > ODID_MAX_SPEED_V) { // constraint function can't be used, because out of range value is invalid
         speed = ODID_INV_SPEED_V;

--- a/libraries/AP_OpenDroneID/AP_OpenDroneID.h
+++ b/libraries/AP_OpenDroneID/AP_OpenDroneID.h
@@ -184,8 +184,8 @@ private:
     MAV_ODID_SPEED_ACC create_enum_speed_accuracy(float Accuracy) const;
     MAV_ODID_TIME_ACC create_enum_timestamp_accuracy(float Accuracy) const;
     uint16_t create_direction(uint16_t direction) const;
-    uint16_t create_speed_horizontal(uint16_t speed) const;
-    int16_t create_speed_vertical(int16_t speed) const;
+    float create_speed_horizontal(float speed) const;
+    float create_speed_vertical(float speed) const;
     float create_altitude(float altitude) const;
     float create_location_timestamp(float timestamp) const;
 


### PR DESCRIPTION
### Summary

Preserve horizontal and vertical OpenDroneID speed precision by using floating-point values in the speed validation helpers.

### Description

`create_speed_horizontal()` and `create_speed_vertical()` previously accepted and returned integer values. This caused fractional speed values to be truncated before they were assigned to the OpenDroneID location message.

Change both helpers to accept and return `float`, preserving speed precision while retaining the existing Remote ID range validation and invalid-value handling. 