### PR TITLE
HAL_ChibiOS: avoid stale FAT32 FSINFO free-space counts

### DIFF
--- a/libraries/AP_HAL_ChibiOS/hwdef/common/ffconf.h
+++ b/libraries/AP_HAL_ChibiOS/hwdef/common/ffconf.h
@@ -253,7 +253,7 @@
 /  These options have no effect in read-only configuration (FF_FS_READONLY = 1). */
 
 
-#define FF_FS_NOFSINFO	0
+#define FF_FS_NOFSINFO	1
 /* If you need to know correct free space on the FAT32 volume, set bit 0 of this
 /  option, and f_getfree() function at first time after volume mount will force
 /  a full FAT scan. Bit 1 controls the use of last allocated cluster number.


### PR DESCRIPTION
### Summary

Set FatFs `FF_FS_NOFSINFO` bit 0 so FAT32 free-space queries rescan the FAT after mount instead of trusting stale FSINFO free-cluster counts. Fixes #34348.

### Classification & Testing (check all that apply and add your own)

- [ ] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

A temporary in-memory FAT32 harness using the bundled FatFs implementation reproduced the issue: with `FF_FS_NOFSINFO=0`, a valid stale FSINFO count of 255 clusters was returned; with `FF_FS_NOFSINFO=1`, the actual FAT count of 69,999 free clusters was returned. The scan result was cached by FatFs.

A full SITL `arducopter` build completed successfully. A native ChibiOS build was attempted but could not be configured because `arm-none-eabi-ar` was unavailable in the local environment.

### Description

The bundled FatFs is R0.14b. With `FF_FS_NOFSINFO=0`, `f_getfree()` trusts the FAT32 FSINFO `Free_Count` field when it passes validation. After an unclean shutdown this cached value can be stale, causing `AP_Logger_File` to believe the card has less than its minimum free space and stop logging.

Setting `FF_FS_NOFSINFO=1` forces one full FAT scan on the first `f_getfree()` call after each mount, then caches the result in `FATFS.free_clst`. Subsequent logger checks do not rescan, and the normal FatFs allocation paths keep the cached count updated.

Bit 1 is intentionally left clear so FatFs can continue using the FSINFO next-free-cluster hint. The logger minimum-space protection and `LOG_FILE_MB_FREE` semantics are unchanged.