### PR TITLE
AP_ADSB: bound Sagetech GPS message field widths

### DIFF
--- a/libraries/AP_ADSB/AP_ADSB_Backend.cpp
+++ b/libraries/AP_ADSB/AP_ADSB_Backend.cpp
@@ -17,6 +17,11 @@
 
 #if HAL_ADSB_ENABLED
 
+#include <AP_Math/AP_Math.h>
+
+#include <stdio.h>
+#include <time.h>
+
 /*
   base class constructor.
 */
@@ -25,6 +30,65 @@ AP_ADSB_Backend::AP_ADSB_Backend(AP_ADSB &frontend, uint8_t instance) :
     _frontend(frontend)
 {
 }
+
+#if HAL_ADSB_SAGETECH_ENABLED || HAL_ADSB_SAGETECH_MXS_ENABLED
+
+// NOTE: the coordinate maths MUST be done in double or else we get
+// roundoff in the maths
+
+void AP_ADSB_Backend::format_longitude(char *buf, size_t buflen, int32_t lng_1e7)
+{
+    const double deg = lng_1e7 * (double)1.0e-7 * (lng_1e7 < 0 ? -1 : 1);
+    const double minutes = (deg - int(deg)) * 60;
+    snprintf(buf, buflen, "%03u%02u.%05u",
+             MIN(unsigned(deg), 180U),
+             MIN(unsigned(minutes), 59U),
+             MIN(unsigned((minutes - (int)minutes) * 1.0E5), 99999U));
+}
+
+void AP_ADSB_Backend::format_latitude(char *buf, size_t buflen, int32_t lat_1e7)
+{
+    const double deg = lat_1e7 * (double)1.0e-7 * (lat_1e7 < 0 ? -1 : 1);
+    const double minutes = (deg - int(deg)) * 60;
+    snprintf(buf, buflen, "%02u%02u.%05u",
+             MIN(unsigned(deg), 90U),
+             MIN(unsigned(minutes), 59U),
+             MIN(unsigned((minutes - (int)minutes) * 1.0E5), 99999U));
+}
+
+void AP_ADSB_Backend::format_speed_knots(char *buf, size_t buflen, float knots)
+{
+    snprintf(buf, buflen, "%03u.%02u",
+             MIN(unsigned(knots), 999U),
+             MIN(unsigned((knots - (int)knots) * 1.0E2), 99U));
+}
+
+void AP_ADSB_Backend::format_track_deg(char *buf, size_t buflen, float track_deg)
+{
+    snprintf(buf, buflen, "%03u.%04u",
+             MIN(unsigned(track_deg), 359U),
+             MIN(unsigned((track_deg - (int)track_deg) * 1.0E4), 9999U));
+}
+
+void AP_ADSB_Backend::format_time_of_day(char *buf, size_t buflen, uint64_t time_usec)
+{
+    const time_t time_sec = time_usec / 1000000;
+    struct tm tmd {};
+    gmtime_r(&time_sec, &tmd);
+
+    // the seconds are formatted as an integer rather than as a float so
+    // that the width of the field is known; the milliseconds are rounded
+    // and carried into the seconds to match the "%06.3f" this replaced
+    const unsigned msec = unsigned((time_usec % 1000000 + 500) / 1000);
+    const unsigned sec = unsigned(tmd.tm_sec) + msec / 1000;
+    snprintf(buf, buflen, "%02u%02u%02u.%03u",
+             MIN(unsigned(tmd.tm_hour), 23U),
+             MIN(unsigned(tmd.tm_min), 59U),
+             MIN(sec, 61U),
+             msec % 1000);
+}
+
+#endif // HAL_ADSB_SAGETECH_ENABLED || HAL_ADSB_SAGETECH_MXS_ENABLED
 
 #endif // HAL_ADSB_ENABLED
 

--- a/libraries/AP_ADSB/AP_ADSB_Backend.h
+++ b/libraries/AP_ADSB/AP_ADSB_Backend.h
@@ -36,6 +36,16 @@ public:
 
 protected:
 
+#if HAL_ADSB_SAGETECH_ENABLED || HAL_ADSB_SAGETECH_MXS_ENABLED
+    // format the fixed-width ASCII fields the Sagetech protocols use.  Each
+    // component is bounded so it can not overflow into the following field.
+    static void format_longitude(char *buf, size_t buflen, int32_t lng_1e7);   // "dddmm.mmmmm", 11 characters
+    static void format_latitude(char *buf, size_t buflen, int32_t lat_1e7);    // "ddmm.mmmmm", 10 characters
+    static void format_speed_knots(char *buf, size_t buflen, float knots);     // "sss.ss", 6 characters
+    static void format_track_deg(char *buf, size_t buflen, float track_deg);   // "ttt.tttt", 8 characters
+    static void format_time_of_day(char *buf, size_t buflen, uint64_t time_usec); // "hhmmss.sss", 10 characters
+#endif // HAL_ADSB_SAGETECH_ENABLED || HAL_ADSB_SAGETECH_MXS_ENABLED
+
     uint8_t _instance;
 
     AP_HAL::UARTDriver *_port;

--- a/libraries/AP_ADSB/AP_ADSB_Sagetech.cpp
+++ b/libraries/AP_ADSB/AP_ADSB_Sagetech.cpp
@@ -486,24 +486,18 @@ void AP_ADSB_Sagetech::send_msg_GPS()
     const int32_t longitude = loc.lng;
     const int32_t latitude =  loc.lat;
 
-    // longitude and latitude
-    // NOTE: these MUST be done in double or else we get roundoff in the maths
-    const double lon_deg = longitude * (double)1.0e-7 * (longitude < 0 ? -1 : 1);
-    const double lon_minutes = (lon_deg - int(lon_deg)) * 60;
-    snprintf((char*)&pkt.payload[0], 12, "%03u%02u.%05u", (unsigned)lon_deg, (unsigned)lon_minutes, unsigned((lon_minutes - (int)lon_minutes) * 1.0E5));
-
-    const double lat_deg = latitude * (double)1.0e-7 * (latitude < 0 ? -1 : 1);
-    const double lat_minutes = (lat_deg - int(lat_deg)) * 60;
-    snprintf((char*)&pkt.payload[11], 11, "%02u%02u.%05u", (unsigned)lat_deg, (unsigned)lat_minutes, unsigned((lat_minutes - (int)lat_minutes) * 1.0E5));
+    // longitude and latitude.  Each field's nul terminator lands on the
+    // first byte of the field which follows it, so these must stay in
+    // ascending order of offset.
+    format_longitude((char*)&pkt.payload[0], 12, longitude);
+    format_latitude((char*)&pkt.payload[11], 11, latitude);
 
     // ground speed
     const Vector2f speed = loc.groundspeed_vector();
-    float speed_knots = speed.length() * M_PER_SEC_TO_KNOTS;
-    snprintf((char*)&pkt.payload[21], 7, "%03u.%02u", (unsigned)speed_knots, unsigned((speed_knots - (int)speed_knots) * 1.0E2));
+    format_speed_knots((char*)&pkt.payload[21], 7, speed.length() * M_PER_SEC_TO_KNOTS);
 
     // heading
-    float heading = wrap_360(degrees(speed.angle()));
-    snprintf((char*)&pkt.payload[27], 10, "%03u.%04u", unsigned(heading), unsigned((heading - (int)heading) * 1.0E4));
+    format_track_deg((char*)&pkt.payload[27], 10, wrap_360(degrees(speed.angle())));
 
     // hemisphere
     uint8_t hemisphere = 0;
@@ -513,15 +507,9 @@ void AP_ADSB_Sagetech::send_msg_GPS()
     pkt.payload[35] = hemisphere;
 
     // time
-    uint64_t time_usec = loc.epoch_from_rtc_us;
     if (loc.have_epoch_from_rtc_us) {
         // not completely accurate, our time includes leap seconds and time_t should be without
-        const time_t time_sec = time_usec / 1000000;
-        struct tm tmd {};
-        struct tm* tm = gmtime_r(&time_sec, &tmd);
-
-        // format time string
-        snprintf((char*)&pkt.payload[36], 11, "%02u%02u%06.3f", tm->tm_hour, tm->tm_min, tm->tm_sec + (time_usec % 1000000) * 1.0e-6);
+        format_time_of_day((char*)&pkt.payload[36], 11, loc.epoch_from_rtc_us);
     } else {
         memset(&pkt.payload[36],' ', 10);
     }

--- a/libraries/AP_ADSB/AP_ADSB_Sagetech_MXS.cpp
+++ b/libraries/AP_ADSB/AP_ADSB_Sagetech_MXS.cpp
@@ -615,22 +615,17 @@ void AP_ADSB_Sagetech_MXS::send_gps_msg()
     // Get Vehicle Longitude and Latitude and Convert to string
     const int32_t longitude = _frontend._my_loc.lng;
     const int32_t latitude =  _frontend._my_loc.lat;
-    const double lon_deg = longitude * (double)1.0e-7 * (longitude < 0 ? -1 : 1);
-    const double lon_minutes = (lon_deg - int(lon_deg)) * 60;
-    snprintf((char*)&gps.longitude, 12, "%03u%02u.%05u", (unsigned)lon_deg, (unsigned)lon_minutes, unsigned((lon_minutes - (int)lon_minutes) * 1.0E5));
-
-    const double lat_deg = latitude * (double)1.0e-7 * (latitude < 0 ? -1 : 1);
-    const double lat_minutes = (lat_deg - int(lat_deg)) * 60;
-    snprintf((char*)&gps.latitude, 11, "%02u%02u.%05u", (unsigned)lat_deg, (unsigned)lat_minutes, unsigned((lat_minutes - (int)lat_minutes) * 1.0E5));
+    format_longitude(gps.longitude, sizeof(gps.longitude), longitude);
+    format_latitude(gps.latitude, sizeof(gps.latitude), latitude);
 
     const Vector2f speed = _frontend._my_loc.groundspeed_vector();
     const float speed_knots = speed.length() * M_PER_SEC_TO_KNOTS;
-    snprintf((char*)&gps.grdSpeed, 7, "%03u.%02u", (unsigned)speed_knots, unsigned((speed_knots - (int)speed_knots) * 1.0E2));
+    format_speed_knots(gps.grdSpeed, sizeof(gps.grdSpeed), speed_knots);
 
     if (!is_zero(speed_knots)) {
         cog = wrap_360(degrees(speed.angle()));
     }
-    snprintf((char*)&gps.grdTrack, 9, "%03u.%04u", unsigned(cog), unsigned((cog - (int)cog) * 1.0E4));
+    format_track_deg(gps.grdTrack, sizeof(gps.grdTrack), cog);
 
 
     gps.latNorth = (latitude >= 0 ? true: false);
@@ -638,13 +633,8 @@ void AP_ADSB_Sagetech_MXS::send_gps_msg()
 
     gps.gpsValid = ap_gps.status() >=  AP_GPS_FixType::FIX_2D;
 
-    uint64_t time_usec = ap_gps.epoch_from_rtc_us;
     if (ap_gps.have_epoch_from_rtc_us) {
-        const time_t time_sec = time_usec * 1E-6;
-        struct tm tmd {};
-        struct tm* tm = gmtime_r(&time_sec, &tmd);
-
-        snprintf((char*)&gps.timeOfFix, 11, "%02u%02u%06.3f", tm->tm_hour, tm->tm_min, tm->tm_sec + (time_usec % 1000000) * 1.0e-6);
+        format_time_of_day(gps.timeOfFix, sizeof(gps.timeOfFix), ap_gps.epoch_from_rtc_us);
     } else {
         strncpy(gps.timeOfFix, "      .   ", 11);
     }


### PR DESCRIPTION
### Summary

The Sagetech ADS-B GPS message fields were formatted with no bound on the values, so an out-of-range input could overflow its fixed-width field and corrupt the rest of the packet; gcc-14+ rejects the latitude field outright on boards built with `-O2`. This bounds each component to its field width and shares the formatting between the two Sagetech drivers.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Toolchain for all of the below: `arm-none-eabi-g++ 16.1.0` (ArduPilot toolchain).

**Build.** `./waf configure --board=sparknavi-blue && ./waf plane` fails on master and succeeds on this branch. Both Sagetech drivers also compile clean at `-Wformat-truncation=2`, which is stricter than the build uses.

**Autotest.** `Tools/autotest/autotest.py build.Plane test.Plane.SagetechMXS` passes. This test is relevant rather than incidental: the SITL Sagetech MXS model decodes the fixed-width strings positionally (`lat_string_to_double()` in `libraries/SITL/SIM_ADSB_Sagetech_MXS.cpp` reads `str[0]`..`str[9]`), so any shift in field layout would break it. Its assertion is coarse, though — the decoded vehicle need only be within 10 km of home — so it catches gross corruption, not rounding.

**Output equivalence.** An off-tree harness (not included in this PR) compared the old and new formatting over 1.4M values:

- latitude, longitude, ground speed and track: byte-identical in every case.
- time of fix: identical except on exact half-millisecond ties — 105 of 200,000 random samples — where `printf("%06.3f")` rounds half-to-even and the new integer path rounds half-up.

**Binary size.** `Tools/scripts/size_compare_branches.py --board=CubeOrangePlus --vehicle=plane` against master reports **-248 bytes** for plane. CubeOrangePlus builds at the ChibiOS default `-Os`, so master compiles there and a direct comparison is possible; on one of the affected `-O2` boards master does not build at all, so no baseline exists to compare against. The saving comes from the two drivers no longer carrying duplicate copies of the formatting.

**Not tested on hardware.** I have no Sagetech transponder, so the actual wire output has not been confirmed against a device. Review by someone who has one would be welcome.

### Description

`AP_ADSB_Sagetech::send_msg_GPS()` builds a packet from a run of fixed-width ASCII fields. Each field is exactly as wide as the value it holds, and the next field begins at the following byte, so each `snprintf()`'s terminating nul deliberately lands on the first byte of the next field and is overwritten by it. The field order is load-bearing — `payload[35]` is written by the heading `snprintf()`'s nul and then assigned the hemisphere byte.

Nothing bounded the formatted values. `%02u` sets a minimum width, not a maximum, so a latitude outside ±90° — `loc.lat` is an `int32_t` and can reach 214.7° — produces three digits where the field holds two, overflowing into the following field and truncating the end of the packet. This is a runtime defect independent of the compiler: gcc-10 compiles the same code with no diagnostic at all.

gcc-14+ does diagnose it, but only at `-O2`/`-O3`, since the analysis depends on optimisation:

```
AP_ADSB_Sagetech.cpp:497: error: 'snprintf' output may be truncated
before the last format character [-Werror=format-truncation=]
note: 'snprintf' output between 11 and 25 bytes into a destination of size 11
```

ChibiOS defaults to `-Os` (`Tools/ardupilotwaf/chibios.py:531`), and 14 boards override that with `env OPTIMIZE -O2` or `-O3` in their hwdef — `sparknavi-blue`, `CubeBlack`, `CubeSolo`, `MambaH743v4`, `flycore` and others. Those boards no longer build; the rest are unaffected, which is why this has gone unnoticed.

This PR bounds every component to the largest value its field can represent, so the packet stays well-formed whatever the input, and moves the formatting into five helpers on `AP_ADSB_Backend`, shared with `AP_ADSB_Sagetech_MXS` which carried a character-identical copy of the same code.

Two behavioural notes, both in the time-of-fix field:

- The seconds are now formatted as an integer rather than `%06.3f`, so the width of the field is known; the milliseconds are rounded and carried into the seconds to match what `%06.3f` did.
- The MXS driver converted its epoch to seconds via a `double` (`time_usec * 1E-6`), which at present-day epoch values can round up and report the following second. It now uses integer division, as the XP driver already did.

Not addressed here, but worth knowing: the reason this is an *error* rather than a warning is that `Tools/ardupilotwaf/boards.py` adds `-Wno-error=format-truncation` for gcc 14.0–16.2 (issue #33206), and then `-Werror=format` is applied again afterwards — `boards.py:218` prepends the board env into `cfg.env`, so anything written directly to `cfg.env.CXXFLAGS` lands last and wins. `-Werror=format` covers the whole `-Wformat` family, so the suppression never takes effect on ChibiOS builds. That is a separate `Tools` change.

### AI assistance

This change was AI-assisted. 
