### PR TITLE
AP_VideoTX: user-definable VTX power table & IRC Tramp command retries

### DIFF
--- a/libraries/AP_VideoTX/AP_Tramp.cpp
+++ b/libraries/AP_VideoTX/AP_Tramp.cpp
@@ -357,9 +357,29 @@ void AP_Tramp::process_requests()
         // Note after config a status update request is made, a new status
         // request is made, this request is handled above and should prevent
         // subsequent config updates if the config is now correct
-        if (retry_count > 0 && ((now - last_time_us) >= TRAMP_MIN_REQUEST_PERIOD_US)) {
-            AP_VideoTX& vtx = AP::vtx();
-            // Config retries remain and min request period exceeded, check freq
+        AP_VideoTX& vtx = AP::vtx();
+        const bool pitmode_disagreed = is_pitmode_disagreed();
+        const uint32_t now_ms = AP_HAL::millis();
+
+        // A pit mode change is prioritised over every other pending change
+        // and retried on its own schedule so a refused or missed value can
+        // neither strand the VTX in pit mode nor burn the retry budget armed
+        // for frequency/power changes
+        if (pitmode_disagreed) {
+            if ((now_ms - _last_pitmode_send_ms) >= VTX_TRAMP_PITMODE_RETRY_MS) {
+                debug("Changing pitmode");
+                // intentionally ignores race lock: a race-locked VTX would
+                // ignore the request anyway
+                send_command('I', vtx.has_option(AP_VideoTX::VideoOptions::VTX_PITMODE) ? 0 : 1);
+                _last_pitmode_send_ms = now_ms;
+
+                // Update last time
+                last_time_us = now;
+
+                // Advance state
+                set_status(TrampStatus::TRAMP_STATUS_ONLINE_CONFIG);
+            }
+        } else if (retry_count > 0 && ((now - last_time_us) >= TRAMP_MIN_REQUEST_PERIOD_US)) {
             if (!is_race_lock_enabled() && vtx.update_frequency()) {
                 debug("Updating frequency to %uMhz", vtx.get_configured_frequency_mhz());
                 // Freq can be and needs to be updated, issue request
@@ -398,7 +418,7 @@ void AP_Tramp::process_requests()
         }
 
         /* Was a config update made? */
-        if (!configUpdateRequired) {
+        if (!configUpdateRequired && !pitmode_disagreed) {
             /* No, look to continue monitoring */
             if ((now - last_time_us) >= TRAMP_STATUS_REQUEST_PERIOD_US) {
                 // Request period exceeded, issue freq/power/pit query
@@ -452,6 +472,13 @@ void AP_Tramp::process_requests()
     }
 }
 
+// the reported and configured pit modes disagree
+bool AP_Tramp::is_pitmode_disagreed() const
+{
+    const AP_VideoTX& vtx = AP::vtx();
+    return vtx.get_pitmode() != vtx.get_configured_pitmode();
+}
+
 bool AP_Tramp::is_device_ready()
 {
     return status >= TrampStatus::TRAMP_STATUS_ONLINE_MONITOR_FREQPWRPIT;
@@ -487,7 +514,31 @@ void AP_Tramp::update()
 
     AP_VideoTX& vtx = AP::vtx();
 
-    if (vtx.have_params_changed() && retry_count == 0) {
+    const bool pitmode_disagreed = is_pitmode_disagreed();
+    const uint32_t now_ms = AP_HAL::millis();
+
+    if (pitmode_disagreed) {
+        if (!_pitmode_disagreement_started) {
+            _pitmode_disagreement_started = true;
+            _pitmode_disagree_ms = now_ms;
+        }
+        // a VTX that is still starting up takes the request well inside this,
+        // so only complain once one has been refusing for a while
+        if (!_pitmode_warned
+            && now_ms - _pitmode_disagree_ms >= VTX_TRAMP_OPTIONS_WARN_MS) {
+            GCS_SEND_TEXT(MAV_SEVERITY_WARNING,
+                          "VTX: pitmode change not accepted");
+            _pitmode_warned = true;
+        }
+    } else {
+        // no disagreement, so forget the history: a later episode starts from
+        // scratch rather than warning immediately
+        _pitmode_disagreement_started = false;
+        _pitmode_disagree_ms = 0;
+        _pitmode_warned = false;
+    }
+
+    if (vtx.have_params_changed() && retry_count == 0 && !pitmode_disagreed) {
         // check changes in the order they will be processed; re-arm retries
         // only on real changes so a VTX rejecting a value can't loop forever
         if (vtx.update_frequency() || vtx.update_band() || vtx.update_channel()) {
@@ -508,10 +559,19 @@ void AP_Tramp::update()
                 _last_conf_power = conf_power;
                 retry_count = VTX_TRAMP_MAX_RETRIES;
                 _power_warn_pending = true;
+                _last_power_rearm_ms = now_ms;
             } else if (_power_warn_pending) {
                 GCS_SEND_TEXT(MAV_SEVERITY_WARNING,
                               "VTX: rejected power %umW", unsigned(conf_power));
                 _power_warn_pending = false;
+            }
+            // keep asking: giving up strands the VTX at the old power until a
+            // different level is requested, so re-arm the request budget
+            // periodically while the VTX keeps reporting a different power
+            if (retry_count == 0
+                && (now_ms - _last_power_rearm_ms) >= VTX_TRAMP_POWER_RETRY_MS) {
+                _last_power_rearm_ms = now_ms;
+                retry_count = VTX_TRAMP_MAX_RETRIES;
             }
         }
         else if (vtx.update_options()) {

--- a/libraries/AP_VideoTX/AP_Tramp.cpp
+++ b/libraries/AP_VideoTX/AP_Tramp.cpp
@@ -132,7 +132,9 @@ char AP_Tramp::handle_response(void)
 
             // VTX-reported rf_power_max is unreliable, so warn on the user cap instead
             if (!_act_power_warned && cur_act_power != 0) {
-                const uint16_t user_cap = vtx.get_max_power_mw();
+                // the cap is the top user power table entry when that table is
+                // in use, otherwise VTX_MAX_POWER
+                const uint16_t user_cap = vtx.get_power_cap_mw();
                 const bool over_cap = (user_cap != 0 && cur_act_power > user_cap);
                 const bool over_request = (power != 0 && cur_act_power > power + (power / 2));
                 if (over_cap || over_request) {

--- a/libraries/AP_VideoTX/AP_Tramp.h
+++ b/libraries/AP_VideoTX/AP_Tramp.h
@@ -27,8 +27,6 @@
 #include <AP_HAL/utility/RingBuffer.h>
 #include "AP_VideoTX.h"
 
-#define VTX_TRAMP_POWER_COUNT 5
-
 #define VTX_TRAMP_MIN_FREQUENCY_MHZ 1000             //min freq in MHz
 #define VTX_TRAMP_MAX_FREQUENCY_MHZ 5999             //max freq in MHz
 // Maximum number of requests sent to try a config change
@@ -77,8 +75,6 @@ private:
     void process_requests();
     bool is_device_ready();
     void set_frequency(uint16_t freq);
-    void set_power(uint16_t power);
-    void set_pit_mode(uint8_t onoff);
     // change baud automatically when request-response fails many times
     void update_baud_rate();
 

--- a/libraries/AP_VideoTX/AP_Tramp.h
+++ b/libraries/AP_VideoTX/AP_Tramp.h
@@ -33,6 +33,18 @@
 // Some VTX fail to respond to every request (like Matek FCHUB-VTX) so
 // we sometimes need multiple retries to get the VTX to respond.
 #define VTX_TRAMP_MAX_RETRIES (20)
+// Retry period for a pit mode change the VTX is not accepting. Giving up
+// strands the VTX in pit mode with no way back, so keep asking indefinitely.
+// Also bounds how long video can stay dark once the VTX is ready again.
+#define VTX_TRAMP_PITMODE_RETRY_MS (1000)
+// only complain once the VTX has been refusing for this long: one that is
+// merely still starting up recovers well inside it and should stay silent
+#define VTX_TRAMP_OPTIONS_WARN_MS (30000)
+// Re-arm period for a power change the VTX is not applying. The initial
+// request burst can land while the VTX is still settling (e.g. just after a
+// pit mode change), so keep re-arming instead of giving up: giving up strands
+// the VTX at the old power until a different level is requested.
+#define VTX_TRAMP_POWER_RETRY_MS (1000)
 // Race lock - settings can't be changed
 #define TRAMP_CONTROL_RACE_LOCK (0x01)
 
@@ -74,6 +86,11 @@ private:
     void send_query(uint8_t cmd);
     void process_requests();
     bool is_device_ready();
+    // the reported and configured pit modes disagree. A change to pit mode is
+    // prioritised over every other pending change: update_power() refuses to
+    // send power while in pit mode, and a frequency change cannot be seen on
+    // a dark video feed.
+    bool is_pitmode_disagreed() const;
     void set_frequency(uint16_t freq);
     // change baud automatically when request-response fails many times
     void update_baud_rate();
@@ -139,6 +156,16 @@ private:
     uint16_t _last_conf_power;
     uint16_t _last_conf_options;
     bool _power_warn_pending;
+    // pit mode changes are retried periodically while the VTX disagrees, so
+    // that a refused or missed request cannot strand the VTX with no way back
+    uint32_t _last_pitmode_send_ms {0};
+    // whether the current pit mode disagreement is being timed
+    bool _pitmode_disagreement_started {false};
+    // when the current pit mode disagreement began
+    uint32_t _pitmode_disagree_ms {0};
+    bool _pitmode_warned {false};
+    // last time the retry budget was re-armed for a pending power change
+    uint32_t _last_power_rearm_ms {0};
 
     // Receive state machine
     enum class ReceiveState {

--- a/libraries/AP_VideoTX/AP_VideoTX.cpp
+++ b/libraries/AP_VideoTX/AP_VideoTX.cpp
@@ -36,8 +36,9 @@ const AP_Param::GroupInfo AP_VideoTX::var_info[] = {
 
     // @Param: POWER
     // @DisplayName: Video Transmitter Power Level
-    // @Description: Video Transmitter Power Level. Different VTXs support different power levels, the power level chosen will be rounded down to the nearest supported power level
-    // @Range: 1 1000
+    // @Description: Video Transmitter Power Level. Different VTXs support different power levels, the power level chosen will be rounded down to the nearest supported power level. When VTX_PWRTBL_EN is enabled the value is used as-is on transports that accept arbitrary power levels (IRC Tramp).
+    // @Range: 0 32767
+    // @Units: mW
     AP_GROUPINFO("POWER",    2, AP_VideoTX, _power_mw, 0),
 
     // @Param: CHANNEL
@@ -71,8 +72,9 @@ const AP_Param::GroupInfo AP_VideoTX::var_info[] = {
 
     // @Param: MAX_POWER
     // @DisplayName: Video Transmitter Max Power Level
-    // @Description: Video Transmitter Maximum Power Level. Different VTXs support different power levels, this prevents the power aux switch from requesting too high a power level. The switch supports 6 power levels and the selected power will be a subdivision between 0 and this setting.
-    // @Range: 25 1000
+    // @Description: Video Transmitter Maximum Power Level. Different VTXs support different power levels, this prevents the power aux switch from requesting too high a power level. The switch supports 6 power levels and the selected power will be a subdivision between 0 and this setting. 0 means no limit. This is ignored when VTX_PWRTBL_EN is enabled, since the user power table then defines the available levels.
+    // @Range: 0 32767
+    // @Units: mW
     AP_GROUPINFO("MAX_POWER", 7, AP_VideoTX, _max_power_mw, 800),
 
     // @Param: TYPES
@@ -81,6 +83,61 @@ const AP_Param::GroupInfo AP_VideoTX::var_info[] = {
     // @Bitmask: 0:CRSF,1:SmartAudio,2:Tramp,3:MSP
     // @User: Advanced
     AP_GROUPINFO("TYPES", 8, AP_VideoTX, _types_allowed, uint8_t(CRSF | SmartAudio | Tramp | MSP)),
+
+    // @Param: PWRTBL_EN
+    // @DisplayName: Enable user-defined VTX power table
+    // @Description: Enables the user-defined power table in VTX_PWRTBL1 to VTX_PWRTBL6, which replaces the built-in power levels and VTX_MAX_POWER for the VTX power aux switch. Only transports that accept arbitrary power levels (IRC Tramp) can use levels outside the built-in list.
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+    AP_GROUPINFO("PWRTBL_EN", 9, AP_VideoTX, _power_table_enabled, 0),
+
+    // @Param: PWRTBL1
+    // @DisplayName: Video Transmitter Power Table Entry 1
+    // @Description: Power in mW for power table entry 1, used by the VTX power aux switch (RCn_OPTION = 94) when VTX_PWRTBL_EN is enabled. 0 means unused. Set the entries in ascending order.
+    // @Range: 0 32767
+    // @Units: mW
+    // @User: Advanced
+    AP_GROUPINFO("PWRTBL1", 10, AP_VideoTX, _power_table[0], 0),
+
+    // @Param: PWRTBL2
+    // @DisplayName: Video Transmitter Power Table Entry 2
+    // @Description: Power in mW for power table entry 2, used by the VTX power aux switch (RCn_OPTION = 94) when VTX_PWRTBL_EN is enabled. 0 means unused. Set the entries in ascending order.
+    // @Range: 0 32767
+    // @Units: mW
+    // @User: Advanced
+    AP_GROUPINFO("PWRTBL2", 11, AP_VideoTX, _power_table[1], 0),
+
+    // @Param: PWRTBL3
+    // @DisplayName: Video Transmitter Power Table Entry 3
+    // @Description: Power in mW for power table entry 3, used by the VTX power aux switch (RCn_OPTION = 94) when VTX_PWRTBL_EN is enabled. 0 means unused. Set the entries in ascending order.
+    // @Range: 0 32767
+    // @Units: mW
+    // @User: Advanced
+    AP_GROUPINFO("PWRTBL3", 12, AP_VideoTX, _power_table[2], 0),
+
+    // @Param: PWRTBL4
+    // @DisplayName: Video Transmitter Power Table Entry 4
+    // @Description: Power in mW for power table entry 4, used by the VTX power aux switch (RCn_OPTION = 94) when VTX_PWRTBL_EN is enabled. 0 means unused. Set the entries in ascending order.
+    // @Range: 0 32767
+    // @Units: mW
+    // @User: Advanced
+    AP_GROUPINFO("PWRTBL4", 13, AP_VideoTX, _power_table[3], 0),
+
+    // @Param: PWRTBL5
+    // @DisplayName: Video Transmitter Power Table Entry 5
+    // @Description: Power in mW for power table entry 5, used by the VTX power aux switch (RCn_OPTION = 94) when VTX_PWRTBL_EN is enabled. 0 means unused. Set the entries in ascending order.
+    // @Range: 0 32767
+    // @Units: mW
+    // @User: Advanced
+    AP_GROUPINFO("PWRTBL5", 14, AP_VideoTX, _power_table[4], 0),
+
+    // @Param: PWRTBL6
+    // @DisplayName: Video Transmitter Power Table Entry 6
+    // @Description: Power in mW for power table entry 6, used by the VTX power aux switch (RCn_OPTION = 94) when VTX_PWRTBL_EN is enabled. 0 means unused. Set the entries in ascending order.
+    // @Range: 0 32767
+    // @Units: mW
+    // @User: Advanced
+    AP_GROUPINFO("PWRTBL6", 15, AP_VideoTX, _power_table[5], 0),
 
     AP_GROUPEND
 };
@@ -150,18 +207,22 @@ bool AP_VideoTX::init(void)
         return false;
     }
 
-    // find the index into the power table
-    for (uint8_t i = 0; i < VTX_MAX_POWER_LEVELS; i++) {
-        if (_power_mw <= _power_levels[i].mw) {
-            if (_power_mw != _power_levels[i].mw) {
-                if (i > 0) {
-                    _current_power = i - 1;
+    // find the index into the power table. When the user has declared the
+    // levels their VTX supports, take the configured power as-is instead of
+    // rounding it down to a built-in level.
+    if (!use_power_table()) {
+        for (uint8_t i = 0; i < VTX_MAX_POWER_LEVELS; i++) {
+            if (_power_mw <= _power_levels[i].mw) {
+                if (_power_mw != _power_levels[i].mw) {
+                    if (i > 0) {
+                        _current_power = i - 1;
+                    }
+                    _power_mw.set_and_save(get_power_mw());
+                } else {
+                    _current_power = i;
                 }
-                _power_mw.set_and_save(get_power_mw());
-            } else {
-                _current_power = i;
+                break;
             }
-            break;
         }
     }
     _current_band = _band;
@@ -192,6 +253,60 @@ bool AP_VideoTX::get_band_and_channel(uint16_t freq, VideoBand& band, uint8_t& c
 void AP_VideoTX::set_configured_power_mw(uint16_t power)
 {
     _power_mw.set_and_save_ifchanged(power);
+}
+
+// get the power in dbm, rounding appropriately
+uint8_t AP_VideoTX::get_configured_power_dbm() const
+{
+    const uint8_t idx = find_current_power();
+    if (_power_levels[idx].mw == _power_mw) {
+        return _power_levels[idx].dbm;
+    }
+    // a level with no table entry, e.g. a VTX_PWRTBL entry on a transport that
+    // takes an arbitrary power: derive its dbm rather than reporting the 0mW
+    // entry that find_current_power() falls back to
+    const int16_t power = _power_mw.get();
+    if (power <= 0) {
+        return 0;
+    }
+    return uint8_t(roundf(10.0f * log10f(float(power))));
+}
+
+// get the power "level"
+uint8_t AP_VideoTX::get_configured_power_level() const
+{
+    return _power_levels[find_current_power()].level & 0xF;
+}
+
+// get the power "dac"
+uint8_t AP_VideoTX::get_configured_power_dac() const
+{
+    return _power_levels[find_current_power()].dac;
+}
+
+// true when the user has enabled the user power table
+bool AP_VideoTX::use_power_table() const
+{
+    // the parameter is the only thing that decides this. An enabled table with
+    // no entries leaves the aux switch with pitmode alone, which is what was
+    // asked for; silently falling back to the built-in levels would be worse.
+    return _power_table_enabled != 0;
+}
+
+// highest power the user has authorised
+uint16_t AP_VideoTX::get_power_cap_mw() const
+{
+    if (!use_power_table()) {
+        return _max_power_mw;
+    }
+    uint16_t cap = 0;
+    for (uint8_t i = 0; i < VTX_USER_POWER_LEVELS; i++) {
+        const uint16_t entry = get_table_entry_mw(i);
+        if (entry > cap) {
+            cap = entry;
+        }
+    }
+    return cap;
 }
 
 uint8_t AP_VideoTX::find_current_power() const
@@ -432,8 +547,10 @@ void AP_VideoTX::update(void)
         }
     }
     // check that the requested power is actually allowed
-    // reset if not
-    if (_power_mw != get_power_mw()) {
+    // reset if not. The user table is the user's own statement of what this
+    // VTX supports, so this check does not apply when it is enabled; the
+    // built-in slot lookup below predates the table and does not know about it
+    if (!use_power_table() && _power_mw != get_power_mw()) {
         if (_power_levels[find_current_power()].active == PowerActive::Inactive) {
             // reset to something we know works
             debug("power reset to %dmw from %dmw", get_power_mw(), _power_mw.get());
@@ -590,32 +707,15 @@ void AP_VideoTX::change_power(int8_t position)
     if (!_enabled || position < 0 || position > 5) {
         return;
     }
-    // first find out how many possible levels there are
-    uint8_t num_active_levels = 0;
-    for (uint8_t i = 0; i < VTX_MAX_POWER_LEVELS; i++) {
-        if (_power_levels[i].active != PowerActive::Inactive && _power_levels[i].mw <= _max_power_mw) {
-            num_active_levels++;
-        }
+    uint16_t table[VTX_USER_POWER_LEVELS];
+    for (uint8_t i = 0; i < VTX_USER_POWER_LEVELS; i++) {
+        table[i] = get_table_entry_mw(i);
     }
-    // iterate through to find the level
-    uint16_t level = constrain_int16(roundf((num_active_levels * (position + 1)/ 6.0f) - 1), 0, num_active_levels - 1);
-    debug("looking for pos %d power level %d from %d", position, level, num_active_levels);
-    uint16_t power = 0;
-    for (uint8_t i = 0, j = 0; i < num_active_levels; i++, j++) {
-        while (j < VTX_MAX_POWER_LEVELS-1 && _power_levels[j].active == PowerActive::Inactive) {
-            j++;
-        }
-        if (i == level) {
-            power = _power_levels[j].mw;
-            debug("selected power %dmw", power);
-            break;
-        }
+    uint16_t power;
+    if (!switch_power_mw(position, table, VTX_USER_POWER_LEVELS, use_power_table(), _max_power_mw.get(), power)) {
+        return;
     }
-
-    if (position == 5 && power < _max_power_mw) {
-        power = _max_power_mw;
-        debug("selected power %dmw", power);
-    }
+    debug("pos %d selected power %dmw", position, power);
 
     if (power == 0) {
         if (!hal.util->get_soft_armed()) {    // don't allow pitmode to be entered if already armed
@@ -627,6 +727,63 @@ void AP_VideoTX::change_power(int8_t position)
         }
         set_configured_power_mw(power);
     }
+}
+
+// build the list of powers the switch selects between for the given
+// configuration and select the one matching the switch position
+bool AP_VideoTX::switch_power_mw(int8_t position, const uint16_t *user_table, uint8_t user_table_len, bool user_table_enabled, uint16_t max_power_mw, uint16_t &power_mw)
+{
+    uint16_t steps[VTX_MAX_POWER_LEVELS + 1];
+    uint8_t num_steps = 0;
+
+    if (user_table_enabled) {
+        // the user table is the definitive list of what this VTX supports, so
+        // VTX_MAX_POWER does not apply - the table itself is the ceiling that
+        // was asked for. Entries are taken in slot order; the user is expected
+        // to set them in ascending order
+        for (uint8_t i = 0; i < user_table_len; i++) {
+            if (user_table[i] != 0) {
+                steps[num_steps++] = user_table[i];
+            }
+        }
+        // the switch has six positions; six table entries map onto them 1:1
+        // and there is no pitmode slot, otherwise position 0 is pitmode
+        if (num_steps < VTX_USER_POWER_LEVELS) {
+            // shift the entries up one slot to make room for pitmode first
+            for (uint8_t i = num_steps; i > 0; i--) {
+                steps[i] = steps[i-1];
+            }
+            steps[0] = 0;
+            num_steps++;
+        }
+    } else {
+        // every level we believe the VTX supports, up to VTX_MAX_POWER. The
+        // table is in ascending order, so this is the built-in list with
+        // anything above the cap trimmed off the top. 0 means no cap.
+        const uint32_t cap = max_power_mw > 0 ? uint32_t(max_power_mw) : UINT16_MAX;
+        for (uint8_t i = 0; i < VTX_MAX_POWER_LEVELS; i++) {
+            if (_power_levels[i].active != PowerActive::Inactive
+                && _power_levels[i].mw <= cap) {
+                steps[num_steps++] = _power_levels[i].mw;
+            }
+        }
+    }
+
+    if (num_steps == 0) {
+        return false;
+    }
+
+    // subdivide the 6 switch positions over the steps
+    const uint16_t level = constrain_int16(roundf((num_steps * (position + 1) / 6.0f) - 1), 0, num_steps - 1);
+    power_mw = steps[level];
+    debug("pos %d selected power %dmw (step %d of %d)", position, power_mw, level, num_steps);
+
+    if (!user_table_enabled && position == 5 && power_mw < max_power_mw) {
+        power_mw = max_power_mw;
+        debug("selected power %dmw", power_mw);
+    }
+
+    return true;
 }
 
 namespace AP {

--- a/libraries/AP_VideoTX/AP_VideoTX.cpp
+++ b/libraries/AP_VideoTX/AP_VideoTX.cpp
@@ -86,55 +86,55 @@ const AP_Param::GroupInfo AP_VideoTX::var_info[] = {
 
     // @Param: PWRTBL_EN
     // @DisplayName: Enable user-defined VTX power table
-    // @Description: Enables the user-defined power table in VTX_PWRTBL1 to VTX_PWRTBL6, which replaces the built-in power levels and VTX_MAX_POWER for the VTX power aux switch. Only transports that accept arbitrary power levels (IRC Tramp) can use levels outside the built-in list.
+    // @Description: Enables the user-defined power table in VTX_PWRTBL1 to VTX_PWRTBL6, which replaces the built-in power levels and VTX_MAX_POWER for the VTX power aux switch. A value of -1 ignores a table entry, a 0 entry selects pit mode at its switch position, and the used entries in slot order are the switch choices. Only transports that accept arbitrary power levels (IRC Tramp) can use levels outside the built-in list.
     // @Values: 0:Disabled,1:Enabled
     // @User: Advanced
     AP_GROUPINFO("PWRTBL_EN", 9, AP_VideoTX, _power_table_enabled, 0),
 
     // @Param: PWRTBL1
     // @DisplayName: Video Transmitter Power Table Entry 1
-    // @Description: Power in mW for power table entry 1, used by the VTX power aux switch (RCn_OPTION = 94) when VTX_PWRTBL_EN is enabled. 0 means unused. Set the entries in ascending order.
-    // @Range: 0 32767
+    // @Description: Power table entry 1 for the VTX power aux switch (RCn_OPTION = 94) when VTX_PWRTBL_EN is enabled. A value of -1 ignores this entry, 0 selects pit mode at this switch position, otherwise the power in mW.
+    // @Range: -1 32767
     // @Units: mW
     // @User: Advanced
     AP_GROUPINFO("PWRTBL1", 10, AP_VideoTX, _power_table[0], 0),
 
     // @Param: PWRTBL2
     // @DisplayName: Video Transmitter Power Table Entry 2
-    // @Description: Power in mW for power table entry 2, used by the VTX power aux switch (RCn_OPTION = 94) when VTX_PWRTBL_EN is enabled. 0 means unused. Set the entries in ascending order.
-    // @Range: 0 32767
+    // @Description: Power table entry 2 for the VTX power aux switch (RCn_OPTION = 94) when VTX_PWRTBL_EN is enabled. A value of -1 ignores this entry, 0 selects pit mode at this switch position, otherwise the power in mW.
+    // @Range: -1 32767
     // @Units: mW
     // @User: Advanced
     AP_GROUPINFO("PWRTBL2", 11, AP_VideoTX, _power_table[1], 0),
 
     // @Param: PWRTBL3
     // @DisplayName: Video Transmitter Power Table Entry 3
-    // @Description: Power in mW for power table entry 3, used by the VTX power aux switch (RCn_OPTION = 94) when VTX_PWRTBL_EN is enabled. 0 means unused. Set the entries in ascending order.
-    // @Range: 0 32767
+    // @Description: Power table entry 3 for the VTX power aux switch (RCn_OPTION = 94) when VTX_PWRTBL_EN is enabled. A value of -1 ignores this entry, 0 selects pit mode at this switch position, otherwise the power in mW.
+    // @Range: -1 32767
     // @Units: mW
     // @User: Advanced
     AP_GROUPINFO("PWRTBL3", 12, AP_VideoTX, _power_table[2], 0),
 
     // @Param: PWRTBL4
     // @DisplayName: Video Transmitter Power Table Entry 4
-    // @Description: Power in mW for power table entry 4, used by the VTX power aux switch (RCn_OPTION = 94) when VTX_PWRTBL_EN is enabled. 0 means unused. Set the entries in ascending order.
-    // @Range: 0 32767
+    // @Description: Power table entry 4 for the VTX power aux switch (RCn_OPTION = 94) when VTX_PWRTBL_EN is enabled. A value of -1 ignores this entry, 0 selects pit mode at this switch position, otherwise the power in mW.
+    // @Range: -1 32767
     // @Units: mW
     // @User: Advanced
     AP_GROUPINFO("PWRTBL4", 13, AP_VideoTX, _power_table[3], 0),
 
     // @Param: PWRTBL5
     // @DisplayName: Video Transmitter Power Table Entry 5
-    // @Description: Power in mW for power table entry 5, used by the VTX power aux switch (RCn_OPTION = 94) when VTX_PWRTBL_EN is enabled. 0 means unused. Set the entries in ascending order.
-    // @Range: 0 32767
+    // @Description: Power table entry 5 for the VTX power aux switch (RCn_OPTION = 94) when VTX_PWRTBL_EN is enabled. A value of -1 ignores this entry, 0 selects pit mode at this switch position, otherwise the power in mW.
+    // @Range: -1 32767
     // @Units: mW
     // @User: Advanced
     AP_GROUPINFO("PWRTBL5", 14, AP_VideoTX, _power_table[4], 0),
 
     // @Param: PWRTBL6
     // @DisplayName: Video Transmitter Power Table Entry 6
-    // @Description: Power in mW for power table entry 6, used by the VTX power aux switch (RCn_OPTION = 94) when VTX_PWRTBL_EN is enabled. 0 means unused. Set the entries in ascending order.
-    // @Range: 0 32767
+    // @Description: Power table entry 6 for the VTX power aux switch (RCn_OPTION = 94) when VTX_PWRTBL_EN is enabled. A value of -1 ignores this entry, 0 selects pit mode at this switch position, otherwise the power in mW.
+    // @Range: -1 32767
     // @Units: mW
     // @User: Advanced
     AP_GROUPINFO("PWRTBL6", 15, AP_VideoTX, _power_table[5], 0),
@@ -275,13 +275,36 @@ uint8_t AP_VideoTX::get_configured_power_dbm() const
 // get the power "level"
 uint8_t AP_VideoTX::get_configured_power_level() const
 {
-    return _power_levels[find_current_power()].level & 0xF;
+    return _power_levels[find_nearest_power_level()].level & 0xF;
 }
 
 // get the power "dac"
 uint8_t AP_VideoTX::get_configured_power_dac() const
 {
-    return _power_levels[find_current_power()].dac;
+    return _power_levels[find_nearest_power_level()].dac;
+}
+
+// index of the nearest SmartAudio level slot for the configured power: an
+// exact match among the built-in slots first, then the highest built-in level
+// not exceeding it. The custom learned slot never matches here - its level
+// and dac values are Tramp bookkeeping, not SmartAudio levels - so a user
+// table power with no SmartAudio equivalent is reported as the closest lower
+// supported level instead of a meaningless level byte
+uint8_t AP_VideoTX::find_nearest_power_level() const
+{
+    if (_power_mw <= 0) {
+        return 0;
+    }
+    uint8_t nearest = 1;
+    for (uint8_t i = 1; i < VTX_MAX_POWER_LEVELS - 1; i++) {
+        if (_power_mw == _power_levels[i].mw) {
+            return i;
+        }
+        if (_power_levels[i].mw < _power_mw && _power_levels[i].mw > _power_levels[nearest].mw) {
+            nearest = i;
+        }
+    }
+    return nearest;
 }
 
 // true when the user has enabled the user power table
@@ -301,9 +324,9 @@ uint16_t AP_VideoTX::get_power_cap_mw() const
     }
     uint16_t cap = 0;
     for (uint8_t i = 0; i < VTX_USER_POWER_LEVELS; i++) {
-        const uint16_t entry = get_table_entry_mw(i);
-        if (entry > cap) {
-            cap = entry;
+        const int16_t entry = get_table_entry(i);
+        if (entry > 0 && uint16_t(entry) > cap) {
+            cap = uint16_t(entry);
         }
     }
     return cap;
@@ -707,9 +730,9 @@ void AP_VideoTX::change_power(int8_t position)
     if (!_enabled || position < 0 || position > 5) {
         return;
     }
-    uint16_t table[VTX_USER_POWER_LEVELS];
+    int16_t table[VTX_USER_POWER_LEVELS];
     for (uint8_t i = 0; i < VTX_USER_POWER_LEVELS; i++) {
-        table[i] = get_table_entry_mw(i);
+        table[i] = get_table_entry(i);
     }
     uint16_t power;
     if (!switch_power_mw(position, table, VTX_USER_POWER_LEVELS, use_power_table(), _max_power_mw.get(), power)) {
@@ -731,7 +754,7 @@ void AP_VideoTX::change_power(int8_t position)
 
 // build the list of powers the switch selects between for the given
 // configuration and select the one matching the switch position
-bool AP_VideoTX::switch_power_mw(int8_t position, const uint16_t *user_table, uint8_t user_table_len, bool user_table_enabled, uint16_t max_power_mw, uint16_t &power_mw)
+bool AP_VideoTX::switch_power_mw(int8_t position, const int16_t *user_table, uint8_t user_table_len, bool user_table_enabled, uint16_t max_power_mw, uint16_t &power_mw)
 {
     uint16_t steps[VTX_MAX_POWER_LEVELS + 1];
     uint8_t num_steps = 0;
@@ -739,33 +762,36 @@ bool AP_VideoTX::switch_power_mw(int8_t position, const uint16_t *user_table, ui
     if (user_table_enabled) {
         // the user table is the definitive list of what this VTX supports, so
         // VTX_MAX_POWER does not apply - the table itself is the ceiling that
-        // was asked for. Entries are taken in slot order; the user is expected
-        // to set them in ascending order
+        // was asked for. A value of -1 ignores an entry, a 0 entry is pit mode at
+        // that position, and the used entries in slot order are the switch's
+        // only choices
         for (uint8_t i = 0; i < user_table_len; i++) {
-            if (user_table[i] != 0) {
-                steps[num_steps++] = user_table[i];
+            if (user_table[i] >= 0) {
+                steps[num_steps++] = uint16_t(user_table[i]);
             }
-        }
-        // the switch has six positions; six table entries map onto them 1:1
-        // and there is no pitmode slot, otherwise position 0 is pitmode
-        if (num_steps < VTX_USER_POWER_LEVELS) {
-            // shift the entries up one slot to make room for pitmode first
-            for (uint8_t i = num_steps; i > 0; i--) {
-                steps[i] = steps[i-1];
-            }
-            steps[0] = 0;
-            num_steps++;
         }
     } else {
-        // every level we believe the VTX supports, up to VTX_MAX_POWER. The
-        // table is in ascending order, so this is the built-in list with
-        // anything above the cap trimmed off the top. 0 means no cap.
+        // every level we believe the VTX supports, up to VTX_MAX_POWER. This
+        // is the built-in list with anything above the cap trimmed off the
+        // top; 0 means no cap
         const uint32_t cap = max_power_mw > 0 ? uint32_t(max_power_mw) : UINT16_MAX;
         for (uint8_t i = 0; i < VTX_MAX_POWER_LEVELS; i++) {
             if (_power_levels[i].active != PowerActive::Inactive
                 && _power_levels[i].mw <= cap) {
                 steps[num_steps++] = _power_levels[i].mw;
             }
+        }
+        // the custom learned slot can sit out of order - a VTX-reported power
+        // like 300mW is stored in the slot after the built-in 1000mW slot - so
+        // sort to keep the position mapping monotonic
+        for (uint8_t i = 1; i < num_steps; i++) {
+            const uint16_t key = steps[i];
+            uint8_t j = i;
+            while (j > 0 && steps[j-1] > key) {
+                steps[j] = steps[j-1];
+                j--;
+            }
+            steps[j] = key;
         }
     }
 

--- a/libraries/AP_VideoTX/AP_VideoTX.h
+++ b/libraries/AP_VideoTX/AP_VideoTX.h
@@ -126,15 +126,15 @@ public:
     // user-defined power table (VTX_PWRTBL_EN, VTX_PWRTBL1 to VTX_PWRTBL6).
     // These parameters are the table: _power_levels describes the SmartAudio
     // levels and is not extended with user values.
-    // mW for table entry i, 0 if unused. There is no unsigned parameter type,
-    // so this is the one place the signed parameter is read and anything <= 0
-    // is treated as unused; everything downstream is uint16_t.
-    uint16_t get_table_entry_mw(uint8_t i) const {
+    // raw table entry i: a value of -1 ignores the entry, 0 is pit mode,
+    // otherwise the power in mW. There is no unsigned parameter type, so this
+    // is the one place the signed parameter is read; everything downstream is
+    // uint16_t
+    int16_t get_table_entry(uint8_t i) const {
         if (i >= VTX_USER_POWER_LEVELS) {
-            return 0;
+            return -1;
         }
-        const int16_t entry = _power_table[i].get();
-        return entry > 0 ? uint16_t(entry) : 0;
+        return _power_table[i].get();
     }
     // true when the user has enabled the user power table
     bool use_power_table() const;
@@ -165,13 +165,13 @@ public:
     void change_power(int8_t position);
     // the power in mW that the power aux switch (RCx_OPTION 94) selects for the
     // given switch position, 0 meaning pitmode. user_table holds the raw
-    // VTX_PWRTBL values; when the table is enabled and all VTX_USER_POWER_LEVELS
-    // entries are set the six switch positions map 1:1 onto the table and
-    // pitmode is not among the choices, otherwise position 0 is pitmode.
-    // Returns false when there is nothing to select. Static and side-effect
-    // free so the mapping can be unit tested
+    // VTX_PWRTBL values: a value of -1 ignores the entry, a 0 entry selects pit
+    // mode at that position. The used entries in slot order are the switch's
+    // only choices; when fewer than six are used the six positions subdivide
+    // over them. Returns false when there is nothing to select. Static and
+    // side-effect free so the mapping can be unit tested
     static bool switch_power_mw(int8_t position,
-                                const uint16_t *user_table, uint8_t user_table_len,
+                                const int16_t *user_table, uint8_t user_table_len,
                                 bool user_table_enabled, uint16_t max_power_mw,
                                 uint16_t &power_mw);
     // get / set the frequency band
@@ -231,13 +231,19 @@ public:
 
 private:
     uint8_t find_current_power() const;
+    // index of the configured power's SmartAudio level slot: an exact match
+    // first, otherwise the nearest lower built-in level, floored at the 25mW
+    // slot for any positive power. The custom learned slot is skipped - its
+    // level and dac values are Tramp bookkeeping, not SmartAudio levels - so a
+    // user-table power always yields a wire-valid level byte
+    uint8_t find_nearest_power_level() const;
     // channel frequency
     AP_Int16 _frequency_mhz;
     uint16_t _current_frequency;
 
     // power output in mw
     AP_Int16 _power_mw;
-    uint16_t _current_power;
+    uint16_t _current_power {0};
     int32_t _actual_power_mw {-1};
     AP_Int16 _max_power_mw;
 

--- a/libraries/AP_VideoTX/AP_VideoTX.h
+++ b/libraries/AP_VideoTX/AP_VideoTX.h
@@ -22,6 +22,9 @@
 
 #define VTX_MAX_CHANNELS 8
 #define VTX_MAX_POWER_LEVELS 10
+// number of user-definable power table entries (VTX_PWRTBL1 to VTX_PWRTBL6),
+// sized to match the 6 positions of the power aux switch
+#define VTX_USER_POWER_LEVELS 6
 
 class AP_VideoTX {
 public:
@@ -120,18 +123,31 @@ public:
     int32_t get_actual_power_mw() const { return _actual_power_mw; }
     uint16_t get_max_power_mw() const { return _max_power_mw; }
 
+    // user-defined power table (VTX_PWRTBL_EN, VTX_PWRTBL1 to VTX_PWRTBL6).
+    // These parameters are the table: _power_levels describes the SmartAudio
+    // levels and is not extended with user values.
+    // mW for table entry i, 0 if unused. There is no unsigned parameter type,
+    // so this is the one place the signed parameter is read and anything <= 0
+    // is treated as unused; everything downstream is uint16_t.
+    uint16_t get_table_entry_mw(uint8_t i) const {
+        if (i >= VTX_USER_POWER_LEVELS) {
+            return 0;
+        }
+        const int16_t entry = _power_table[i].get();
+        return entry > 0 ? uint16_t(entry) : 0;
+    }
+    // true when the user has enabled the user power table
+    bool use_power_table() const;
+    // highest power the user has authorised: the top table entry when the user
+    // table is in use, otherwise VTX_MAX_POWER
+    uint16_t get_power_cap_mw() const;
+
     // get the power in dbm, rounding appropriately
-    uint8_t get_configured_power_dbm() const {
-        return _power_levels[find_current_power()].dbm;
-    }
+    uint8_t get_configured_power_dbm() const;
     // get the power "level"
-    uint8_t get_configured_power_level() const {
-        return _power_levels[find_current_power()].level & 0xF;
-    }
+    uint8_t get_configured_power_level() const;
     // get the power "dac"
-    uint8_t get_configured_power_dac() const {
-        return _power_levels[find_current_power()].dac;
-    }
+    uint8_t get_configured_power_dac() const;
 
     // mark the power level matching the given mW as supported, learning it
     // into the custom slot if it is not a standard value
@@ -147,6 +163,17 @@ public:
     bool update_power() const;
     // change the video power based on switch input
     void change_power(int8_t position);
+    // the power in mW that the power aux switch (RCx_OPTION 94) selects for the
+    // given switch position, 0 meaning pitmode. user_table holds the raw
+    // VTX_PWRTBL values; when the table is enabled and all VTX_USER_POWER_LEVELS
+    // entries are set the six switch positions map 1:1 onto the table and
+    // pitmode is not among the choices, otherwise position 0 is pitmode.
+    // Returns false when there is nothing to select. Static and side-effect
+    // free so the mapping can be unit tested
+    static bool switch_power_mw(int8_t position,
+                                const uint16_t *user_table, uint8_t user_table_len,
+                                bool user_table_enabled, uint16_t max_power_mw,
+                                uint16_t &power_mw);
     // get / set the frequency band
     void set_band(uint8_t band) { _current_band = band; }
     void set_configured_band(uint8_t band) { _band.set_and_save_ifchanged(band); }
@@ -213,6 +240,10 @@ private:
     uint16_t _current_power;
     int32_t _actual_power_mw {-1};
     AP_Int16 _max_power_mw;
+
+    // user-defined power table
+    AP_Int8 _power_table_enabled;
+    AP_Int16 _power_table[VTX_USER_POWER_LEVELS];
 
     // frequency band
     AP_Int8 _band;

--- a/libraries/AP_VideoTX/tests/test_vtx_power.cpp
+++ b/libraries/AP_VideoTX/tests/test_vtx_power.cpp
@@ -25,15 +25,16 @@
 
 const AP_HAL::HAL &hal = AP_HAL::get_HAL();
 
-static bool switch_power(int8_t position, const uint16_t table[VTX_USER_POWER_LEVELS], bool table_enabled, uint16_t max_power, uint16_t &power)
+static bool switch_power(int8_t position, const int16_t table[VTX_USER_POWER_LEVELS], bool table_enabled, uint16_t max_power, uint16_t &power)
 {
     return AP_VideoTX::switch_power_mw(position, table, VTX_USER_POWER_LEVELS, table_enabled, max_power, power);
 }
 
-// six entries and six switch positions: 1:1 mapping, no pitmode slot
+// six used entries and six switch positions: 1:1 mapping, pit mode is the
+// explicit 0 entry at position 0
 TEST(VTXPowerSwitch, SixEntriesMapOneToOne)
 {
-    const uint16_t table[VTX_USER_POWER_LEVELS] = { 25, 100, 200, 500, 800, 1000 };
+    const int16_t table[VTX_USER_POWER_LEVELS] = { 0, 25, 400, 800, 1500, 2500 };
     uint16_t power = 42;
     for (int8_t pos = 0; pos < 6; pos++) {
         EXPECT_TRUE(switch_power(pos, table, true, 800, power));
@@ -41,11 +42,12 @@ TEST(VTXPowerSwitch, SixEntriesMapOneToOne)
     }
 }
 
-// five entries: position 0 is pitmode, the rest map 1:1 onto the entries
-TEST(VTXPowerSwitch, FiveEntriesPitmodeFirst)
+// a value of -1 ignores the entry: five used entries spread over six positions,
+// edge positions repeat
+TEST(VTXPowerSwitch, NegativeEntriesIgnored)
 {
-    const uint16_t table[VTX_USER_POWER_LEVELS] = { 25, 100, 200, 500, 800, 0 };
-    const uint16_t expected[6] = { 0, 25, 100, 200, 500, 800 };
+    const int16_t table[VTX_USER_POWER_LEVELS] = { 25, -1, 400, -1, 800, -1 };
+    const uint16_t expected[6] = { 25, 25, 400, 400, 800, 800 };
     uint16_t power;
     for (int8_t pos = 0; pos < 6; pos++) {
         EXPECT_TRUE(switch_power(pos, table, true, 800, power));
@@ -53,23 +55,21 @@ TEST(VTXPowerSwitch, FiveEntriesPitmodeFirst)
     }
 }
 
-// entries are taken in slot order; the user is expected to set them ascending,
-// zero entries are skipped
-TEST(VTXPowerSwitch, SlotOrderPreserved)
+// a table with no used entries leaves the switch with nothing to select
+TEST(VTXPowerSwitch, AllNegativeNothingSelectable)
 {
-    const uint16_t table[VTX_USER_POWER_LEVELS] = { 500, 0, 25, 0, 800, 0 };
-    const uint16_t expected[6] = { 0, 0, 500, 25, 25, 800 };
-    uint16_t power;
+    const int16_t table[VTX_USER_POWER_LEVELS] = { -1, -1, -1, -1, -1, -1 };
+    uint16_t power = 42;
     for (int8_t pos = 0; pos < 6; pos++) {
-        EXPECT_TRUE(switch_power(pos, table, true, 800, power));
-        EXPECT_EQ(power, expected[pos]);
+        EXPECT_FALSE(switch_power(pos, table, true, 800, power));
+        EXPECT_EQ(power, 42);
     }
 }
 
-// an enabled but empty table leaves only pitmode on the switch
-TEST(VTXPowerSwitch, EmptyEnabledTableIsPitmodeOnly)
+// a table of nothing but 0 entries is pit mode on every position
+TEST(VTXPowerSwitch, AllZeroAllPitmode)
 {
-    const uint16_t table[VTX_USER_POWER_LEVELS] = { 0, 0, 0, 0, 0, 0 };
+    const int16_t table[VTX_USER_POWER_LEVELS] = { 0, 0, 0, 0, 0, 0 };
     uint16_t power;
     for (int8_t pos = 0; pos < 6; pos++) {
         EXPECT_TRUE(switch_power(pos, table, true, 800, power));
@@ -77,11 +77,23 @@ TEST(VTXPowerSwitch, EmptyEnabledTableIsPitmodeOnly)
     }
 }
 
+// pitmode is an explicit table entry, so it can sit anywhere in the table
+TEST(VTXPowerSwitch, MidTablePitmode)
+{
+    const int16_t table[VTX_USER_POWER_LEVELS] = { 25, 400, 0, 800, -1, -1 };
+    const uint16_t expected[6] = { 25, 25, 400, 0, 0, 800 };
+    uint16_t power;
+    for (int8_t pos = 0; pos < 6; pos++) {
+        EXPECT_TRUE(switch_power(pos, table, true, 800, power));
+        EXPECT_EQ(power, expected[pos]);
+    }
+}
+
 // built-in levels: the top position offers VTX_MAX_POWER even when the
 // largest active level is below it
 TEST(VTXPowerSwitch, BuiltInTopPositionReachesMaxPower)
 {
-    const uint16_t table[VTX_USER_POWER_LEVELS] = { 0, 0, 0, 0, 0, 0 };
+    const int16_t table[VTX_USER_POWER_LEVELS] = { -1, -1, -1, -1, -1, -1 };
     uint16_t power;
     EXPECT_TRUE(switch_power(5, table, false, 750, power));
     EXPECT_EQ(power, 750);
@@ -90,7 +102,7 @@ TEST(VTXPowerSwitch, BuiltInTopPositionReachesMaxPower)
 // built-in levels: VTX_MAX_POWER of 0 means no cap
 TEST(VTXPowerSwitch, BuiltInZeroMaxPowerMeansNoCap)
 {
-    const uint16_t table[VTX_USER_POWER_LEVELS] = { 0, 0, 0, 0, 0, 0 };
+    const int16_t table[VTX_USER_POWER_LEVELS] = { -1, -1, -1, -1, -1, -1 };
     uint16_t power;
     EXPECT_TRUE(switch_power(5, table, false, 0, power));
     EXPECT_EQ(power, 1000);

--- a/libraries/AP_VideoTX/tests/test_vtx_power.cpp
+++ b/libraries/AP_VideoTX/tests/test_vtx_power.cpp
@@ -1,0 +1,101 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// tests for the power aux switch mapping in AP_VideoTX::switch_power_mw()
+
+#include <AP_gtest.h>
+
+#include <AP_VideoTX/AP_VideoTX_config.h>
+
+#if AP_VIDEOTX_ENABLED
+
+#include <AP_VideoTX/AP_VideoTX.h>
+
+const AP_HAL::HAL &hal = AP_HAL::get_HAL();
+
+static bool switch_power(int8_t position, const uint16_t table[VTX_USER_POWER_LEVELS], bool table_enabled, uint16_t max_power, uint16_t &power)
+{
+    return AP_VideoTX::switch_power_mw(position, table, VTX_USER_POWER_LEVELS, table_enabled, max_power, power);
+}
+
+// six entries and six switch positions: 1:1 mapping, no pitmode slot
+TEST(VTXPowerSwitch, SixEntriesMapOneToOne)
+{
+    const uint16_t table[VTX_USER_POWER_LEVELS] = { 25, 100, 200, 500, 800, 1000 };
+    uint16_t power = 42;
+    for (int8_t pos = 0; pos < 6; pos++) {
+        EXPECT_TRUE(switch_power(pos, table, true, 800, power));
+        EXPECT_EQ(power, table[pos]);
+    }
+}
+
+// five entries: position 0 is pitmode, the rest map 1:1 onto the entries
+TEST(VTXPowerSwitch, FiveEntriesPitmodeFirst)
+{
+    const uint16_t table[VTX_USER_POWER_LEVELS] = { 25, 100, 200, 500, 800, 0 };
+    const uint16_t expected[6] = { 0, 25, 100, 200, 500, 800 };
+    uint16_t power;
+    for (int8_t pos = 0; pos < 6; pos++) {
+        EXPECT_TRUE(switch_power(pos, table, true, 800, power));
+        EXPECT_EQ(power, expected[pos]);
+    }
+}
+
+// entries are taken in slot order; the user is expected to set them ascending,
+// zero entries are skipped
+TEST(VTXPowerSwitch, SlotOrderPreserved)
+{
+    const uint16_t table[VTX_USER_POWER_LEVELS] = { 500, 0, 25, 0, 800, 0 };
+    const uint16_t expected[6] = { 0, 0, 500, 25, 25, 800 };
+    uint16_t power;
+    for (int8_t pos = 0; pos < 6; pos++) {
+        EXPECT_TRUE(switch_power(pos, table, true, 800, power));
+        EXPECT_EQ(power, expected[pos]);
+    }
+}
+
+// an enabled but empty table leaves only pitmode on the switch
+TEST(VTXPowerSwitch, EmptyEnabledTableIsPitmodeOnly)
+{
+    const uint16_t table[VTX_USER_POWER_LEVELS] = { 0, 0, 0, 0, 0, 0 };
+    uint16_t power;
+    for (int8_t pos = 0; pos < 6; pos++) {
+        EXPECT_TRUE(switch_power(pos, table, true, 800, power));
+        EXPECT_EQ(power, 0);
+    }
+}
+
+// built-in levels: the top position offers VTX_MAX_POWER even when the
+// largest active level is below it
+TEST(VTXPowerSwitch, BuiltInTopPositionReachesMaxPower)
+{
+    const uint16_t table[VTX_USER_POWER_LEVELS] = { 0, 0, 0, 0, 0, 0 };
+    uint16_t power;
+    EXPECT_TRUE(switch_power(5, table, false, 750, power));
+    EXPECT_EQ(power, 750);
+}
+
+// built-in levels: VTX_MAX_POWER of 0 means no cap
+TEST(VTXPowerSwitch, BuiltInZeroMaxPowerMeansNoCap)
+{
+    const uint16_t table[VTX_USER_POWER_LEVELS] = { 0, 0, 0, 0, 0, 0 };
+    uint16_t power;
+    EXPECT_TRUE(switch_power(5, table, false, 0, power));
+    EXPECT_EQ(power, 1000);
+}
+
+AP_GTEST_MAIN()
+
+#endif  // AP_VIDEOTX_ENABLED

--- a/libraries/AP_VideoTX/tests/wscript
+++ b/libraries/AP_VideoTX/tests/wscript
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+def build(bld):
+    bld.ap_find_tests(
+        use='ap',
+    )


### PR DESCRIPTION
### Summary

Adds a user-definable VTX power table for the VTX power aux switch, and fixes a Tramp driver bug where a missed or refused VTX command could permanently strand the VTX in pit mode or at the wrong power level.

<img width="368" height="308" alt="Screenshot 2026-09-13 053745" src="https://github.com/user-attachments/assets/841e5401-e740-4e1a-b64b-a5997328243a" />

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [x] Tested on hardware
- [x] Logs available on request

**Unit tests**: new GTest suite `libraries/AP_VideoTX/tests/` (`test_vtx_power`, 7 tests) covering the power aux switch position mapping: explicit-pitmode 1:1 mapping, `-1` entry skipping, empty tables, all-pitmode tables, mid-table pitmode, and `VTX_MAX_POWER` cap handling in built-in mode. All pass. The suite is guarded by `AP_VIDEOTX_ENABLED` so it compiles out with the feature disabled.

**Hardware testing** (SpeedyBee F405 V4, IRC Tramp protocol VTX, power table `{0, 25, 400, 800, 1500, 2500}`):

- All six aux-switch positions select the expected table entry, including pit mode at position 0; pit→25, pit→400 and 400→25 transitions verified on the bench.
- Repro steps for the pit mode stranding (fails on master, fixed by this PR):
  1. Power the flight controller via USB only, leaving the VTX unpowered.
  2. Wait 20 seconds.
  3. Power the VTX by plugging in the flight battery.
  4. The VTX boots after ArduPilot has already sent its initial pit mode command, misses it, and is left stuck in pit mode (video dark) with no further attempts. After the fix, the command is retried every second and the VTX recovers.

### Description

#### Background: power switch logic, old vs new

On master the power aux switch subdivides the built-in level list (0/25/100/200/400/500/600/800/1000 mW, learned and trimmed at runtime by the SmartAudio backends) evenly over the six switch positions, capped by `VTX_MAX_POWER`. That mapping is not deterministic: it depends on which levels the VTX happened to report, it can silently skip levels, there is no guaranteed pitmode position, and power is always snapped to the built-in list (`VTX_POWER` is rounded down at init, and arbitrary mW is impossible on Tramp). `MAX_POWER` tops out at 1000 mW.

This PR makes the six user parameters the complete and only definition of the VTX power levels when the table is enabled:

- **Level source**: user table (`VTX_PWRTBL1-6`) when `VTX_PWRTBL_EN=1`, built-in list otherwise.
- **Entry semantics**: a value of -1 ignores the entry, a value of 0 selects **pit mode** at that switch position, otherwise the value is the power in mW. Entries are used in slot order; the used entries are the switch's only choices.
- **Mapping**: six used entries → positions 1-6 map 1:1 onto the table (e.g. `{0, 25, 400, 800, 1500, 2500}` = pitmode plus five powers, each position exactly one entry). Fewer used entries → the six positions subdivide over them (edge positions repeat). No pitmode position is ever added automatically — if the table has no `0` entry, the switch has no pitmode position.
- **VTX_POWER**: used as-is on transports that accept arbitrary mW (IRC Tramp) instead of being rounded down; `VTX_POWER` up to 32767 mW is now representable (`@Units: mW` annotations added). dBm is derived (`10·log10(mW)`) for powers matching no built-in entry, keeping CRSF/SmartAudio telemetry sane.
- **Level byte reporting**: powers with no SmartAudio equivalent are reported as the nearest lower built-in level (the learned custom slot is excluded from level/dac reporting, since its values are Tramp bookkeeping) — so SmartAudio and CRSF command frames always carry a wire-valid level byte.
- **Ceiling**: the table itself is the ceiling and `VTX_MAX_POWER` is ignored in table mode; in built-in mode `VTX_MAX_POWER` of 0 now means no cap (previously 25-1000 required).
- **High-power VTXs**: levels above 1000 mW (e.g. 1500/2500) and arbitrary values are now expressible, which master cannot do.
- **Safety guard changes**: a non-builtin `VTX_POWER` (e.g. 1200 mW) now survives `update()`, since the power-reset check is skipped in table mode and `_current_power` is default-initialised (previously an uninitialised index could be read before the first VTX reply, and `VTX_POWER` above 1000 mW left the index unset on master's snapping path).

#### Changes

**User power table** (commit `3bdeb4018a`):

- Adds `VTX_PWRTBL_EN` and six table entries `VTX_PWRTBL1-6`, which replace the built-in power levels and `VTX_MAX_POWER` for the VTX power aux switch (RCx_OPTION = 94). `@Range: -1 32767`; a value of -1 ignores the entry, 0 selects pit mode, otherwise power in mW.
- With the table enabled, `VTX_POWER` is sent as-is on transports that accept arbitrary power levels (IRC Tramp) instead of being rounded down to a SmartAudio level; `VTX_POWER` up to 32767 mW is now representable.
- `VTX_MAX_POWER` of 0 now means no cap; it is ignored entirely when the table is enabled.
- SmartAudio "level"/"dac" reporting clamps a table power to the nearest lower supported level, so command frames never carry a meaningless level byte (e.g. 1500 mW reports as the 1000 mW level).
- Two intentional behaviour changes:
  - `update()` no longer "corrects" configured power against the learned built-in level list when the table is enabled — the table is the user's own statement of what the VTX supports.
  - `change_power()` returns without action when no power levels are selectable, instead of falling back to `MAX_POWER`.
- In built-in (non-table) mode, learned non-standard powers now sort into the switch's step list instead of appearing out of order (a VTX-reported 300 mW was previously offered at a high switch position).

**Tramp command retries** (commit `49c4d4fcbc`):

- Pit mode: the pit mode command is sent on its own 1 s schedule, prioritised over all other pending changes and retried indefinitely, in both directions. Previously a refused or missed pit mode command exhausted the 20-attempt budget and stranded the VTX in pit mode with no way back (`update_power()` refuses to send power while in pit mode, so video stays dark regardless of frequency). A race-locked VTX ignores the command; sending regardless is deliberate, as the request is harmless and keeps the retry loop simple.
- Power: the power request budget is re-armed every 1 s (the same cadence as the pit mode retry) while the VTX reports a power other than the requested one, so a request burst that lands in the settle window after a pit mode change cannot strand the VTX at the old power.
- Warnings remain one-per-episode: `VTX: pitmode change not accepted` after 30 s of continuous refusal (a VTX still starting up stays well inside that), `VTX: rejected power XmW` once per power episode.

**Design note**: frequency and power changes stay blocked while a pit mode change is pending, by design — video is dark so a frequency change is unseeable, and `update_power()` (pre-existing) refuses power in pit mode.

**Dead code removal** (commit `dc5c0ba6bc`): removes two unused `AP_Tramp` method declarations.

**Contribution disclosure**: this PR was prepared with AI assistance (code authorship, review and testing were performed and verified by a human).
