### PR TITLE
AP_NavEKF3: fix the sign of the SRTM height used for flow scaling

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -14978,6 +14978,93 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
     def get_touchdownexpected_durations_from_current_onboard_log(self, ignore_multi=False):
         return self.get_ground_effect_duration_from_current_onboard_log(12, ignore_multi=ignore_multi)
 
+    def EK3_OptflowTerrainScaleHeight(self):
+        '''optical flow scale height from the terrain database is right over slopes'''
+        # Above the rangefinder range with EK3_OPTIONS bit 2 the optical flow scale
+        # height comes from the terrain database. terrain_srtm_alt is measured up from
+        # the EKF origin while the position state is down-positive, so where the terrain
+        # sits at the origin altitude the two conventions agree and nothing would
+        # discriminate. Off the Kalaupapa cliffs the ground falls about 160 m below the
+        # origin, where getting it the wrong way round drives the scale height into the
+        # on-ground clamp.
+        #
+        # GPS navigates here, so flow is not fused into velocity and the trajectory does
+        # not depend on the scale height: a correct and an inverted build fly the same
+        # path. The scale height still sets the predicted flow rate, so the XKF5
+        # innovation consistency ratio is what the test reads.
+        #
+        # What this does NOT prove is that the database rather than the terrain offset
+        # state supplied the height. Measured with the option cleared, the frozen
+        # terrain state gives a scale height about 3.7x low and a ratio of 3, well
+        # inside the gate, against 0 with the option set and 255 with the sign inverted.
+        # So a negative leg on this signal would not discriminate, and is not attempted.
+        self.install_terrain_handlers_context()
+        self.set_parameters({
+            "SIM_FLOW_ENABLE": 1,
+            "FLOW_TYPE": 10,
+            "EK3_IMU_MASK": 1,
+            "TERRAIN_ENABLE": 1,
+            "EK3_OPTIONS": 1 << 2,   # OptflowMayUseTerrainAlt
+            "LOG_FILE_DSRMROT": 1,
+        })
+        self.set_analog_rangefinder_parameters()
+        self.set_parameter("RNGFND1_MAX", 8)
+        self.customise_SITL_commandline(["--home", "KalaupapaCliffs"])
+
+        # terrain requests cannot start until the EKF has a location, so let the vehicle
+        # reach armable before timing the delivery
+        self.wait_ready_to_arm()
+        tstart = self.get_sim_time()
+        while True:
+            if self.get_sim_time_cached() - tstart > 120:
+                raise NotAchievedException("terrain tiles were never delivered")
+            report = self.assert_receive_message("TERRAIN_REPORT", timeout=10)
+            if report.pending == 0 and report.loaded > 0:
+                break
+
+        # 60 m clears the 185.8 m AMSL ridge 50 m north of home by about 40 m. At 40 m
+        # the margin is 19.5 m, and dropping to a few metres AGL would put the
+        # rangefinder back in range and bypass the branch under test
+        self.takeoff(60, mode='GUIDED')
+        # gndOffsetValid surfaces as EKF_POS_VERT_AGL; wait for it to go clear so the
+        # terrain offset state is not what is supplying the height
+        self.wait_ekf_flags(0, mavutil.mavlink.ESTIMATOR_POS_VERT_AGL, timeout=60)
+
+        # the scale height only reaches the innovation through vehicle velocity, so the
+        # window that carries the signal is the traverse, not a hover at the end of it
+        window_start_us = self.get_sim_time() * 1e6
+        self.fly_guided_move_local(400, 0, 60)
+        window_end_us = self.get_sim_time() * 1e6
+
+        report = self.assert_receive_message("TERRAIN_REPORT", timeout=10)
+        self.progress("true AGL %.2fm over terrain at %.2fm AMSL"
+                      % (report.current_height, report.terrain_height))
+        if report.current_height < 150:
+            raise NotAchievedException(
+                "terrain did not fall away enough to test the scale height (%.1fm)"
+                % report.current_height)
+        self.disarm_vehicle(force=True)
+
+        dfreader = self.dfreader_for_current_onboard_log()
+        worst = 0
+        count = 0
+        while True:
+            m = dfreader.recv_match(type="XKF5")
+            if m is None:
+                break
+            if window_start_us <= m.TimeUS <= window_end_us:
+                count += 1
+                worst = max(worst, m.NI)
+        if count == 0:
+            raise NotAchievedException("no XKF5 logged over the traverse")
+        self.progress("worst flow innovation ratio %u over %u XKF5 samples"
+                      % (worst, count))
+        # the ratio is logged as 100x, capped at 255. An inverted scale height saturates
+        # the cap and flow is rejected outright; a correct one sits near zero
+        if worst > 50:
+            raise NotAchievedException(
+                "flow innovation ratio reached %u, so the scale height is wrong" % worst)
+
     def ThrowDoubleDrop(self):
         '''Test a more complicated drop-mode scenario'''
         self.progress("Getting a lift to altitude")
@@ -16568,6 +16655,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
              self.BatteryMissing,
              self.VibrationFailsafe,
              self.EK3AccelBias,
+             self.EK3_OptflowTerrainScaleHeight,
              self.EK3_AccelBiasInhibitOnGroundMoving,
              self.EK3_AccelBiasZeroVelOptFlow,
              self.EK3_ZeroVelFusionNotUsedWithGPS,

--- a/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
@@ -308,7 +308,8 @@ void NavEKF3_core::FuseOptFlow(const of_elements &ofDataDelayed, bool really_fus
 #if EK3_FEATURE_OPTFLOW_SRTM
     // if ground offset (aka terrainState) is not valid, use SRTM altitude. terrain_srtm_alt
     // is positive up from the origin where pd and terrainState above are positive down
-    terrain_srtm_alt_valid = ((imuSampleTime_ms - terrain_srtm_alt_ms) < 5000);
+    terrain_srtm_alt_valid = (terrain_srtm_alt_ms != 0) &&
+                             ((imuSampleTime_ms - terrain_srtm_alt_ms) < TERRAIN_SRTM_ALT_TIMEOUT_MS);
     if (!gndOffsetValid && terrain_srtm_alt_valid) {
         heightAboveGndEst = MAX((-pd) - terrain_srtm_alt, rngOnGnd);
     }

--- a/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_OptFlowFusion.cpp
@@ -306,10 +306,11 @@ void NavEKF3_core::FuseOptFlow(const of_elements &ofDataDelayed, bool really_fus
     ftype heightAboveGndEst = MAX((terrainState - pd), rngOnGnd);
 
 #if EK3_FEATURE_OPTFLOW_SRTM
-    // if ground offset (aka terrainState) is not valid, use SRTM altitude
+    // if ground offset (aka terrainState) is not valid, use SRTM altitude. terrain_srtm_alt
+    // is positive up from the origin where pd and terrainState above are positive down
     terrain_srtm_alt_valid = ((imuSampleTime_ms - terrain_srtm_alt_ms) < 5000);
     if (!gndOffsetValid && terrain_srtm_alt_valid) {
-        heightAboveGndEst = MAX((terrain_srtm_alt - pd), rngOnGnd);
+        heightAboveGndEst = MAX((-pd) - terrain_srtm_alt, rngOnGnd);
     }
 #endif
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_core.h
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_core.h
@@ -71,6 +71,9 @@
 // number of seconds a request to reset the yaw to the GSF estimate is active before it times out
 #define YAW_RESET_TO_GSF_TIMEOUT_MS 5000
 
+// age at which a terrain altitude from the database is no longer used
+#define TERRAIN_SRTM_ALT_TIMEOUT_MS 5000
+
 // accuracy threshold applied to GSF yaw estimate use
 #define GSF_YAW_ACCURACY_THRESHOLD_DEG 15.0f
 


### PR DESCRIPTION
### Summary

`FuseOptFlow()` differences an up-positive terrain-database height against a down-positive position state, so above the rangefinder range with `EK3_OPTIONS` bit 2 (`OptflowMayUseTerrainAlt`) the optical flow scale height is wrong by twice the terrain elevation relative to the EKF origin. Over ground that sits below the origin it collapses to the on-ground range and flow is rejected outright.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)

SITL A/B off the Kalaupapa cliffs, holding 60 m above an origin the ground falls to 160 m below, so the true height above ground reaches 220 m. GPS navigates, so flow is not fused into velocity and both builds fly the same trajectory - only the scale height differs. Read across the traverse, which is where vehicle velocity makes the scale height visible in the innovation at all:

| | master | this PR |
|---|---|---|
| peak innovation consistency ratio (`XKF5.NI`, logged 100x, capped at 255) | 255 | 0 |

255 is the ceiling, so the real ratio is at least 2.55 and flow at that geometry is rejected outright. The raw innovation is not quoted because `XKF5` logs it as an int16 scaled by 1000 and the old expression drives it past the wrap point, so the logged value there is aliased rather than real.

### Description

`terrain_srtm_alt` is the terrain height above the EKF origin, positive **up**: `AP_AHRS::writeTerrainAMSL()` computes `alt_amsl_m - origin.alt` and the core stores it verbatim. `pd` is `position.z`, positive **down**. Height above ground is therefore `(-pd) - terrain_srtm_alt`, not `terrain_srtm_alt - pd`. The neighbouring default is right because `terrainState` is itself a D coordinate, built as `position.z + rngOnGnd` - so one variable's two branches were being differenced in opposite conventions.

The error is 2 x `terrain_srtm_alt`, which is why nothing caught it: it is zero where the origin sits at field elevation, which is where almost all testing happens, and it grows with relief. It also moves the wrong way, reading high over ground above the origin.

Two things a reviewer is likely to suggest, both already tried:

**Clamping or falling back where the corrected value comes out low.** The collapse to `rngOnGnd` through the `MAX` is pre-existing and this PR does not close it - the old expression could go negative too, over ground further below the origin than the vehicle is above it. The sign fix moves which geometry triggers it. A guard that kept the terrain estimator's height in that case was written and then dropped: it falls through to a `terrainState` that the enclosing `if (!gndOffsetValid && ...)` has already declared stale, so it substitutes one unusable height for another.

**Fixing it at the writer instead.** `AP_AHRS` subtracts the one public origin and hands the same figure to every core, which then differences it against its own `position.z`. Negating in `writeTerrainAMSL()` would make the member's name and comment ("altitude above the EKF origin") wrong, and would not address the case where a core's own origin altitude has moved - `ekfGpsRefHgt` drift, or lanes aligning against different receivers under `EK3_AFFINITY` - which the corrected form still carries. The trace here is complete only for the default `EK3_OGN_HGT_MASK`.

`EK3_OptflowTerrainScaleHeight` covers it. It flies above the rangefinder range so the database supplies the scale height, waits for `EKF_POS_VERT_AGL` to go clear, checks terrain tiles actually loaded before asserting anything, and reads the innovation consistency ratio across the traverse. It fails on master.

Two limits of that test worth stating rather than leaving to be found. It reads the traverse and not a hover, because the scale height only reaches the innovation through vehicle velocity - over a stationary hold the signal is absent whichever expression is in use. And it does not prove the database rather than the terrain offset state supplied the height: with bit 2 cleared the frozen terrain state gives a scale height about 3.7x low, which measures a ratio of 3, inside the gate and indistinguishable from a pass. A negative leg on this signal would not discriminate, so none is claimed.

Extracted from #33585, which needs this on its own preferred path - that PR forwards terrain data for its option bit and then scales flow through this expression. A follow-up serving the same database height from `getHAGL()` stacks on this rather than racing it, since it touches the adjacent line.
