### PR TITLE
AP_NavEKF3: log XKF5 and XKFA for every core

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -14978,6 +14978,64 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
     def get_touchdownexpected_durations_from_current_onboard_log(self, ignore_multi=False):
         return self.get_ground_effect_duration_from_current_onboard_log(12, ignore_multi=ignore_multi)
 
+    def EK3_PerCoreLogging(self):
+        '''XKF5 and XKFA are logged for every core, not just the primary'''
+        # Under EK3_SRC_OPTIONS bit 3 each core runs its own source set, so the lane
+        # being investigated is usually not the primary one. XKF5 used to return early
+        # for anything but the primary and XKFA is written inside it, so that lane's
+        # innovations, terrain state and AGL KF were absent from the log entirely.
+        #
+        # The configuration mirrors EKF3SRCPerCore: GPS on core 0, VICON on core 1.
+        self.set_parameters({
+            "EK3_ENABLE": 1,
+            "AHRS_EKF_TYPE": 3,
+            "VISO_TYPE": 2,
+            "SERIAL5_PROTOCOL": 2,
+            "EK3_SRC2_POSXY": 6,
+            "EK3_SRC2_VELXY": 6,
+            "EK3_SRC2_POSZ": 6,
+            "EK3_SRC2_VELZ": 6,
+            "EK3_SRC2_YAW": 6,
+            "EK3_SRC_OPTIONS": 8,     # SRC_PER_CORE
+            "EK3_OPTIONS": 1 << 3,    # AglKfForOptflow, so XKFA is written at all
+        })
+        self.set_analog_rangefinder_parameters()
+        self.customise_SITL_commandline(["--serial5=sim:vicon"])
+
+        self.wait_ready_to_arm()
+        self.takeoff(10, mode='GUIDED')
+        self.do_RTL()
+
+        dfreader = self.dfreader_for_current_onboard_log()
+        cores = {"XKF5": set(), "XKFA": set()}
+        source_sets = {}
+        while True:
+            m = dfreader.recv_match(type=["XKF5", "XKFA", "XKFS"])
+            if m is None:
+                break
+            if m.get_type() == "XKFS":
+                source_sets.setdefault(m.C, set()).add(m.SS)
+            else:
+                cores[m.get_type()].add(m.C)
+
+        for mtype in ("XKF5", "XKFA"):
+            self.progress("%s cores seen: %s" % (mtype, sorted(cores[mtype])))
+            if not {0, 1}.issubset(cores[mtype]):
+                raise NotAchievedException(
+                    "%s was not logged for both cores (saw %s)"
+                    % (mtype, sorted(cores[mtype])))
+
+        # the core index is what the message carries, so a message logged twice for one
+        # core cannot masquerade as two. What does need proving is that the two cores
+        # were really running different source sets, or the configuration under test
+        # was not in force and the pass above means nothing.
+        self.progress("source sets per core: %s"
+                      % {c: sorted(v) for c, v in sorted(source_sets.items())})
+        if source_sets.get(0) != {0} or source_sets.get(1) != {1}:
+            raise NotAchievedException(
+                "cores were not on separate source sets (got %s)"
+                % {c: sorted(v) for c, v in sorted(source_sets.items())})
+
     def ThrowDoubleDrop(self):
         '''Test a more complicated drop-mode scenario'''
         self.progress("Getting a lift to altitude")
@@ -16568,6 +16626,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
              self.BatteryMissing,
              self.VibrationFailsafe,
              self.EK3AccelBias,
+             self.EK3_PerCoreLogging,
              self.EK3_AccelBiasInhibitOnGroundMoving,
              self.EK3_AccelBiasZeroVelOptFlow,
              self.EK3_ZeroVelFusionNotUsedWithGPS,

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -11953,14 +11953,14 @@ Also, ignores heartbeats not from our target system'''
         self.wait_disarmed()
         self.delay_sim_time(15, reason="Allow log persistence to finish")
         self.assert_current_log_filesizes({
-            1: (1950*1024, 1980*1024),
+            1: (1950*1024, 1990*1024),
         })
         self.progress("Creating a second log")
         self.arm_vehicle()
         self.wait_disarmed()
         self.delay_sim_time(15, reason="Allow log persistence to finish")
         self.assert_current_log_filesizes({
-            1: (1950*1024, 1980*1024),
+            1: (1950*1024, 1990*1024),
             2: (1000*1024, 1100*1024),
         })
 

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Logging.cpp
@@ -185,11 +185,6 @@ void NavEKF3_core::Log_Write_XKF4(uint64_t time_us) const
 
 void NavEKF3_core::Log_Write_XKF5(uint64_t time_us) const
 {
-    if (core_index != frontend->primary) {
-        // log only primary instance for now
-        return;
-    }
-
     const struct log_XKF5 pkt5{
         LOG_PACKET_HEADER_INIT(LOG_XKF5_MSG),
         time_us : time_us,
@@ -409,8 +404,6 @@ void NavEKF3_core::Log_Write(uint64_t time_us)
     if (level == NavEKF3::LogLevel::XKF4_GSF) {  // only log XKF4 scaled innovations and GSF, otherwise log everything
         return;
     }
-    // note that several of these functions exit-early if they're not
-    // attempting to log the primary core.
     Log_Write_XKF1(time_us);
     Log_Write_XKF2(time_us);
     Log_Write_XKF3(time_us);
@@ -420,6 +413,7 @@ void NavEKF3_core::Log_Write(uint64_t time_us)
     Log_Write_Quaternion(time_us);
 
 
+    // the beacon, body odometry and state variance writers below log the primary core only
 #if EK3_FEATURE_BEACON_FUSION
     // write range beacon fusion debug packet if the range value is non-zero
     Log_Write_Beacon(time_us);

--- a/libraries/AP_NavEKF3/LogStructure.h
+++ b/libraries/AP_NavEKF3/LogStructure.h
@@ -214,7 +214,7 @@ struct PACKED log_XKF4 {
 
 
 // @LoggerMessage: XKF5
-// @Description: EKF3 Sensor innovations (primary core) and general dumping ground
+// @Description: EKF3 Sensor innovations and general dumping ground
 // @Field: TimeUS: Time since system startup
 // @Field: C: EKF3 core this data is for
 // @Field: NI: Normalised flow variance


### PR DESCRIPTION
### Summary

`XKF5` is logged for the primary EKF core only, and `XKFA` is written inside it so it inherits the same guard. Under `EK3_SRC_OPTIONS` bit 3 each core runs its own source set, so the lane being investigated is usually not the primary one - and its innovations, terrain state and AGL KF are then absent from the log entirely.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)

`EK3_PerCoreLogging` flies GPS on core 0 and VICON on core 1 under `EK3_SRC_OPTIONS` bit 3 and requires both messages to carry `C=0` and `C=1`. It fails on master, where `XKF5` carries core 0 only. `test.Copter.Replay` also passes: the replay log carries `XKF5` for `C=0,1,100,101`, so the newly logged non-primary core is compared and replays bit-identically.

### Description

`XKF1` through `XKF4` already log every core. This drops the early return that made `XKF5` the exception.

**Bandwidth**, since that is the obvious objection. Measured on the same autotest with and without the guard: **21.9 kB/s of log becomes 22.5 kB/s** - +597 B/s for the two messages, 2.7% of the log. `XKF5` is 45 B and `XKFA` 29 B on disk, written at 10 Hz on Copter or 25 Hz with `MASK_LOG_ATTITUDE_FAST`, so per additional core the ceiling is +450 B/s at 10 Hz, +1.13 kB/s at 25 Hz, plus +290 B/s for `XKFA` where `EK3_OPTIONS` bit 3 is set. Three cores at 25 Hz with both messages is +3.70 kB/s, the worst case.

Small-board exposure looks acceptable: `LOG_FILE_BUFSIZE` is 16 kB on the smallest boards, so +740 B/s is about 4.5% of one second of buffer; the rate limiter takes one decision per message id per scheduler tick and applies it to every instance, so a budget-limited user drops both cores together rather than one core starving the other; and `EK3_LOG_LEVEL=1` already removes `XKF5` outright for anyone truly out of room.

Gating on `sources.option_is_set(SRC_PER_CORE)` instead was considered and rejected: it leaves the same hole for anyone comparing lanes for a different reason, `EK3_AFFINITY` or a lane-switch investigation, and it is a condition to remember rather than a footgun removed.

`Log_Write_Beacon`, `Log_Write_BodyOdom` and `Log_Write_State_Variances` keep their guards. That is a scope judgement rather than a safety rule - those three are non-const and advance per-core bookkeeping around the guard, but that state is per-core, so removing them would change cadence and cost rather than corrupt anything. EKF2's `NKF5` carries the identical guard and is untouched here.

The autotest also asserts, via `XKFS`, that the two cores really are on different source sets. The core index is what the message carries, so a message logged twice for one core cannot masquerade as two and needs no guarding against; what does need proving is that the per-core configuration was actually in force, or the first assertion passes for a run that never exercised it.
