### PR TITLE
AP_Motors: add MOT_OUTPUT_DIS parameter for safe bench testing

### DIFF
--- a/libraries/AP_Motors/AP_MotorsMatrix.cpp
+++ b/libraries/AP_Motors/AP_MotorsMatrix.cpp
@@ -465,6 +465,10 @@ void AP_MotorsMatrix::check_for_failed_motor(float throttle_thrust_best_plus_adj
 //  pwm value is an actual pwm value that will be output, normally in the range of 1000 ~ 2000
 void AP_MotorsMatrix::_output_test_seq(uint8_t motor_seq, int16_t pwm)
 {
+    if (motor_output_disabled()) {
+        return;
+    }
+
     // loop through all the possible orders spinning any motors that match that description
     for (uint8_t i = 0; i < AP_MOTORS_MAX_NUM_MOTORS; i++) {
         if (motor_enabled[i] && _test_order[i] == motor_seq) {
@@ -481,7 +485,7 @@ void AP_MotorsMatrix::_output_test_seq(uint8_t motor_seq, int16_t pwm)
 //  pwm value is an actual pwm value that will be output, normally in the range of 1000 ~ 2000
 bool AP_MotorsMatrix::output_test_num(uint8_t output_channel, int16_t pwm)
 {
-    if (!armed()) {
+    if (!armed() || motor_output_disabled()) {
         return false;
     }
 

--- a/libraries/AP_Motors/AP_MotorsMulticopter.cpp
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.cpp
@@ -18,6 +18,7 @@
 #include <AP_BattMonitor/AP_BattMonitor.h>
 #include <SRV_Channel/SRV_Channel.h>
 #include <AP_Logger/AP_Logger.h>
+#include <GCS_MAVLink/GCS.h>
 
 #include <AP_Vehicle/AP_Vehicle_Type.h>
 #if APM_BUILD_TYPE(APM_BUILD_ArduPlane)
@@ -254,6 +255,13 @@ const AP_Param::GroupInfo AP_MotorsMulticopter::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("IDLE_SEC", 45, AP_MotorsMulticopter, _idle_time_delay_s, 0),
 
+    // @Param: OUTPUT_DIS
+    // @DisplayName: Motor Output Disable
+    // @Description: Disable physical motor PWM output for safe bench testing and telemetry rate diagnostics. Flight control loops and arming run normally, but physical motors remain stopped.
+    // @Values: 0:Normal, 1:Disable Motor Output
+    // @User: Advanced
+    AP_GROUPINFO("OUTPUT_DIS", 46, AP_MotorsMulticopter, _output_dis, 0),
+
     AP_GROUPEND
 };
 
@@ -268,6 +276,16 @@ AP_MotorsMulticopter::AP_MotorsMulticopter(uint16_t speed_hz) :
 // output - sends commands to the motors
 void AP_MotorsMulticopter::output()
 {
+    // warn on arming if motor output is disabled for bench testing
+    if (armed() && (_output_dis != 0)) {
+        static uint32_t last_warn_ms;
+        const uint32_t now_ms = AP_HAL::millis();
+        if (now_ms - last_warn_ms > 5000) {
+            last_warn_ms = now_ms;
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Motor output disabled (MOT_OUTPUT_DIS=1)");
+        }
+    }
+
     // update throttle filter
     update_throttle_filter();
 
@@ -456,6 +474,10 @@ void AP_MotorsMulticopter::Log_Write()
 // in all other states: map [0..1] linearly between pwm_min and pwm_max
 int16_t AP_MotorsMulticopter::output_to_pwm(float actuator)
 {
+    if (_output_dis != 0) {
+        return (_pwm_type == PWMType::BRUSHED) ? 0 : get_pwm_output_min();
+    }
+
     float pwm_output;
     if (_spool_state == SpoolState::SHUT_DOWN) {
         // in shutdown mode, use PWM 0 or minimum PWM

--- a/libraries/AP_Motors/AP_MotorsMulticopter.h
+++ b/libraries/AP_Motors/AP_MotorsMulticopter.h
@@ -72,6 +72,9 @@ public:
     // get minimum or maximum pwm value that can be output to motors
     int16_t             get_pwm_output_min() const { return _pwm_min; }
     int16_t             get_pwm_output_max() const { return _pwm_max; }
+
+    // return true if physical motor output is disabled for bench testing
+    bool                motor_output_disabled() const { return _output_dis != 0; }
     
     // parameter check for MOT_PWM_MIN/MAX, returns true if parameters are valid
     bool check_mot_pwm_params() const;
@@ -191,6 +194,7 @@ protected:
     AP_Float            _throttle_hover;        // estimated throttle required to hover throttle in the range 0 ~ 1
     AP_Int8             _throttle_hover_learn;  // enable/disabled hover thrust learning
     AP_Int8             _disarm_disable_pwm;    // disable PWM output while disarmed
+    AP_Int8             _output_dis;            // disable motor output for bench testing
 
     // Maximum lean angle of yaw servo in degrees. This is specific to tricopter
     AP_Float            _yaw_servo_angle_max_deg;


### PR DESCRIPTION
Allow disabling physical motor PWM output during armed state for safe bench testing, sensor and AHRS diagnostics, and telemetry stream rate verification without physical propeller rotation.

When MOT_OUTPUT_DIS is set to 1:
- Normal arming and flight control loops execute as usual.
- Motors output disarmed idle/stop PWM (get_pwm_output_min() or 0 for brushed motors), preventing ESC missing-signal beeps while keeping motors stopped.
- Motor test commands are ignored.
- A periodic warning is sent to the GCS every 5 seconds to alert the user that motor output is suppressed.

### Summary

Add `MOT_OUTPUT_DIS` parameter to `AP_MotorsMulticopter` to allow safely disabling physical motor PWM output while armed for indoor bench testing, high-rate telemetry diagnostics, and logging without spinning propellers.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

Tested both on hardware and desk bench setups:
1. Verified arming and flight control loops run normally with `MOT_OUTPUT_DIS = 1`.
2. Verified physical motors remain completely stopped while outputting valid disarm/stop PWM (`get_pwm_output_min()` for brushless, `0` for brushed), preventing ESC missing-signal alarm beeps.
3. Verified periodic warning message `"Motor output disabled (MOT_OUTPUT_DIS=1)"` is sent to GCS every 5 seconds while armed.
4. Verified motor test commands are blocked when `MOT_OUTPUT_DIS = 1`.
5. Verified normal motor spinning resumes when `MOT_OUTPUT_DIS` is set back to `0`.

### Description

#### Motivation
Bench testing and troubleshooting often require the flight controller to be in an **ARMED** state—for example, to:
- Record high-rate DataFlash onboard logs during bench testing.
- Verify high-rate MAVLink telemetry streams (which switch to faster rates only when armed).
- Test arming checks, attitude control loop responses (holding the drone in hand), and armed-only failsafe behaviors safely indoors.

However, physical propeller/motor spinning on the bench is dangerous, generates excessive wind/noise, and can overheat motors or ESCs.

#### Implementation
This PR adds the `MOT_OUTPUT_DIS` parameter to `AP_MotorsMulticopter`:
- **`MOT_OUTPUT_DIS = 0`**: Normal operation.
- **`MOT_OUTPUT_DIS = 1`**: Disables physical motor output while armed:
  - Flight control loops, state estimation, and arming state continue to operate normally.
  - Motor output is held at `get_pwm_output_min()` (or `0` for brushed motors). Outputting a valid stop PWM prevents ESCs from beeping due to a missing signal while ensuring motors remain completely stationary.
  - Motor test commands (`output_test_seq`, `output_test_num`) are safely blocked.
  - A warning message (`Motor output disabled (MOT_OUTPUT_DIS=1)`) is sent to the GCS every 5 seconds while armed to alert the operator.

---
*Note: This PR was developed with the assistance of an AI coding agent. All changes and behavior have been tested and verified by a human developer.*
