### PR TITLE
AP_GPS: fix -Wdangling-pointer warning in convert_parameters

### DIFF
--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -359,7 +359,7 @@ void AP_GPS::convert_parameters()
     }
 
     // table parameters to convert without scaling
-    static const AP_Param::ConversionInfo conversion_info[] {
+    const AP_Param::ConversionInfo conversion_info[] {
         // PARAMETER_CONVERSION - Added: Mar-2024 for ArduPilot-4.6
         { k_param_gps_key, 0, AP_PARAM_INT8, "GPS1_TYPE" },
         { k_param_gps_key, 1, AP_PARAM_INT8, "GPS2_TYPE" },


### PR DESCRIPTION
### Summary

Remove `static` from the `conversion_info` array in `AP_GPS::convert_parameters()` to eliminate a `-Wdangling-pointer` compiler warning on GCC 12+.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [x] Non-functional change
- [ ] No-binary change
- [ ] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [x] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

#### Testing Details:
- Compiled with GCC 12 (`xtensa-esp32s3-elf-gcc 12.2.0`), verifying that the `-Wdangling-pointer` warning is completely resolved.
- Verified branch conventions with `./Tools/scripts/check_branch_conventions.py --base-branch upstream/master` (all checks passed).
- *This PR was prepared with AI assistance and checked by a human.*

BEFORE
<img width="1181" height="569" alt="スクリーンショット 2026-09-13 5 40 41" src="https://github.com/user-attachments/assets/7ae5a1f8-82fd-448f-a02d-ba5641d59aaa" />

### Description

In `AP_GPS::convert_parameters()`, the parameter conversion table was declared as:
```cpp
static const AP_Param::ConversionInfo conversion_info[] {
    { k_param_gps_key, 0, AP_PARAM_INT8, "GPS1_TYPE" },
    ...
};
```
Because `k_param_gps_key` is a local variable on the stack (`uint16_t k_param_gps_key`), storing its value inside a `static` array triggers a `-Wdangling-pointer` warning with GCC 12 and newer toolchains due to the lifetime mismatch between static storage and automatic storage duration.

Removing `static` ensures that `conversion_info` has local storage duration matching `k_param_gps_key`. This also aligns with similar parameter conversion helpers across the codebase (such as `conversion_info` in `libraries/AC_Avoidance/AC_Avoid.cpp`).
