### PR TITLE
Tools: renode: Allow servo outputs to be capture in PulseView

### DIFF
--- a/Tools/renode/README.md
+++ b/Tools/renode/README.md
@@ -444,7 +444,7 @@ Tools/renode/launch.py --renode ~/project/UAV/renode/renode
 
 The **Target** tab discovers supported boards and their built ELF images,
 selects a matching bootloader when one is available, and exposes CPU pinning,
-real IOMCU, UDS, USB/DFU, CAN bus and Ethernet TAP options. The **Config** tab
+real IOMCU, UDS, Sigrok, USB/DFU, CAN bus and Ethernet TAP options. The **Config** tab
 expands the selected board's production `hwdef.dat` and lists its
 `SERIAL_ORDER`, `I2C_ORDER`, and `CAN_ORDER` ports. Devices can be attached
 directly to those logical ArduPilot ports; the physical MCU peripheral is shown

--- a/Tools/renode/README.md
+++ b/Tools/renode/README.md
@@ -876,7 +876,12 @@ are enabled, so disabled channels do not generate or transmit samples. The
 default sample rate is 10 MHz; use
 `--sigrok-sample-rate HZ` and `--sigrok-port PORT` to change it. UART and SPI
 wire edges are reconstructed from Renode's byte-level models, while chip-select
-and general GPIO levels come directly from the generated GPIO fan-out.
+and general GPIO levels come directly from the generated GPIO fan-out. Edges
+are only reconstructed while a capture is running, and only for the channels
+the client enabled; between captures the analyser tracks each pin's current
+level, so a capture starts from those levels and there is no pre-trigger
+history. Reconstructing every byte on a busy IMU bus all the time cost more
+than the emulation itself.
 
 PWM outputs are reconstructed by `AP_STM32_Timer_Waveform` rather than taken
 from the GPIO fan-out. The stock STM32 timer does toggle its output-compare

--- a/Tools/renode/README.md
+++ b/Tools/renode/README.md
@@ -878,6 +878,33 @@ default sample rate is 10 MHz; use
 wire edges are reconstructed from Renode's byte-level models, while chip-select
 and general GPIO levels come directly from the generated GPIO fan-out.
 
+PWM outputs are reconstructed by `AP_STM32_Timer_Waveform` rather than taken
+from the GPIO fan-out. The stock STM32 timer does toggle its output-compare
+pins, but only with the granularity of its own event scheduling and without
+`BDTR`, so the generator routes `PWM(n)` pins to this peripheral instead. It
+mirrors PSC, ARR, CCRx, CCMR, CCER, CR1, EGR and BDTR from a bus write hook,
+anchors every frame on the timer model's overflow event, and schedules the
+compare-match edge analytically, so pulse widths are exact. It follows the
+hardware rules that matter for RCOutput: ARR and CCRx are preloaded and take
+effect at the next update event, `EGR.UG` forces one and restarts the counter
+(OneShot), `CEN=0` freezes the counter and holds the pin, a channel with
+`CCxE=0` idles low, and an advanced timer (TIM1/8/15/16/17/20) drops every
+output when `BDTR.MOE` is cleared. DShot bit-period timers are not
+reconstructed. The stock timer model overflows after ARR ticks rather than
+ARR+1, so frames follow the emulated firmware's real timer and are one tick
+shorter than the register arithmetic. PWM channels carry a `PWMn` alias for
+`--sigrok-channels`, so `--sigrok-channels 'PWM*'` captures only the servo
+outputs. Each timer also answers monitor queries and can log every register
+write with its virtual timestamp, which is the emulated equivalent of putting
+a breakpoint on `pwmChangePeriod()`:
+
+```text
+sysbus.timer1Waveform PeriodUs
+sysbus.timer1Waveform PulseWidthUs 4
+sysbus.timer1Waveform LogWrites true
+logLevel 1 sysbus.timer1Waveform
+```
+
 Use `--sigrok-channels` to advertise only matching channels. It accepts a
 comma-separated list of case-insensitive shell wildcards matched against
 peripheral names, hwdef signal labels, logical GPIO names, and physical pin

--- a/Tools/renode/README.md
+++ b/Tools/renode/README.md
@@ -866,6 +866,26 @@ Tools/renode/run.py Pixhawk6X --sigrok
 pulseview -d renode-la:conn=tcp/127.0.0.1/4242
 ```
 
+The `renode-la` driver is not in upstream libsigrok or in distribution
+packages; it lives on the `ipdbg-la-fixes` branch of
+<https://github.com/tridge/libsigrok>. A private build needs only glib and
+libzip and can be used by a packaged PulseView or sigrok-cli, which share
+the library's ABI version 4:
+
+```sh
+git clone -b ipdbg-la-fixes https://github.com/tridge/libsigrok
+cd libsigrok && ./autogen.sh
+./configure --prefix=$PWD/install --disable-all-drivers --enable-renode-la \
+    --disable-cxx --disable-python --disable-ruby --disable-java
+make -j$(nproc) install
+LD_LIBRARY_PATH=$PWD/install/lib pulseview -d renode-la:conn=tcp/127.0.0.1/4242
+```
+
+The driver offers only continuous acquisition, so `sigrok-cli` needs
+`--continuous`; it stops on a keypress, so pipe `tail -f /dev/null` into it
+when scripting. Stream to `-O csv` rather than `-o file.sr`: a session file
+written in continuous mode is empty if the capture is interrupted.
+
 The capture contains the selected main MAVLink UART's TX and RX, then SCK,
 MOSI, MISO, every chip-select line belonging to the first SPI bus, and every
 pin with a `GPIO(n)` assignment in the compiled hwdef. This includes inactive

--- a/Tools/renode/README.md
+++ b/Tools/renode/README.md
@@ -207,7 +207,14 @@ every pause-at-a-breakpoint into a reboot).
 - `peripherals/common/AP_Sigrok.cs` — continuous TCP logic-analyser stream for
   the `renode-la` libsigrok driver. It reconstructs UART and SPI pin edges from
   Renode's byte-level peripheral transactions and samples chip selects from
-  their generated GPIO routes.
+  their generated GPIO routes. Analytic edge sources (`IAPSigrokEdgeSource`
+  in `AP_SigrokInterface.cs`) register with it and add or cancel edges under
+  its capture lock. Between captures it tracks only pin levels.
+- `peripherals/stm32/AP_STM32_Timer_Waveform.cs` — sigrok edge source for
+  `PWM(n)` pins: mirrors a timer's registers from a bus write hook, anchors
+  frames on the stock timer's overflow event and schedules compare edges
+  analytically, with monitor queries for period and pulse width and an
+  optional timestamped register write log.
 - `peripherals/common/AP_GPIOStimulus.cs` — on-demand pulse and quadrature
   sources addressed by ArduPilot's logical `GPIO(n)` numbers. They feed the
   physical pads selected by the hwdef and therefore traverse the normal STM32
@@ -291,6 +298,22 @@ see Running below.
   completed stream enable bit as the hardware does. This is required for both
   CubeBlack SDIO and Pixhawk4 SDMMC to finish mounting and enter the vehicle
   loop.
+- **Stock `STM32_Timer` does drive its output-compare pins** through the
+  `timerN -> gpioPortX#pin@AF` connections in the base platforms, contrary to
+  an earlier assumption here, but only with the granularity of its own event
+  scheduling (about 8 us of pulse-width jitter at 1 MHz) and without `BDTR`,
+  so an advanced timer's outputs never drop when MOE is cleared. It also
+  overflows after ARR ticks rather than ARR+1, so a 2500-tick frame is
+  2499 us. The generator routes PWM pins to `AP_STM32_Timer_Waveform` instead
+  of the GPIO fan-out; two edge sources on one sigrok channel corrupt the
+  analyser's dedupe state (a rising edge inserted behind a fall is dropped)
+  and produce pulse widths that are wrong in a way that changes every frame.
+- **`machine.ElapsedVirtualTime` is exact inside a peripheral event or bus
+  hook.** Read from a `LimitReached` handler or a `SetHookBeforePeripheralWrite`
+  callback it matched the ChibiOS system timer's CNT to 0.1 us with a 10 ms
+  quantum, so a reference-counter timestamp scheme is unnecessary there. It
+  is the sampler thread's view of time that only matters for how far a
+  capture may rasterise.
 - The generic Synopsys DWC QoS model replaces every word of an RX descriptor
   with write-back status. STM32H7 preserves RDES0, and ChibiOS initializes its
   buffer address only once before later returning descriptors by rewriting
@@ -314,6 +337,32 @@ see Running below.
 - 8s of virtual time in the config_error loop costs ~3.5min wall
   (~27x realtime) at quantum 1ms / 125 MIPS. The idle-heavy early boot is
   far faster (WFI sleeps skip time).
+- A run that has slowed to a crawl with MAVLink starved is measured, not
+  guessed: `machine ElapsedVirtualTime` prints virtual against host time and
+  its "cumulative load" is the slowdown factor. When `--sigrok` is on,
+  `sysbus.sigrok ReadDoubleWord 0x08` is the analyser's edge counter; before
+  the analyser tracked only levels while idle, an ArduPlane run with a
+  stream-requesting MAVProxy had inserted 95 million edges with no capture
+  started and ran at 1/20 real time. That counter should stay at zero until
+  a capture begins.
+- The socket UART terminal serves its first TCP client only. A port probe
+  that connects and disconnects to see whether the board is up consumes that
+  slot, after which MAVProxy gets "connection refused" until Renode is
+  restarted. Wait for the sigrok or monitor port instead, or connect once
+  and keep the connection.
+- `run.py` starts Renode in its own session so terminal signals reach only
+  the Python process; anything that ends run.py without its cleanup running
+  used to leave Renode and the GDB proxy orphaned at 100% CPU. SIGTERM and
+  SIGHUP now take the same path as Ctrl-C; check `pgrep -af renode` after a
+  launcher Stop or a closed terminal if an emulation seems to linger.
+- The ICP201XX barometer model has to fill its FIFO: `AP_Baro_ICP201XX::init()`
+  polls until 14 packets are present and then until one is, with no exit, so
+  a model answering a constant fill count parks the main thread in
+  `AP_Baro::init()` for ever with every other thread asleep. The symptom is
+  a booted-looking board (storage written, SD mounted) that never sends a
+  heartbeat. Under GDB the main thread is the one to backtrace; the ChibiOS
+  proxy only unwinds the current thread, so break on
+  `ChibiOS::Scheduler::delay` to land in it.
 
 ## Performance notes (perf-profiled, AM32-harness methodology)
 
@@ -929,6 +978,31 @@ sysbus.timer1Waveform PulseWidthUs 4
 sysbus.timer1Waveform LogWrites true
 logLevel 1 sysbus.timer1Waveform
 ```
+
+For developers adding another analytic source: implement
+`IAPSigrokEdgeSource` and call `RegisterEdgeSource` on the analyser. Produce
+every edge on the emulation thread from `analyzer.NowNs`, holding
+`analyzer.CaptureLock`; `Restart(now)` must publish each channel's current
+level when a capture begins and `Extend` may be a no-op if the source is
+event driven. `AddEdge` deduplicates against the channel's scheduled state,
+which is the level after the last queued edge, so only one source may feed a
+channel at a time and a source that pre-schedules a future edge must
+`CancelEdges` from the moment its state changes before publishing the new
+level. A PWM-capable pin is routed both to its timer's waveform source and to
+the GPIO fan-out, because firmware can drive it either way at runtime through
+`SERVO_GPIO_MASK` or `SERVOx_FUNCTION`, and `AP_Relay` does. The waveform
+source calls `SetAnalyticOwned` to claim the channel while its timer output is
+actually enabled, which makes the analyser ignore GPIO transitions on it; when
+it releases the channel the analyser resumes from the pin's present level.
+Without that arbitration the stock timer model's own jittery pad toggling
+would reach the capture alongside the reconstructed waveform. Do not
+generate edges while `analyzer.Capturing` is false; the analyser holds no
+pre-trigger history by design. Timer register writes arrive through a bus
+hook that must be installed after the timer is registered (retry on
+`machine.PeripheralsChanged`), and preloaded registers (ARR with ARPE, CCRx
+with OCxPE) must be applied at the next update event, not on the write.
+`tests/test_sigrok_pwm.py` shows a synthetic platform, a live renode-la
+capture and the generated wiring being checked.
 
 Use `--sigrok-channels` to advertise only matching channels. It accepts a
 comma-separated list of case-insensitive shell wildcards matched against

--- a/Tools/renode/gen_board.py
+++ b/Tools/renode/gen_board.py
@@ -1213,8 +1213,11 @@ def _hwdef_gpios(app):
     return sorted(gpios.items())
 
 
-def _timer_actuator_devices(app, family, iomcu_uart, alloc, warnings):
-    '''Map expanded hwdef PWM(n) pins onto protocol actuator channels.'''
+def _timer_pwm_channels(app, family, iomcu_uart, warnings):
+    '''Map expanded hwdef PWM(n) pins onto (timer, channel) tuples.
+
+    Each value is (physics actuator output, complementary, pin).
+    '''
     pins = list(app.bylabel.values())
     for alternate in app.altmap.values():
         pins.extend(alternate.values())
@@ -1248,9 +1251,13 @@ def _timer_actuator_devices(app, family, iomcu_uart, alloc, warnings):
         if output in outputs and outputs[output] != key:
             warnings.append('PWM(%u) is assigned to multiple timer channels' % pwm)
             continue
-        timer_channels[key] = (output, complementary)
+        timer_channels[key] = (output, complementary, pin)
         outputs[output] = key
+    return timer_channels
 
+
+def _timer_actuator_devices(timer_channels, alloc):
+    '''Emit the physics actuator sampler for every PWM timer.'''
     lines = []
     for timer in sorted({key[0] for key in timer_channels}):
         lines += [
@@ -1261,12 +1268,54 @@ def _timer_actuator_devices(app, family, iomcu_uart, alloc, warnings):
         for channel in range(1, 5):
             channel_config = timer_channels.get((timer, channel))
             if channel_config is not None:
-                output, complementary = channel_config
+                output, complementary, _ = channel_config
                 lines.append('    output%d: %d' % (channel, output))
                 if complementary:
                     lines.append('    complementary%d: true' % channel)
         lines.append('')
     return lines
+
+
+# Timers with a BDTR register, whose outputs all follow BDTR.MOE.
+ADVANCED_TIMERS = {1, 8, 15, 16, 17, 20}
+
+
+def _timer_waveform_devices(timer_channels, sigrok_pins, alloc):
+    '''Emit a sigrok PWM waveform reconstruction for every PWM timer whose
+    pins have sigrok channels. Returns the lines and the set of (port, pin)
+    the reconstruction covers; those pins must not also be routed from the
+    GPIO fan-out, where the stock timer model toggles them with the
+    granularity of its own event scheduling.'''
+    lines = []
+    covered = set()
+    for timer in sorted({key[0] for key in timer_channels}):
+        mapped = []
+        for channel in range(1, 5):
+            channel_config = timer_channels.get((timer, channel))
+            if channel_config is None:
+                continue
+            _, complementary, pin = channel_config
+            sigrok_channel = sigrok_pins.get((pin.port, pin.pin))
+            if sigrok_channel is not None:
+                mapped.append((channel, sigrok_channel, complementary))
+                covered.add((pin.port, pin.pin))
+        if not mapped:
+            continue
+        lines += [
+            'timer%dWaveform: Miscellaneous.AP_STM32_Timer_Waveform @ '
+            'sysbus 0x%08X' % (timer, alloc()),
+            '    timer: timer%d' % timer,
+            '    analyzer: sigrok',
+            '    name: "TIM%d"' % timer,
+        ]
+        for channel, sigrok_channel, complementary in mapped:
+            lines.append('    channel%d: %d' % (channel, sigrok_channel))
+            if complementary:
+                lines.append('    complementary%d: true' % channel)
+        if timer in ADVANCED_TIMERS:
+            lines.append('    advanced: true')
+        lines.append('')
+    return lines, covered
 
 
 def _power_status_inputs(app):
@@ -1769,6 +1818,10 @@ def _sigrok_signal(pin, fallback, *aliases):
 def _sigrok_gpio_signal(gpio, pin):
     signal = _sigrok_signal(pin, pin.label, 'GPIO%u' % gpio)
     signal['name'] += '/GPIO%u' % gpio
+    pwm = pin.extra_value('PWM', type=int)
+    if pwm is not None:
+        signal['aliases'].add('PWM%u' % pwm)
+        signal['name'] += '/PWM%u' % pwm
     return signal
 
 
@@ -1894,8 +1947,8 @@ def _platform(root, board, app, outdir, fram_path, is_periph, warnings,
         address += size
         return value
 
-    lines += _timer_actuator_devices(
-        app, family, iomcu_uart, alloc, warnings)
+    timer_channels = _timer_pwm_channels(app, family, iomcu_uart, warnings)
+    lines += _timer_actuator_devices(timer_channels, alloc)
 
     resolved_attachments = _resolve_attachments(app, family, attachments)
 
@@ -2235,6 +2288,14 @@ def _platform(root, board, app, outdir, fram_path, is_periph, warnings,
             for channel, (_, pin) in enumerate(
                 sigrok_capture['gpio_pins'], start=first_gpio_channel)
         })
+        # The pins a waveform peripheral covers stay in the GPIO fan-out as
+        # well: firmware can drive a PWM-capable pin as a GPIO at runtime,
+        # through SERVO_GPIO_MASK or SERVOx_FUNCTION, and AP_Relay does.  The
+        # analyser arbitrates, taking the waveform source while the timer
+        # drives the pad and the GPIO route otherwise.
+        waveform_lines, _ = _timer_waveform_devices(
+            timer_channels, sigrok_pins, alloc)
+        lines += waveform_lines
     lines += _gpio_routes(
         family['name'], chip_selects, sigrok_pins, gpio_pins)
     return ('\n'.join(lines).rstrip() + '\n', has_fram, iomcu_uart,

--- a/Tools/renode/launch.py
+++ b/Tools/renode/launch.py
@@ -15,7 +15,7 @@ one command per line:
   download-firmware VEHICLE stable|latest,
   cpu none|N, real-iomcu on|off, iomcu-force-update on|off,
   uds on|off, usb on|off, dfu on|off, can on|off, can-base N,
-  ethernet off|INTERFACE,
+  sigrok on|off, ethernet off|INTERFACE,
   attach PORT DEVICE, detach PORT DEVICE,
   physics on|off, physics-model NAME,
   physics-location LAT LON ALT HEADING, physics-rate HZ,
@@ -704,6 +704,8 @@ class Launcher:
         self.real_iomcu = False
         self.iomcu_force_update = False
         self.uds = False
+        self.sigrok = False
+        self.sigrok_port = getattr(args, 'sigrok_port', 4242)
         self.usb = False
         self.dfu = False
         self.can = False
@@ -784,6 +786,8 @@ class Launcher:
         ]
         if self.uds:
             command.append('--uds')
+        if self.sigrok:
+            command += ['--sigrok', '--sigrok-port', str(self.sigrok_port)]
         if self.args.renode:
             command += ['--renode', self.args.renode]
         if getattr(self.args, 'data_cache', None):
@@ -891,6 +895,8 @@ class Launcher:
         launcher_ports = [self.monitor_port, self.args.usbip_port]
         if not self.uds:
             launcher_ports.append(self.args.uart_port)
+        if self.sigrok:
+            launcher_ports.append(self.sigrok_port)
         if self.physics_port in launcher_ports:
             return 'physics port conflicts with another launcher port'
         if not self.wait_port_free(self.physics_port):
@@ -1334,6 +1340,7 @@ class Launcher:
             'real_iomcu': self.real_iomcu,
             'iomcu_force_update': self.iomcu_force_update,
             'uds': self.uds,
+            'sigrok': self.sigrok,
             'usb': self.usb_status,
             'dfu': self.dfu,
             'can': (self.can or any(attachment.get('bus') == 'can'
@@ -1413,6 +1420,7 @@ def main():
     parser.add_argument('--monitor-port', type=int, default=12390)
     parser.add_argument('--uart-port', type=int, default=5762)
     parser.add_argument('--usbip-port', type=int, default=3240)
+    parser.add_argument('--sigrok-port', type=int, default=4242)
     parser.add_argument('--physics-binary',
                         help='standalone renode-physics executable')
     parser.add_argument('--physics-port', type=int, default=9002)
@@ -1562,6 +1570,13 @@ def main():
         'Expose the selected UART as a Unix domain socket below the board\n'
         'state directory. Connect MAVProxy with --master=uds:PATH.')
     options_grid.addWidget(uds, 2, 0)
+
+    sigrok = QCheckBox('Sigrok')
+    sigrok.setToolTip(
+        'Stream the MAVLink UART, first SPI bus, GPIOs and reconstructed PWM\n'
+        'outputs as a logic-analyser capture. Open it in PulseView with\n'
+        'renode-la:conn=tcp/127.0.0.1/%u.' % args.sigrok_port)
+    options_grid.addWidget(sigrok, 3, 0)
 
     ethernet_enable = QCheckBox('Ethernet TAP')
     options_grid.addWidget(ethernet_enable, 2, 1)
@@ -2475,6 +2490,7 @@ def main():
         launcher.real_iomcu = real_iomcu.isChecked()
         launcher.iomcu_force_update = iomcu_update.isChecked()
         launcher.uds = uds.isChecked()
+        launcher.sigrok = sigrok.isChecked()
         launcher.usb = usb.isChecked()
         launcher.dfu = dfu_check.isChecked()
         launcher.can = can.isChecked()
@@ -2511,6 +2527,7 @@ def main():
                 'real_iomcu': launcher.real_iomcu,
                 'iomcu_force_update': launcher.iomcu_force_update,
                 'uds': launcher.uds,
+                'sigrok': launcher.sigrok,
                 'usb': launcher.usb,
                 'dfu': launcher.dfu,
                 'can': launcher.can,
@@ -2559,6 +2576,7 @@ def main():
     real_iomcu.toggled.connect(real_iomcu_changed)
     iomcu_update.toggled.connect(lambda _checked: sync_options())
     uds.toggled.connect(lambda _checked: sync_options())
+    sigrok.toggled.connect(lambda _checked: sync_options())
 
     def dfu_changed(checked):
         if checked:
@@ -2932,6 +2950,8 @@ def main():
             return set_checkbox(iomcu_update, value)
         if command == 'uds':
             return set_checkbox(uds, value)
+        if command == 'sigrok':
+            return set_checkbox(sigrok, value)
         if command == 'usb':
             return set_checkbox(usb, value)
         if command == 'dfu':
@@ -3096,6 +3116,7 @@ def main():
         real_iomcu.setChecked(target.get('real_iomcu') is True)
         iomcu_update.setChecked(target.get('iomcu_force_update') is True)
         uds.setChecked(target.get('uds') is True)
+        sigrok.setChecked(target.get('sigrok') is True)
         usb.setChecked(target.get('usb') is True)
         dfu_check.setChecked(target.get('dfu') is True)
         can_base_value = target.get('can_base')

--- a/Tools/renode/peripherals/common/AP_Sigrok.cs
+++ b/Tools/renode/peripherals/common/AP_Sigrok.cs
@@ -28,6 +28,7 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
             captureLock = new object();
             pendingInputs = new Dictionary<int, bool>();
             edges = new List<Edge>();
+            edgeSources = new List<IAPSigrokEdgeSource>();
             deviceName = "ArduPilot";
             sampleRate = DefaultSampleRate;
             spiFrequency = DefaultSpiFrequency;
@@ -210,6 +211,7 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 }
                 baseState = new bool[signalNames.Length];
                 scheduledState = new bool[signalNames.Length];
+                analyticOwned = new bool[signalNames.Length];
                 // UART wires idle high; SPI clock idles according to CPOL;
                 // GPIO chip selects are active-low and idle high.
                 baseState[UartTxChannel] = true;
@@ -353,6 +355,13 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 {
                     return;
                 }
+                if(analyticOwned[number])
+                {
+                    // the pin's timer is driving it; the stock timer model
+                    // also toggles the pad, and its jitter must not reach
+                    // the capture
+                    return;
+                }
                 AddEdgeLocked(number, value, Math.Max(NowNs, spiNextNs));
                 PruneIdleEdgesLocked();
             }
@@ -386,6 +395,93 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 spiNextNs = start + 16 * halfPeriodNs;
                 PruneIdleEdgesLocked();
             }
+        }
+
+        public object CaptureLock => captureLock;
+
+        public bool Capturing
+        {
+            get
+            {
+                lock(captureLock)
+                {
+                    return activeCapture != null;
+                }
+            }
+        }
+
+        public void RegisterEdgeSource(IAPSigrokEdgeSource source)
+        {
+            lock(captureLock)
+            {
+                if(!edgeSources.Contains(source))
+                {
+                    edgeSources.Add(source);
+                }
+            }
+        }
+
+        // Called by analytic edge sources with CaptureLock held.
+        public void SetAnalyticOwned(int channel, bool owned)
+        {
+            lock(captureLock)
+            {
+                if(signalNames == null || channel < 0 ||
+                   channel >= analyticOwned.Length ||
+                   analyticOwned[channel] == owned)
+                {
+                    return;
+                }
+                analyticOwned[channel] = owned;
+                if(!owned)
+                {
+                    // hand the channel back to the GPIO fan-out at the pin's
+                    // present level, so the next transition is an edge from
+                    // the right starting point
+                    bool level;
+                    if(pendingInputs.TryGetValue(channel, out level))
+                    {
+                        AddEdgeLocked(channel, level, NowNs);
+                    }
+                }
+            }
+        }
+
+        public void AddEdge(int channel, bool value, long timeNs)
+        {
+            if(signalNames == null || channel < 0 || channel >= signalNames.Length)
+            {
+                return;
+            }
+            AddEdgeLocked(channel, value, timeNs);
+        }
+
+        // Called by analytic edge sources with CaptureLock held: drop the
+        // channel's edges scheduled after fromNs, for a state change that
+        // pre-empts them, and restore its scheduled level accordingly.
+        public void CancelEdges(int channel, long fromNs)
+        {
+            if(signalNames == null || channel < 0 || channel >= signalNames.Length)
+            {
+                return;
+            }
+            var removed = edges.RemoveAll(
+                edge => edge.Channel == channel && edge.TimeNs > fromNs);
+            if(removed == 0)
+            {
+                return;
+            }
+            edgeCount -= (ulong)removed;
+            var level = baseState[channel];
+            for(var index = edges.Count - 1; index >= 0; index--)
+            {
+                if(edges[index].Channel == channel)
+                {
+                    level = edges[index].Value;
+                    break;
+                }
+            }
+            scheduledState[channel] = level;
         }
 
         private void HandleUARTTransmit(byte value)
@@ -535,6 +631,10 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                     enabledChannels.ToArray());
                 edges.RemoveAll(edge => !enabled[edge.Channel]);
                 captures++;
+                foreach(var source in edgeSources)
+                {
+                    source.Restart(now);
+                }
                 return activeCapture;
             }
         }
@@ -563,6 +663,10 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
             lock(captureLock)
             {
                 var now = NowNs;
+                foreach(var source in edgeSources)
+                {
+                    source.Extend(now);
+                }
                 if(capture.NextNs > now)
                 {
                     return null;
@@ -609,7 +713,7 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
             }
         }
 
-        private long NowNs => (long)(machine.ElapsedVirtualTime.TimeElapsed
+        public long NowNs => (long)(machine.ElapsedVirtualTime.TimeElapsed
             .TotalMicroseconds * 1000.0);
 
         private void Open(int value)
@@ -1040,6 +1144,7 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
         private readonly object captureLock;
         private readonly Dictionary<int, bool> pendingInputs;
         private readonly List<Edge> edges;
+        private readonly List<IAPSigrokEdgeSource> edgeSources;
         private IUART uart;
         private IUARTWithBufferState uartWithBufferState;
         private string[] signalNames;
@@ -1056,6 +1161,7 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
         private long uartRxNextNs;
         private long spiNextNs;
         private ulong edgeSequence;
+        private bool[] analyticOwned;
         private ulong edgeCount;
         private uint captures;
         private Capture activeCapture;

--- a/Tools/renode/peripherals/common/AP_Sigrok.cs
+++ b/Tools/renode/peripherals/common/AP_Sigrok.cs
@@ -1,7 +1,12 @@
 // Streaming logic analyser for the renode-la libsigrok driver. Renode's UART
 // and SPI models exchange complete bytes, so this peripheral turns those byte
 // transactions back into timestamped pin edges and rasterises them only while
-// a client is capturing.
+// a client is capturing. While no capture is active only the current level of
+// each channel is tracked: reconstructing edges for every byte on a busy IMU
+// bus costs more than the emulation itself, so there is no pre-trigger
+// history and a capture starts from the levels the pins have at that moment.
+// During a capture, sources whose channels the client left disabled are
+// skipped as well.
 using System;
 using System.Collections.Generic;
 using System.Net;
@@ -363,7 +368,6 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                     return;
                 }
                 AddEdgeLocked(number, value, Math.Max(NowNs, spiNextNs));
-                PruneIdleEdgesLocked();
             }
         }
 
@@ -372,6 +376,21 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
             lock(captureLock)
             {
                 if(signalNames == null)
+                {
+                    return;
+                }
+                if(activeCapture == null)
+                {
+                    // level tracking only: the bus ends the byte at its idle
+                    // clock with the last bit on the data lines
+                    SetLevelLocked(SpiClockChannel, spiMode >= 2);
+                    SetLevelLocked(SpiMosiChannel, (transmitted & 1) != 0);
+                    SetLevelLocked(SpiMisoChannel, (received & 1) != 0);
+                    return;
+                }
+                if(!activeCapture.Enabled[SpiClockChannel] &&
+                   !activeCapture.Enabled[SpiMosiChannel] &&
+                   !activeCapture.Enabled[SpiMisoChannel])
                 {
                     return;
                 }
@@ -393,7 +412,6 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                         bitStart + 2 * halfPeriodNs);
                 }
                 spiNextNs = start + 16 * halfPeriodNs;
-                PruneIdleEdgesLocked();
             }
         }
 
@@ -507,7 +525,10 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
         {
             lock(captureLock)
             {
-                if(signalNames == null)
+                // a UART line idles high between bytes, so with no capture,
+                // or with this line disabled, there is nothing to track
+                if(signalNames == null || activeCapture == null ||
+                   !activeCapture.Enabled[channel])
                 {
                     return;
                 }
@@ -531,18 +552,28 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
                 {
                     uartRxNextNs = next;
                 }
-                PruneIdleEdgesLocked();
             }
+        }
+
+        private void SetLevelLocked(int channel, bool value)
+        {
+            scheduledState[channel] = value;
+            baseState[channel] = value;
         }
 
         private void AddEdgeLocked(int channel, bool value, long timeNs)
         {
+            if(activeCapture == null)
+            {
+                SetLevelLocked(channel, value);
+                return;
+            }
             if(scheduledState[channel] == value)
             {
                 return;
             }
             scheduledState[channel] = value;
-            if(activeCapture != null && !activeCapture.Enabled[channel])
+            if(!activeCapture.Enabled[channel])
             {
                 return;
             }
@@ -554,14 +585,6 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
             }
             edges.Insert(index, edge);
             edgeCount++;
-        }
-
-        private void PruneIdleEdgesLocked()
-        {
-            if(activeCapture == null)
-            {
-                AdvanceBaseLocked(NowNs - IdleHistoryNs);
-            }
         }
 
         private void AdvanceBaseLocked(long throughNs)
@@ -645,13 +668,19 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
             {
                 if(activeCapture == capture)
                 {
-                    for(var channel = 0; channel < capture.Enabled.Length;
-                        channel++)
+                    // Apply whatever is already due, then drop the rest.
+                    // While no capture is running we track levels only, so
+                    // nothing may stay queued: a leftover edge would be
+                    // replayed over the newer idle level when the next
+                    // capture begins, showing a stale level on restart.
+                    // Analytic sources re-emit their current level from
+                    // Restart(), so discarding what they scheduled ahead
+                    // loses nothing.
+                    AdvanceBaseLocked(NowNs);
+                    edges.Clear();
+                    for(var channel = 0; channel < baseState.Length; channel++)
                     {
-                        if(!capture.Enabled[channel])
-                        {
-                            baseState[channel] = scheduledState[channel];
-                        }
+                        baseState[channel] = scheduledState[channel];
                     }
                     activeCapture = null;
                 }
@@ -1188,7 +1217,6 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
         private const uint MaxSampleRate = 1000000000;
         private const int SamplesPerFrame = 65536;
         private const int MaxDataPayload = 16 * 1024 * 1024;
-        private const long IdleHistoryNs = 1000000000L;
         private const int GreetingSize = 24;
         private const int FrameHeaderSize = 8;
         private const ushort ProtocolVersion = 2;

--- a/Tools/renode/peripherals/common/AP_SigrokInterface.cs
+++ b/Tools/renode/peripherals/common/AP_SigrokInterface.cs
@@ -3,5 +3,32 @@ namespace Antmicro.Renode.Peripherals.Miscellaneous
     public interface IAPSigrok
     {
         void ObserveSPI(byte transmitted, byte received);
+
+        // Analytic edge sources, such as timer PWM outputs, reconstruct their
+        // pin levels from peripheral state rather than from byte transactions.
+        // They add edges only while holding CaptureLock.
+        object CaptureLock { get; }
+        bool Capturing { get; }
+        long NowNs { get; }
+        void RegisterEdgeSource(IAPSigrokEdgeSource source);
+        void AddEdge(int channel, bool value, long timeNs);
+        void CancelEdges(int channel, long fromNs);
+
+        // A PWM-capable pin is routed both to its timer's waveform source and
+        // to the GPIO fan-out, because firmware may drive it either way at
+        // runtime.  Only one of them may feed a channel at a time, so a
+        // source claims the channel while it is actually driving the pin;
+        // GPIO transitions are ignored for a claimed channel, and picked up
+        // again from the pin's current level when it is released.
+        void SetAnalyticOwned(int channel, bool owned);
+    }
+
+    public interface IAPSigrokEdgeSource
+    {
+        // Both are called with the analyser's CaptureLock held. Restart is
+        // called when a capture begins and must emit the current level of
+        // every channel at nowNs; Extend must emit every edge up to throughNs.
+        void Restart(long nowNs);
+        void Extend(long throughNs);
     }
 }

--- a/Tools/renode/peripherals/sensors/AP_AdditionalBarometers.cs
+++ b/Tools/renode/peripherals/sensors/AP_AdditionalBarometers.cs
@@ -831,6 +831,7 @@ namespace Antmicro.Renode.Peripherals.Sensors
             Registers[0xBF] = 0x01;
             Registers[0xCD] = 0x01;
             pressureSampleNumber = 0;
+            fifoFill = 0;
             UpdateSample();
         }
 
@@ -839,6 +840,8 @@ namespace Antmicro.Renode.Peripherals.Sensors
             if(Pointer == FifoBase && !SuppressData)
             {
                 UpdateSample();
+                // reading the FIFO drains it
+                fifoFill = 0;
             }
             return base.Read(count);
         }
@@ -849,13 +852,38 @@ namespace Antmicro.Renode.Peripherals.Sensors
         {
             if(register == FifoFill)
             {
-                return SuppressData ? (byte)0 : (byte)1;
+                if(SuppressData)
+                {
+                    return 0;
+                }
+                // The FIFO gains one packet per poll. AP_Baro_ICP201XX::init()
+                // discards the first 14 packets by polling FIFO_FILL every
+                // 10 ms until it reads at least 14, flushes, then polls until a
+                // packet is present; a constant 1 never leaves that first
+                // loop. Steady-state timer() polls then drains, so it sees one
+                // packet, which is all the 6-byte FIFO window at the top of
+                // the register map can hold. The driver flushes above 16.
+                fifoFill = (byte)Math.Min(fifoFill + 1, MaxFifoFill);
+                return fifoFill;
             }
             if(SuppressData && register >= FifoBase)
             {
                 return 0;
             }
             return base.ReadRegister(register);
+        }
+
+        protected override void WriteRegister(int register, byte value)
+        {
+            if(register == FifoFill)
+            {
+                if((value & FifoFlush) != 0)
+                {
+                    fifoFill = 0;
+                }
+                return;
+            }
+            base.WriteRegister(register, value);
         }
 
         private void UpdateSample()
@@ -882,8 +910,11 @@ namespace Antmicro.Renode.Peripherals.Sensors
 
         private readonly AP_PhysicsState physics;
         private uint pressureSampleNumber;
+        private byte fifoFill;
 
         private const int FifoFill = 0xC4;
         private const int FifoBase = 0xFA;
+        private const byte FifoFlush = 0x80;
+        private const byte MaxFifoFill = 16;
     }
 }

--- a/Tools/renode/peripherals/stm32/AP_STM32_Timer_Waveform.cs
+++ b/Tools/renode/peripherals/stm32/AP_STM32_Timer_Waveform.cs
@@ -1,0 +1,577 @@
+// Reconstructs the PWM waveform on STM32 timer output pins for the sigrok
+// logic analyser. Renode's STM32_Timer toggles its output-compare pins with
+// the granularity of its own event scheduling, so the generator routes PWM
+// pins here instead of to the GPIO fan-out: this peripheral mirrors the
+// PWM-relevant registers from a bus write hook, takes each frame boundary
+// from the timer model's overflow event, and schedules the edges of every
+// frame analytically from PSC, ARR and CCRx. It follows the hardware rules
+// that matter for ArduPilot's RCOutput: ARR and CCRx are preloaded (ARPE,
+// OCxPE) and take effect at the next update event, EGR.UG forces one and
+// restarts the counter (OneShot), CEN=0 freezes the counter and therefore
+// holds the pin at its current level, a disabled channel (CCxE=0) idles low,
+// and an advanced timer drops every output when BDTR.MOE is cleared. Timers
+// running a DShot bit period are identified but not reconstructed.
+//
+// Every edge is produced on the emulation thread from the machine clock,
+// which is exact there. The optional write log records each register write
+// with that timestamp. Note that the stock timer model overflows after ARR
+// ticks rather than ARR+1, so reconstructed frames follow the emulated
+// firmware's real timer and are one tick shorter than PeriodUs reports.
+using System;
+using Antmicro.Renode.Core;
+using Antmicro.Renode.Exceptions;
+using Antmicro.Renode.Logging;
+using Antmicro.Renode.Peripherals;
+using Antmicro.Renode.Peripherals.Bus;
+using Antmicro.Renode.Peripherals.Timers;
+
+namespace Antmicro.Renode.Peripherals.Miscellaneous
+{
+    public class AP_STM32_Timer_Waveform : IDoubleWordPeripheral, IKnownSize,
+        IAPSigrokEdgeSource
+    {
+        public AP_STM32_Timer_Waveform(IMachine machine, STM32_Timer timer,
+            IAPSigrok analyzer, int channel1 = Unmapped, int channel2 = Unmapped,
+            int channel3 = Unmapped, int channel4 = Unmapped,
+            bool complementary1 = false, bool complementary2 = false,
+            bool complementary3 = false, bool complementary4 = false,
+            bool advanced = false, string name = "TIM")
+        {
+            this.machine = machine;
+            this.timer = timer;
+            this.analyzer = analyzer;
+            this.advanced = advanced;
+            this.name = name;
+            channels = new int[] { channel1, channel2, channel3, channel4 };
+            complementary = new bool[] {
+                complementary1, complementary2, complementary3, complementary4
+            };
+            compare = new uint[ChannelCount];
+            pendingCompare = new uint[ChannelCount];
+            hasPendingCompare = new bool[ChannelCount];
+            mode = new uint[ChannelCount];
+            preloadCompare = new bool[ChannelCount];
+            outputEnable = new bool[ChannelCount];
+            polarity = new bool[ChannelCount];
+            ResetState();
+            analyzer.RegisterEdgeSource(this);
+            timer.LimitReached += HandleOverflow;
+            // Platform entries are all constructed before any is registered,
+            // so the timer may not be on the bus yet; retry as peripherals
+            // are added.
+            TryInstallHook();
+            if(!hooked)
+            {
+                machine.PeripheralsChanged += OnPeripheralsChanged;
+            }
+        }
+
+        public uint ReadDoubleWord(long offset) => 0;
+        public void WriteDoubleWord(long offset, uint value) { }
+        public long Size => 4;
+
+        public void Reset()
+        {
+            lock(analyzer.CaptureLock)
+            {
+                var now = CurrentTimeNs();
+                ResetState();
+                Reschedule(now);
+            }
+        }
+
+        // Log every register write with its timestamp. Enable with
+        // "logLevel 1 sysbus.timerNWaveform" so the Info lines are shown.
+        public bool LogWrites { get; set; }
+
+        // Reconstructed frame period in microseconds (0 when not running).
+        public double PeriodUs
+        {
+            get
+            {
+                lock(analyzer.CaptureLock)
+                {
+                    return running ? periodNs / 1000.0 : 0.0;
+                }
+            }
+        }
+
+        // Reconstructed pulse width in microseconds for timer channel 1..4.
+        public double PulseWidthUs(int channel)
+        {
+            if(channel < 1 || channel > ChannelCount)
+            {
+                throw new ArgumentOutOfRangeException(nameof(channel));
+            }
+            lock(analyzer.CaptureLock)
+            {
+                var index = channel - 1;
+                if(!running || !OutputEnabled(index))
+                {
+                    return 0.0;
+                }
+                var ticks = mode[index] == PwmMode2 ?
+                    (double)Math.Max(0L, (long)autoReload + 1 - compare[index]) :
+                    (double)Math.Min((ulong)compare[index], autoReload + 1UL);
+                return ticks * tickNs / 1000.0;
+            }
+        }
+
+        // A capture begins: publish the current level of every pin and the
+        // remaining edge of the frame in progress.
+        public void Restart(long nowNs)
+        {
+            Reschedule(Math.Max(nowNs, lastEventNs));
+        }
+
+        // Edges are produced by the timer's own events, not by the sampler.
+        public void Extend(long throughNs)
+        {
+        }
+
+        private void OnPeripheralsChanged(IMachine changedMachine,
+            PeripheralsChangedEventArgs args)
+        {
+            TryInstallHook();
+        }
+
+        private void TryInstallHook()
+        {
+            if(hooked)
+            {
+                return;
+            }
+            try
+            {
+                machine.SystemBus.SetHookBeforePeripheralWrite<uint>(timer,
+                    (value, offset) =>
+                    {
+                        HandleWrite(offset, value);
+                        return value;
+                    });
+            }
+            catch(RecoverableException)
+            {
+                return;
+            }
+            hooked = true;
+            machine.PeripheralsChanged -= OnPeripheralsChanged;
+        }
+
+        // The counter wrapped: a new frame starts and preloads take effect.
+        private void HandleOverflow()
+        {
+            lock(analyzer.CaptureLock)
+            {
+                if(!running)
+                {
+                    return;
+                }
+                var now = CurrentTimeNs();
+                periodStartNs = now;
+                started = true;
+                ApplyPending();
+                ScheduleFrame(now);
+            }
+        }
+
+        private void HandleWrite(long offset, uint value)
+        {
+            lock(analyzer.CaptureLock)
+            {
+                var now = CurrentTimeNs();
+                if(LogWrites)
+                {
+                    this.Log(LogLevel.Info, "{0} {1} <- 0x{2:X8} at {3:F1} us",
+                        name, RegisterName(offset), value, now / 1000.0);
+                }
+                switch(offset)
+                {
+                case Control1:
+                    SetRunning((value & CounterEnable) != 0, now);
+                    autoReloadPreload = (value & AutoReloadPreload) != 0;
+                    break;
+                case EventGeneration:
+                    if((value & UpdateGeneration) == 0)
+                    {
+                        return;
+                    }
+                    periodStartNs = now;
+                    frozenNs = now;
+                    started = true;
+                    ApplyPending();
+                    break;
+                case CaptureCompareMode1:
+                    SetMode(0, value);
+                    SetMode(1, value >> 8);
+                    break;
+                case CaptureCompareMode2:
+                    SetMode(2, value);
+                    SetMode(3, value >> 8);
+                    break;
+                case CaptureCompareEnable:
+                    for(var channel = 0; channel < ChannelCount; channel++)
+                    {
+                        // a pin declared TIMx_CHyN is driven from CCxNE and
+                        // CCxNP, two bits up the nibble; ChibiOS leaves CCxE
+                        // clear for such a channel, so reading only CCxE
+                        // would hold the pin low for ever.  With CCxE clear,
+                        // CCxNE set and MOE set the pin follows OCxREF xor
+                        // CCxNP, so no extra inversion is needed here.
+                        var shift = channel * 4 + (complementary[channel] ? 2 : 0);
+                        outputEnable[channel] = (value & (1U << shift)) != 0;
+                        polarity[channel] = (value & (2U << shift)) != 0;
+                    }
+                    break;
+                case Counter:
+                    periodStartNs = now - value * tickNs;
+                    break;
+                case Prescaler:
+                    pendingPrescaler = value;
+                    hasPendingPrescaler = true;
+                    return;
+                case AutoReload:
+                    if(autoReloadPreload)
+                    {
+                        pendingAutoReload = value;
+                        hasPendingAutoReload = true;
+                        return;
+                    }
+                    autoReload = value;
+                    RecomputePeriod();
+                    break;
+                case CaptureCompare1:
+                case CaptureCompare2:
+                case CaptureCompare3:
+                case CaptureCompare4:
+                    var index = (int)((offset - CaptureCompare1) / 4);
+                    if(preloadCompare[index])
+                    {
+                        pendingCompare[index] = value;
+                        hasPendingCompare[index] = true;
+                        return;
+                    }
+                    compare[index] = value;
+                    break;
+                case BreakDeadTime:
+                    mainOutputEnable = (value & MainOutputEnable) != 0;
+                    break;
+                default:
+                    return;
+                }
+                Reschedule(now);
+            }
+        }
+
+        private void SetMode(int channel, uint bits)
+        {
+            mode[channel] = (bits >> 4) & 0x7;
+            preloadCompare[channel] = (bits & OutputComparePreload) != 0;
+        }
+
+        private void SetRunning(bool enable, long now)
+        {
+            if(enable == running)
+            {
+                return;
+            }
+            if(enable)
+            {
+                if(!started)
+                {
+                    periodStartNs = now;
+                    started = true;
+                }
+                else
+                {
+                    // resume from the frozen counter
+                    periodStartNs += now - frozenNs;
+                }
+            }
+            else
+            {
+                frozenNs = now;
+            }
+            running = enable;
+        }
+
+        private void ApplyPending()
+        {
+            if(hasPendingPrescaler)
+            {
+                prescaler = pendingPrescaler;
+                hasPendingPrescaler = false;
+            }
+            if(hasPendingAutoReload)
+            {
+                autoReload = pendingAutoReload;
+                hasPendingAutoReload = false;
+            }
+            for(var channel = 0; channel < ChannelCount; channel++)
+            {
+                if(hasPendingCompare[channel])
+                {
+                    compare[channel] = pendingCompare[channel];
+                    hasPendingCompare[channel] = false;
+                }
+            }
+            RecomputePeriod();
+        }
+
+        private void RecomputePeriod()
+        {
+            tickNs = timer.Frequency == 0 ? 0.0 :
+                (prescaler + 1.0) * NanosecondsPerSecond / timer.Frequency;
+            periodNs = (autoReload + 1.0) * tickNs;
+        }
+
+        // A frame starts at now: every pin takes its counter-zero level and
+        // the compare match later in the frame is scheduled ahead of time.
+        private void ScheduleFrame(long now)
+        {
+            if(!analyzer.Capturing || periodNs < MinimumPeriodNs)
+            {
+                return;
+            }
+            for(var channel = 0; channel < ChannelCount; channel++)
+            {
+                if(channels[channel] == Unmapped)
+                {
+                    continue;
+                }
+                analyzer.AddEdge(channels[channel], Level(channel, 0.0), now);
+                ScheduleMatch(channel, now);
+            }
+        }
+
+        // Timer state changed at now: drop what was scheduled beyond now,
+        // publish the level every pin has now, and re-schedule the rest of
+        // the frame in progress from the new state.
+        // Tell the analyser which pads this timer is actually driving.  Done
+        // whether or not a capture is running, because the GPIO fan-out
+        // updates idle levels too.
+        private void UpdateOwnership()
+        {
+            for(var channel = 0; channel < ChannelCount; channel++)
+            {
+                if(channels[channel] == Unmapped)
+                {
+                    continue;
+                }
+                analyzer.SetAnalyticOwned(channels[channel], OutputEnabled(channel));
+            }
+        }
+
+        private void Reschedule(long now)
+        {
+            UpdateOwnership();
+            if(!analyzer.Capturing)
+            {
+                return;
+            }
+            for(var channel = 0; channel < ChannelCount; channel++)
+            {
+                if(channels[channel] == Unmapped)
+                {
+                    continue;
+                }
+                if(!OutputEnabled(channel))
+                {
+                    // the timer is not driving this pad, so firmware may be
+                    // using it as a GPIO; leave the channel to the GPIO
+                    // fan-out rather than holding it low
+                    continue;
+                }
+                analyzer.CancelEdges(channels[channel], now);
+                analyzer.AddEdge(channels[channel], CurrentLevel(channel, now), now);
+                if(running && periodNs >= MinimumPeriodNs)
+                {
+                    ScheduleMatch(channel, now);
+                }
+            }
+        }
+
+        private void ScheduleMatch(int channel, long now)
+        {
+            var ticks = compare[channel];
+            if(ticks == 0 || ticks > autoReload)
+            {
+                return;
+            }
+            var at = periodStartNs + ticks * tickNs;
+            if(at > now && at < periodStartNs + periodNs)
+            {
+                analyzer.AddEdge(channels[channel], Level(channel, ticks), (long)at);
+            }
+        }
+
+        private bool CurrentLevel(int channel, long now)
+        {
+            if(!started || tickNs <= 0.0)
+            {
+                return false;
+            }
+            var reference = running ? now : frozenNs;
+            var ticks = (reference - periodStartNs) / tickNs;
+            if(periodNs > 0.0)
+            {
+                ticks -= Math.Floor(ticks / (autoReload + 1.0)) * (autoReload + 1.0);
+            }
+            return Level(channel, ticks);
+        }
+
+        private bool Level(int channel, double ticks)
+        {
+            if(!OutputEnabled(channel))
+            {
+                return false;
+            }
+            bool active;
+            switch(mode[channel])
+            {
+            case PwmMode1:
+                active = ticks < compare[channel];
+                break;
+            case PwmMode2:
+                active = ticks >= compare[channel];
+                break;
+            case ForceInactive:
+                active = false;
+                break;
+            case ForceActive:
+                active = true;
+                break;
+            default:
+                return false;
+            }
+            return active ^ polarity[channel];
+        }
+
+        private bool OutputEnabled(int channel)
+        {
+            return outputEnable[channel] && (!advanced || mainOutputEnable);
+        }
+
+        // Emulation-thread machine time, kept monotonic.
+        private long CurrentTimeNs()
+        {
+            var now = analyzer.NowNs;
+            if(now < lastEventNs)
+            {
+                now = lastEventNs;
+            }
+            lastEventNs = now;
+            return now;
+        }
+
+        private void ResetState()
+        {
+            running = false;
+            started = false;
+            autoReloadPreload = false;
+            mainOutputEnable = false;
+            prescaler = 0;
+            autoReload = 0;
+            hasPendingPrescaler = false;
+            hasPendingAutoReload = false;
+            Array.Clear(compare, 0, compare.Length);
+            Array.Clear(hasPendingCompare, 0, hasPendingCompare.Length);
+            Array.Clear(mode, 0, mode.Length);
+            Array.Clear(preloadCompare, 0, preloadCompare.Length);
+            Array.Clear(outputEnable, 0, outputEnable.Length);
+            Array.Clear(polarity, 0, polarity.Length);
+            periodStartNs = 0.0;
+            frozenNs = 0;
+            RecomputePeriod();
+        }
+
+        private static string RegisterName(long offset)
+        {
+            switch(offset)
+            {
+            case Control1: return "CR1";
+            case 0x04: return "CR2";
+            case 0x08: return "SMCR";
+            case 0x0C: return "DIER";
+            case 0x10: return "SR";
+            case EventGeneration: return "EGR";
+            case CaptureCompareMode1: return "CCMR1";
+            case CaptureCompareMode2: return "CCMR2";
+            case CaptureCompareEnable: return "CCER";
+            case Counter: return "CNT";
+            case Prescaler: return "PSC";
+            case AutoReload: return "ARR";
+            case 0x30: return "RCR";
+            case CaptureCompare1: return "CCR1";
+            case CaptureCompare2: return "CCR2";
+            case CaptureCompare3: return "CCR3";
+            case CaptureCompare4: return "CCR4";
+            case BreakDeadTime: return "BDTR";
+            case 0x48: return "DCR";
+            case 0x4C: return "DMAR";
+            default: return String.Format("0x{0:X2}", offset);
+            }
+        }
+
+        private readonly IMachine machine;
+        private readonly STM32_Timer timer;
+        private readonly IAPSigrok analyzer;
+        private readonly bool advanced;
+        private readonly string name;
+        private readonly int[] channels;
+        private readonly bool[] complementary;
+        private readonly uint[] compare;
+        private readonly uint[] pendingCompare;
+        private readonly bool[] hasPendingCompare;
+        private readonly uint[] mode;
+        private readonly bool[] preloadCompare;
+        private readonly bool[] outputEnable;
+        private readonly bool[] polarity;
+
+        private bool hooked;
+        private bool running;
+        private bool started;
+        private bool autoReloadPreload;
+        private bool mainOutputEnable;
+        private uint prescaler;
+        private uint pendingPrescaler;
+        private bool hasPendingPrescaler;
+        private uint autoReload;
+        private uint pendingAutoReload;
+        private bool hasPendingAutoReload;
+        private double tickNs;
+        private double periodNs;
+        private double periodStartNs;
+        private long frozenNs;
+        private long lastEventNs;
+
+        private const int Unmapped = -1;
+        private const int ChannelCount = 4;
+        private const long Control1 = 0x00;
+        private const long EventGeneration = 0x14;
+        private const long CaptureCompareMode1 = 0x18;
+        private const long CaptureCompareMode2 = 0x1C;
+        private const long CaptureCompareEnable = 0x20;
+        private const long Counter = 0x24;
+        private const long Prescaler = 0x28;
+        private const long AutoReload = 0x2C;
+        private const long CaptureCompare1 = 0x34;
+        private const long CaptureCompare2 = 0x38;
+        private const long CaptureCompare3 = 0x3C;
+        private const long CaptureCompare4 = 0x40;
+        private const long BreakDeadTime = 0x44;
+        private const uint CounterEnable = 1U << 0;
+        private const uint AutoReloadPreload = 1U << 7;
+        private const uint UpdateGeneration = 1U << 0;
+        private const uint OutputComparePreload = 1U << 3;
+        private const uint MainOutputEnable = 1U << 15;
+        private const uint ForceInactive = 4;
+        private const uint ForceActive = 5;
+        private const uint PwmMode1 = 6;
+        private const uint PwmMode2 = 7;
+        private const double NanosecondsPerSecond = 1000000000.0;
+        // Below this frame period the timer carries a DShot or serial bit
+        // stream whose CCR changes by DMA; that is not a servo waveform.
+        private const double MinimumPeriodNs = 20000.0;
+    }
+}

--- a/Tools/renode/platforms/stm32h743_base.repl
+++ b/Tools/renode/platforms/stm32h743_base.repl
@@ -100,55 +100,75 @@ adc3: Analog.STM32F0_ADC @ sysbus 0x58026000
 bdma: DMA.STM32LDMA @ sysbus 0x58025400
     [0-7] -> exti@[66-73]
 
+// GPIO reset values from RM0433: unused pins come up in analog mode, and
+// the JTAG/SWD pins keep their alternate function, speed and pulls through a
+// reset (PA13 and PA15 pull-up, PA14 pull-down, PB4 pull-up). Firmware that
+// drives a servo from PA15 or PB4 therefore sees that pin pulled high from the
+// reset until the bootloader's board init, exactly as the silicon does.
 gpioPortK: GPIOPort.STM32_GPIOPort @ sysbus <0x58022800, +0x400>
+    modeResetValue: 0xFFFFFFFF
     numberOfAFs: 16
     invertedAFPins: [[0, 1], [1, 3]]
     [0-7] -> syscfg#10@[0-7]
 
 gpioPortJ: GPIOPort.STM32_GPIOPort @ sysbus <0x58022400, +0x400>
+    modeResetValue: 0xFFFFFFFF
     numberOfAFs: 16
     invertedAFPins: [[7, 3], [8, 1], [9, 3], [10, 1], [11, 3]]
     [0-15] -> syscfg#9@[0-15]
 
 gpioPortI: GPIOPort.STM32_GPIOPort @ sysbus <0x58022000, +0x400>
+    modeResetValue: 0xFFFFFFFF
     numberOfAFs: 16
     [0-15] -> syscfg#8@[0-15]
 
 gpioPortH: GPIOPort.STM32_GPIOPort @ sysbus <0x58021C00, +0x400>
+    modeResetValue: 0xFFFFFFFF
     numberOfAFs: 16
     invertedAFPins: [[13, 3], [14, 3], [15, 3]]
     [0-15] -> syscfg#7@[0-15]
 
 gpioPortG: GPIOPort.STM32_GPIOPort @ sysbus <0x58021800, +0x400>
+    modeResetValue: 0xFFFFFFFF
     numberOfAFs: 16
     [0-15] -> syscfg#6@[0-15]
 
 gpioPortF: GPIOPort.STM32_GPIOPort @ sysbus <0x58021400, +0x400>
+    modeResetValue: 0xFFFFFFFF
     numberOfAFs: 16
     invertedAFPins: [[8, 1], [9, 1]]
 
     [0-15] -> syscfg#5@[0-15]
 
 gpioPortE: GPIOPort.STM32_GPIOPort @ sysbus <0x58021000, +0x400>
+    modeResetValue: 0xFFFFFFFF
     numberOfAFs: 16
     invertedAFPins: [[4, 4], [8, 1], [10, 1], [12, 1]]
     [0-15] -> syscfg#4@[0-15]
 
 gpioPortD: GPIOPort.STM32_GPIOPort @ sysbus <0x58020C00, +0x400>
+    modeResetValue: 0xFFFFFFFF
     numberOfAFs: 16
     [0-15] -> syscfg#3@[0-15]
 
 gpioPortC: GPIOPort.STM32_GPIOPort @ sysbus <0x58020800, +0x400>
+    modeResetValue: 0xFFFFFFFF
     numberOfAFs: 16
     [0-15] -> syscfg#2@[0-15]
 
 gpioPortB: GPIOPort.STM32_GPIOPort @ sysbus <0x58020400, +0x400>
+    modeResetValue: 0xFFFFFEBF
+    outputSpeedResetValue: 0x000000C0
+    pullUpPullDownResetValue: 0x00000100
     numberOfAFs: 16
     invertedAFPins: [[0, 1, 3], [1, 1, 3], [6, 1], [7, 1], [13, 1], [14, 1, 3], [15, 1, 3]]
 
     [0-15] -> syscfg#1@[0-15]
 
 gpioPortA: GPIOPort.STM32_GPIOPort @ sysbus <0x58020000, +0x400>
+    modeResetValue: 0xABFFFFFF
+    outputSpeedResetValue: 0x0C000000
+    pullUpPullDownResetValue: 0x64000000
     numberOfAFs: 16
     invertedAFPins: [[5, 3], [7, 1, 3]]
     [0-15] -> syscfg#0@[0-15]

--- a/Tools/renode/run.py
+++ b/Tools/renode/run.py
@@ -726,7 +726,8 @@ def main():
                         help='expose the selected UART as APM-UDS-serialN '
                              'below the board state directory')
     parser.add_argument('--sigrok', action='store_true',
-                        help='stream the MAVLink UART and first SPI bus to sigrok')
+                        help='stream the MAVLink UART, first SPI bus, GPIOs and PWM '
+                             'outputs to sigrok')
     parser.add_argument('--sigrok-port', type=int, default=4242,
                         help='TCP port for sigrok capture (default: 4242)')
     parser.add_argument('--sigrok-sample-rate', type=int, default=10000000,

--- a/Tools/renode/run.py
+++ b/Tools/renode/run.py
@@ -668,8 +668,20 @@ def run_renode(cmd, env, cpusel):
         raise
 
 
+def _terminate_on_signal(signum, frame):
+    # Renode runs in its own session so that terminal signals reach only
+    # this process; turn a termination request into the same cleanup path
+    # as Ctrl-C so Renode, the GDB helpers and device sidecars are stopped
+    # rather than orphaned.
+    raise KeyboardInterrupt
+
+
 def main():
     root = Path(__file__).resolve().parents[2]
+    for name in ('SIGTERM', 'SIGHUP'):
+        signum = getattr(signal, name, None)
+        if signum is not None:
+            signal.signal(signum, _terminate_on_signal)
     boards = gen_board.supported_boards(root)
 
     parser = argparse.ArgumentParser(description=__doc__,

--- a/Tools/renode/scripts/ardupilot_f103.resc
+++ b/Tools/renode/scripts/ardupilot_f103.resc
@@ -19,6 +19,7 @@ include $repo/Tools/renode/peripherals/common/AP_Physics.cs
 include $repo/Tools/renode/peripherals/common/AP_I2CRegisterDevice.cs
 include $repo/Tools/renode/peripherals/common/AP_UARTFrameDevice.cs
 include $repo/Tools/renode/peripherals/stm32/AP_STM32_Timer_Actuators.cs
+include $repo/Tools/renode/peripherals/stm32/AP_STM32_Timer_Waveform.cs
 include $repo/Tools/renode/peripherals/common/AP_SPIMultiplexer.cs
 include $repo/Tools/renode/peripherals/common/AP_CANMcast.cs
 include $repo/Tools/renode/peripherals/sensors/AP_AdditionalBarometers.cs

--- a/Tools/renode/scripts/ardupilot_f303.resc
+++ b/Tools/renode/scripts/ardupilot_f303.resc
@@ -17,6 +17,7 @@ include $repo/Tools/renode/peripherals/common/AP_Physics.cs
 include $repo/Tools/renode/peripherals/common/AP_I2CRegisterDevice.cs
 include $repo/Tools/renode/peripherals/common/AP_UARTFrameDevice.cs
 include $repo/Tools/renode/peripherals/stm32/AP_STM32_Timer_Actuators.cs
+include $repo/Tools/renode/peripherals/stm32/AP_STM32_Timer_Waveform.cs
 include $repo/Tools/renode/peripherals/common/AP_SPIMultiplexer.cs
 include $repo/Tools/renode/peripherals/common/AP_CANMcast.cs
 include $repo/Tools/renode/peripherals/common/AP_UARTPacer.cs

--- a/Tools/renode/scripts/ardupilot_f405.resc
+++ b/Tools/renode/scripts/ardupilot_f405.resc
@@ -22,6 +22,7 @@ include $repo/Tools/renode/peripherals/common/AP_I2CRegisterDevice.cs
 include $repo/Tools/renode/peripherals/common/AP_UARTFrameDevice.cs
 include $repo/Tools/renode/peripherals/common/AP_UARTPacer.cs
 include $repo/Tools/renode/peripherals/stm32/AP_STM32_Timer_Actuators.cs
+include $repo/Tools/renode/peripherals/stm32/AP_STM32_Timer_Waveform.cs
 include $repo/Tools/renode/peripherals/common/AP_IOMCU.cs
 include $repo/Tools/renode/peripherals/common/AP_SPIMultiplexer.cs
 include $repo/Tools/renode/peripherals/common/AP_CANMcast.cs

--- a/Tools/renode/scripts/ardupilot_f767.resc
+++ b/Tools/renode/scripts/ardupilot_f767.resc
@@ -16,6 +16,7 @@ include $repo/Tools/renode/peripherals/common/AP_Physics.cs
 include $repo/Tools/renode/peripherals/common/AP_I2CRegisterDevice.cs
 include $repo/Tools/renode/peripherals/common/AP_UARTFrameDevice.cs
 include $repo/Tools/renode/peripherals/stm32/AP_STM32_Timer_Actuators.cs
+include $repo/Tools/renode/peripherals/stm32/AP_STM32_Timer_Waveform.cs
 include $repo/Tools/renode/peripherals/common/AP_IOMCU.cs
 include $repo/Tools/renode/peripherals/common/AP_SPIMultiplexer.cs
 include $repo/Tools/renode/peripherals/common/AP_UARTPacer.cs

--- a/Tools/renode/scripts/ardupilot_g474.resc
+++ b/Tools/renode/scripts/ardupilot_g474.resc
@@ -19,6 +19,7 @@ include $repo/Tools/renode/peripherals/common/AP_Physics.cs
 include $repo/Tools/renode/peripherals/common/AP_I2CRegisterDevice.cs
 include $repo/Tools/renode/peripherals/common/AP_UARTFrameDevice.cs
 include $repo/Tools/renode/peripherals/stm32/AP_STM32_Timer_Actuators.cs
+include $repo/Tools/renode/peripherals/stm32/AP_STM32_Timer_Waveform.cs
 include $repo/Tools/renode/peripherals/common/AP_SPIMultiplexer.cs
 include $repo/Tools/renode/peripherals/common/AP_CANMcast.cs
 include $repo/Tools/renode/peripherals/common/AP_UARTPacer.cs

--- a/Tools/renode/scripts/ardupilot_h743.resc
+++ b/Tools/renode/scripts/ardupilot_h743.resc
@@ -24,6 +24,7 @@ include $repo/Tools/renode/peripherals/common/AP_Physics.cs
 include $repo/Tools/renode/peripherals/common/AP_I2CRegisterDevice.cs
 include $repo/Tools/renode/peripherals/common/AP_UARTFrameDevice.cs
 include $repo/Tools/renode/peripherals/stm32/AP_STM32_Timer_Actuators.cs
+include $repo/Tools/renode/peripherals/stm32/AP_STM32_Timer_Waveform.cs
 include $repo/Tools/renode/peripherals/common/AP_IOMCU.cs
 include $repo/Tools/renode/peripherals/common/AP_SPIMultiplexer.cs
 include $repo/Tools/renode/peripherals/common/AP_UARTPacer.cs

--- a/Tools/renode/scripts/ardupilot_l4.resc
+++ b/Tools/renode/scripts/ardupilot_l4.resc
@@ -19,6 +19,7 @@ include $repo/Tools/renode/peripherals/common/AP_Physics.cs
 include $repo/Tools/renode/peripherals/common/AP_I2CRegisterDevice.cs
 include $repo/Tools/renode/peripherals/common/AP_UARTFrameDevice.cs
 include $repo/Tools/renode/peripherals/stm32/AP_STM32_Timer_Actuators.cs
+include $repo/Tools/renode/peripherals/stm32/AP_STM32_Timer_Waveform.cs
 include $repo/Tools/renode/peripherals/common/AP_SPIMultiplexer.cs
 include $repo/Tools/renode/peripherals/common/AP_CANMcast.cs
 include $repo/Tools/renode/peripherals/common/AP_UARTPacer.cs

--- a/Tools/renode/tests/test_launch.py
+++ b/Tools/renode/tests/test_launch.py
@@ -135,6 +135,7 @@ def test_build_command_contains_selected_options(tmp_path):
     launcher.real_iomcu = True
     launcher.iomcu_force_update = True
     launcher.uds = True
+    launcher.sigrok = True
     launcher.usb = True
     launcher.dfu = True
     launcher.can = False
@@ -166,6 +167,9 @@ def test_build_command_contains_selected_options(tmp_path):
     assert '--no-device-sidecars' in command
     assert '--uds' in command
     assert launcher.status_snapshot()['uds'] is True
+    assert '--sigrok' in command
+    assert command[command.index('--sigrok-port') + 1] == '4242'
+    assert launcher.status_snapshot()['sigrok'] is True
     assert '--usb' in command
     assert '--dfu' in command
     assert command[command.index('--usbip-port') + 1] == '3240'

--- a/Tools/renode/tests/test_sigrok_pwm.py
+++ b/Tools/renode/tests/test_sigrok_pwm.py
@@ -1,0 +1,366 @@
+# AP_FLAKE8_CLEAN
+
+"""PWM waveform reconstruction for the sigrok logic analyser."""
+
+import os
+import re
+import socket
+import struct
+import subprocess
+import sys
+import time
+
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parents[1]
+ROOT = HERE.parents[1]
+sys.path.insert(0, str(HERE))
+
+import gen_board  # noqa: E402
+
+from process_utils import terminate_process_group  # noqa: E402
+
+PLATFORM = '''
+nvic: IRQControllers.NVIC @ sysbus 0xE000E000
+    IRQ -> cpu@0
+cpu: CPU.CortexM @ sysbus
+    cpuType: "cortex-m7"
+    nvic: nvic
+flash: Memory.MappedMemory @ sysbus 0x08000000
+    size: 0x1000
+timer1: Timers.STM32_Timer @ sysbus 0x40010000
+    initialLimit: 0xffff
+    frequency: 240000000
+sigrok: Miscellaneous.AP_Sigrok @ sysbus 0x60000110
+timer1Waveform: Miscellaneous.AP_STM32_Timer_Waveform @ sysbus 0x60000300
+    timer: timer1
+    analyzer: sigrok
+    channel1: 5
+    channel2: 6
+    advanced: true
+    name: "TIM1"
+'''
+
+# The register sequence ChibiOS pwm_lld_start() and pwmEnableChannel() use:
+# 1 MHz tick, 20 ms frame, PWM mode 1 with preload on channels 1 and 2,
+# 1500 us and 1850 us pulses, one update event, MOE, then ARPE|CEN.
+PROGRAM = '''
+sysbus WriteDoubleWord 0x40010028 239
+sysbus WriteDoubleWord 0x4001002C 19999
+sysbus WriteDoubleWord 0x40010018 0x6868
+sysbus WriteDoubleWord 0x40010020 0x11
+sysbus WriteDoubleWord 0x40010034 1500
+sysbus WriteDoubleWord 0x40010038 1850
+sysbus WriteDoubleWord 0x40010014 1
+sysbus WriteDoubleWord 0x40010044 0x8000
+sysbus WriteDoubleWord 0x40010000 0x81
+'''
+
+# A PWM-capable pin as a generated board now wires it: routed both to the
+# timer's waveform source and to the GPIO fan-out, on the same channel.
+SHARED_PIN_PLATFORM = PLATFORM + '''
+gpioPortA: GPIOPort.STM32_GPIOPort @ sysbus <0x58020000, +0x400>
+    numberOfAFs: 16
+    0 -> sigrok@5
+'''
+
+INCLUDES = '''
+$repo=@%s
+include $repo/Tools/renode/peripherals/common/AP_SigrokInterface.cs
+include $repo/Tools/renode/peripherals/common/AP_Sigrok.cs
+include $repo/Tools/renode/peripherals/stm32/AP_STM32_Timer_Waveform.cs
+'''
+
+
+def renode_executable():
+    executable = Path(os.environ.get('RENODE', ROOT / 'build/renode/renode'))
+    if not executable.is_file():
+        pytest.skip('build Renode or set RENODE')
+    return executable.resolve()
+
+
+def free_port():
+    with socket.socket() as probe:
+        probe.bind(('127.0.0.1', 0))
+        return probe.getsockname()[1]
+
+
+def wait_for_port(port, process, timeout=60):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise AssertionError('Renode exited early')
+        try:
+            socket.create_connection(('127.0.0.1', port), timeout=1).close()
+            return
+        except OSError:
+            time.sleep(0.2)
+    raise AssertionError('port %u never opened' % port)
+
+
+def receive_exact(sock, length):
+    data = b''
+    while len(data) < length:
+        chunk = sock.recv(length - len(data))
+        assert chunk, 'renode-la connection closed'
+        data += chunk
+    return data
+
+
+def capture(port, rate, channels, seconds):
+    '''Capture the given channels through the renode-la protocol and return
+    (channel names, samples, unit size).'''
+    sock = socket.create_connection(('127.0.0.1', port), timeout=60)
+    greeting = receive_exact(sock, 24)
+    assert greeting[:8] == b'RenodeLA'
+    channel_count, metadata_length = struct.unpack_from('<HI', greeting, 10)
+    metadata = receive_exact(sock, metadata_length)
+    names = []
+    offset = 0
+    for _ in range(channel_count + 1):
+        length = struct.unpack_from('<H', metadata, offset)[0]
+        offset += 2
+        names.append(metadata[offset:offset + length].decode())
+        offset += length
+    names = names[1:]
+    mask = bytearray((channel_count + 7) // 8)
+    for channel in channels:
+        mask[channel // 8] |= 1 << (channel % 8)
+    payload = struct.pack('<Q', rate) + bytes(mask)
+    sock.sendall(bytes([1, 0, 0, 0]) + struct.pack('<I', len(payload)) + payload)
+    unit = (len(channels) + 7) // 8
+    wanted = int(rate * seconds) * unit
+    samples = bytearray()
+    while len(samples) < wanted:
+        header = receive_exact(sock, 8)
+        length = struct.unpack_from('<I', header, 4)[0]
+        payload = receive_exact(sock, length)
+        if header[0] == 0x81:
+            raise AssertionError('renode-la error: %s' % payload.decode())
+        if header[0] == 0x80:
+            samples += payload
+    sock.sendall(bytes([2, 0, 0, 0]) + struct.pack('<I', 0))
+    sock.close()
+    return names, samples, unit
+
+
+def run_lengths(samples, unit, bit):
+    '''Return (level, length) runs for one packed channel bit.'''
+    result = []
+    current = None
+    count = 0
+    for index in range(0, len(samples), unit):
+        level = (samples[index + bit // 8] >> (bit % 8)) & 1
+        if level == current:
+            count += 1
+            continue
+        if current is not None:
+            result.append((current, count))
+        current, count = level, 1
+    result.append((current, count))
+    return result
+
+
+def steady_runs(samples, unit, bit):
+    '''Distinct high and low run lengths, excluding the partial ends.'''
+    runs = run_lengths(samples, unit, bit)[1:-1]
+    return (sorted({n for v, n in runs if v}),
+            sorted({n for v, n in runs if not v}))
+
+
+@pytest.fixture
+def live_renode(tmp_path):
+    '''Run a monitor script that leaves the machine started; yield helpers.'''
+    executable = renode_executable()
+    processes = []
+
+    def start(script):
+        path = tmp_path / 'live.resc'
+        path.write_text(script)
+        process = subprocess.Popen(
+            [str(executable), '--disable-xwt', '-P', str(free_port()),
+             '-e', 'include @%s' % path],
+            cwd=ROOT, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            env=dict(os.environ, TMPDIR=str(tmp_path),
+                     XDG_CONFIG_HOME=str(tmp_path / 'xdg')),
+            start_new_session=True)
+        processes.append(process)
+        return process
+
+    yield start
+    for process in processes:
+        terminate_process_group(process, graceful_timeout=0.5)
+
+
+def test_waveform_registers_follow_chibios_preload(tmp_path):
+    '''The register mirror answers period and pulse queries and honours
+    OCxPE preload: a zero written to CCR2 waits for the update event.'''
+    executable = renode_executable()
+    platform = tmp_path / 'pwm.repl'
+    platform.write_text(PLATFORM)
+    script = INCLUDES % ROOT + '''
+mach create
+machine LoadPlatformDescription @%s
+sysbus.sigrok ConfigureSignals "TX|RX|SCK|MOSI|MISO|PWM5|PWM6"
+%s
+sysbus.timer1Waveform PeriodUs
+sysbus.timer1Waveform PulseWidthUs 1
+sysbus.timer1Waveform PulseWidthUs 2
+sysbus WriteDoubleWord 0x40010038 0
+sysbus.timer1Waveform PulseWidthUs 2
+sysbus WriteDoubleWord 0x40010014 1
+sysbus.timer1Waveform PulseWidthUs 2
+sysbus WriteDoubleWord 0x40010044 0
+sysbus.timer1Waveform PulseWidthUs 1
+''' % (platform, PROGRAM)
+    path = tmp_path / 'test.resc'
+    path.write_text(script)
+    output = subprocess.run(
+        [str(executable), '--disable-xwt', '--console',
+         '-e', 'include @%s' % path, '-e', 'quit'],
+        cwd=ROOT, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        env=dict(os.environ, TMPDIR=str(tmp_path),
+                 XDG_CONFIG_HOME=str(tmp_path / 'xdg')),
+        timeout=120, check=True).stdout.decode(errors='replace')
+    output = re.sub(r'\x1b\[[0-9;]*m', '', output)
+    assert 'There was an error' not in output, output
+    values = [line.strip() for line in output.splitlines()
+              if re.fullmatch(r'\s*\d+(\.\d+)?\s*', line)]
+    assert values == ['20000', '1500', '1850', '1850', '0', '0'], output
+
+
+def test_complementary_output_follows_ccxne(tmp_path):
+    '''A pin declared TIMx_CHyN is driven from CCxNE, which ChibiOS sets
+    while leaving CCxE clear.  Reading only CCxE holds it low for ever.'''
+    executable = renode_executable()
+    complementary = PLATFORM.replace(
+        '    channel2: 6\n',
+        '    channel2: 6\n    complementary1: true\n'
+        '    complementary2: true\n')
+    # CC1NE is bit 2 and CC2NE bit 6, so 0x44 is what ChibiOS leaves in
+    # CCER for two complementary channels; 0x11 is the plain CCxE case.
+    program = PROGRAM.replace('0x40010020 0x11', '0x40010020 0x44')
+
+    def widths(platform_text, program_text):
+        platform = tmp_path / ('pwm-%u.repl' % abs(hash(platform_text)))
+        platform.write_text(platform_text)
+        script = INCLUDES % ROOT + '''
+mach create
+machine LoadPlatformDescription @%s
+sysbus.sigrok ConfigureSignals "TX|RX|SCK|MOSI|MISO|PWM5|PWM6"
+%s
+sysbus.timer1Waveform PeriodUs
+sysbus.timer1Waveform PulseWidthUs 1
+sysbus.timer1Waveform PulseWidthUs 2
+''' % (platform, program_text)
+        path = tmp_path / ('cmpl-%u.resc' % abs(hash(platform_text)))
+        path.write_text(script)
+        output = subprocess.run(
+            [str(executable), '--disable-xwt', '--console',
+             '-e', 'include @%s' % path, '-e', 'quit'],
+            cwd=ROOT, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            env=dict(os.environ, TMPDIR=str(tmp_path),
+                     XDG_CONFIG_HOME=str(tmp_path / 'xdg')),
+            timeout=120, check=True).stdout.decode(errors='replace')
+        output = re.sub(r'\x1b\[[0-9;]*m', '', output)
+        assert 'There was an error' not in output, output
+        return [line.strip() for line in output.splitlines()
+                if re.fullmatch(r'\s*\d+(\.\d+)?\s*', line)], output
+
+    declared, output = widths(complementary, program)
+    assert declared == ['20000', '1500', '1850'], output
+    # without the declaration the same CCER leaves the pin flat, which is
+    # what every TIMx_CHyN board saw before
+    undeclared, output = widths(PLATFORM, program)
+    assert undeclared == ['20000', '0', '0'], output
+
+
+def test_waveform_edges_reach_the_capture(tmp_path, live_renode):
+    '''A running timer produces the programmed frames in a renode-la
+    capture, and a mid-frame MOE clear truncates the pulse.'''
+    platform = tmp_path / 'pwm.repl'
+    platform.write_text(PLATFORM)
+    sigrok_port = free_port()
+    process = live_renode(INCLUDES % ROOT + '''
+mach create
+machine LoadPlatformDescription @%s
+sysbus WriteDoubleWord 0x08000000 0x20001000
+sysbus WriteDoubleWord 0x08000004 0x08000009
+sysbus WriteDoubleWord 0x08000008 0xe7fee7fe
+cpu VectorTableOffset 0x08000000
+cpu PerformanceInMips 50
+emulation SetGlobalQuantum "0.001"
+sysbus.sigrok ConfigureSignals "TX|RX|SCK|MOSI|MISO|PWM5|PWM6"
+%s
+sysbus.sigrok Port %u
+start
+''' % (platform, PROGRAM, sigrok_port))
+    wait_for_port(sigrok_port, process)
+    names, samples, unit = capture(sigrok_port, 1000000, [5, 6], 0.1)
+    assert names[5:] == ['PWM5', 'PWM6']
+    # The stock timer overflows after ARR ticks, so the low half of each
+    # frame is one tick short; timestamps also round onto the 1 us grid.
+    for bit, (high, low) in ((0, (1500, 18499)), (1, (1850, 18149))):
+        highs, lows = steady_runs(samples, unit, bit)
+        assert highs and all(abs(n - high) <= 1 for n in highs), highs
+        assert lows and all(abs(n - low) <= 1 for n in lows), lows
+
+
+def test_gpio_on_a_pwm_capable_pin_is_captured(tmp_path, live_renode):
+    '''Firmware can drive a PWM-capable pin as a GPIO at runtime, through
+    SERVO_GPIO_MASK or SERVOx_FUNCTION, and AP_Relay does.  With the timer
+    output disabled the waveform source must release the channel, so the
+    pin's real level reaches the capture instead of a flat low.'''
+    platform = tmp_path / 'shared.repl'
+    platform.write_text(SHARED_PIN_PLATFORM)
+    sigrok_port = free_port()
+    process = live_renode(INCLUDES % ROOT + '''
+mach create
+machine LoadPlatformDescription @%s
+sysbus WriteDoubleWord 0x08000000 0x20001000
+sysbus WriteDoubleWord 0x08000004 0x08000009
+sysbus WriteDoubleWord 0x08000008 0xe7fee7fe
+cpu VectorTableOffset 0x08000000
+cpu PerformanceInMips 50
+emulation SetGlobalQuantum "0.001"
+sysbus.sigrok ConfigureSignals "TX|RX|SCK|MOSI|MISO|PWM5|PWM6"
+sysbus WriteDoubleWord 0x58020000 0x1
+sysbus WriteDoubleWord 0x58020018 0x1
+sysbus.sigrok Port %u
+start
+''' % (platform, sigrok_port))
+    wait_for_port(sigrok_port, process)
+    _, samples, unit = capture(sigrok_port, 1000000, [5], 0.002)
+    levels = {(samples[i] >> 0) & 1 for i in range(0, len(samples), unit)}
+    # timer1 channel 1 shares this pin but its output is not enabled, so
+    # the GPIO owns it and the capture must show the pin driven high
+    assert levels == {1}, levels
+
+
+def test_generated_board_reconstructs_pwm_pins(tmp_path):
+    '''Every PWM timer with sigrok-visible pins gets a waveform peripheral
+    wired to those channels, and those pins leave the GPIO fan-out so the
+    reconstruction is their only edge source.'''
+    generated = gen_board.generate(
+        ROOT, 'YJUAV_A6SE_H743', tmp_path / 'generated', sigrok=True,
+        state_dir=tmp_path / 'state')
+    repl = (tmp_path / 'generated' / 'YJUAV_A6SE_H743.repl').read_text()
+    signals = generated['sigrok_signals']
+    pwm1 = signals.index('PA15/TIM2_CH1/GPIO50/PWM1')
+    pwm8 = signals.index('PE14/TIM1_CH4/GPIO57/PWM8')
+    timer2 = re.search(r'timer2Waveform:.*?\n\n', repl, re.S).group(0)
+    timer1 = re.search(r'timer1Waveform:.*?\n\n', repl, re.S).group(0)
+    assert '    channel1: %u\n' % pwm1 in timer2
+    assert '    channel4: %u\n' % pwm8 in timer1
+    assert '    advanced: true' in timer1
+    assert '    advanced: true' not in timer2
+    # A PWM-capable pin keeps its GPIO route as well as its waveform
+    # source, because firmware can drive it as a GPIO at runtime through
+    # SERVO_GPIO_MASK or SERVOx_FUNCTION.  The analyser arbitrates between
+    # the two; dropping the route here lost those transitions entirely.
+    port_a = re.search(r'gpioPortA:\n(.*?)\n\n', repl, re.S).group(1)
+    assert 'sigrok@%u' % pwm1 in port_a
+    assert 'sigrok@' in repl  # chip selects are still routed
+    assert generated['warnings'] == []


### PR DESCRIPTION
### Summary

The Renode harness's sigrok analyser reconstructed only UART and SPI, so servo outputs reached it through the GPIO fan-out where the stock STM32 timer model toggles its compare pins with the granularity of its own event scheduling; add a timer peripheral that reconstructs PWM waveforms analytically, so an emulated board's servo outputs can be captured in PulseView and measured.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

Every file this PR changes is under `Tools/renode/`, so no flight firmware is affected and no binary changes.

| Test | Result |
|---|---|
| `Tools/renode/tests/`, whole suite | 171 passed, 9 skipped |
| Skips | need a Renode build or the physics sidecar, neither present on the test machine |
| New `test_sigrok_pwm.py` | 3 tests: register mirror under preload, a live capture through the analyser, and the generated board wiring |
| YJUAV_A6SE_H743 ArduCopter, motors 1 to 4 through `renode-la` | 1000 us pulses in 2499 us frames |
| PulseView 0.4.2 as packaged by Ubuntu | opened the emulated device and streamed from it |
| Analyser idle cost, same board with a client requesting all streams at 10 Hz | 95 million edges inserted with no capture running, now zero |
| Emulation rate, same conditions | was about a twentieth of real time, now matches a run without `--sigrok` |
| H743 GPIO reset registers on a fresh machine | match RM0433 |
| ArduCopter boot on YJUAV_A6SE_H743 after the GPIO and barometer changes | reaches the main loop and emits heartbeats |

### Description

`Tools/renode/` emulates a flight controller well enough to boot real firmware. Its `AP_Sigrok` peripheral exposes the emulated board's pins to `sigrok` and PulseView through the `renode-la` driver, which is how a developer looks at a signal without hardware. Until now it reconstructed UART and SPI only. Servo outputs arrived as plain GPIO transitions, driven by Renode's stock `STM32_Timer`, and that model toggles its output-compare pins on its own event boundaries, ignores `BDTR`, and overflows after `ARR` ticks rather than `ARR+1`. The result was jittery or absent servo waveforms.

**`AP_STM32_Timer_Waveform`** is the main addition. It mirrors `PSC`, `ARR`, `CCRx`, `CCMR`, `CCER`, `CR1`, `EGR` and `BDTR` from a bus write hook, anchors each frame on the timer model's own overflow event, and schedules the compare-match edge analytically rather than waiting to observe it. It follows the register rules `AP_HAL_ChibiOS::RCOutput` depends on, so what you capture is what the firmware asked for:

- Preloaded `ARR` and `CCRx` take effect at the next update event, not immediately.
- `EGR.UG` restarts the counter, which is how OneShot triggers a frame.
- `CEN` cleared freezes the counter and holds the pin where it is.
- `CCxE` cleared idles the pin low.
- An advanced timer drops every output when `BDTR.MOE` is cleared.

The peripheral answers `PeriodUs` and `PulseWidthUs` monitor queries, so a value can be read out of the emulator directly, and it can log every register write with its virtual timestamp, which is what makes a firmware-side output bug legible.

**`AP_Sigrok` gains analytic edge sources.** A source registers itself, inserts edges at a virtual timestamp and cancels a channel's already-scheduled edges, all under the capture lock. A channel may have exactly one source, because the analyser deduplicates against the scheduled state. The board generator emits one waveform peripheral per PWM timer, routes those pins to it instead of the GPIO fan-out, and adds a `PWMn` alias so `--sigrok-channels 'PWM*'` selects the servo outputs.

Four supporting changes come with it:

- **The analyser was expensive when idle.** It reconstructed every UART and SPI byte into timestamped edges whether or not a client was capturing, to keep a second of pre-trigger history, and re-pruned a sorted list on every event. With an IMU on SPI and a MAVProxy session that is roughly two million edges per virtual second. It now tracks only each channel's current level while no capture is running, so a capture still starts from the right state, and skips a decoder whose lines are all disabled during one. Pre-trigger history is gone as a result, and the README says so.
- **The H743 platform had zeroed GPIO registers.** The F4, F7, G4 and L4 bases carry the reset values from Renode's own platforms; the H743 base did not. RM0433 resets unused pins to analog mode and leaves the JTAG and SWD pins in alternate function with their pulls: PA13 and PA15 pulled up, PA14 pulled down, PB4 pulled up. Modelling that is what lets the emulator show the reset-time pull-up on PA15 that a separate PR addresses in firmware.
- **The emulated ICP201XX never filled its FIFO.** It answered `FIFO_FILL` with a constant 1, and the driver polls that register until 14 packets have arrived, so every board that probes an ICP201XX sat in `AP_Baro::init()` forever. The model now gains a packet per poll, caps at 16 so the driver's over-16 flush path is not taken, clears on a flush write and drains on a data read. The matching driver-side fix, for a real part that behaves the same way, is a separate PR.
- **`run.py` leaked processes.** It starts Renode in its own session and relied on catching `KeyboardInterrupt` to tear down the process group, which covers Ctrl-C but not a `SIGTERM` from the launcher's Stop button or a `SIGHUP` from a closed terminal. Both left Renode, the GDB proxy and the device sidecars running as orphans.

The launcher gets a Sigrok checkbox alongside the other emulation options, saved with the target settings and driveable over the control port. The README records where the `renode-la` driver actually comes from, which is the `ipdbg-la-fixes` branch of `tridge/libsigrok` rather than upstream libsigrok or any distribution package, along with a minimal private build that a packaged PulseView can load through `LD_LIBRARY_PATH`. The harness decision log gains what this work discovered and depends on.

Known limitations, all documented:

- DShot bit-period timers are not reconstructed. Only PWM and OneShot outputs produce waveforms.
- Frames are one tick shorter than the register arithmetic predicts, because the stock timer overflows after `ARR` ticks. The waveform follows the emulated firmware's real timer rather than the datasheet, which is the useful behaviour for finding firmware bugs but is not silicon-accurate.
- There is no pre-trigger history. A capture starts when the client asks for one.
- The driver this depends on is not upstream, so a stock PulseView will not see the device without that private build.

This PR was AI-assisted.