### PR TITLE
Tools: enable math index checks for every build.Rover CI job

### DIFF
--- a/Tools/scripts/build_ci.sh
+++ b/Tools/scripts/build_ci.sh
@@ -113,7 +113,7 @@ function run_autotest() {
     if [ $c_compiler == "clang" ]; then
         w="$w --check-c-compiler=clang --check-cxx-compiler=clang++"
     fi
-    if [ "$NAME" == "Rover" ]; then
+    if [ "$BVEHICLE" == "build.Rover" ]; then
         w="$w --enable-math-check-indexes"
     fi
     if [ "x$CI_BUILD_DEBUG" != "x" ]; then


### PR DESCRIPTION
### Summary

Use same build flags in citest for BalanceBot as we do for Rover to improve ccache usage

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [ ] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

The rover workflow's build job primes ccache with
--enable-math-check-indexes, matching sitltest-rover and sitltest-sailboat, which both pass "Rover" as the run_autotest name. sitltest-balancebot passes "BalanceBot", so it configured without the flag, missed the cache on 872 of 1382 compiles and spent 6m33s building ardurover against 14s in the other two jobs.

Key the flag on the build step rather than the name, so BalanceBot builds the same binary as the other build.Rover jobs.

