### PR TITLE
AP_Baro: bound the ICP201XX init waits so a dead sensor cannot hang boot

### DIFF
--- a/libraries/AP_Baro/AP_Baro_ICP201XX.cpp
+++ b/libraries/AP_Baro/AP_Baro_ICP201XX.cpp
@@ -36,6 +36,23 @@ extern const AP_HAL::HAL &hal;
 
 #define CONVERSION_INTERVAL     25000
 
+/*
+  The waits in init() are bounded by elapsed time, not by a count of polls.
+  Each read_reg() can take several times the sleep between polls while the
+  I2C layer retries against a part that clock-stretches or holds SDA, and the
+  device keeps its default retries until init() has succeeded, so a count
+  would understate how long a dead part can block the boot.
+ */
+#define ICP201XX_MODE_SYNC_TIMEOUT_MS   100
+#define ICP201XX_OTP_READ_TIMEOUT_MS    50
+/*
+  _op_mode is OP_MODE1, ODR 120Hz, so the 14 settling packets take about
+  117ms and the first packet after a flush about 8ms; 2s leaves ample margin
+  for both.  OP_MODE3 (2Hz) needs about 7s just to settle, so raise this if
+  the configured mode is ever slowed down.
+ */
+#define ICP201XX_FIFO_WAIT_TIMEOUT_MS   2000
+
 #define REG_EMPTY               0x00
 #define REG_TRIM1_MSB           0x05
 #define REG_TRIM2_LSB           0x06
@@ -123,7 +140,9 @@ bool AP_Baro_ICP201XX::init()
         goto failed;
     }
 
-    wait_read();
+    if (!wait_read()) {
+        goto failed;
+    }
 
     dev->set_retries(0);
 
@@ -193,15 +212,20 @@ bool AP_Baro_ICP201XX::mode_select(uint8_t mode)
 {
     uint8_t mode_sync_status = 0;
 
+    // a mode change normally syncs within a few milliseconds; give up on
+    // a device that stops responding rather than hanging the boot
+    bool synced = false;
+    const uint32_t start_ms = AP_HAL::millis();
     do {
-        read_reg(REG_DEVICE_STATUS, &mode_sync_status, 1);
-
-        if (mode_sync_status & 0x01) {
-            break;
+        synced = read_reg(REG_DEVICE_STATUS, &mode_sync_status, 1) &&
+                 (mode_sync_status & 0x01);
+        if (!synced) {
+            hal.scheduler->delay(1);
         }
-
-        hal.scheduler->delay(1);
-    } while (1);
+    } while (!synced && AP_HAL::millis() - start_ms < ICP201XX_MODE_SYNC_TIMEOUT_MS);
+    if (!synced) {
+        return false;
+    }
 
     return write_reg(REG_MODE_SELECT, mode);
 }
@@ -220,15 +244,17 @@ bool AP_Baro_ICP201XX::read_otp_data(uint8_t addr, uint8_t cmd, uint8_t *val)
     }
 
     /* Wait for the OTP read to finish Monitor otp_status */
-    do     {
-        read_reg(REG_OTP_MTP_OTP_STATUS, &otp_status);
-
-        if (otp_status == 0) {
-            break;
+    bool ready = false;
+    const uint32_t start_ms = AP_HAL::millis();
+    do {
+        ready = read_reg(REG_OTP_MTP_OTP_STATUS, &otp_status) && otp_status == 0;
+        if (!ready) {
+            hal.scheduler->delay_microseconds(10);
         }
-
-        hal.scheduler->delay_microseconds(1);
-    } while (1);
+    } while (!ready && AP_HAL::millis() - start_ms < ICP201XX_OTP_READ_TIMEOUT_MS);
+    if (!ready) {
+        return false;
+    }
 
     /* Read the data from register */
     if (!read_reg(REG_OTP_MTP_RD_DATA, val)) {
@@ -312,7 +338,9 @@ bool AP_Baro_ICP201XX::boot_sequence()
     }
 
     /* Bring the ASIC in power mode to activate the OTP power domain and get access to the main registers */
-    mode_select(0x04);
+    if (!mode_select(0x04)) {
+        return false;
+    }
     hal.scheduler->delay(4);
 
     /* Unlock the main registers */
@@ -388,7 +416,9 @@ bool AP_Baro_ICP201XX::boot_sequence()
     write_reg(REG_MASTER_LOCK, 0x00);
 
     /* Move to standby */
-    mode_select(0x00);
+    if (!mode_select(0x00)) {
+        return false;
+    }
 
     return ret;
 }
@@ -415,29 +445,42 @@ bool AP_Baro_ICP201XX::configure()
     return mode_select(reg_value);
 }
 
-void AP_Baro_ICP201XX::wait_read()
+bool AP_Baro_ICP201XX::wait_read()
 {
     /*
     * If FIR filter is enabled, it will cause a settling effect on the first 14 pressure values.
     * Therefore the first 14 pressure output values are discarded.
+    *
+    * Both waits give up after ICP201XX_FIFO_WAIT_TIMEOUT_MS so a sensor that
+    * never fills its FIFO cannot hang the boot; see its definition for how
+    * that relates to the configured ODR.
     **/
     uint8_t fifo_packets = 0;
-    uint8_t fifo_packets_to_skip = 14;
+    const uint8_t fifo_packets_to_skip = 14;
 
+    bool settled = false;
+    uint32_t start_ms = AP_HAL::millis();
     do {
         hal.scheduler->delay(10);
-        read_reg(REG_FIFO_FILL, &fifo_packets);
-        fifo_packets = (uint8_t)(fifo_packets & 0x1F);
-    } while (fifo_packets < fifo_packets_to_skip);
+        settled = read_reg(REG_FIFO_FILL, &fifo_packets) &&
+                  (uint8_t)(fifo_packets & 0x1F) >= fifo_packets_to_skip;
+    } while (!settled && AP_HAL::millis() - start_ms < ICP201XX_FIFO_WAIT_TIMEOUT_MS);
+    if (!settled) {
+        return false;
+    }
 
-    flush_fifo();
-    fifo_packets = 0;
+    if (!flush_fifo()) {
+        return false;
+    }
 
+    bool refilled = false;
+    start_ms = AP_HAL::millis();
     do {
         hal.scheduler->delay(10);
-        read_reg(REG_FIFO_FILL, &fifo_packets);
-        fifo_packets = (uint8_t)(fifo_packets & 0x1F);
-    } while (fifo_packets == 0);
+        refilled = read_reg(REG_FIFO_FILL, &fifo_packets) &&
+                   (uint8_t)(fifo_packets & 0x1F) != 0;
+    } while (!refilled && AP_HAL::millis() - start_ms < ICP201XX_FIFO_WAIT_TIMEOUT_MS);
+    return refilled;
 }
 
 bool AP_Baro_ICP201XX::flush_fifo()

--- a/libraries/AP_Baro/AP_Baro_ICP201XX.h
+++ b/libraries/AP_Baro/AP_Baro_ICP201XX.h
@@ -29,7 +29,7 @@ private:
     void soft_reset();
     bool boot_sequence();
     bool configure();
-    void wait_read();
+    bool wait_read();
     bool flush_fifo();
     void timer();
 


### PR DESCRIPTION
### Summary

Bound the three ICP201XX initialisation waits by elapsed time, so a sensor that answers the ID probe and then stops responding, or never fills its FIFO, fails its probe instead of hanging the boot for ever.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Tested under Renode on YJUAV_A6SE_H743. The emulated ICP201XX in the harness reports a FIFO fill of 1, so it can never satisfy the driver's first wait, which makes it a faithful stand-in for a part that probes and then never fills.

| Test | Parent commit | This commit |
|---|---|---|
| Renode, YJUAV_A6SE_H743 Copter, time to first MAVLink heartbeat | none within 180 s | 32 s |
| Firmware builds compared | | differ only by this commit |
| YJUAV_A6SE_H743 Plane and Copter build | pass | pass |
| MatekH743 Copter build | pass | pass |
| SITL Plane build | pass | pass |
| `Tools/scripts/check_branch_conventions.py` | | all checks pass |

This has not been exercised against a real failing part. The fault was found in emulation, and on hardware the sensor has always come up normally.

### Description

Three waits reachable from `AP_Baro_ICP201XX::init()` had no exit:

- `mode_select()` polled the device-status register until its sync bit was set.
- `read_otp_data()` polled the OTP status register until it read zero.
- `wait_read()` polled `FIFO_FILL` until 14 packets had arrived, and again after a flush until one had.

Each loop inspected only the value it polled and never whether the read succeeded, so a part that answers the ID probe and then stops acknowledging, or keeps acknowledging but never fills its FIFO, holds `init()` there indefinitely.

Nothing recovers from that. On every board except those defining `HAL_EARLY_WATCHDOG_INIT`, currently only Here4FC, `setup()` runs before the watchdog is started at all, so there is nothing to fire. Where the watchdog is started early, the scheduler keeps patting it until the system is marked initialised. Either way the board sits there with no MAVLink, no console message and no reboot, which is a much worse failure than a missing barometer.

Each wait now gives up after a fixed elapsed time and returns false: 100 ms for mode sync, 50 ms for an OTP read, and 2 s for each FIFO wait. `wait_read()` returns `bool`, `init()` takes its existing failed path on a timeout, and `boot_sequence()` now checks the `mode_select()` results it previously ignored. The probe fails cleanly and the other barometers on the board carry on.

**Why elapsed time and not a count of polls.** Each `read_reg()` can take several times the sleep between polls. The I2C layer defaults to three attempts per transaction with a 4 ms minimum timeout, and `init()` only calls `set_retries(0)` after everything has succeeded, so during initialisation a part that clock-stretches or holds SDA makes every poll expensive. A limit on the number of polls would therefore understate how long a dead part can block the boot. Bounding by elapsed time makes the stated figures real ceilings, give or take the duration of the last bus read in each loop.

**Worst case.** A failed `mode_select()` returns at once, the three OTP reads run as a group, and the two FIFO waits dominate. A dead part can now hold the boot for at most about four seconds, if it satisfies the first FIFO wait just before its limit and then fails the second.

**Where the FIFO limit comes from.** The driver configures `OP_MODE1`, which runs at 120 Hz, so the 14 settling packets take about 117 ms and the first packet after a flush about 8 ms. Two seconds is a wide margin for both. `OP_MODE3` runs at 2 Hz and would need about 7 s just to settle, so the constant would have to be raised if the configured mode were ever slowed. The comment on the constant says so, so the next person to change `_op_mode` finds it.

Points worth knowing:

- **The emulated sensor still does not register with this PR alone.** It changes the emulated board from hanging to failing the ICP201XX probe after the timeout. Getting the emulated part to fill its FIFO and actually register as a barometer is the harness model fix in #34357.
- **A pre-existing bug nearby is deliberately left alone.** In `boot_sequence()` the OTP boot-done flag is written only when reading its status register *fails*, so on the success path it is never set and the OTP boot sequence re-runs on every boot of an A1 part. That predates this change and is not a hang, so it belongs in its own PR.

This PR was AI-assisted.
