### PR TITLE
AP_GroundEffect: stop touchdown_expected latching in cruise

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -14978,6 +14978,59 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
     def get_touchdownexpected_durations_from_current_onboard_log(self, ignore_multi=False):
         return self.get_ground_effect_duration_from_current_onboard_log(12, ignore_multi=ignore_multi)
 
+    def TouchdownGroundEffectCruise(self):
+        '''touchdown_expected must not latch in cruise but must still arm on a landing'''
+        # In a hover the desired vertical velocity holds a small negative residual, and
+        # beyond AP_GROUNDEFFECT_TAKEOFF_DRIFT_NE_MAX_M the relative-to-takeoff height
+        # stops referring to the ground below the vehicle. Together those held the gate
+        # open for a whole 17.9m cruise hover. Both legs fly out to the same distance;
+        # only the height source differs, so a fix that just never arms the gate fails
+        # the second leg.
+        self.set_parameter("LOG_FILE_DSRMROT", 1)
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+        self.disarm_vehicle()
+
+        self.start_subtest("Cruise hover far from takeoff does not expect touchdown")
+        self.set_parameters({
+            "GNDEFF_ALT": 1.0,
+            "RNGFND1_TYPE": 0,   # no rangefinder, so there is no true height above ground
+        })
+        self.reboot_sitl()
+        self.wait_ready_to_arm()
+        self.takeoff(20, mode='GUIDED', alt_minimum_duration=2)
+        self.fly_guided_move_local(30, 0, 20)
+        self.delay_sim_time(20, "hold a stationary hover well above the gate")
+        self.disarm_vehicle(force=True)
+        cruise = self.get_touchdownexpected_durations_from_current_onboard_log(ignore_multi=True)
+        total_cruise = sum(cruise)
+        self.progress("touchdown_expected in cruise: %fs %s" % (total_cruise, str(cruise)))
+        if total_cruise > 1.0:
+            raise NotAchievedException(
+                "touchdown_expected must not fire in a cruise hover (got %fs)" % total_cruise)
+
+        self.start_subtest("A real landing far from takeoff still expects touchdown")
+        self.set_analog_rangefinder_parameters()
+        self.set_parameter("GNDEFF_ALT", 1.0)
+        self.reboot_sitl()
+        self.wait_ready_to_arm()
+        self.takeoff(5, mode='GUIDED', alt_minimum_duration=2)
+        self.fly_guided_move_local(30, 0, 5)
+        self.change_mode('LAND')
+        self.wait_disarmed(timeout=180)
+        landing = self.get_touchdownexpected_durations_from_current_onboard_log(ignore_multi=True)
+        total_landing = sum(landing)
+        self.progress("touchdown_expected on a real landing: %fs %s" % (total_landing, str(landing)))
+        if total_landing < 0.5:
+            raise NotAchievedException(
+                "touchdown_expected must still arm for a real landing (got %fs)" % total_landing)
+
+        # not at the home location, and the second leg fitted a range finder that
+        # context_pop restores in name only - AP_RangeFinder detects backends at
+        # init - so clear it before the reboot rather than hand it to the next test
+        self.set_parameter("RNGFND1_TYPE", 0)
+        self.reboot_sitl()
+
     def ThrowDoubleDrop(self):
         '''Test a more complicated drop-mode scenario'''
         self.progress("Getting a lift to altitude")
@@ -16574,6 +16627,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
              self.EK3_ZeroVelFusionNotUsedWithGPS,
              self.TakeoffGroundEffectAlt,
              self.TouchdownGroundEffectAlt,
+             self.TouchdownGroundEffectCruise,
              self.StabilityPatch,
              self.OBSTACLE_DISTANCE_3D,
              self.AC_Avoidance_Proximity,

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -15223,10 +15223,11 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
                 "Larger threshold should have longer touchdown (large=%fs <= small=%fs)"
                 % (total_large, total_small))
 
-        # Subtest C: more than 20m from the takeoff point the baro fallback
-        # cannot assume flat ground, so the altitude gate is dropped and the
-        # whole slow descent counts, as it did before the gate existed.
-        self.start_subtest("Far from takeoff the touchdown gate is dropped")
+        # Subtest C: more than 20m from the takeoff point the relative-to-takeoff
+        # height no longer refers to the ground below the vehicle, so without a
+        # true AGL the gate must not fire at all. It used to count any gentle
+        # descent out here, which is what latched it through a cruise hover.
+        self.start_subtest("Far from takeoff the touchdown gate does not fire")
         self.set_parameter("GNDEFF_ALT", 1.0)
         self.takeoff(3, mode='GUIDED', alt_minimum_duration=2)
         self.fly_guided_move_local(30, 0, 3)
@@ -15235,10 +15236,10 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         durations_far = self.get_touchdownexpected_durations_from_current_onboard_log(ignore_multi=True)
         total_far = sum(durations_far)
         self.progress("touchdown_expected total with GNDEFF_ALT=1.0 30m from takeoff: %fs" % total_far)
-        if total_far <= total_small:
+        if total_far > 0.5:
             raise NotAchievedException(
-                "Dropping the gate far from takeoff should lengthen touchdown (far=%fs <= near=%fs)"
-                % (total_far, total_small))
+                "touchdown_expected should not fire 30m from takeoff without a true AGL (got %fs)"
+                % total_far)
 
         # we are not at the home location - reboot so the next test starts there
         self.reboot_sitl()

--- a/libraries/AP_GroundEffect/AP_GroundEffect.cpp
+++ b/libraries/AP_GroundEffect/AP_GroundEffect.cpp
@@ -36,6 +36,10 @@
 // zero, so a bare "< 0" reads a commanded descent for as long as the vehicle hovers
 #define AP_GROUNDEFFECT_DESCENT_DEADBAND_MS 0.05f
 
+// hard cap on the touchdown_expected window, sized well clear of the longest
+// legitimate landing so it only catches a latch that would never clear
+#define AP_GROUNDEFFECT_TOUCHDOWN_MAX_MS 60000U
+
 const AP_Param::GroupInfo AP_GroundEffect::var_info[] = {
 
     // @Param: ALT
@@ -70,6 +74,7 @@ void AP_GroundEffect::update(bool armed, bool land_complete, bool throttle_up)
         // disarmed or disabled (GNDEFF_ALT < 0) - clear state and tell EKF nothing is expected
         _state.takeoff_expected = false;
         _state.touchdown_expected = false;
+        _state.touchdown_time_ms = 0;
         ahrs.set_takeoff_expected(false);
         ahrs.set_touchdown_expected(false);
         return;
@@ -162,7 +167,18 @@ void AP_GroundEffect::update(bool armed, bool land_complete, bool throttle_up)
                       || (height_m < _alt_m);
     }
 
-    _state.touchdown_expected = slow_horizontal && slow_descent && near_ground;
+    const bool touchdown_signal = slow_horizontal && slow_descent && near_ground;
+    if (!touchdown_signal) {
+        _state.touchdown_time_ms = 0;
+    } else if (_state.touchdown_time_ms == 0) {
+        _state.touchdown_time_ms = tnow_ms;
+    }
+    // a touchdown that has not arrived within the window is not a touchdown. GNDEFF_ALT
+    // of zero asks for no altitude gate at all, so it gets no time bound either
+    const bool touchdown_timed_out = is_positive(_alt_m) &&
+                                     AP_HAL::timeout_expired(_state.touchdown_time_ms, tnow_ms,
+                                                             AP_GROUNDEFFECT_TOUCHDOWN_MAX_MS);
+    _state.touchdown_expected = touchdown_signal && !touchdown_timed_out;
 
     ahrs.set_takeoff_expected(_state.takeoff_expected);
     ahrs.set_touchdown_expected(_state.touchdown_expected);

--- a/libraries/AP_GroundEffect/AP_GroundEffect.cpp
+++ b/libraries/AP_GroundEffect/AP_GroundEffect.cpp
@@ -44,7 +44,7 @@ const AP_Param::GroupInfo AP_GroundEffect::var_info[] = {
 
     // @Param: ALT
     // @DisplayName: Ground effect altitude threshold
-    // @Description: Ground effect compensation altitude threshold. Compensation is turned off once the vehicle climbs this many meters above the takeoff location. Positive values cause compensation to be applied both during takeoff and landing. Zero keeps compensation enabled but removes the altitude gating: the takeoff window is released once GNDEFF_TMO has elapsed and the vehicle has climbed at all, and any gentle descent counts as a landing (the legacy behaviour). Negative values disable the feature. Altitude of the vehicle is derived from a downward facing rangefinder (if present) or using the height-change-since-takeoff assuming flat ground and no baro drift. More than 20m from the takeoff location (when a horizontal position is available) the landing altitude gate is dropped and any gentle descent counts as a landing.
+    // @Description: Ground effect compensation altitude threshold. Compensation is turned off once the vehicle climbs this many meters above the takeoff location. Positive values cause compensation to be applied both during takeoff and landing. Zero keeps compensation enabled but removes the altitude gating: the takeoff window is released once GNDEFF_TMO has elapsed and the vehicle has climbed at all, and any gentle descent counts as a landing (the legacy behaviour). Negative values disable the feature. Altitude of the vehicle is derived from a downward facing rangefinder (if present) or using the height-change-since-takeoff assuming flat ground and no baro drift. More than 20m from the takeoff location (when a horizontal position is available) that height no longer refers to the ground below the vehicle, so the landing gate does not fire at all unless the EKF has a valid height above ground, which today means a range finder in range.
     // @Range: -1 10
     // @Units: m
     // @User: Advanced
@@ -153,8 +153,8 @@ void AP_GroundEffect::update(bool armed, bool land_complete, bool throttle_up)
     //   - HAGL: trust height_m directly
     //   - relative-to-takeoff fallback with horizontal position: gate only
     //     while within AP_GROUNDEFFECT_TAKEOFF_DRIFT_NE_MAX_M of the launch
-    //     point; further out we cannot assume the ground beneath us is at
-    //     the takeoff elevation, so any gentle descent counts
+    //     point; further out the height is not referred to the ground below
+    //     us, and not knowing the height is not a reason to assert proximity
     //   - baro-only fallback (no horizontal position): assume flat ground
     bool near_ground;
     if (!is_positive(_alt_m)) {
@@ -163,8 +163,8 @@ void AP_GroundEffect::update(bool armed, bool land_complete, bool throttle_up)
         near_ground = height_m < _alt_m;
     } else {
         const float drift_ne_m = (pos_ne_m - _state.takeoff_pos_ne_m).length();
-        near_ground = (drift_ne_m >= AP_GROUNDEFFECT_TAKEOFF_DRIFT_NE_MAX_M)
-                      || (height_m < _alt_m);
+        near_ground = (drift_ne_m < AP_GROUNDEFFECT_TAKEOFF_DRIFT_NE_MAX_M)
+                      && (height_m < _alt_m);
     }
 
     const bool touchdown_signal = slow_horizontal && slow_descent && near_ground;

--- a/libraries/AP_GroundEffect/AP_GroundEffect.cpp
+++ b/libraries/AP_GroundEffect/AP_GroundEffect.cpp
@@ -31,6 +31,11 @@
 // the terrain elevation under it may differ from the launch site
 #define AP_GROUNDEFFECT_TAKEOFF_DRIFT_NE_MAX_M 20.0f
 
+// deadband (m/s) on the commanded descent test. In a hover the desired vertical
+// velocity settles to a small persistently negative residual and never reaches
+// zero, so a bare "< 0" reads a commanded descent for as long as the vehicle hovers
+#define AP_GROUNDEFFECT_DESCENT_DEADBAND_MS 0.05f
+
 const AP_Param::GroupInfo AP_GroundEffect::var_info[] = {
 
     // @Param: ALT
@@ -132,7 +137,7 @@ void AP_GroundEffect::update(bool armed, bool land_complete, bool throttle_up)
                                  || _pilot_slow_horizontal;
 
     const float target_climb_rate_ms = d_active ? _pos_control->get_vel_desired_U_ms() : 0.0f;
-    const bool descent_demanded = d_active && target_climb_rate_ms < 0.0f;
+    const bool descent_demanded = d_active && target_climb_rate_ms < -AP_GROUNDEFFECT_DESCENT_DEADBAND_MS;
     const bool slow_descent_demanded = descent_demanded && target_climb_rate_ms >= -1.0f;
     float vel_d_ms = 0;
     const bool speed_low_d = ahrs.get_velocity_D(vel_d_ms, _high_vibrations) && fabsf(vel_d_ms) <= 0.6f;

--- a/libraries/AP_GroundEffect/AP_GroundEffect.h
+++ b/libraries/AP_GroundEffect/AP_GroundEffect.h
@@ -140,6 +140,7 @@ private:
         bool     takeoff_expected;
         bool     touchdown_expected;
         uint32_t takeoff_time_ms;
+        uint32_t touchdown_time_ms; // when the touchdown signal first went true, 0 while it is false
         float    takeoff_alt_m;
         float    takeoff_hagl_m;    // HAGL while on the ground, 0 if HAGL was unavailable
         Vector2f takeoff_pos_ne_m;  // EKF-origin XY at takeoff, used by the relative-to-takeoff fallback


### PR DESCRIPTION
### Summary

`touchdown_expected` can latch in level cruise. On one flight it held for 51 s in a stationary hover 17.9 m up, which opens the EKF's ground-effect baro protection nowhere near the ground. Three independent reasons, one commit each.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Logs available on request

SITL, measured on this branch against master:

| | master | this PR |
|---|---|---|
| gate open in a 20 m hover 30 m from takeoff | 19.8 s | 0.0 s |
| gate open landing 30 m from takeoff, no range finder | 11.9 s | 0.0 s |
| gate open on a real landing at 30 m, range finder fitted | - | 3.7 s |
| `GNDEFF_ALT=1` / `=5` landing at the takeoff point | 6.8 s / 11.8 s | 3.6 s / 7.9 s |

The last row is the deadband alone: near the takeoff point the drift rule is inert, so the gate was being held open through the hover-residual part of an ordinary approach as well as in cruise.

### Description

**The descent test had no deadband.** `AC_PosControl::get_vel_desired_U_ms()` does not settle to zero in a hover - it holds a small persistently negative residual - so testing it against zero reads a commanded descent for as long as the vehicle hovers. On the flight above it was true in 100% of 508 samples at a median of -0.0000 m/s. 0.05 m/s is not a delicate value: 0.01 already removes 98.2% of those samples against 98.4% at 0.05, and a real approach runs an order of magnitude clear of either. A constant rather than a parameter, because a threshold here that competes with the operating envelope becomes a floor on the useful hover band - which is the trap #32472 already recorded for `GNDEFF_ALT` itself.

**Nothing bounded the latch.** `takeoff_expected` has an unconditional 5 s cap; `touchdown_expected` had none, so once the three conditions coincided the gate could hold for the rest of the flight. The cap here is 60 s, not 5 s, because the legitimate window is `GNDEFF_ALT` divided by the landing descent rate: SITL measures 35.2 s at the documented extremes of both, 21.6 s at `GNDEFF_ALT` 10 with the default rate, 11.6 s at 5. Copying the takeoff cap across would have halved a normal landing. `GNDEFF_ALT = 0` is exempt - that setting asks for no altitude gate at all, so a time bound there would switch compensation off part way down a long slow descent.

Worth saying plainly: 60 s would not have fired on the 51 s hover that motivated this. It stops a latch that would otherwise never clear; the deadband is what closes the observed case.

**Horizontal drift was being read as ground proximity.** Beyond 20 m from the takeoff point the relative-to-takeoff height stops referring to the ground below the vehicle, and the rule treated that as `near_ground` unconditionally. Not knowing the height is not a reason to assert proximity. On the flight a 21.8 m drift - 1.8 m past the threshold - made the gate true at 17.9 m.

This one is a real trade and it is why it is last and separately revertable: a vehicle landing more than 20 m from where it lifted off now gets no ground-effect protection unless the EKF can supply a true height above ground, which today means a range finder in range. That costs 11.9 s of gate, measured.

Deleting the drift term rather than inverting it is the obvious alternative and it is worse. `height_m` is measured from the takeoff elevation, so landing on ground *below* that point drives it toward zero and would open the gate high - descending to a field 30 m below the launch point reads `height_m` near zero at 30 m AGL. The drift term is what refuses that; its sense was simply backwards.

Two things a reviewer should know rather than find. Only the drift change has a test that fails without it: the cruise leg passes with the drift change alone, and the 60 s cap has no test at all, so reverting either of those two today leaves the suite green. And `AP_GroundEffect` handles no EKF lateral position resets, so a lane switch that jumps NE position past 20 m used to assert `near_ground` and now suppresses it - pre-existing, but this flips the sign of its consequence.
