### PR TITLE
hwdef: NucleoH753ZI: let the DMA resolver allocate the ADC stream

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/NucleoH753ZI/hwdef.dat
+++ b/libraries/AP_HAL_ChibiOS/hwdef/NucleoH753ZI/hwdef.dat
@@ -202,12 +202,9 @@ PA7  SPI1_MOSI SPI1
 # (PB12, PB13 now used for UART5)
 # (PA2, PA7, PC1, PC4, PC5, PB11 freed from Ethernet)
 # ADC inputs (battery monitoring) - repurposed from GPIO
-PC4  BAT_VOLTAGE ADC1_INP14 ADC1 SCALE(11)
-PC5  BAT_CURRENT ADC1_INP15 ADC1 SCALE(11)
+PC4  BAT_VOLTAGE ADC1 SCALE(11)
+PC5  BAT_CURRENT ADC1 SCALE(11)
 
-
-# ADC DMA stream definitions for STM32H753
-define STM32_ADC_ADC12_DMA_STREAM STM32_DMA_STREAM_ID(1, 0)
 
 # GPIO pins can be used for:
 # - RC Input/Output (RC7_FUNCTION, SERVO7_FUNCTION)


### PR DESCRIPTION
The hwdef hand-assigns `STM32_ADC_ADC12_DMA_STREAM` to DMA1 stream 0. The resolver does not see manual defines and gives the same stream to USART1_RX, so the second `dmaStreamAllocI` returns NULL and the driver writes through address 0. Caught booting ArduCopter for this board in an STM32H753 simulation model; on silicon it is silent low-RAM corruption whenever ADC and USART1 are both up.

The manual define exists because the pin type was written as `ADC1_INP14` / `ADC1_INP15` instead of `ADC1`. In DMAMUX mode the resolver accepts any label, so it allocated streams for two phantom peripherals and never emitted `STM32_ADC_ADC1_DMA_STREAM`.

Tested by regenerating `hwdef.h` (ADC1 now on DMA2 stream 0 with `STM32_DMAMUX1_ADC1`, no stream allocated twice) and building ArduCopter. In simulation the pre-fix image fires DMA1 Stream0 (IRQ11) ~3.7k times in 15 s and prints `memory guard error size=1023`; the fixed image moves the ADC to DMA2 Stream0 (IRQ56), the error is gone, and MAVLink heartbeats run at 1.0 s. No hardware test.

