### PR TITLE
AP_Camera: ignore zoom commands intended for external MAVLink cameras

### DIFF
--- a/libraries/AP_Camera/AP_Camera.cpp
+++ b/libraries/AP_Camera/AP_Camera.cpp
@@ -420,10 +420,14 @@ MAV_RESULT AP_Camera::handle_command(const mavlink_command_int_t &packet)
             packet.param1                   // distance
         );
     case MAV_CMD_SET_CAMERA_ZOOM:
+        // Do not consume zoom commands intended for external MAVLink cameras
+        if (packet.target_component == MAV_COMP_ID_CAMERA) {
+            return MAV_RESULT_UNSUPPORTED;
+        }
         return handle_mav_SET_CAMERA_ZOOM(
-            packet.param3,                   // instance
+            packet.param3,                  // instance
             CAMERA_ZOOM_TYPE(packet.param1), // zoom type
-            packet.param2                    // zoom level
+            packet.param2                   // zoom level
         );
     case MAV_CMD_SET_CAMERA_FOCUS:
         return handle_mav_SET_CAMERA_FOCUS(


### PR DESCRIPTION
### Summary

Fixes a routing bug where the autopilot incorrectly intercepts and consumes MAVLink zoom commands intended for external MAVLink cameras. 

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Compiled successfully for the SITL environment. 

### Description

Closes #34343.

**The Problem:**
Currently, when a Ground Control Station sends a `MAV_CMD_SET_CAMERA_ZOOM` command explicitly addressed to an external camera (`target_component` = 100 / `MAV_COMP_ID_CAMERA`), the autopilot's internal `AP_Camera` library consumes it. This prevents the actual MAVLink camera payload from properly receiving and executing the zoom request.

**The Solution:**
Added a component ID validation check inside `AP_Camera::handle_command()` for the `MAV_CMD_SET_CAMERA_ZOOM` case. If the incoming packet's `target_component` matches `MAV_COMP_ID_CAMERA`, the function now immediately returns `MAV_RESULT_UNSUPPORTED`. This ensures the autopilot ignores the message and allows the command to pass through to the intended external payload.