### PR TITLE
autotest: detect MAVFTP fetch completion by MAVProxy's success message

### DIFF
--- a/Tools/autotest/vehicle_test_suite.py
+++ b/Tools/autotest/vehicle_test_suite.py
@@ -16449,20 +16449,25 @@ switch value'''
         try:
             mavproxy.send("module load ftp\n")
             mavproxy.expect(["Loaded module ftp", "module ftp already loaded"])
-            mavproxy.send("ftp get %s %s\n" % (path, tmpfile.name))
-            mavproxy.expect("Getting")
-            tstart = self.get_sim_time()
-            while True:
-                now = self.get_sim_time()
-                if now - tstart > timeout:
-                    raise NotAchievedException("expected complete transfer")
-                self.progress("Polling status")
-                mavproxy.send("ftp status\n")
+            mavproxy.send("ftp set debug 1\n")  # so we get the "Terminated session" message
+            # Completion is detected by MAVProxy's own success message
+            # ("Wrote N bytes to ...", printed only when the whole file
+            # has been written).  "No transfer in progress" cannot tell
+            # a completed transfer from one not yet started or aborted.
+            # Timeouts here are wall-clock: everything is paced by
+            # MAVProxy and pexpect, not the simulation.
+            for attempt in range(3):
+                mavproxy.send("ftp get %s %s\n" % (path, tmpfile.name))
+                mavproxy.expect("Getting")
                 try:
-                    mavproxy.expect("No transfer in progress", timeout=1)
+                    mavproxy.expect(r"Wrote \d+ bytes to ", timeout=timeout)
                     break
-                except Exception:  # noqa: BLE001
-                    continue
+                except pexpect.TIMEOUT:
+                    self.progress("Transfer did not complete (attempt=%u)" % attempt)
+                    mavproxy.send("ftp cancel\n")
+                    mavproxy.expect("Terminated session")
+            else:
+                raise NotAchievedException("expected complete transfer")
         except Exception as e:  # noqa: BLE001
             self.print_exception_caught(e)
             ex = e


### PR DESCRIPTION
### Summary

Fix `fetch_file_via_ftp()`, and so `Copter.PerfInfo`: detect a completed MAVFTP download by MAVProxy's "Wrote N bytes" message, with a wall-clock timeout, instead of polling `ftp status` against a sim-time budget.

### Classification & Testing (check all that apply and add your own)

- [x] Checked by a human programmer
- [ ] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (e.g. unit tests, helper scripts)
- [x] Automated test(s) verify changes (e.g. unit test, autotest)
- [ ] Tested manually, description below (e.g. SITL)
- [ ] Tested on hardware
- [ ] Logs attached
- [x] Logs available on request

This change has been running in the parallel-autotest work since August, including under `--parallel=32` and with 28 CPU burners loading the machine, where `PerfInfo` had failed in each of the ways described below.

### Description

`fetch_file_via_ftp()` sent `ftp get`, then polled `ftp status` once a (wall) second for "No transfer in progress", giving up after 20 seconds of *simulated* time.  Both parts are wrong:

- **The timeout clock.**  Nothing in the loop is paced by the simulation; it is MAVProxy and pexpect.  At full speedup, a single one-second `expect` consumes the whole 20-second sim-time budget.  So a status poll which lands while the transfer is still in progress fails the fetch about a second after it began, even though the file arrives:

  ```
  STABILIZE> Transfer at offset 3440 with 0 gaps 0 retries 243.2 kByte/sec
  Wrote 7403 bytes to /tmp/tmptcsw8tm2 in 0.02s 391.1kByte/s
  Timed out looking for No transfer in progress
  AT-0360.9: Exception caught: expected complete transfer
  ```

  (from a serial `test.CopterTests1d` run; the fetch started at AT-0359.8)

- **The completion test.**  "No transfer in progress" is also true before the transfer has started and after one has been aborted.  So the helper can return an empty or truncated file, and `PerfInfo` then fails on its content instead:

  ```
  Expected TasksV2 as first line first not ()
  Expected EFI last not (AP_Generator::update ...)
  ```

The helper now:

- expects MAVProxy's `Wrote N bytes to` message, which is printed only once the whole file has been written, with the `timeout` applied in wall-clock time;
- if that doesn't arrive, cancels the transfer (`ftp set debug 1` makes MAVProxy print the "Terminated session" message this waits for) and retries, up to three attempts in all.
