### PR TITLE
Copter: do not disarm the vehicle on battery fs if fs is none

### DIFF
--- a/ArduCopter/events.cpp
+++ b/ArduCopter/events.cpp
@@ -103,7 +103,7 @@ void Copter::handle_battery_failsafe(const char *type_str, const int8_t action)
     FailsafeAction desired_action = (FailsafeAction)action;
 
     // Conditions to deviate from BATT_FS_XXX_ACT parameter setting
-    if (should_disarm_on_failsafe()) {
+    if (should_disarm_on_failsafe() && desired_action != FailsafeAction::NONE) {
         // should immediately disarm when we're on the ground
         arming.disarm(AP_Arming::Method::BATTERYFAILSAFE);
         desired_action = FailsafeAction::NONE;

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -1814,6 +1814,31 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         # failsafe actions disabled; clear it so a following test can arm
         self.clear_battery_failsafe()
 
+    def BatteryFailsafeDisabledOnGround(self):
+        '''Test that with battery failsafe disabled the vehicle is not disarmed on the ground'''
+        # Trigger a low battery condition while armed on the ground with
+        # the failsafe action set to None.  Verify the vehicle stays armed.
+        self.batt_failsafe_init()
+        self.set_parameters({
+            'DISARM_DELAY': 0,  # stop the auto-disarm-when-landed timer
+        })
+        self.change_mode('LOITER')
+        self.wait_ready_to_arm()
+        self.arm_vehicle()
+        self.set_parameter('SIM_BATT_VOLTAGE', 11.4)
+        self.wait_statustext("Battery 1 is low", timeout=60)
+        self.delay_sim_time(5, reason="battery failsafe to not disarm vehicle")
+        self.assert_armed()
+        self.set_parameter('SIM_BATT_VOLTAGE', 10.0)
+        self.wait_statustext("Battery 1 is critical", timeout=60)
+        self.delay_sim_time(5, reason="battery critical failsafe to not disarm vehicle")
+        self.assert_armed()
+        self.disarm_vehicle()
+        self.set_parameter('SIM_BATT_VOLTAGE', 12.5)
+        # driving the battery critical latches the failsafe even with the
+        # failsafe actions disabled; clear it so a following test can arm
+        self.clear_battery_failsafe()
+
     def BatteryFailsafeTwoStage(self):
         '''Two stage battery failsafe test with RTL and Land'''
         # TWO STAGE BATTERY FAILSAFE: Trigger low battery condition,
@@ -16558,6 +16583,7 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         '''return list of all tests'''
         ret = ([
              self.BatteryFailsafeDisabled,
+             self.BatteryFailsafeDisabledOnGround,
              self.BatteryFailsafeTwoStage,
              self.BatteryFailsafeTwoStageSmartRTL,
              self.BatteryFailsafeOptionsContinueLanding,

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -11708,7 +11708,12 @@ class AutoTestCopter(vehicle_test_suite.TestSuite):
         # Test that error code does result in failsafe
         self.start_subtest("Protocol %i: Without taken off generator error should cause failsafe and disarm" % proto_ver)
         self.change_mode("STABILIZE")
-        self.set_parameter("DISARM_DELAY", 0)
+        self.set_parameters({
+            "DISARM_DELAY": 0,
+            # a failsafe action of None does not disarm the vehicle on the ground
+            "BATT%u_FS_LOW_ACT" % (elec_battery_instance + 1): 1,  # LAND
+            "BATT%u_FS_CRT_ACT" % (elec_battery_instance + 1): 1,  # LAND
+        })
         self.arm_vehicle()
         self.set_parameter("SIM_IE24_ERROR", 30)
         self.disarm_wait(timeout=1)


### PR DESCRIPTION
### Summary

Prevents instant disarm if you force-arm a vehicle over the battery failsafe you might have on the ground.  NONE means NONE!

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

force-arming over a failsafe is annoying as there's an instant disarm
