### PR TITLE
AC_WPNav: Loiter: separate the drag model's terminal speed from LOIT_SPEED_MS

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -4324,6 +4324,36 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
 
         self.disarm_vehicle(force=True)
 
+    def LoiterSpeedLimit(self):
+        '''LOIT_SPEED_MS holds as a speed limit on a vehicle that can fly faster'''
+        # LOIT_SPEED_MS shapes the loiter trajectory and LOIT_TERM_MS tells the
+        # controller how fast the vehicle actually flies at LOIT_ANG_MAX, so it can
+        # work out how much lean angle the vehicle needs to hold a given speed.
+        # Without it the controller assumes the vehicle needs full lean to hold
+        # LOIT_SPEED_MS and drives it past the limit. The SITL + frame reaches about
+        # 8.9 m/s at 25 degrees of lean (SIM_FRAME reference drag test: 15.08 m/s at
+        # 45 degrees).
+        self.set_parameters({
+            "ATC_ANGLE_MAX": 45,
+            "LOIT_ANG_MAX": 25,
+            "LOIT_SPEED_MS": 3,
+            "LOIT_TERM_MS": 8.9,
+            "SIM_WIND_SPD": 0,
+        })
+        self.takeoff(40, mode='LOITER')
+
+        self.start_subtest("full stick settles at the speed limit, not above it")
+        self.set_rc(2, 1000)
+        self.wait_groundspeed(2.7, 3.2, timeout=60, minimum_duration=15)
+
+        self.start_subtest("half stick still gives half the loiter speed")
+        self.set_rc(2, 1250)
+        self.wait_groundspeed(1.1, 1.7, timeout=60, minimum_duration=10)
+
+        self.set_rc(2, 1500)
+        self.wait_groundspeed(0, 0.5, timeout=90, minimum_duration=5)
+        self.do_RTL()
+
     def ModeFlowHold(self):
         '''test FlowHold mode - position hold and flow-based height estimation'''
         self.set_parameters({
@@ -16628,6 +16658,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
              self.LoiterNoCompassYaw,
              self.LoiterNoCompassYawGPS,
              self.LoiterFlowBrakeOvershoot,
+             self.LoiterSpeedLimit,
              self.ModeFlowHold,
              self.OpticalFlowCalibration,
              self.MotorFail,

--- a/libraries/AC_WPNav/AC_Loiter.cpp
+++ b/libraries/AC_WPNav/AC_Loiter.cpp
@@ -344,6 +344,7 @@ void AC_Loiter::calc_desired_velocity(bool avoidance_on)
     desired_vel_ne_ms += _predicted_accel_ne_mss * dt_s;
 
     Vector2f loiter_accel_brake_mss;
+    Vector2f loiter_accel_limit_mss;
     float desired_speed_ms = desired_vel_ne_ms.length();
     if (!is_zero(desired_speed_ms)) {
         Vector2f desired_vel_norm = desired_vel_ne_ms / desired_speed_ms;
@@ -364,17 +365,25 @@ void AC_Loiter::calc_desired_velocity(bool avoidance_on)
 
         // Update desired speed based on braking and drag
         desired_speed_ms = MAX(desired_speed_ms - (drag_decel_mss + _brake_accel_mss) * dt_s, 0.0f);
+
+        // Apply the speed limit. The acceleration removed here is also removed from the
+        // feed-forward acceleration below, otherwise the position controller is asked to hold the
+        // full pilot lean angle while the feed-forward velocity is held at the limit and the
+        // vehicle settles faster than the limit. The removed acceleration is constrained so that a
+        // step change in the speed limit cannot produce a large transient.
+        if (desired_speed_ms > gnd_speed_limit_ms) {
+            if (is_positive(dt_s)) {
+                const float limit_decel_mss = MIN((desired_speed_ms - gnd_speed_limit_ms) / dt_s, pilot_acceleration_max_mss);
+                loiter_accel_limit_mss = desired_vel_norm * limit_decel_mss;
+            }
+            desired_speed_ms = gnd_speed_limit_ms;
+        }
+
         desired_vel_ne_ms = desired_vel_norm * desired_speed_ms;
     }
 
-    // Apply braking acceleration to overall feed-forward acceleration
-    _desired_accel_ne_mss -= loiter_accel_brake_mss;
-
-    // Apply final velocity magnitude constraint
-    float desired_vel_ms = desired_vel_ne_ms.length();
-    if (desired_vel_ms > gnd_speed_limit_ms) {
-        desired_vel_ne_ms = desired_vel_ne_ms * gnd_speed_limit_ms / desired_vel_ms;
-    }
+    // Apply braking and speed limit accelerations to overall feed-forward acceleration
+    _desired_accel_ne_mss -= loiter_accel_brake_mss + loiter_accel_limit_mss;
 
 #if AP_AVOIDANCE_ENABLED && !APM_BUILD_TYPE(APM_BUILD_ArduPlane)
     if (avoidance_on) {

--- a/libraries/AC_WPNav/AC_Loiter.cpp
+++ b/libraries/AC_WPNav/AC_Loiter.cpp
@@ -93,6 +93,15 @@ const AP_Param::GroupInfo AC_Loiter::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("BRK_JRK_M", 11, AC_Loiter, _brake_jerk_max_msss, LOITER_BRAKE_JERK_DEFAULT_MSSS),
 
+    // @Param: TERM_MS
+    // @DisplayName: Loiter terminal speed
+    // @Description: Horizontal speed in m/s the vehicle reaches in still air at the LOIT_ANG_MAX lean angle. This is used only to estimate how hard the vehicle has to lean against its own aerodynamic drag, it does not limit the vehicle and does not change the stick to speed response. Set to zero to assume the vehicle reaches LOIT_SPEED_MS at LOIT_ANG_MAX. Set this to the vehicle's measured terminal speed whenever LOIT_SPEED_MS is set below what the vehicle can fly, otherwise the loiter controller commands more lean angle than the vehicle needs and the vehicle flies faster than LOIT_SPEED_MS.
+    // @Units: m/s
+    // @Range: 0 35
+    // @Increment: 0.05
+    // @User: Advanced
+    AP_GROUPINFO("TERM_MS", 12, AC_Loiter, _speed_terminal_ne_ms, 0.0),
+
     AP_GROUPEND
 };
 
@@ -259,6 +268,16 @@ void AC_Loiter::set_speed_max_NE_ms(float speed_max_ne_ms)
     _speed_max_ne_ms.set(MAX(speed_max_ne_ms, LOITER_SPEED_MIN_MS));
 }
 
+// Returns the terminal speed in m/s used by the loiter drag model.
+// Falls back to the loiter speed limit when LOIT_TERM_MS has not been set.
+float AC_Loiter::get_terminal_speed_NE_ms() const
+{
+    if (is_positive(_speed_terminal_ne_ms)) {
+        return MAX(_speed_terminal_ne_ms, LOITER_SPEED_MIN_MS);
+    }
+    return MAX(_speed_max_ne_ms, LOITER_SPEED_MIN_MS);
+}
+
 // perform any required parameter conversions
 void AC_Loiter::convert_parameters()
 {
@@ -329,8 +348,17 @@ void AC_Loiter::calc_desired_velocity(bool avoidance_on)
     float gnd_speed_limit_ms = MIN(_speed_max_ne_ms, ekfGndSpdLimit_ms);
     gnd_speed_limit_ms = MAX(gnd_speed_limit_ms, LOITER_SPEED_MIN_MS);
 
+    // Speed the desired velocity is shaped towards. Referenced to _speed_max_ne_ms rather than
+    // gnd_speed_limit_ms so that an estimator speed limit does not change the stick response;
+    // gnd_speed_limit_ms is enforced by the speed limit below.
+    const float shaping_speed_ms = MAX(_speed_max_ne_ms, LOITER_SPEED_MIN_MS);
+
+    // Speed the vehicle reaches at the maximum pilot lean angle. Used to estimate the aerodynamic
+    // drag the vehicle generates, which is a property of the airframe rather than a limit.
+    const float terminal_speed_ms = get_terminal_speed_NE_ms();
+
     // Determine acceleration limit based on maximum allowed lean angle
-    float pilot_acceleration_max_mss = (gnd_speed_limit_ms / _speed_max_ne_ms) * angle_rad_to_accel_mss(get_angle_max_rad());
+    const float pilot_acceleration_max_mss = angle_rad_to_accel_mss(get_angle_max_rad());
 
     // Check for invalid dt
     if (is_negative(dt_s)) {
@@ -345,12 +373,23 @@ void AC_Loiter::calc_desired_velocity(bool avoidance_on)
 
     Vector2f loiter_accel_brake_mss;
     Vector2f loiter_accel_limit_mss;
+    Vector2f loiter_accel_shaping_mss;
     float desired_speed_ms = desired_vel_ne_ms.length();
     if (!is_zero(desired_speed_ms)) {
         Vector2f desired_vel_norm = desired_vel_ne_ms / desired_speed_ms;
 
-        // Apply drag: deceleration proportional to current velocity
-        float drag_decel_mss = pilot_acceleration_max_mss * desired_speed_ms / gnd_speed_limit_ms;
+        // Apply drag: deceleration proportional to current velocity, reaching the pilot's maximum
+        // acceleration at the shaping speed. This settles the desired velocity at the fraction of
+        // the loiter speed the pilot has asked for.
+        float drag_decel_mss = pilot_acceleration_max_mss * desired_speed_ms / shaping_speed_ms;
+
+        // Aerodynamic deceleration the vehicle is expected to generate at this speed. The
+        // feed-forward acceleration must carry this, because the vehicle has to lean against its
+        // own drag to hold speed, but it must not carry the shaping deceleration above, which
+        // belongs to the trajectory rather than to the vehicle. These are equal, and the
+        // correction below is zero, when the terminal speed is left at the loiter speed.
+        float aero_decel_mss = pilot_acceleration_max_mss * desired_speed_ms / terminal_speed_ms;
+        loiter_accel_shaping_mss = desired_vel_norm * (drag_decel_mss - aero_decel_mss);
 
         // Determine braking acceleration based on stick release and delay timer, stick must have been released for at least a full loop
         float loiter_brake_accel_mss = 0.0f;
@@ -382,8 +421,10 @@ void AC_Loiter::calc_desired_velocity(bool avoidance_on)
         desired_vel_ne_ms = desired_vel_norm * desired_speed_ms;
     }
 
-    // Apply braking and speed limit accelerations to overall feed-forward acceleration
-    _desired_accel_ne_mss -= loiter_accel_brake_mss + loiter_accel_limit_mss;
+    // Apply braking, speed limit and trajectory shaping accelerations to the feed-forward
+    // acceleration, leaving it equal to the rate of change of the feed-forward velocity plus the
+    // drag the vehicle must lean against
+    _desired_accel_ne_mss -= loiter_accel_brake_mss + loiter_accel_limit_mss + loiter_accel_shaping_mss;
 
 #if AP_AVOIDANCE_ENABLED && !APM_BUILD_TYPE(APM_BUILD_ArduPlane)
     if (avoidance_on) {

--- a/libraries/AC_WPNav/AC_Loiter.h
+++ b/libraries/AC_WPNav/AC_Loiter.h
@@ -74,6 +74,10 @@ public:
     // Sets the maximum allowed horizontal loiter speed in m/s.
     void set_speed_max_NE_ms(float speed_max_NE_ms);
 
+    // Returns the terminal speed in m/s used by the loiter drag model.
+    // Falls back to the loiter speed limit when LOIT_TERM_MS has not been set.
+    float get_terminal_speed_NE_ms() const;
+
     // Returns the desired roll angle in centidegrees from the loiter controller.
     float get_roll_cd() const { return rad_to_cd(get_roll_rad()); }
 
@@ -115,6 +119,7 @@ protected:
     // parameters
     AP_Float    _angle_max_deg;         // Maximum pilot-commanded lean angle in degrees. Set to zero to default to 2/3 of PSC_ANGLE_MAX (or Q_ANGLE_MAX for QuadPlane).
     AP_Float    _speed_max_ne_ms;       // Maximum horizontal speed in m/s while in loiter mode. Used to limit both user and internal trajectory velocities.
+    AP_Float    _speed_terminal_ne_ms;  // Horizontal speed in m/s the vehicle reaches at the maximum pilot lean angle, used to model aerodynamic drag. Zero falls back to _speed_max_ne_ms.
     AP_Float    _accel_max_ne_mss;      // Maximum horizontal acceleration (in m/s²) applied during normal loiter corrections.
     AP_Float    _brake_accel_max_mss;   // Maximum braking acceleration (in m/s²) applied when pilot sticks are released.
     AP_Float    _brake_jerk_max_msss;   // Maximum braking jerk (in m/s³) applied during braking transitions after pilot release.


### PR DESCRIPTION
## Summary

`LOIT_SPEED_MS` does two unrelated jobs in `AC_Loiter::calc_desired_velocity()`. It shapes the loiter trajectory — giving stick position a proportional mapping onto the configured loiter speed — and it is also taken as the speed the airframe *reaches* at `LOIT_ANG_MAX`, which is what the feed-forward acceleration is built on. Pilots reasonably use it as a speed limit, and when they do, the second job is wrong: the controller asks for far more lean angle than the vehicle needs, and the vehicle flies *faster* than the limit it was given.

This adds `LOIT_TERM_MS`, the speed the vehicle actually reaches at `LOIT_ANG_MAX`, so the two can be separated. Default zero keeps the current assumption, so existing setups are unchanged.

## Why the two are currently tied together

The drag term shapes the desired velocity into a first-order response that settles at `LOIT_SPEED_MS`:

```cpp
float drag_decel_mss = pilot_acceleration_max_mss * desired_speed_ms / gnd_speed_limit_ms;
```

That shaping is good and this PR does not change it. The problem is the feed-forward acceleration, which is the pilot's lean-angle acceleration with the shaping deceleration left in. That is only correct if the shaped trajectory decelerates at the same rate the vehicle does — in other words, only if the vehicle really does reach `LOIT_SPEED_MS` at `LOIT_ANG_MAX`. Then the feed-forward is exactly the lean the vehicle needs to hold its speed against its own drag, and the velocity and acceleration handed to the position controller agree.

Lower `LOIT_SPEED_MS` to cap the vehicle and that stops being true. The feed-forward still commands the full lean angle to hold the limit, while the airframe needs almost none. The position controller is given two contradictory commands — *hold `LOIT_SPEED_MS`* and *hold `LOIT_ANG_MAX` of lean* — and the velocity loop resolves the conflict by flying above the limit.

## Flight evidence

Three flights on the same airframe (Copter 4.7.0-dev, `LOIT_ANG_MAX` = 25°, so full stick = 4.57 m/s²), differing only in `LOIT_SPEED_MS`. `DVN`/`DVE` in `PSCN`/`PSCE` is the loiter feed-forward velocity, `DAN`/`DAE` the feed-forward acceleration.

<img width="1805" height="852" alt="image" src="https://github.com/user-attachments/assets/08e87f1f-a1dd-4353-b9d2-f4f68e38e99b" />

| `LOIT_SPEED_MS` | feed-forward speed saturated | mean actual speed while saturated | peak actual speed |
|---|---|---|---|
| 5 m/s  | 25 % of the Loiter time | 6.41 m/s | **6.70 m/s (+34 % over the limit)** |
| 15 m/s | never                   | –        | 13.97 m/s |
| 15 m/s | never                   | –        | 9.02 m/s |

With `LOIT_SPEED_MS` = 5 the feed-forward speed sits pinned at 5.0 m/s while the feed-forward acceleration sits pinned at the full 4.57 m/s², and the vehicle holds a steady **+1.47 m/s** error for minutes at a time. The limit is not just soft, it is exceeded by a third.

The airframe's real drag, from the steady-state lean angle across all three logs, fits a terminal speed of ~25 m/s at `LOIT_ANG_MAX`. So at 5 m/s the feed-forward asks for 4.57 m/s² of lean where the airframe needs about 0.4 m/s². At `LOIT_SPEED_MS` = 15 the assumption is much better and the overshoot markedly reduced.

<img width="1805" height="852" alt="image" src="https://github.com/user-attachments/assets/38ad6a3b-96b7-4d14-af0f-5e4564042de1" />

### Target velocity vs actual velocity

`TVN`/`TVE` is the velocity the position controller is actually tracking — the loiter feed-forward velocity plus the position-error correction. The vehicle runs persistently above it, and the gap scales with how far `LOIT_SPEED_MS` sits below the airframe's terminal speed:

| `LOIT_SPEED_MS` | actual - target velocity, mean | 95th pct | peak |
|---|---|---|---|
| 5 m/s  | **+2.37 m/s** | +2.95 | +3.05 |
| 15 m/s | +0.93 m/s | +1.44 | +1.78 |

In both runs the desired-position error spends most of its time pinned at the 2 m clamp, so the position loop is already subtracting its full authority from the target velocity and the vehicle still outruns it.

The drag bookkeeping behind that, at the speed each vehicle actually reached:

| | feed-forward drag today | with `LOIT_TERM_MS` = 16.4 | airframe actually generates |
|---|---|---|---|
| `LOIT_SPEED_MS` = 5, at 6.5 m/s  | 5.94 m/s² | **1.81 m/s²** | 0.71 m/s² |
| `LOIT_SPEED_MS` = 15, at 8.7 m/s | 2.67 m/s² | 2.43 m/s² | 1.29 m/s² |

At `LOIT_SPEED_MS` = 5 the feed-forward asks for roughly eight times the drag the airframe generates, and the fix removes most of that. At `LOIT_SPEED_MS` = 15 there is much less to remove: the bulk of the remaining error there is the drag model being linear in speed where the airframe is quadratic, which this PR does not change. What the fix removes is the part of the mismatch caused by treating the speed limit as a terminal speed — the part that grows without bound as `LOIT_SPEED_MS` is lowered.

This airframe has `PSC_VELXY_I` = 0.02. A higher velocity-I gain will eventually wind out the inconsistency in a long steady hold, which is why this is easy to miss; it still shows up on every stick input, and on a low-I airframe it never winds out at all. Both cases are measured below.

## The change

**1. `remove feed-forward acceleration cancelled by the speed limit`**

The speed limit clipped the feed-forward velocity but left the feed-forward acceleration untouched. Subtract the acceleration the clip has already removed. Constrained to the maximum pilot acceleration so an in-flight change of the limit cannot produce a large transient.

No-op whenever the clip does not engage — with the shaping referenced to `LOIT_SPEED_MS` the feed-forward approaches it asymptotically, so this only matters when the estimator limits ground speed or the limit changes in flight.

**2. `add LOIT_TERM_MS to separate the drag model from the speed limit`**

`LOIT_TERM_MS` (`Q_LOIT_TERM_MS` on QuadPlane) is the speed the vehicle reaches in still air at `LOIT_ANG_MAX`. It is used only to estimate the drag the vehicle must lean against. The feed-forward now carries that estimate instead of the shaping deceleration, so it stays equal to `d(desired_vel)/dt` plus the vehicle's own drag.

The velocity shaping is untouched, so **the stick-to-speed response does not change** — measured below. Zero, the default, makes the two terms equal and the correction vanishes, so behaviour is bit-identical to master.

This folds in @lthall's #33639. Scaling the pilot acceleration by `gnd_speed_limit_ms / _speed_max_ne_ms` and then dividing by `gnd_speed_limit_ms` is algebraically identical to dividing by `_speed_max_ne_ms`, which is what the shaping speed now is — so that behaviour is preserved and written directly.

**3. `autotest: add LoiterSpeedLimit test`**

## Relationship to #33318

@andyp1per's #33318 is the same diagnosis and worth reading alongside this. It removes the *whole* drag term from the feed-forward, leaving nothing for the vehicle to lean against, so the velocity integrator has to supply the real drag — the cost @lthall raised for the well-calibrated case.

This PR replaces the shaping term with an *estimate of the real drag* rather than deleting it, which is the general fix @lthall described in that thread: keep a real terminal velocity in the model rather than reusing whichever cap happens to be active. With `LOIT_TERM_MS` at its default the feed-forward is unchanged, so nothing is taken away from vehicles that are already consistent.

Commit 1 is narrower than #33318 and independent of it: it only removes acceleration the speed-limit clip has already taken out of the velocity.

## Tuning

Fly Loiter at full stick with `LOIT_SPEED_MS` set high and note the speed reached in still air — that is `LOIT_TERM_MS`. Then set `LOIT_SPEED_MS` to whatever limit you want.

## Testing

### Speed limit is respected — new `LoiterSpeedLimit` autotest scenario

SITL `+` frame, `LOIT_ANG_MAX` = 25°, no wind. Measured terminal speed at 25° lean (ALT_HOLD, `ATC_ANGLE_MAX` = 25): **8.88 m/s**. `LOIT_SPEED_MS` = 3.0, i.e. a third of what the airframe can fly. Peak speed over three 6 s full-stick jabs:

| `PSC_NE_VEL_I` | `LOIT_TERM_MS` = 0 | `LOIT_TERM_MS` = 8.9 |
|---|---|---|
| 1.0 (SITL default) | 3.40 m/s (+13 %) | **2.99 m/s** |
| 0.02 (as flown above) | 3.55 m/s (+18 %) | **2.96 m/s** |

### Stick response is unchanged

Settled speed at each stick position, same configuration, `PSC_NE_VEL_I` at the default:

| stick | `LOIT_TERM_MS` = 0 | `LOIT_TERM_MS` = 8.9 |
|---|---|---|
| 25 %  | 0.600 m/s | 0.626 m/s |
| 50 %  | 1.364 m/s | 1.375 m/s |
| 75 %  | 2.157 m/s | 2.153 m/s |
| 100 % | 2.999 m/s | 2.998 m/s |

Identical within run-to-run noise: stick position still maps proportionally onto `LOIT_SPEED_MS`, and the limit is reached at the top of the stick rather than being blown through.

### Optical-flow Loiter — existing `LoiterFlowBrakeOvershoot` autotest

The test in master that landed with #33639. Deterministic forward jab and release at ~2 m on flow with no GPS, `LOIT_ANG_MAX` = 30, `LOIT_SPEED_MS` = 5, so the EKF cap is what binds. Matched builds.

| | master | this branch, default | this branch, `LOIT_TERM_MS` = 11.45 |
|---|---|---|---|
| peak over-drive (actual / feed-forward speed) | 1.51x | 1.39x | **1.20x** |
| mean over-drive | 1.14x | 1.06x | **1.01x** |
| peak position error \|TPN-PN\| | 1.012 m | 0.595 m | **0.330 m** |
| peak backward reversal on release | 0.419 m/s | 0.142 m/s | **0.089 m/s** |

11.45 m/s is the SITL `+` frame's terminal speed at 30°, scaled from its reference drag test (15.08 m/s at 45°). The middle column is commit 1 alone; the drag model is untouched there because the test does not set `LOIT_TERM_MS`.

Single runs of a stochastic simulation, so individual figures are loose; the trend is consistent across metrics.

### Not yet flown on hardware with the fix

The flight logs above are the unfixed behaviour.

