### PR TITLE
Correct build flags used by the CI periph tests

### DIFF
--- a/.github/workflows/test_sitl_copter.yml
+++ b/.github/workflows/test_sitl_copter.yml
@@ -221,6 +221,9 @@ jobs:
           # directory must match (ccache sees it via generated-header paths)
           ./waf configure --board sitl_periph_can_to_serial --debug --out build-periph
           ./waf build --target bin/AP_Periph
+          # DroneCANCompass builds this via restart_SITL_frame('copter-periph-compass')
+          ./waf configure --board sitl_periph_universal --debug
+          ./waf build --target bin/AP_Periph
           ccache -s
       - uses: ./.github/actions/save-ccache
         with:

--- a/.github/workflows/test_sitl_plane.yml
+++ b/.github/workflows/test_sitl_plane.yml
@@ -215,10 +215,14 @@ jobs:
           PATH="/github/home/.local/bin:$PATH"
           ./waf build --target tool/Replay
           # PPPPeriph rebuilds the plane and a sitl_periph_PPP AP_Periph via
-          # restart_SITL_frame('quadplane-PPP', extra_configure_args=['--debug'])
-          ./waf configure --board sitl --enable-PPP --enable-networking-tests --debug
+          # restart_SITL_frame('quadplane-PPP'), with the Plane jobs' options
+          ./waf configure --board sitl --enable-PPP --enable-networking-tests --debug --num-aux-imus=2
           ./waf build --target bin/arduplane
-          ./waf configure --board sitl_periph_PPP --enable-PPP --enable-networking-tests --debug
+          ./waf configure --board sitl_periph_PPP --enable-PPP --enable-networking-tests --debug --num-aux-imus=2
+          ./waf build --target bin/AP_Periph
+          # CircuitStatusScript builds this via restart_SITL_frame('quadplane-can'),
+          # with the QuadPlane jobs' options
+          ./waf configure --board sitl_periph_universal --debug
           ./waf build --target bin/AP_Periph
           ccache -s
       - uses: ./.github/actions/save-ccache

--- a/Tools/autotest/arduplane.py
+++ b/Tools/autotest/arduplane.py
@@ -9719,7 +9719,6 @@ class AutoTestPlane(vehicle_test_suite.TestSuite):
         })
         self.restart_SITL_frame(
             'quadplane-PPP',
-            extra_configure_args=['--debug'],
             # lockstep: the periph's PPP endpoint must not fall behind
             # simulation time when the runner is loaded
             customisations=['--serial5=tcp:{port}', '--sim-periph-lockstep'],

--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -3403,10 +3403,19 @@ class TestSuite(abc.ABC):
             vehicleinfo_key = self.vehicleinfo_key()
 
         self.context_backup_file(self.binary)
+        # build with the suite's own options (--debug, --num-aux-imus,
+        # ...) so the frame binary matches the one under test, and so
+        # the rebuild can reuse the objects already built that way
+        build_opts = copy.copy(self.build_opts)
+        build_opts["clean"] = False
+        build_opts["configure"] = True
+        configure_args = list(build_opts.pop("extra_configure_args", None) or [])
+        if extra_configure_args is not None:
+            configure_args += list(extra_configure_args)
         frame_opts = util.build_SITL_frame(
             vehicleinfo_key, frame,
-            extra_configure_args=extra_configure_args,
-            clean=False, configure=True,
+            extra_configure_args=configure_args,
+            **build_opts,
         )
 
         periph_port = None


### PR DESCRIPTION
### Summary

Tests that rebuild firmware through `restart_SITL_frame()` were building it without the suite's build options (`--debug`, `--num-aux-imus`, ...).  On CI that meant rebuilding both the vehicle and the peripheral from scratch inside the test, which is where nearly all of `DroneCANCompass`'s ~12 minutes and `CircuitStatusScript`'s ~9 minutes go.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [ ] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

`restart_SITL_frame()` called `util.build_SITL_frame()` with none of the suite's `build_opts`, so the frame's vehicle and AP_Periph binaries were always configured without `--debug`, `--num-aux-imus` and the other options the suite was built with.  This has three effects:

- **The binary under test doesn't match the suite's configuration.**  For example, `PPPPeriph` on a Plane job rebuilds arduplane without `--num-aux-imus=2` while the suite sets `SIM_IMU_COUNT` for the aux IMUs.
- **`build/sitl` is left configured without `--debug`** for whatever test runs next.
- **CI rebuilds from scratch.**  CI builds with `--debug` and its ccache holds `--debug` objects, so the in-test builds miss the cache almost entirely.  From the logs of a green master run (acef45eb0f):

| test | CI time | vehicle rebuild | periph rebuild |
| --- | --- | --- | --- |
| `Copter.DroneCANCompass` | 743s | `sitl` 8m19s | `sitl_periph_universal` 3m51s |
| `QuadPlane.CircuitStatusScript` | 520s | `sitl` 5m51s | `sitl_periph_universal` 2m43s |

On a desktop, where the builds don't dominate, these tests take ~20-30s.

`PPPPeriph` already worked around the problem by passing `extra_configure_args=['--debug']` itself.

This PR:

1. **autotest:** makes `restart_SITL_frame()` build with a copy of the suite's `build_opts`, forcing `clean=False, configure=True` and appending any caller-supplied configure arguments.  This is the same approach `build_replay_tool()` already takes.  `PPPPeriph`'s hard-coded `--debug` is removed.
2. **.github:** adds `sitl_periph_universal --debug` to the master-only "pre-build test-time firmware" steps in the Copter and Plane workflows, so the in-test periph builds become ccache hits.  It also adds `--num-aux-imus=2` to the `PPPPeriph` pre-builds, since that rebuild now uses the Plane jobs' options.

The vehicle half of the rebuild needs no priming: each job has already built `build/sitl` with the same options in its `build.<Vehicle>` step, so waf finds nothing to do.

Once this is in, `DroneCANCompass` and `CircuitStatusScript` stop being outliers, and the CI test buckets can be rebalanced without single-test batches built around them.
